### PR TITLE
Unset DOT_PATH in doxyfiles

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1807,7 +1807,7 @@ INTERACTIVE_SVG        = NO
 # The tag DOT_PATH can be used to specify the path where the dot tool can be 
 # found. If left blank, it is assumed the dot tool can be found in the path.
 
-DOT_PATH               = D:\utah\opt\ATT\Graphviz\bin
+DOT_PATH               =
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that 
 # contain dot files that are included in the documentation (see the 

--- a/doc/Doxyfile-CsoundAC
+++ b/doc/Doxyfile-CsoundAC
@@ -1532,7 +1532,7 @@ DOT_IMAGE_FORMAT       = png
 # The tag DOT_PATH can be used to specify the path where the dot tool can be 
 # found. If left blank, it is assumed the dot tool can be found in the path.
 
-DOT_PATH               = D:\utah\opt\ATT\Graphviz\bin
+DOT_PATH               =
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that 
 # contain dot files that are included in the documentation (see the 


### PR DESCRIPTION
The paths set are probably where @gogins has it installed, but it is very unlikely anyone else has such a path. Clear them so that we simply rely on the PATH environment variable.

I am submitting this as a pull request because I do not want to surreptitiously disrupt anyone's workflow, but I think this should be merged. Merging this would allow debian to drop a patch.