### PR TITLE
Make the Emscripten examples work again, now compiles with -O3

### DIFF
--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -19,7 +19,7 @@ emcc -s LINKABLE=1 ../src/CsoundObj.c -I../../include -Iinclude -o CsoundObj.bc
 # !/bin/bash
 
 # build_libcsound64.js.sh
-emcc -O2 -s LINKABLE=1 -s ASM_JS=1 -s VERBOSE=1 -s EXPORTED_FUNCTIONS="['_CsoundObj_new', '_CsoundObj_compileCSD', '_CsoundObj_process', '_CsoundObj_compileOrc', '_CsoundObj_readScore', '_CsoundObj_test', '_CsoundObj_getKsmps','_CsoundObj_getNchnls', '_CsoundObj_getNchnlsInput', '_CsoundObj_stop', '_CsoundObj_reset', '_CsoundObj_start', '_CsoundObj_setControlChannel', '_CsoundObj_setUsingAudioInput']"  CsoundObj.bc libcsound64.a ../deps/libsndfile-1.0.25/src/.libs/libsndfile.a -o libcsound.js
+emcc -O3 --post-js ../src/post.js -s LINKABLE=1 -s ASM_JS=1 -s VERBOSE=1 -s EXPORTED_FUNCTIONS="['_CsoundObj_new', '_CsoundObj_compileCSD', '_CsoundObj_process', '_CsoundObj_compileOrc', '_CsoundObj_readScore', '_CsoundObj_test', '_CsoundObj_getKsmps','_CsoundObj_getNchnls', '_CsoundObj_getNchnlsInput', '_CsoundObj_stop', '_CsoundObj_reset', '_CsoundObj_start', '_CsoundObj_setControlChannel', '_CsoundObj_setUsingAudioInput']"  CsoundObj.bc libcsound64.a ../deps/libsndfile-1.0.25/src/.libs/libsndfile.a -o libcsound.js
 
 
 cd ..

--- a/emscripten/examples/index.html
+++ b/emscripten/examples/index.html
@@ -18,35 +18,41 @@
 <script src="javascripts/jquery.js"></script>
 <script>
 
+function createCsoundInstance() {
+    
+    csoundObj = new CsoundObj();
+    
+};
 
-var csoundObj = new CsoundObj();
+
+var csoundObj;
 
 var csdFileReader = new FileReader();
 var testFilePath = "test.csd";
 var textEditor;
 csdFileReader.onloadend = function()
 {
-	var data = new Uint8Array(csdFileReader.result);
-	var stream = FS.open(testFilePath, 'w+');
-	FS.write(stream, data, 0, data.length, 0);
-	FS.close(stream);
-	csoundObj.compileCSD(testFilePath);
+var data = new Uint8Array(csdFileReader.result);
+var stream = FS.open(testFilePath, 'w+');
+FS.write(stream, data, 0, data.length, 0);
+FS.close(stream);
+csoundObj.compileCSD(testFilePath);
 }
 compile = function()
 {
-	editorText = textEditor.getValue();
-	textBlob = new Blob([editorText], {type:"text/plain"});
-	csdFileReader.readAsArrayBuffer(textBlob);
+editorText = textEditor.getValue();
+textBlob = new Blob([editorText], {type:"text/plain"});
+csdFileReader.readAsArrayBuffer(textBlob);
 }
 
 perform = function()
 {
-	csoundObj.startAudioCallback();
+csoundObj.startAudioCallback();
 }
 
 stop = function()
 {
-	csoundObj.stopAudioCallback();
+csoundObj.stopAudioCallback();
 }
 
 var fileReader = new FileReader();
@@ -55,36 +61,37 @@ var file;
 
 
 fileReader.onload = (function(theFile) {
-		     return function(e) {
+return function(e) {
 
-		     console.log("Opened File %s", file.name);
-		     FS.createDataFile('/', file.name, e.target.result, true, false);
-		     };
-		     })(file)
+console.log("Opened File %s", file.name);
+FS.createDataFile('/', file.name, e.target.result, true, false);
+};
+})(file)
 
 function handleFileSelect(evt) {
 
-	var files = evt.target.files;
-	file = files[0];
-	console.log(file.name);
+var files = evt.target.files;
+file = files[0];
+console.log(file.name);
 
-	fileReader.readAsBinaryString(file);
+fileReader.readAsBinaryString(file);
 }
 
 FS.createDataFile('/', testFilePath, null, true, true);
 
 function setEditorContentsFromFile(filePath)
 {
-	fileString = fileToString(filePath);
-	textEditor.setValue(fileString);
+fileString = fileToString(filePath);
+textEditor.setValue(fileString);
 }
 
 var indexFilePath = "index.txt"
 
 function loadContent(elementSelector, sourceUrl) {
 
-	$(""+elementSelector+"").load(""+sourceUrl+"");
+$(""+elementSelector+"").load(""+sourceUrl+"");
 }
+
 </script>
 </head>
 <body>
