### PR TITLE
Fix undefined symbol on Linux

### DIFF
--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -51,6 +51,11 @@ static inline void rtJack_Lock(CSOUND *csound, pthread_mutex_t *p)
     pthread_mutex_lock(p);
 }
 
+static inline int rtJack_LockTimeout(CSOUND *csound, void **p, size_t timeout)
+{
+  return csound->WaitThreadLock(*p, timeout);
+}
+
 static inline int rtJack_TryLock(CSOUND *csound, pthread_mutex_t *p)
 {
     (void) csound;


### PR DESCRIPTION
Prior to applying this patch I was getting...

    WARNING: could not open library '.../lib/csound/plugins-6.0/librtjack.so' (.../lib/csound/plugins-6.0/librtjack.so: undefined symbol: rtJack_LockTimeout)

...in csound startup messages when running...

    csound -+rtaudio=jack -B 1024 -odac:system:playback_ -+rtmidi=alsa -Ma -d --port=6871

...on Debian GNU/Linux 7.7.