### PR TITLE
added EVTBLK member to FUNC in csoundCore.h and access method in csound.c

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -213,6 +213,7 @@ int hfgens(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp, int mode)
         return -1;
       }
       *ftpp = ftp;
+      ftp->e = *evtblkp;       /* assigning evtblk */
       return 0;
     }
     /* if user flen given */
@@ -265,7 +266,7 @@ int hfgens(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp, int mode)
     /* VL 11.01.05 for deferred GEN01, it's called in gen01raw */
     ftresdisp(&ff, ftp);                        /* rescale and display      */
     *ftpp = ftp;
-
+    ftp->e = *evtblkp;                          /* assigning evtblk */
     return 0;
 }
 

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -3261,6 +3261,15 @@ static void csoundTableSetInternal(CSOUND *csound,
     csound->flist[table]->ftable[index] = value;
 }
 
+PUBLIC void* csoundTableGetEvtblk(CSOUND *csound, int table)
+{
+    /* check if table is valid */
+    if(csoundTableLength(csound, table)!=-1)
+        return &(csound->flist[table]->e);
+    else
+        return NULL;
+}
+
 PUBLIC void csoundTableSet(CSOUND *csound, int table, int index, MYFLT value)
 {
     /* in realtime mode init pass is executed in a separate thread, so

--- a/include/csound.h
+++ b/include/csound.h
@@ -1661,6 +1661,12 @@ extern "C" {
     PUBLIC MYFLT csoundTableGet(CSOUND *, int table, int index);
 
     /**
+     * Returns the EVTBLK structure that was used to first create
+     * the table. Returns NULL is table is not valid
+     */
+    PUBLIC void* csoundTableGetEvtblk(CSOUND *csound, int table);
+
+    /**
      * Sets the value of a slot in a function table.
      * The table number and index are assumed to be valid.
      */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -629,6 +629,8 @@ typedef struct {
     GEN01ARGS gen01args;
     /** table data (flen + 1 MYFLT values) */
     MYFLT   *ftable;
+    /** EVTBLK **/
+    EVTBLK  e;
   } FUNC;
 
   typedef struct {


### PR DESCRIPTION
As discussed on the dev list, I would like to have access to the evtblk structure that is filled when a table is first created. I've been using a local build with these changes for the past few weeks without any problems. I'm calling csoundTableLength() to check if the table is valid but perhaps there is a more eloquent way of checking the validity of a table. Or perhaps it's best left up to the developer using the API?  