@@ -97,6 +104,7 @@ function loadContent(elementSelector, sourceUrl) {
 		<div class="colleft">
 			<div class="col1">
 
+                <button class="button" onclick="createCsoundInstance();">Instantiate</button>
 				<button class="button" onclick="compile();">Compile</button>
 				<button class="button" onclick="perform();">Perform</button>
 				<button class="button" onclick="stop();">Stop</button>

--- a/emscripten/examples/tests/test4.html
+++ b/emscripten/examples/tests/test4.html
@@ -2,9 +2,20 @@
 <div>
 
 <script>
+    
+var divElement = document.getElementById("slider");
+var range = document.createElement("input");
+range.type = "range";
+range.max = 1000;
+range.min = 0;
+divElement.appendChild(range);
 var slider1Channel = csoundObj.addControlChannel("slider1", 0);
+
+range.oninput = function sliderChanged() {
+    
+    csoundObj.setControlChannelValue(slider1Channel, range.value)
+};
 </script>
-	<input type="range" min="0" max="1000" oninput="csoundObj.setControlChannelValue(slider1Channel, this.value)"/>
 </div>
-<p>Slider controls "slider1" channel, range 0-1000</p>
+<p id="slider">Slider controls "slider1" channel, range 0-1000</p>
 </html>

--- a/emscripten/src/CsoundObj.c
+++ b/emscripten/src/CsoundObj.c
@@ -25,28 +25,26 @@ CsoundObj *CsoundObj_new()
 
 void CsoundObj_compileCSD(CsoundObj *self,
 		char *filePath,
-		uint32_t samplerate,
-		double controlrate,
-		uint32_t bufferSize)
-{ 
-	char samplerateArgument[10] = {0};
-	char controlrateArgument[10] = {0};
-	char bufferSizeArgument[10] = {0};
+		uint32_t samplerate)
+{
+	char samplerateArgument[20] = {0};
+	char controlrateArgument[20] = {0};
+	char bufferSizeArgument[20] = {0};
+    double controlRate = (double)samplerate/256.;
 	sprintf((char *)&samplerateArgument, "-r %d", samplerate);
-	sprintf((char *)&controlrateArgument, "-k %f", controlrate);
-	sprintf((char *)&bufferSizeArgument, "-b %d", bufferSize);
+	sprintf((char *)&controlrateArgument, "-k %f", controlRate);
+	sprintf((char *)&bufferSizeArgument, "-b %d", 256);
 
-	char *argv[5] = {
+	char *argv[6] = {
 		"csound",
+        "-odac",
 		samplerateArgument,
 		controlrateArgument,
 		bufferSizeArgument,
 		filePath
 	};
-
-	printf("File name is %s\n", filePath);
-
-	int result = csoundCompile(self->csound, 5, argv);
+    
+	int result = csoundCompile(self->csound, 6, argv);
 
 	if (result == 0) {
 

--- a/emscripten/src/CsoundObj.js
+++ b/emscripten/src/CsoundObj.js
@@ -29,7 +29,7 @@ CsoundObj = function()
 
 	//Wrap C functions
 	var _new = cwrap('CsoundObj_new', 'number', null);
-	var _compileCSD = cwrap('CsoundObj_compileCSD', null, ['number','string', 'number', 'number', 'number']);
+	var _compileCSD = cwrap('CsoundObj_compileCSD', null, ['number','string', 'number']);
 	var _process = cwrap('CsoundObj_process', ['number'], ['number', 'number', 'number', 'number']);
 	var _getKsmps = cwrap('CsoundObj_getKsmps', ['number'], ['number']);
 	var _getNchnls = cwrap('CsoundObj_getNchnls',['number'], ['number']);
@@ -82,7 +82,7 @@ CsoundObj = function()
 	var outputChannelCount;
 	var inputChannelCount;
 	var samplerate = audioContext.sampleRate;
-	var framesPerCallback = 256;
+	var framesPerCallback = 256.000;
 	var krate = samplerate / framesPerCallback;
 	var useAudioInput = false;
 	var scriptProcessor;
@@ -106,7 +106,7 @@ CsoundObj = function()
 
 	this.compileCSD = function(fileName)
 	{       _reset(_self);
-		_compileCSD(_self, fileName, samplerate, krate, framesPerCallback);
+		_compileCSD(_self, fileName, samplerate);
 		outputChannelCount = _getNchnls(_self);
 		inputChannelCount = _getNchnlsInput(_self);
 

--- a/emscripten/src/post.js
+++ b/emscripten/src/post.js
@@ -1,0 +1,3 @@
+
+Module["noExitRuntime"] = true;
+Module["noInitialRun"] = true;

--- a/emscripten/update_example_libs_from_dist.sh
+++ b/emscripten/update_example_libs_from_dist.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
 cp dist/* examples/javascripts
+mv examples/javascripts/libcsound.js.mem examples


### PR DESCRIPTION
Emscripten now works again, but I had to add a hackish instantiate button to the examples as I couldn't get emscriptens module main callback to work on firefox, so all works now except you have to instantiate before you compile and run the examples.
