### PR TITLE
if skipping phase init in adsynt2, then skip amplitude init also

### DIFF
--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -506,7 +506,7 @@ static int adsynt2_set(CSOUND *csound,ADSYNT2 *p)
     if (p->pamp.auxp==NULL ||
         p->pamp.size < (uint32_t)(sizeof(MYFLT)*p->count))
       csound->AuxAlloc(csound, sizeof(MYFLT)*p->count, &p->pamp);
-    else                        /* AuxAlloc clear anyway */
+    else if (iphs >= 0)   /* AuxAlloc clear anyway */
       memset(p->pamp.auxp, 0, sizeof(MYFLT)*p->count);
     /* count = (int)*p->icnt; */
     /* do { */

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1193,7 +1193,7 @@ int kphsorbnk(CSOUND *csound, PHSORBNK *p)
     *p->sr = (MYFLT)(phs = curphs[index]);
     if (UNLIKELY((phs += *p->xcps * csound->onedkr) >= 1.0))
       phs -= 1.0;
-    else if (UNLIKELY(phs < 1.0))
+    else if (UNLIKELY(phs < 0.0))
       phs += 1.0;
     curphs[index] = phs;
     return OK;


### PR DESCRIPTION
The adsynt2 opcode allows skipping _phase_ initialization, but that is not very useful unless we also skip _amplitude interpolation_ initialization.  Amplitudes are interpolated at k-rate.  In a tied note, if adsynt2 is allowed to initialize the amplitudes to zero when it is already playing, it puts an annoying click into the audio, most noticeable when ksmps is large.  The proposed change makes "initialization skip" apply to amplitude interpolation as well as phase - which was probably the intended behaviour all along.

By the way, although it's not really necessary to credit me on minor patches like this, if you want to do so, my name is correctly spelled with a "k".