### PR TITLE
Avoid unsafe and potentially overlapping string copies.

### DIFF
--- a/Top/main.c
+++ b/Top/main.c
@@ -246,12 +246,10 @@ PUBLIC int csoundCompileArgs(CSOUND *csound, int argc, char **argv)
 
     s = csoundQueryGlobalVariable(csound, "_RTMIDI");
     if (csound->enableHostImplementedMIDIIO == 1) {
-        if (s == NULL) {
-          s = "hostbased";
-        } else {
+        if (s) {
             strcpy(s, "hostbased");
         }
-        csoundSetConfigurationVariable(csound,"rtmidi", s);
+        csoundSetConfigurationVariable(csound,"rtmidi", "hostbased");
     }
 
     /* IV - Jan 28 2005 */
@@ -376,8 +374,9 @@ PUBLIC int csoundStart(CSOUND *csound) // DEBUG
      }
   else {
    s = csoundQueryGlobalVariable(csound, "_RTMIDI");
-   strcpy(s, "hostbased");
-   csoundSetConfigurationVariable(csound,"rtmidi", s);
+   if (s)
+     strcpy(s, "hostbased");
+   csoundSetConfigurationVariable(csound,"rtmidi", "hostbased");
   }
    }
 


### PR DESCRIPTION
There were some problems in the way the option strings were handled for MIDI options, which could lead to calls with `strcpy()` with identical strings, which is undefined and led to some early crashes in certain conditions.
