### PR TITLE
Set install path to Homebrew's default and set the rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,16 @@ set(LUA_MODULE_INSTALL_DIR ${LIBRARY_INSTALL_DIR})
 set(LOCALE_INSTALL_DIR "share/locale")
 set(HEADER_INSTALL_DIR "include/csound")
 
-set(CS_FRAMEWORK_DEST "~/Library/Frameworks")
+if(APPLE)
+	# Install frameworks in Homebrew's default path
+	set(HOMEBREW_PREFIX "/usr/local")
+	set(HOMEBREW_FRAMEWORK "${HOMEBREW_PREFIX}/Frameworks")
+	set(CS_FRAMEWORK_DEST "${HOMEBREW_FRAMEWORK}")
+	# Add Homebrew's path to the rpath
+	set(CMAKE_MACOSX_RPATH ON)
+	set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} ${HOMEBREW_FRAMEWORK})
+endif(APPLE) 
+
 include(TestBigEndian)
 include(CheckFunctionExists)
 include(CheckIncludeFile)


### PR DESCRIPTION
This fixes the "could not fix CsoundLib64" and the "library not loaded" issues when installing csound via homebrew on OSX (see https://github.com/csound/homebrew-csound/issues/12). CsoundLib64.framework is now installed in /usr/local/Frameworks, and this path is added to the rpath.