### PR TITLE
Added websocket and framebuffer opcodes

### DIFF
--- a/Opcodes/CMakeLists.txt
+++ b/Opcodes/CMakeLists.txt
@@ -287,3 +287,6 @@ add_subdirectory(stk)
 add_subdirectory(cuda)
 add_subdirectory(opencl)
 add_subdirectory(hdf5)
+add_subdirectory(websockets)
+add_subdirectory(framebuffer)
+

--- a/Opcodes/framebuffer/CMakeLists.txt
+++ b/Opcodes/framebuffer/CMakeLists.txt
@@ -1,0 +1,10 @@
+option(BUILD_FRAMEBUFFER_OPCODES "Build the framebuffer opcodes" ON)
+
+
+if(BUILD_FRAMEBUFFER_OPCODES)
+
+
+	set(SOURCES Framebuffer.c OLABuffer.c OpcodeEntries.c)
+ 	make_plugin(framebuffer "${SOURCES}")
+
+endif()

--- a/Opcodes/framebuffer/Framebuffer.c
+++ b/Opcodes/framebuffer/Framebuffer.c
@@ -1,0 +1,204 @@
+/*
+ 
+ Framebuffer.c
+ Framebuffer
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#include "Framebuffer.h"
+
+ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument);
+void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self);
+
+int Framebuffer_initialise(CSOUND *csound, Framebuffer *self)
+{
+    self->inputType = Framebuffer_getArgumentType(csound, self->inputArgument);
+    self->outputType = Framebuffer_getArgumentType(csound, self->outputArgument);
+    self->elementCount = *self->sizeArgument;
+    self->ksmps = csound->GetKsmps(csound);
+    
+    Framebuffer_checkArgumentSanity(csound, self);
+    
+    csound->AuxAlloc(csound, self->elementCount * sizeof(MYFLT), &self->bufferMemory);
+    self->buffer = self->bufferMemory.auxp;
+    
+    if (self->outputType == KRATE_ARRAY) {
+        
+        ARRAYDAT *array = (ARRAYDAT *) self->outputArgument;
+        array->sizes = csound->Calloc(csound, sizeof(int));
+        array->sizes[0] = self->elementCount;
+        array->dimensions = 1;
+        CS_VARIABLE *var = array->arrayType->createVariable(csound, NULL);
+        array->arrayMemberSize = var->memBlockSize;
+        array->data = csound->Calloc(csound, var->memBlockSize * self->elementCount);
+    }
+    
+    return OK;
+}
+
+void Framebuffer_writeBuffer(CSOUND *csound, Framebuffer *self, MYFLT *inputSamples, u_int32_t inputSamplesCount)
+{
+    if (self->writeIndex + inputSamplesCount <= self->elementCount) {
+        
+        memcpy(&self->buffer[self->writeIndex], inputSamples, sizeof(MYFLT) * inputSamplesCount);
+        self->writeIndex += self->ksmps;
+        self->writeIndex %= self->elementCount;
+    }
+    else {
+        
+        u_int32_t firstHalf = self->elementCount - self->writeIndex;
+        memcpy(&self->buffer[self->writeIndex], inputSamples, sizeof(MYFLT) * firstHalf);
+        u_int32_t secondHalf = self->elementCount - firstHalf;
+        memcpy(self->buffer, &inputSamples[firstHalf], sizeof(MYFLT) * secondHalf);
+        self->writeIndex = secondHalf;
+    }
+}
+
+void Framebuffer_readBuffer(CSOUND *csound, Framebuffer *self, MYFLT *outputSamples, u_int32_t outputSamplesCount)
+{
+    if (self->writeIndex + outputSamplesCount < self->elementCount) {
+        
+        memcpy(outputSamples, &self->buffer[self->writeIndex], sizeof(MYFLT) * outputSamplesCount);
+    }
+    else {
+        
+        u_int32_t firstHalf = self->elementCount - self->writeIndex;
+        memcpy(outputSamples, &self->buffer[self->writeIndex], sizeof(MYFLT) * firstHalf);
+        u_int32_t secondHalf = self->elementCount - firstHalf;
+        memcpy(&outputSamples[firstHalf], self->buffer, sizeof(MYFLT) * secondHalf);
+    }
+}
+
+void Framebuffer_processAudioInFrameOut(CSOUND *csound, Framebuffer *self)
+{
+    Framebuffer_writeBuffer(csound, self, self->inputArgument, self->ksmps);
+    ARRAYDAT *array = (ARRAYDAT *)self->outputArgument;
+    Framebuffer_readBuffer(csound, self, array->data, array->sizes[0]);
+}
+
+
+void Framebuffer_processFrameInAudioOut(CSOUND *csound, Framebuffer *self)
+{
+    ARRAYDAT *array = (ARRAYDAT *)self->inputArgument;
+    Framebuffer_writeBuffer(csound, self, array->data, array->sizes[0]);
+    Framebuffer_readBuffer(csound, self, self->outputArgument, self->ksmps);
+}
+
+int Framebuffer_process(CSOUND *csound, Framebuffer *self)
+{
+    if (self->inputType == KRATE_ARRAY) {
+        
+        
+        Framebuffer_processFrameInAudioOut(csound, self);
+    }
+    else if (self->inputType == ARATE_VAR) {
+        
+        Framebuffer_processAudioInFrameOut(csound, self);
+    }
+    
+    
+    return OK;
+}
+
+void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self)
+{
+    if (self->elementCount < csound->GetKsmps(csound)) {
+        
+        csound->Die(csound, "framebuffer: Error, specified element count less than ksmps value, Exiting");
+    }
+    
+    if (self->inputType == ARATE_VAR) {
+        
+        if (self->outputType != KRATE_ARRAY) {
+            
+            csound->Die(csound, "framebuffer: Error, only k-rate arrays allowed for a-rate var inputs, Exiting");
+        }
+    }
+    else if (self->inputType == KRATE_ARRAY) {
+        
+        if (self->outputType != ARATE_VAR) {
+            
+            csound->Die(csound, "framebuffer: Error, only a-rate vars allowed for k-rate array inputs, Exiting");
+        }
+        
+        ARRAYDAT *array = (ARRAYDAT *) self->inputArgument;
+        
+        if (array->dimensions != 1) {
+            
+            csound->Die(csound, "framebuffer: Error, k-rate array input must be one dimensional, Exiting");
+        }
+        
+        if (array->sizes[0] > self->elementCount) {
+            
+            csound->Die(csound, "framebuffer: Error, k-rate array input element count must be less than or equal to specified framebuffer size, Exiting");
+        }
+    }
+    else {
+        
+        csound->Die(csound, "framebuffer: Error, only a-rate var input with k-rate array output or k-rate array input with a-rate var output are valid arguments, Exiting");
+    }
+}
+
+ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument)
+{
+    const CS_TYPE *csoundType = csound->GetTypeForArg((void *)argument);
+    const char *type = csoundType->varTypeName;
+    ArgumentType argumentType = UNKNOWN;
+    
+    if (strcmp("S", type) == 0) {
+        
+        argumentType = STRING_VAR;
+    }
+    else if (strcmp("a", type) == 0) {
+        
+        argumentType = ARATE_VAR;
+    }
+    else if (strcmp("k", type) == 0) {
+        
+        argumentType = KRATE_VAR;
+    }
+    else if (strcmp("i", type) == 0) {
+        
+        argumentType = IRATE_VAR;
+    }
+    else if (strcmp("[", type) == 0) {
+        
+        ARRAYDAT *array = (ARRAYDAT *)argument;
+        
+        if (strcmp("k", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = KRATE_ARRAY;
+        }
+        else if (strcmp("a", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = ARATE_ARRAY;
+        }
+        else if (strcmp("i", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = IRATE_ARRAY;
+        }
+    }
+    
+    return argumentType;
+}
+
+

--- a/Opcodes/framebuffer/Framebuffer.h
+++ b/Opcodes/framebuffer/Framebuffer.h
@@ -1,0 +1,66 @@
+/*
+ 
+ Framebuffer.h
+ Framebuffer
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#include "csdl.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    
+    typedef enum ArgumentType
+    {
+        STRING_VAR,
+        ARATE_VAR,
+        KRATE_VAR,
+        IRATE_VAR,
+        ARATE_ARRAY,
+        KRATE_ARRAY,
+        IRATE_ARRAY,
+        UNKNOWN
+    } ArgumentType;
+    
+    typedef struct Framebuffer {
+        
+        OPDS h;
+        MYFLT *outputArgument;
+        MYFLT *inputArgument;
+        MYFLT *sizeArgument;
+        ArgumentType inputType;
+        ArgumentType outputType;
+        MYFLT *buffer;
+        AUXCH bufferMemory;
+        u_int32_t elementCount;
+        u_int32_t writeIndex;
+        u_int32_t ksmps;
+    } Framebuffer;
+    
+    int Framebuffer_initialise(CSOUND *csound, Framebuffer *self);
+    int Framebuffer_process(CSOUND *csound, Framebuffer *self);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Opcodes/framebuffer/OLABuffer.c
+++ b/Opcodes/framebuffer/OLABuffer.c
@@ -66,10 +66,10 @@ void OLABuffer_readFrame(OLABuffer *self, MYFLT *outputFrame, u_int32_t outputFr
 {
     memcpy(&outputFrame[outputFrameOffset], &self->frames[0][olaBufferOffset], samplesCount * sizeof(MYFLT));
     
-    u_int32_t i;
+    u_int32_t i, j;
     for (i = 1; i < self->framesCount; ++i) {
         
-        for (size_t j = 0; j < samplesCount; ++j) {
+        for (j = 0; j < samplesCount; ++j) {
             
             outputFrame[j + outputFrameOffset] += self->frames[i][j + olaBufferOffset];
         }

--- a/Opcodes/framebuffer/OLABuffer.c
+++ b/Opcodes/framebuffer/OLABuffer.c
@@ -1,0 +1,146 @@
+/*
+ 
+ OLABuffer.c
+ Framebuffer
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#include "OLABuffer.h"
+#include <tgmath.h>
+
+void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self);
+
+int OLABuffer_initialise(CSOUND *csound, OLABuffer *self)
+{
+    OLABuffer_checkArgumentSanity(csound, self);
+    self->inputArray = (ARRAYDAT *)self->inputArgument;
+    self->frameSamplesCount = self->inputArray->sizes[0];
+    self->framesCount = *self->overlapArgument;
+    self->overlapSamplesCount = self->frameSamplesCount / self->framesCount;
+    csound->AuxAlloc(csound, self->frameSamplesCount * self->framesCount * sizeof(MYFLT), &self->frameSamplesMemory);
+    csound->AuxAlloc(csound, self->framesCount * sizeof(MYFLT *), &self->framePointerMemory);
+    self->frames = self->framePointerMemory.auxp;
+    self->ksmps = csound->GetKsmps(csound);
+    
+    for (size_t i = 0; i < self->framesCount; ++i) {
+        
+        self->frames[i] = &((MYFLT *)self->frameSamplesMemory.auxp)[i * self->frameSamplesCount];
+    }
+    
+    self->overlapSampleIndex = self->overlapSamplesCount;
+    
+    return OK;
+}
+
+void OLABuffer_writeFrame(OLABuffer *self, MYFLT *inputFrame, u_int32_t frameIndex)
+{
+    u_int32_t firstHalfOffset = self->overlapSamplesCount * frameIndex;
+    u_int32_t firstHalfCount = self->frameSamplesCount - firstHalfOffset;
+    u_int32_t secondHalfCount = self->frameSamplesCount - firstHalfCount;
+    memcpy(&self->frames[frameIndex][firstHalfOffset], inputFrame, firstHalfCount * sizeof(MYFLT));
+    memcpy(self->frames[frameIndex], &inputFrame[firstHalfCount], secondHalfCount * sizeof(MYFLT));
+}
+
+void OLABuffer_readFrame(OLABuffer *self, MYFLT *outputFrame, u_int32_t outputFrameOffset,
+                         u_int32_t olaBufferOffset, u_int32_t samplesCount)
+{
+    memcpy(&outputFrame[outputFrameOffset], &self->frames[0][olaBufferOffset], samplesCount * sizeof(MYFLT));
+    
+    for (size_t i = 1; i < self->framesCount; ++i) {
+        
+        for (size_t j = 0; j < samplesCount; ++j) {
+            
+            outputFrame[j + outputFrameOffset] += self->frames[i][j + olaBufferOffset];
+        }
+    }
+}
+
+int OLABuffer_process(CSOUND *csound, OLABuffer *self)
+{
+    u_int32_t nextKPassSampleIndex = (self->readSampleIndex + self->ksmps) % self->overlapSamplesCount;
+    
+    if (nextKPassSampleIndex < self->overlapSampleIndex) {
+        
+        u_int32_t firstHalfCount = self->overlapSamplesCount - self->overlapSampleIndex;
+        
+        if (firstHalfCount != 0) {
+            
+            OLABuffer_readFrame(self, self->outputArgument, 0, self->readSampleIndex, firstHalfCount);
+        }
+    
+        OLABuffer_writeFrame(self, self->inputArray->data, self->frameIndex);
+        
+        u_int32_t secondHalfCount = self->ksmps - firstHalfCount;
+        
+        if (secondHalfCount != 0) {
+            
+            OLABuffer_readFrame(self, self->outputArgument, firstHalfCount, self->readSampleIndex, secondHalfCount);
+        }
+        
+        self->frameIndex++;
+        self->frameIndex %= self->framesCount;
+    }
+    else {
+        
+        OLABuffer_readFrame(self, self->outputArgument, 0, self->readSampleIndex, self->ksmps);
+    }
+
+    self->overlapSampleIndex += self->ksmps;
+    self->overlapSampleIndex %= self->overlapSamplesCount;
+    self->readSampleIndex += self->ksmps;
+    self->readSampleIndex %= self->frameSamplesCount;
+    return OK;
+}
+
+void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
+{
+    MYFLT overlapCount = *self->overlapArgument;
+    
+    if (floor(overlapCount) != overlapCount) {
+        
+        csound->Die(csound, "olabuffer: Error, overlap factor must be an integer");
+    }
+    
+    ARRAYDAT *array = (ARRAYDAT *) self->inputArgument;
+    
+    if (array->dimensions != 1) {
+        
+        csound->Die(csound, "olabuffer: Error, k-rate array must be one dimensional");
+    }
+    
+    u_int32_t frameSampleCount = array->sizes[0];
+    
+    if (frameSampleCount <= (int)overlapCount) {
+        
+        csound->Die(csound, "olabuffer: Error, k-rate array size must be larger than ovelap factor");
+    }
+    
+    if (frameSampleCount % (int)overlapCount != 0) {
+        
+        csound->Die(csound, "olabuffer: Error, overlap factor must be an integer multiple of k-rate array size");
+    }
+    
+    if (frameSampleCount / (int)overlapCount < csound->GetKsmps(csound)) {
+        
+        csound->Die(csound, "olabuffer: Error, k-rate array size divided by overlap factor must be larger than or equal to ksmps");
+    }
+}

--- a/Opcodes/framebuffer/OLABuffer.c
+++ b/Opcodes/framebuffer/OLABuffer.c
@@ -40,8 +40,9 @@ int OLABuffer_initialise(CSOUND *csound, OLABuffer *self)
     csound->AuxAlloc(csound, self->framesCount * sizeof(MYFLT *), &self->framePointerMemory);
     self->frames = self->framePointerMemory.auxp;
     self->ksmps = csound->GetKsmps(csound);
-    
-    for (size_t i = 0; i < self->framesCount; ++i) {
+   
+    u_int32_t i;
+    for (i = 0; i < self->framesCount; ++i) {
         
         self->frames[i] = &((MYFLT *)self->frameSamplesMemory.auxp)[i * self->frameSamplesCount];
     }
@@ -65,7 +66,8 @@ void OLABuffer_readFrame(OLABuffer *self, MYFLT *outputFrame, u_int32_t outputFr
 {
     memcpy(&outputFrame[outputFrameOffset], &self->frames[0][olaBufferOffset], samplesCount * sizeof(MYFLT));
     
-    for (size_t i = 1; i < self->framesCount; ++i) {
+    u_int32_t i;
+    for (i = 1; i < self->framesCount; ++i) {
         
         for (size_t j = 0; j < samplesCount; ++j) {
             

--- a/Opcodes/framebuffer/OLABuffer.h
+++ b/Opcodes/framebuffer/OLABuffer.h
@@ -1,0 +1,58 @@
+/*
+ 
+ OLABuffer.h
+ Framebuffer
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#include "csdl.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    
+    typedef struct OLABuffer {
+        
+        OPDS h;
+        MYFLT *outputArgument;
+        MYFLT *inputArgument;
+        MYFLT *overlapArgument;
+        ARRAYDAT *inputArray;
+        AUXCH frameSamplesMemory;
+        AUXCH framePointerMemory;
+        u_int32_t frameIndex;
+        u_int32_t overlapSampleIndex;
+        u_int32_t readSampleIndex;
+        u_int32_t framesCount;
+        u_int32_t frameSamplesCount;
+        u_int32_t overlapSamplesCount;
+        u_int32_t ksmps;
+        MYFLT **frames;
+    } OLABuffer;
+    
+    int OLABuffer_initialise(CSOUND *csound, OLABuffer *self);
+    int OLABuffer_process(CSOUND *csound, OLABuffer *self);
+    
+#ifdef __cplusplus
+}
+#endif

--- a/Opcodes/framebuffer/OpcodeEntries.c
+++ b/Opcodes/framebuffer/OpcodeEntries.c
@@ -1,0 +1,55 @@
+/*
+ 
+ OpcodeEntries.c
+ Framebuffer
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#include "Framebuffer.h"
+#include "OLABuffer.h"
+
+static OENTRY localops[] = {
+    
+    {
+        .opname = "framebuffer",
+        .dsblksiz = sizeof(Framebuffer),
+        .thread = 3,
+        .outypes = "*",
+        .intypes = "*",
+        .iopadr = (SUBR)Framebuffer_initialise,
+        .kopadr = (SUBR)Framebuffer_process,
+        .aopadr = NULL
+    },
+    {
+        .opname = "olabuffer",
+        .dsblksiz = sizeof(OLABuffer),
+        .thread = 3,
+        .outypes = "a",
+        .intypes = "k[]i",
+        .iopadr = (SUBR)OLABuffer_initialise,
+        .kopadr = (SUBR)OLABuffer_process,
+        .aopadr = NULL
+    }
+};
+
+
+LINKAGE

--- a/Opcodes/websockets/CMakeLists.txt
+++ b/Opcodes/websockets/CMakeLists.txt
@@ -1,0 +1,19 @@
+option(BUILD_WEBSOCKET_OPCODE "Build the websocket opcode" ON)
+FIND_PATH ( WEBSOCKETS_H libwebsockets.h
+    /usr/local/include
+    /usr/include
+)
+
+FIND_LIBRARY ( websockets_library websockets
+    /usr/local/lib
+    /usr/lib
+)
+
+find_library (websockets_library NAMES websockets)
+check_include_file(libwebsockets.h WEBSOCKETS_H)
+
+check_deps(BUILD_WEBSOCKET_OPCODE websockets_library WEBSOCKETS_H)
+if(BUILD_WEBSOCKET_OPCODE)
+ 	make_plugin(websocketIO WebSocketOpcode.c)
+ 	target_link_libraries(websocketIO ${websockets_library} ${CSOUNDLIB})
+endif()

--- a/Opcodes/websockets/WebSocketOpcode.c
+++ b/Opcodes/websockets/WebSocketOpcode.c
@@ -265,8 +265,8 @@ static int Websocket_callback(struct libwebsocket_context *context,
 int WebSocketOpcode_getArrayElementCount(ARRAYDAT *array)
 {
     int elementCount = array->sizes[0];
-    
-    for (size_t i = 1; i < array->dimensions; ++i) {
+    u_int32_t i;
+    for (i = 1; i < array->dimensions; ++i) {
         
         elementCount *= array->sizes[i];
     }
@@ -344,7 +344,8 @@ void WebSocketOpcode_allocateVariableArgument(MYFLT *argument, OpcodeArgument *a
 void WebSocketOpcode_initialiseArgumentsArray(CSOUND *csound, WebSocketOpcode *self, OpcodeArgument *argumentsArray,
                                               size_t argumentsCount, MYFLT **arguments, bool areInputArguments)
 {
-    for (int i = 0; i < argumentsCount; ++i) {
+    u_int32_t i;
+    for (i = 0; i < argumentsCount; ++i) {
         
         OpcodeArgument *argumentArrayItem = &argumentsArray[i];
         argumentArrayItem->argumentType = WebSocketOpcode_getArgumentType(csound, arguments[i]);
@@ -405,14 +406,14 @@ void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound)
     self->webSocket = csound->Calloc(csound, sizeof(WebSocket));
     self->webSocket->protocols = csound->Calloc(csound, sizeof(struct libwebsocket_protocols) * (argumentsCount + 1)); //Last protocol is null
     size_t argumentIndex = 0;
-    
-    for (int i = 0; i < self->outputArgumentCount; ++i, ++argumentIndex) {
+    u_int32_t i;
+    for (i = 0; i < self->outputArgumentCount; ++i, ++argumentIndex) {
         
         self->webSocket->protocols[argumentIndex].name = self->outputArguments[i].name;
         self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
         self->webSocket->protocols[argumentIndex].per_session_data_size = self->outputArguments[i].bytesCount;
     }
-    for (int i = 0; i < self->inputArgumentCount; ++i, ++argumentIndex) {
+    for (i = 0; i < self->inputArgumentCount; ++i, ++argumentIndex) {
         
         self->webSocket->protocols[argumentIndex].name = self->inputArguments[i].name;
         self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
@@ -441,7 +442,8 @@ void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound)
 
 void WebSocketOpcode_sendInputArgumentData(CSOUND *csound, WebSocketOpcode *self)
 {
-    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+    u_int32_t i;
+    for (i = 0; i < self->inputArgumentCount; ++i) {
         
         OpcodeArgument *currentArgument = &self->inputArguments[i];
         
@@ -462,7 +464,8 @@ void WebSocketOpcode_sendInputArgumentData(CSOUND *csound, WebSocketOpcode *self
 
 void WebSocketOpcode_receiveOutputArgumentData(CSOUND *csound, WebSocketOpcode *self)
 {
-    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+    u_int32_t i;
+    for (i = 0; i < self->outputArgumentCount; ++i) {
         
         OpcodeArgument *currentArgument = &self->outputArguments[i];
         
@@ -492,12 +495,12 @@ int WebSocketOpcode_finish(CSOUND *csound, void *opaqueReference)
     
     libwebsocket_cancel_service(self->webSocket->context);
     libwebsocket_context_destroy(self->webSocket->context);
-    
-    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+    u_int32_t i;
+    for (i = 0; i < self->outputArgumentCount; ++i) {
         
         csoundDestroyCircularBuffer(csound, self->outputArguments[i].circularBuffer);
     }
-    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+    for (i = 0; i < self->inputArgumentCount; ++i) {
         
         csoundDestroyCircularBuffer(csound, self->inputArguments[i].circularBuffer);
     }

--- a/Opcodes/websockets/WebSocketOpcode.c
+++ b/Opcodes/websockets/WebSocketOpcode.c
@@ -1,0 +1,578 @@
+/*
+ 
+ WebSocketOpcode.c
+ WebSockets
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+#import "WebSocketOpcode.h"
+#import <sys/param.h>
+#import <stdio.h>
+#import <libwebsockets.h>
+#import <stdlib.h>
+
+typedef enum ArgumentType
+{
+    STRING_VAR,
+    ARATE_VAR,
+    KRATE_VAR,
+    IRATE_VAR,
+    ARATE_ARRAY,
+    KRATE_ARRAY,
+    IRATE_ARRAY,
+    UNKNOWN
+} ArgumentType;
+
+struct OpcodeArgument{
+    
+    void *dataPointer;
+    ArgumentType argumentType;
+    AUXCH auxillaryMemory;
+    void *circularBuffer;
+    char *name;
+    void *readBuffer;
+    int itemsCount;
+    int bytesCount;
+    int bytesWritten;
+    bool iRateVarSent;
+};
+
+struct WebSocket{
+    
+    struct libwebsocket_context *context;
+    struct libwebsocket *websocket;
+    struct libwebsocket_protocols *protocols;
+    void *processThread;
+    unsigned char *messageBuffer;
+    struct lws_context_creation_info info;
+};
+
+static const size_t writeBufferBytesCount = 2048;
+static const size_t stringVarMaximumBytesCount = 4096;
+static const size_t ringBufferItemsCount = 2048;
+
+void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound);
+int WebSocketOpcode_finish(CSOUND *csound, void *opaqueReference);
+void WebSocketOpcode_initialiseArguments(WebSocketOpcode *self, CSOUND *csound);
+ArgumentType WebSocketOpcode_getArgumentType(CSOUND *csound, MYFLT *argument);
+
+int WebSocketOpcode_initialise(CSOUND *csound, WebSocketOpcode *self)
+{
+    self->inputArgumentCount = self->INOCOUNT - 1;
+    self->outputArgumentCount = self->OUTOCOUNT;
+    self->csound = csound;
+    WebSocketOpcode_initialiseArguments(self, csound);
+    WebSocketOpcode_initialiseWebSocket(self, csound);
+    csound->RegisterDeinitCallback(csound, self, WebSocketOpcode_finish);
+    return OK;
+}
+
+uintptr_t WebSocketOpcode_processThread(void *opaquePointer)
+{
+    WebSocketOpcode *self = opaquePointer;
+    
+    while (self->isRunning == 1) {
+        
+        libwebsocket_service(self->webSocket->context, 10);
+        libwebsocket_callback_on_writable_all_protocol(self->webSocket->protocols);
+    }
+    
+    return 0;
+}
+
+void WebSocketOpcode_writeOnce(WebSocketOpcode *self, OpcodeArgument *inputArgument,
+                               void *messageBuffer, struct libwebsocket *websocket)
+{
+    unsigned char *inputData = (unsigned char *)inputArgument->readBuffer;
+    memcpy(messageBuffer, inputData, inputArgument->bytesCount);
+    libwebsocket_write(websocket, messageBuffer, inputArgument->bytesCount, LWS_WRITE_BINARY);
+}
+
+void WebSocketOpcode_writeFragments(WebSocketOpcode *self, OpcodeArgument *inputArgument,
+                                    void *messageBuffer, struct libwebsocket *websocket)
+{
+    unsigned char *inputData = &((unsigned char *)inputArgument->readBuffer)[inputArgument->bytesWritten];
+    
+    if (inputArgument->bytesWritten + writeBufferBytesCount < inputArgument->bytesCount) {
+        
+        int writeFlags = LWS_WRITE_NO_FIN;
+        writeFlags |= inputArgument->bytesWritten == 0 ? LWS_WRITE_BINARY : LWS_WRITE_CONTINUATION;
+        memcpy(messageBuffer, inputData, writeBufferBytesCount);
+        inputArgument->bytesWritten += libwebsocket_write(websocket, messageBuffer, writeBufferBytesCount, writeFlags);
+    }
+    else {
+        
+        size_t fragmentBytesCount = inputArgument->bytesCount - inputArgument->bytesWritten;
+        memcpy(messageBuffer, inputData, fragmentBytesCount);
+        libwebsocket_write(websocket, messageBuffer, fragmentBytesCount, LWS_WRITE_CONTINUATION);
+        inputArgument->bytesWritten = 0;
+    }
+}
+
+void WebSocketOpcode_writeMessage(WebSocketOpcode *self, OpcodeArgument *inputArgument,
+                                  void *messageBuffer, struct libwebsocket *websocket)
+{
+    if (inputArgument->bytesCount <= writeBufferBytesCount) {
+        
+        WebSocketOpcode_writeOnce(self, inputArgument, messageBuffer, websocket);
+    }
+    else {
+        
+        WebSocketOpcode_writeFragments(self, inputArgument, messageBuffer, websocket);
+    }
+}
+
+void WebSocketOpcode_handleServerWritable(struct libwebsocket *websocket, WebSocketOpcode *self, CSOUND *csound, void *messageBuffer)
+{
+    const struct libwebsocket_protocols *protocol = libwebsockets_get_protocol(websocket);
+    
+    // If it's an output argument just return
+    if (protocol->protocol_index < self->outputArgumentCount) {
+        
+        usleep(100);
+        return;
+    }
+    
+    int inputIndex = protocol->protocol_index - self->outputArgumentCount;
+    OpcodeArgument *argument = &self->inputArguments[inputIndex];
+    
+    int readItems = 0;
+    
+    if (argument->bytesWritten == 0) {
+        
+        readItems = csoundReadCircularBuffer(csound, argument->circularBuffer,
+                                             argument->readBuffer, argument->itemsCount);
+    }
+    if (readItems != 0 || argument->bytesWritten != 0) {
+        
+        WebSocketOpcode_writeMessage(self, argument, messageBuffer, websocket);
+        
+        if (argument->argumentType == IRATE_VAR || argument->argumentType == IRATE_ARRAY) {
+            
+            argument->iRateVarSent = true;
+        }
+    }
+    
+    usleep(100);
+    
+    if (argument->iRateVarSent == false) {
+        
+        libwebsocket_callback_on_writable(self->webSocket->context, websocket);
+    }
+}
+
+void WebSocketOpcode_handleReceive(struct libwebsocket *websocket, WebSocketOpcode *self, CSOUND *csound, size_t inputDataSize, void *inputData)
+{
+    const struct libwebsocket_protocols *protocol = libwebsockets_get_protocol(websocket);
+    OpcodeArgument *argument = &self->outputArguments[protocol->protocol_index];
+    
+    if (protocol->protocol_index >= self->outputArgumentCount
+        ||
+        argument->iRateVarSent == true) {
+        
+        return;
+    }
+    
+    if (argument->bytesCount != inputDataSize
+        &&
+        argument->argumentType != STRING_VAR) {
+        
+        csound->Message(csound, "websocket: received message from %s is not correct size for variable %s, message dumped", protocol->name, argument->name);
+        return;
+    }
+    
+    if (argument->argumentType == STRING_VAR
+        &&
+        argument->bytesCount > stringVarMaximumBytesCount) {
+        
+        csound->Message(csound, "websocket: received string message from %s is too large, message dumped", protocol->name, argument->name);
+        
+        return;
+    }
+    
+    int writtenItems = csoundWriteCircularBuffer(csound, argument->circularBuffer, inputData, argument->itemsCount);
+    
+    if (writtenItems == 0) {
+        
+        csound->Message(csound, "websocket: received message from %s dumped, buffer overrrun", argument->name);
+    }
+    else {
+        
+        if (argument->argumentType == IRATE_VAR
+            ||
+            argument->argumentType == IRATE_ARRAY) {
+            
+            argument->iRateVarSent = true;
+        }
+    }
+}
+
+static int Websocket_callback(struct libwebsocket_context *context,
+                              struct libwebsocket *websocket,
+                              enum libwebsocket_callback_reasons reason,
+                              void *user, void *inputData, size_t inputDataSize)
+{
+    WebSocketOpcode *self = libwebsocket_context_user(context);
+    CSOUND *csound = self->csound;
+    void *messageBuffer = (void *)&self->webSocket->messageBuffer[LWS_SEND_BUFFER_PRE_PADDING];
+    
+    switch (reason) {
+            
+        case LWS_CALLBACK_ESTABLISHED: {
+            
+            const struct libwebsocket_protocols *protocol = libwebsockets_get_protocol(websocket);
+            csound->Message(csound, "websocket: connection established for %s\n", protocol->name);
+            break;
+        }
+        case LWS_CALLBACK_SERVER_WRITEABLE: {
+            
+            WebSocketOpcode_handleServerWritable(websocket, self, csound, messageBuffer);
+            break;
+        }
+        case LWS_CALLBACK_RECEIVE: {
+            
+            WebSocketOpcode_handleReceive(websocket, self, csound, inputDataSize, inputData);
+            break;
+        }
+        default: {
+            
+            break;
+        }
+    }
+    
+    return OK;
+}
+
+int WebSocketOpcode_getArrayElementCount(ARRAYDAT *array)
+{
+    int elementCount = array->sizes[0];
+    
+    for (size_t i = 1; i < array->dimensions; ++i) {
+        
+        elementCount *= array->sizes[i];
+    }
+    
+    return elementCount;
+}
+
+
+void WebSocketOpcode_allocateStringArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound, bool isInputArgument)
+{
+    STRINGDAT *string = (STRINGDAT *)argument;
+    
+    if (isInputArgument == true) {
+        
+        csound->Die(csound,
+                    "websocket: this opcode doesn't send strings, only receiving them is supported\nExiting",
+                    argumentArrayItem->name);
+    }
+    else {
+        
+        if (string->size != 0) {
+            
+            csound->Die(csound,
+                        "websocket: error output string variable %s must not be initialised\nExiting",
+                        argumentArrayItem->name);
+        }
+        else {
+            
+            argumentArrayItem->itemsCount = stringVarMaximumBytesCount;
+            string->data = csound->ReAlloc(csound, string->data, stringVarMaximumBytesCount);
+        }
+    }
+    
+    argumentArrayItem->dataPointer = string->data;
+    argumentArrayItem->bytesCount = sizeof(char) * stringVarMaximumBytesCount;
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound,
+                                                                   argumentArrayItem->itemsCount * ringBufferItemsCount + 1,
+                                                                   sizeof(char));
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
+}
+
+void WebSocketOpcode_allocateArrayArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound)
+{
+    ARRAYDAT *array = (ARRAYDAT *)argument;
+    
+    if (array->dimensions == 0) {
+        
+        csound->Die(csound,
+                    "websocket: error array variable %s has not been initialised\nExiting",
+                    argumentArrayItem->name);
+    }
+    
+    argumentArrayItem->dataPointer = array->data;
+    argumentArrayItem->itemsCount = WebSocketOpcode_getArrayElementCount(array);
+    argumentArrayItem->bytesCount = array->arrayMemberSize * argumentArrayItem->itemsCount;
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound,
+                                                                   argumentArrayItem->itemsCount * ringBufferItemsCount + 1,
+                                                                   array->arrayMemberSize);
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
+}
+
+void WebSocketOpcode_allocateVariableArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound, int bytesCount)
+{
+    argumentArrayItem->dataPointer = argument;
+    argumentArrayItem->itemsCount = 1;
+    argumentArrayItem->bytesCount = bytesCount;
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound, ringBufferItemsCount + 1, argumentArrayItem->bytesCount);
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
+}
+
+
+void WebSocketOpcode_initialiseArgumentsArray(CSOUND *csound, WebSocketOpcode *self, OpcodeArgument *argumentsArray,
+                                              size_t argumentsCount, MYFLT **arguments, bool areInputArguments)
+{
+    for (int i = 0; i < argumentsCount; ++i) {
+        
+        OpcodeArgument *argumentArrayItem = &argumentsArray[i];
+        argumentArrayItem->argumentType = WebSocketOpcode_getArgumentType(csound, arguments[i]);
+        argumentArrayItem->name = areInputArguments ? csound->GetInputArgName((void *)self, i + 1)
+        : csound->GetOutputArgName((void *)self, i);
+        
+        switch (argumentsArray[i].argumentType) {
+                
+            case IRATE_ARRAY:
+            case ARATE_ARRAY:
+            case KRATE_ARRAY: {
+                
+                WebSocketOpcode_allocateArrayArgument(arguments[i], argumentArrayItem, csound);
+                break;
+            }
+            case STRING_VAR: {
+                
+                WebSocketOpcode_allocateStringArgument(arguments[i], argumentArrayItem, csound, areInputArguments);
+                break;
+            }
+            case ARATE_VAR: {
+                
+                WebSocketOpcode_allocateVariableArgument(arguments[i], argumentArrayItem, csound, sizeof(MYFLT) * csound->GetKsmps(csound));
+                break;
+            }
+            case IRATE_VAR:
+            case KRATE_VAR: {
+                
+                WebSocketOpcode_allocateVariableArgument(arguments[i], argumentArrayItem, csound, sizeof(MYFLT));
+                break;
+            }
+            default: {
+                
+                csound->Die(csound, "websocket: error, incompatible argument detected\nExiting");
+                break;
+            }
+        }
+    }
+}
+
+void WebSocketOpcode_initialiseArguments(WebSocketOpcode *self, CSOUND *csound)
+{
+    self->inputArguments = csound->Calloc(csound, sizeof(OpcodeArgument) * self->inputArgumentCount);
+    self->outputArguments = csound->Calloc(csound, sizeof(OpcodeArgument) * self->outputArgumentCount);
+    
+    WebSocketOpcode_initialiseArgumentsArray(csound, self, self->inputArguments,
+                                             self->inputArgumentCount,
+                                             &self->arguments[self->outputArgumentCount + 1], true);
+    WebSocketOpcode_initialiseArgumentsArray(csound, self, self->outputArguments,
+                                             self->outputArgumentCount,
+                                             self->arguments, false);
+}
+
+void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound)
+{
+    size_t argumentsCount = self->inputArgumentCount + self->outputArgumentCount;
+    
+    self->webSocket = csound->Calloc(csound, sizeof(WebSocket));
+    self->webSocket->protocols = csound->Calloc(csound, sizeof(struct libwebsocket_protocols) * (argumentsCount + 1)); //Last protocol is null
+    size_t argumentIndex = 0;
+    
+    for (int i = 0; i < self->outputArgumentCount; ++i, ++argumentIndex) {
+        
+        self->webSocket->protocols[argumentIndex].name = self->outputArguments[i].name;
+        self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
+        self->webSocket->protocols[argumentIndex].per_session_data_size = self->outputArguments[i].bytesCount;
+    }
+    for (int i = 0; i < self->inputArgumentCount; ++i, ++argumentIndex) {
+        
+        self->webSocket->protocols[argumentIndex].name = self->inputArguments[i].name;
+        self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
+        self->webSocket->protocols[argumentIndex].per_session_data_size = self->inputArguments[i].bytesCount;
+    }
+    
+    self->webSocket->info.port = *self->arguments[self->outputArgumentCount];
+    self->webSocket->info.protocols = self->webSocket->protocols;
+    self->webSocket->info.extensions = libwebsocket_get_internal_extensions();
+    self->webSocket->info.gid = -1;
+    self->webSocket->info.uid = -1;
+    self->webSocket->info.user = self;
+    self->webSocket->context = libwebsocket_create_context(&self->webSocket->info);
+    self->webSocket->messageBuffer = csound->Calloc(csound, LWS_SEND_BUFFER_PRE_PADDING +
+                                                    (sizeof(char) * writeBufferBytesCount) +
+                                                    LWS_SEND_BUFFER_POST_PADDING);
+    
+    if (self->webSocket->context == NULL) {
+        
+        csound->Die(csound, "websocket: couldn't initialise websocket, Exiting");
+    }
+    
+    self->isRunning = true;
+    self->webSocket->processThread = csound->CreateThread(WebSocketOpcode_processThread, self);
+}
+
+void WebSocketOpcode_sendInputArgumentData(CSOUND *csound, WebSocketOpcode *self)
+{
+    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+        
+        OpcodeArgument *currentArgument = &self->inputArguments[i];
+        
+        if (currentArgument->iRateVarSent == true) {
+            
+            continue;
+        }
+        
+        int itemsWritten = csoundWriteCircularBuffer(csound, currentArgument->circularBuffer,
+                                                     currentArgument->dataPointer, currentArgument->itemsCount);
+        
+        if (itemsWritten != currentArgument->itemsCount) {
+            
+            csound->Message(csound, "websocket: variable %s data not sent, buffer overrrun\n", currentArgument->name);
+        }
+    }
+}
+
+void WebSocketOpcode_receiveOutputArgumentData(CSOUND *csound, WebSocketOpcode *self)
+{
+    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+        
+        OpcodeArgument *currentArgument = &self->outputArguments[i];
+        
+        if (currentArgument->iRateVarSent == true) {
+            
+            continue;
+        }
+        
+        csoundReadCircularBuffer(csound, currentArgument->circularBuffer,
+                                 currentArgument->dataPointer, currentArgument->itemsCount);
+    }
+}
+
+int WebSocketOpcode_process(CSOUND *csound, WebSocketOpcode *self)
+{
+    WebSocketOpcode_sendInputArgumentData(csound, self);
+    WebSocketOpcode_receiveOutputArgumentData(csound, self);
+    return OK;
+}
+
+int WebSocketOpcode_finish(CSOUND *csound, void *opaqueReference)
+{
+    WebSocketOpcode *self = opaqueReference;
+    self->isRunning = false;
+    
+    csound->JoinThread(self->webSocket->processThread);
+    
+    libwebsocket_cancel_service(self->webSocket->context);
+    libwebsocket_context_destroy(self->webSocket->context);
+    
+    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+        
+        csoundDestroyCircularBuffer(csound, self->outputArguments[i].circularBuffer);
+    }
+    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+        
+        csoundDestroyCircularBuffer(csound, self->inputArguments[i].circularBuffer);
+    }
+    
+    csound->Free(csound, self->webSocket->protocols);
+    csound->Free(csound, self->webSocket->messageBuffer);
+    csound->Free(csound, self->webSocket);
+    if (self->inputArgumentCount > 0) {
+        
+        csound->Free(csound, self->inputArguments);
+    }
+    if (self->outputArgumentCount > 0) {
+        
+        csound->Free(csound, self->outputArguments);
+    }
+    return OK;
+}
+
+
+ArgumentType WebSocketOpcode_getArgumentType(CSOUND *csound, MYFLT *argument)
+{
+    const CS_TYPE *csoundType = csound->GetTypeForArg((void *)argument);
+    const char *type = csoundType->varTypeName;
+    ArgumentType argumentType = UNKNOWN;
+    
+    if (strcmp("S", type) == 0) {
+        
+        argumentType = STRING_VAR;
+    }
+    else if (strcmp("a", type) == 0) {
+        
+        argumentType = ARATE_VAR;
+    }
+    else if (strcmp("k", type) == 0) {
+        
+        argumentType = KRATE_VAR;
+    }
+    else if (strcmp("i", type) == 0) {
+        
+        argumentType = IRATE_VAR;
+    }
+    else if (strcmp("[", type) == 0) {
+        
+        ARRAYDAT *array = (ARRAYDAT *)argument;
+        
+        if (strcmp("k", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = KRATE_ARRAY;
+        }
+        else if (strcmp("a", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = ARATE_ARRAY;
+        }
+        else if (strcmp("i", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = IRATE_ARRAY;
+        }
+    }
+    
+    return argumentType;
+}
+
+static OENTRY localops[] = {
+    
+    {
+        .opname = "websocket",
+        .dsblksiz = sizeof(WebSocketOpcode),
+        .thread = 3,
+        .outypes = "*",
+        .intypes = "*",
+        .iopadr = (SUBR)WebSocketOpcode_initialise,
+        .kopadr = (SUBR)WebSocketOpcode_process,
+        .aopadr = NULL
+    }
+};
+
+
+LINKAGE

--- a/Opcodes/websockets/WebSocketOpcode.h
+++ b/Opcodes/websockets/WebSocketOpcode.h
@@ -1,0 +1,57 @@
+/*
+ 
+ WebSocketOpcode.h
+ WebSockets
+ 
+ Created by Edward Costello on 10/06/2015.
+ Copyright (c) 2015 Edward Costello. All rights reserved.
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
+
+
+#include <stdbool.h>
+#include "csdl.h"
+#include "csound.h"
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+   
+
+    typedef struct OpcodeArgument OpcodeArgument;
+    typedef struct WebSocket WebSocket;
+    
+    typedef struct WebSocketOpcode
+    {
+        OPDS h;
+        MYFLT *arguments[20];
+        u_int16_t inputArgumentCount;
+        u_int16_t outputArgumentCount;
+        WebSocket *webSocket;
+        OpcodeArgument *inputArguments;
+        OpcodeArgument *outputArguments;
+        bool isRunning;
+        CSOUND *csound;
+    } WebSocketOpcode;
+    
+    int WebSocketOpcode_initialise(CSOUND *csound, WebSocketOpcode *self);
+    int WebSocketOpcode_process(CSOUND *csound, WebSocketOpcode *self);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added new opcodes,

websocket: reads and writes to websockets
framebuffer: similar to shiftin, shiftout but does both avar to karray and karray to avar in one opcode, also the size of the buffer can be set.
olabuffer: takes k-rate 1D arrays and overlap adds them together giving an a-rate output, any number of overlapping frames can be set 