### PR TITLE
Overloaded pvs2tab and tab2pvs, update websocket opcode

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -2449,10 +2449,11 @@ int  pvs2tabsplit(CSOUND *csound, PVS2TABSPLIT_T *p){
     
     int mags_size = p->mags->sizes[0], freqs_size = p->freqs->sizes[0], N = p->fsig->N, i, j;
     float *fsig = (float *) p->fsig->frame.auxp;
-    for(i = 0, j = 0; i < mags_size && i < N+2; i += 2, j++)
+    for(i = 0, j = 0; j < mags_size && i < N+2; i += 2, j++) {
         p->mags->data[j] = (MYFLT) fsig[i];
+    }
     
-    for(i = 1, j = 0; i < freqs_size && i < N+2; i += 2, j++)
+    for(i = 1, j = 0; j < freqs_size && i < N+2; i += 2, j++)
         p->freqs->data[j] = (MYFLT) fsig[i];
     
     *p->framecount = (MYFLT) p->fsig->framecount;

--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -2424,6 +2424,41 @@ int  pvs2tab(CSOUND *csound, PVS2TAB_T *p){
   return OK;
 }
 
+typedef struct pvs2tabsplit_t {
+    OPDS h;
+    MYFLT *framecount;
+    ARRAYDAT *mags;
+    ARRAYDAT *freqs;
+    PVSDAT *fsig;
+} PVS2TABSPLIT_T;
+
+int pvs2tabsplit_init(CSOUND *csound, PVS2TABSPLIT_T *p)
+{
+    if (UNLIKELY(!(p->fsig->format == PVS_AMP_FREQ) ||
+                 (p->fsig->format == PVS_AMP_PHASE)))
+        return csound->InitError(csound, Str("pvs2tab: signal format "
+                                             "must be amp-phase or amp-freq."));
+    
+    if (LIKELY(p->mags->data) && LIKELY(p->freqs->data))
+        return OK;
+    
+    return csound->InitError(csound, Str("array-variable not initialised"));
+}
+
+int  pvs2tabsplit(CSOUND *csound, PVS2TABSPLIT_T *p){
+    
+    int mags_size = p->mags->sizes[0], freqs_size = p->freqs->sizes[0], N = p->fsig->N, i, j;
+    float *fsig = (float *) p->fsig->frame.auxp;
+    for(i = 0, j = 0; i < mags_size && i < N+2; i += 2, j++)
+        p->mags->data[j] = (MYFLT) fsig[i];
+    
+    for(i = 1, j = 0; i < freqs_size && i < N+2; i += 2, j++)
+        p->freqs->data[j] = (MYFLT) fsig[i];
+    
+    *p->framecount = (MYFLT) p->fsig->framecount;
+    return OK;
+}
+
 typedef struct tab2pvs_t {
   OPDS h;
   PVSDAT *fout;
@@ -2477,7 +2512,60 @@ int  tab2pvs(CSOUND *csound, TAB2PVS_T *p)
     return OK;
 }
 
+typedef struct tab2pvssplit_t {
+    OPDS h;
+    PVSDAT *fout;
+    ARRAYDAT *mags;
+    ARRAYDAT *freqs;
+    MYFLT  *olap, *winsize, *wintype, *format;
+    uint32 ktime;
+    uint32  lastframe;
+} TAB2PVSSPLIT_T;
 
+int tab2pvssplit_init(CSOUND *csound, TAB2PVSSPLIT_T *p)
+{
+    if (LIKELY(p->mags->data) && LIKELY(p->freqs->data) && (p->mags->sizes[0] == p->freqs->sizes[0])){
+        int N;
+        p->fout->N = N = (p->mags->sizes[0] * 2) - 2;
+        p->fout->overlap = (int32)(*p->olap ? *p->olap : N/4);
+        p->fout->winsize = (int32)(*p->winsize ? *p->winsize : N);
+        p->fout->wintype = (int32) *p->wintype;
+        p->fout->format = 0;
+        p->fout->framecount = 1;
+        p->lastframe = 0;
+        p->ktime = 0;
+        if (p->fout->frame.auxp == NULL ||
+            p->fout->frame.size < sizeof(float) * (N + 2)) {
+            csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
+        }
+        else
+            memset(p->fout->frame.auxp, 0, sizeof(float)*(N+2));
+        return OK;
+    }
+    else return csound->InitError(csound, Str("magnitude and frequency arrays not initialised, or are not the same size"));
+}
+
+int  tab2pvssplit(CSOUND *csound, TAB2PVSSPLIT_T *p)
+{
+    int size = p->mags->sizes[0], i;
+    float *fout = (float *) p->fout->frame.auxp;
+    
+    p->ktime += CS_KSMPS;
+    if (p->ktime > (uint32) p->fout->overlap) {
+        p->fout->framecount++;
+        p->ktime -= p->fout->overlap;
+    }
+    
+    if (p->lastframe < p->fout->framecount){
+        for (i = 0; i < size; i++){
+            fout[i * 2] = (float) p->mags->data[i];
+            fout[i * 2 + 1] = (float) p->freqs->data[i];
+        }
+        p->lastframe = p->fout->framecount;
+    }
+    
+    return OK;
+}
 
 
 static OENTRY localops[] = {
@@ -2527,12 +2615,20 @@ static OENTRY localops[] = {
    (SUBR) pvsgainset, (SUBR) pvsgain, NULL},
   {"pvs2tab", sizeof(PVS2TAB_T), 0,3, "k", "k[]f",
    (SUBR) pvs2tab_init, (SUBR) pvs2tab, NULL},
+  {"pvs2tab", sizeof(PVS2TABSPLIT_T), 0,3, "k", "k[]k[]f",
+        (SUBR) pvs2tabsplit_init, (SUBR) pvs2tabsplit, NULL},
   {"tab2pvs", sizeof(TAB2PVS_T), 0, 3, "f", "k[]oop", (SUBR) tab2pvs_init,
    (SUBR) tab2pvs, NULL},
+  {"tab2pvs", sizeof(TAB2PVSSPLIT_T), 0, 3, "f", "k[]k[]oop", (SUBR) tab2pvssplit_init,
+        (SUBR) tab2pvssplit, NULL},
   {"pvs2array", sizeof(PVS2TAB_T), 0,3, "k", "k[]f",
    (SUBR) pvs2tab_init, (SUBR) pvs2tab, NULL},
+  {"pvs2array", sizeof(PVS2TABSPLIT_T), 0,3, "k", "k[]k[]f",
+        (SUBR) pvs2tabsplit_init, (SUBR) pvs2tabsplit, NULL},
   {"pvsfromarray", sizeof(TAB2PVS_T), 0, 3, "f", "k[]oop",
-   (SUBR) tab2pvs_init, (SUBR) tab2pvs, NULL}
+   (SUBR) tab2pvs_init, (SUBR) tab2pvs, NULL},
+  {"pvsfromarray", sizeof(TAB2PVSSPLIT_T), 0, 3, "f", "k[]k[]oop",
+        (SUBR) tab2pvssplit_init, (SUBR) tab2pvssplit, NULL}
 };
 
 int pvsbasic_init_(CSOUND *csound)

--- a/Opcodes/websockets/CMakeLists.txt
+++ b/Opcodes/websockets/CMakeLists.txt
@@ -16,14 +16,12 @@ endif()
 
 check_include_file(libwebsockets.h WEBSOCKETS_H)
 
-
 if(WEBSOCKETS_H AND websockets_library) 
   set(CMAKE_REQUIRED_INCLUDES libwebsockets.h)
   set(CMAKE_REQUIRED_LIBRARIES ${websockets_library})
-  check_function_exists(libwebsocket_cancel_service LIBWEBSOCKET_CANCEL_SERVICE)
 endif()
 
-check_deps(BUILD_WEBSOCKET_OPCODE websockets_library WEBSOCKETS_H LIBWEBSOCKET_CANCEL_SERVICE)
+check_deps(BUILD_WEBSOCKET_OPCODE websockets_library)
 if(BUILD_WEBSOCKET_OPCODE)
  	make_plugin(websocketIO WebSocketOpcode.c)
  	target_link_libraries(websocketIO ${websockets_library} ${CSOUNDLIB})

--- a/Opcodes/websockets/WebSocketOpcode.c
+++ b/Opcodes/websockets/WebSocketOpcode.c
@@ -1,35 +1,16 @@
-/*
+//
+//  WebSocketOpcode.c
+//  WebSocketOpcode
+//
+//  Created by Edward Costello on 10/05/2015.
+//  Copyright (c) 2015 Edward Costello. All rights reserved.
+//
 
- WebSocketOpcode.c
- WebSockets
-
- Created by Edward Costello on 10/06/2015.
-
- Copyright (c) 2015 Edward Costello.
-
- This file is part of Csound.
-
- The Csound Library is free software; you can redistribute it
- and/or modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation; either
- version 2.1 of the License, or (at your option) any later version.
-
- Csound is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with Csound; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- 02111-1307 USA
- */
-
-#include "WebSocketOpcode.h"
-#include <sys/param.h>
-#include <stdio.h>
-#include <libwebsockets.h>
-#include <stdlib.h>
+#import "WebSocketOpcode.h"
+#import <sys/param.h>
+#import <stdio.h>
+#import <libwebsockets.h>
+#import <stdlib.h>
 
 typedef enum ArgumentType
 {
@@ -44,8 +25,10 @@ typedef enum ArgumentType
 } ArgumentType;
 
 struct OpcodeArgument{
-
+    
     void *dataPointer;
+    MYFLT *argumentPointer;
+    bool receivedNewData;
     ArgumentType argumentType;
     AUXCH auxillaryMemory;
     void *circularBuffer;
@@ -58,10 +41,10 @@ struct OpcodeArgument{
 };
 
 struct WebSocket{
-
-    struct libwebsocket_context *context;
-    struct libwebsocket *websocket;
-    struct libwebsocket_protocols *protocols;
+    
+    struct lws_context *context;
+    struct lws *websocket;
+    struct lws_protocols *protocols;
     void *processThread;
     unsigned char *messageBuffer;
     struct lws_context_creation_info info;
@@ -69,7 +52,7 @@ struct WebSocket{
 
 static const size_t writeBufferBytesCount = 2048;
 static const size_t stringVarMaximumBytesCount = 4096;
-static const size_t ringBufferItemsCount = 2048;
+static const size_t ringBufferItemsCount = 2048 * 16;
 
 void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound);
 int WebSocketOpcode_finish(CSOUND *csound, void *opaqueReference);
@@ -90,484 +73,430 @@ int WebSocketOpcode_initialise(CSOUND *csound, WebSocketOpcode *self)
 uintptr_t WebSocketOpcode_processThread(void *opaquePointer)
 {
     WebSocketOpcode *self = opaquePointer;
-
+    
     while (self->isRunning == 1) {
-
-      libwebsocket_service(self->webSocket->context, 10);
-      libwebsocket_callback_on_writable_all_protocol(self->webSocket->protocols);
+        
+        
+        lws_service(self->webSocket->context, 10);
+        lws_callback_on_writable_all_protocol(self->webSocket->context, self->webSocket->protocols);
     }
-
+    
     return 0;
 }
 
 void WebSocketOpcode_writeOnce(WebSocketOpcode *self, OpcodeArgument *inputArgument,
-                               void *messageBuffer, struct libwebsocket *websocket)
+                               void *messageBuffer, struct lws *websocket)
 {
     unsigned char *inputData = (unsigned char *)inputArgument->readBuffer;
     memcpy(messageBuffer, inputData, inputArgument->bytesCount);
-    libwebsocket_write(websocket, messageBuffer,
-                       inputArgument->bytesCount, LWS_WRITE_BINARY);
+    lws_write(websocket, messageBuffer, inputArgument->bytesCount, LWS_WRITE_BINARY);
 }
 
-void WebSocketOpcode_writeFragments(WebSocketOpcode *self,
-                                    OpcodeArgument *inputArgument,
-                                    void *messageBuffer,
-                                    struct libwebsocket *websocket)
+void WebSocketOpcode_writeFragments(WebSocketOpcode *self, OpcodeArgument *inputArgument,
+                                    void *messageBuffer, struct lws *websocket)
 {
-    unsigned char *inputData =
-      &((unsigned char *)inputArgument->readBuffer)[inputArgument->bytesWritten];
-
-    if (inputArgument->bytesWritten + writeBufferBytesCount <
-        inputArgument->bytesCount) {
-
-      int writeFlags = LWS_WRITE_NO_FIN;
-      writeFlags |= inputArgument->bytesWritten == 0 ?
-        LWS_WRITE_BINARY : LWS_WRITE_CONTINUATION;
-      memcpy(messageBuffer, inputData, writeBufferBytesCount);
-      inputArgument->bytesWritten +=
-        libwebsocket_write(websocket, messageBuffer, writeBufferBytesCount,
-                           writeFlags);
+    unsigned char *inputData = &((unsigned char *)inputArgument->readBuffer)[inputArgument->bytesWritten];
+    
+    if (inputArgument->bytesWritten + writeBufferBytesCount < inputArgument->bytesCount) {
+        
+        int writeFlags = LWS_WRITE_NO_FIN;
+        writeFlags |= inputArgument->bytesWritten == 0 ? LWS_WRITE_BINARY : LWS_WRITE_CONTINUATION;
+        memcpy(messageBuffer, inputData, writeBufferBytesCount);
+        inputArgument->bytesWritten += lws_write(websocket, messageBuffer, writeBufferBytesCount, writeFlags);
     }
     else {
-
-      size_t fragmentBytesCount =
-        inputArgument->bytesCount - inputArgument->bytesWritten;
-      memcpy(messageBuffer, inputData, fragmentBytesCount);
-      libwebsocket_write(websocket, messageBuffer, fragmentBytesCount,
-                         LWS_WRITE_CONTINUATION);
-      inputArgument->bytesWritten = 0;
+        
+        size_t fragmentBytesCount = inputArgument->bytesCount - inputArgument->bytesWritten;
+        memcpy(messageBuffer, inputData, fragmentBytesCount);
+        lws_write(websocket, messageBuffer, fragmentBytesCount, LWS_WRITE_CONTINUATION);
+        inputArgument->bytesWritten = 0;
     }
 }
 
-void WebSocketOpcode_writeMessage(WebSocketOpcode *self,
-                                  OpcodeArgument *inputArgument,
-                                  void *messageBuffer,
-                                  struct libwebsocket *websocket)
+
+typedef struct _circular_buffer {
+    char *buffer;
+    int  wp;
+    int rp;
+    int numelem;
+    int elemsize; /* in number of bytes */
+} circular_buffer;
+
+void WebSocketOpcode_writeMessage(WebSocketOpcode *self, OpcodeArgument *inputArgument,
+                                  void *messageBuffer, struct lws *websocket)
 {
     if (inputArgument->bytesCount <= writeBufferBytesCount) {
-
-      WebSocketOpcode_writeOnce(self, inputArgument, messageBuffer, websocket);
+        
+        WebSocketOpcode_writeOnce(self, inputArgument, messageBuffer, websocket);
     }
     else {
-
-      WebSocketOpcode_writeFragments(self, inputArgument, messageBuffer, websocket);
+        
+        //        circular_buffer *buffer = self->outputArguments[0].circularBuffer;
+        WebSocketOpcode_writeFragments(self, inputArgument, messageBuffer, websocket);
+        
     }
 }
 
-void WebSocketOpcode_handleServerWritable(struct libwebsocket *websocket,
-                                          WebSocketOpcode *self,
-                                          CSOUND *csound, void *messageBuffer)
+void WebSocketOpcode_handleServerWritable(struct lws *websocket, WebSocketOpcode *self, CSOUND *csound, void *messageBuffer)
 {
-    const struct libwebsocket_protocols *protocol =
-      libwebsockets_get_protocol(websocket);
-
+    const struct lws_protocols *protocol = lws_get_protocol(websocket);
+    
     // If it's an output argument just return
-    if (protocol->protocol_index < self->outputArgumentCount) {
-
-      usleep(100);
-      return;
+    if (protocol->id < self->outputArgumentCount) {
+        
+        usleep(100);
+        return;
     }
-
-    int inputIndex = protocol->protocol_index - self->outputArgumentCount;
+    
+    int inputIndex = protocol->id - self->outputArgumentCount;
     OpcodeArgument *argument = &self->inputArguments[inputIndex];
-
+    
     int readItems = 0;
-
+    
     if (argument->bytesWritten == 0) {
-
-      readItems =
-        csoundReadCircularBuffer(csound, argument->circularBuffer,
-                                 argument->readBuffer, argument->itemsCount);
+        
+        readItems = csoundReadCircularBuffer(csound, argument->circularBuffer,
+                                             argument->readBuffer, argument->itemsCount);
     }
     if (readItems != 0 || argument->bytesWritten != 0) {
-
-      WebSocketOpcode_writeMessage(self, argument, messageBuffer, websocket);
-
-      if (argument->argumentType == IRATE_VAR ||
-          argument->argumentType == IRATE_ARRAY) {
-
-        argument->iRateVarSent = true;
-      }
+        
+        WebSocketOpcode_writeMessage(self, argument, messageBuffer, websocket);
+        
+        if (argument->argumentType == IRATE_VAR || argument->argumentType == IRATE_ARRAY) {
+            
+            argument->iRateVarSent = true;
+        }
     }
-
+    
     usleep(100);
-
+    
     if (argument->iRateVarSent == false) {
-
-      libwebsocket_callback_on_writable(self->webSocket->context, websocket);
+        
+        lws_callback_on_writable(websocket);
     }
 }
 
-void WebSocketOpcode_handleReceive(struct libwebsocket *websocket,
-                                   WebSocketOpcode *self, CSOUND *csound,
-                                   size_t inputDataSize, void *inputData)
+void WebSocketOpcode_handleReceive(struct lws *websocket, WebSocketOpcode *self, CSOUND *csound, size_t inputDataSize, void *inputData)
 {
-    const struct libwebsocket_protocols *protocol =
-      libwebsockets_get_protocol(websocket);
-    OpcodeArgument *argument = &self->outputArguments[protocol->protocol_index];
-
-    if (protocol->protocol_index >= self->outputArgumentCount
+    const struct lws_protocols *protocol = lws_get_protocol(websocket);
+    OpcodeArgument *argument = &self->outputArguments[protocol->id];
+    
+    if (protocol->id >= self->outputArgumentCount
         ||
         argument->iRateVarSent == true) {
-
-      return;
+        
+        return;
     }
-
+    
     if (argument->bytesCount != inputDataSize
         &&
         argument->argumentType != STRING_VAR) {
-
-      csound->Message(csound,
-                      Str("websocket: received message from %s is not correct "
-                          "size for variable %s, message dumped"),
-                      protocol->name, argument->name);
-      return;
+        
+        csound->Message(csound, "websocket: received message from is not correct size for variable %s, message dumped", protocol->name);
+        return;
     }
-
+    
     if (argument->argumentType == STRING_VAR
         &&
         argument->bytesCount > stringVarMaximumBytesCount) {
-
-      csound->Message(csound,
-                      Str("websocket: received string message from %s is "
-                          "too large, message dumped"),
-                      protocol->name, argument->name);
-
-      return;
+        
+        csound->Message(csound, "websocket: received string message from %s is too large, message dumped", protocol->name);
+        
+        return;
     }
-
-    int writtenItems = csoundWriteCircularBuffer(csound, argument->circularBuffer,
-                                                 inputData, argument->itemsCount);
-
+    
+    int writtenItems = csoundWriteCircularBuffer(csound, argument->circularBuffer, inputData, argument->itemsCount);
+    argument->receivedNewData = true;
+    
     if (writtenItems == 0) {
-
-      csound->Message(csound,
-                      Str("websocket: received message from %s dumped, "
-                          "buffer overrrun"), argument->name);
+        
+        csound->Message(csound, "websocket: received message from %s dumped, buffer overrrun", argument->name);
     }
     else {
-
-      if (argument->argumentType == IRATE_VAR
-          ||
-          argument->argumentType == IRATE_ARRAY) {
-
-        argument->iRateVarSent = true;
-      }
+        
+        if (argument->argumentType == IRATE_VAR
+            ||
+            argument->argumentType == IRATE_ARRAY) {
+            
+            argument->iRateVarSent = true;
+        }
     }
 }
 
-static int Websocket_callback(struct libwebsocket_context *context,
-                              struct libwebsocket *websocket,
-                              enum libwebsocket_callback_reasons reason,
+
+static int Websocket_callback(struct lws *websocket,
+                              enum lws_callback_reasons reason,
                               void *user, void *inputData, size_t inputDataSize)
 {
-    WebSocketOpcode *self = libwebsocket_context_user(context);
+    
+    if (reason != LWS_CALLBACK_ESTABLISHED && reason != LWS_CALLBACK_SERVER_WRITEABLE && reason != LWS_CALLBACK_RECEIVE) {
+        return OK;
+    }
+    
+    const struct lws_protocols *protocol = lws_get_protocol(websocket);
+    WebSocketOpcode *self = lws_get_protocol(websocket)->user;
     CSOUND *csound = self->csound;
-    void *messageBuffer =
-      (void *)&self->webSocket->messageBuffer[LWS_SEND_BUFFER_PRE_PADDING];
-
+    
     switch (reason) {
-
-    case LWS_CALLBACK_ESTABLISHED: {
-
-      const struct libwebsocket_protocols *protocol =
-        libwebsockets_get_protocol(websocket);
-      csound->Message(csound,
-                      Str("websocket: connection established for %s\n"),
-                      protocol->name);
-      break;
+            
+        case LWS_CALLBACK_ESTABLISHED: {
+            
+            
+            csound->Message(csound, "websocket: connection established for %s\n", protocol->name);
+            break;
+        }
+        case LWS_CALLBACK_SERVER_WRITEABLE: {
+            
+            void *messageBuffer = (void *)&self->webSocket->messageBuffer[LWS_SEND_BUFFER_PRE_PADDING];
+            
+            WebSocketOpcode_handleServerWritable(websocket, self, csound, messageBuffer);
+            break;
+        }
+        case LWS_CALLBACK_RECEIVE: {
+            
+            WebSocketOpcode_handleReceive(websocket, self, csound, inputDataSize, inputData);
+            break;
+        }
+        default: {
+            
+            break;
+        }
     }
-    case LWS_CALLBACK_SERVER_WRITEABLE: {
-
-      WebSocketOpcode_handleServerWritable(websocket, self, csound, messageBuffer);
-      break;
-    }
-    case LWS_CALLBACK_RECEIVE: {
-
-      WebSocketOpcode_handleReceive(websocket, self, csound,
-                                    inputDataSize, inputData);
-      break;
-    }
-    default: {
-
-      break;
-    }
-    }
-
+    
     return OK;
 }
 
 int WebSocketOpcode_getArrayElementCount(ARRAYDAT *array)
 {
     int elementCount = array->sizes[0];
-    int i;
-    for (i = 1; i < array->dimensions; ++i) {
-
-      elementCount *= array->sizes[i];
+    
+    for (size_t i = 1; i < array->dimensions; ++i) {
+        
+        elementCount *= array->sizes[i];
     }
-
+    
     return elementCount;
 }
 
 
-void WebSocketOpcode_allocateStringArgument(MYFLT *argument,
-                                            OpcodeArgument *argumentArrayItem,
-                                            CSOUND *csound, bool isInputArgument)
+void WebSocketOpcode_allocateStringArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound, bool isInputArgument)
 {
     STRINGDAT *string = (STRINGDAT *)argument;
-
+    
     if (isInputArgument == true) {
-
-      csound->Die(csound,
-                  Str("websocket: this opcode does not send strings, "
-                      "only receiving them is supported\nExiting"),
-                  argumentArrayItem->name);
+        
+        csound->Die(csound,
+                    "websocket: this opcode doesn't send strings, only receiving them is supported\nExiting");
     }
     else {
-
-      if (string->size != 0) {
-
-        csound->Die(csound,
-                    Str("websocket: error output string variable %s must "
-                        "not be initialised\nExiting"),
-                    argumentArrayItem->name);
-      }
-      else {
-
-        argumentArrayItem->itemsCount = stringVarMaximumBytesCount;
-        string->data = csound->ReAlloc(csound,
-                                       string->data, stringVarMaximumBytesCount);
-      }
+        
+        if (string->size != 0) {
+            
+            csound->Die(csound,
+                        "websocket: error output string variable %s must not be initialised\nExiting",
+                        argumentArrayItem->name);
+        }
+        else {
+            
+            argumentArrayItem->itemsCount = stringVarMaximumBytesCount;
+            string->data = csound->ReAlloc(csound, string->data, stringVarMaximumBytesCount);
+            memset(string->data, 0, stringVarMaximumBytesCount);
+        }
     }
-
+    
     argumentArrayItem->dataPointer = string->data;
     argumentArrayItem->bytesCount = sizeof(char) * stringVarMaximumBytesCount;
-    argumentArrayItem->circularBuffer =
-      csoundCreateCircularBuffer(csound,
-                                 argumentArrayItem->itemsCount *
-                                 ringBufferItemsCount + 1,
-                                 sizeof(char));
-    csound->AuxAlloc(csound, argumentArrayItem->bytesCount,
-                     &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound,
+                                                                   argumentArrayItem->itemsCount * ringBufferItemsCount + 1,
+                                                                   sizeof(char));
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
     argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
 }
 
-void WebSocketOpcode_allocateArrayArgument(MYFLT *argument,
-                                           OpcodeArgument *argumentArrayItem,
-                                           CSOUND *csound)
+void WebSocketOpcode_allocateArrayArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound)
 {
     ARRAYDAT *array = (ARRAYDAT *)argument;
-
+    
     if (array->dimensions == 0) {
-
-      csound->Die(csound,
-                  Str("websocket: error array variable %s has not been "
-                      "initialised\nExiting"),
-                  argumentArrayItem->name);
+        
+        csound->Die(csound,
+                    "websocket: error array variable %s has not been initialised\nExiting",
+                    argumentArrayItem->name);
     }
-
+    
     argumentArrayItem->dataPointer = array->data;
     argumentArrayItem->itemsCount = WebSocketOpcode_getArrayElementCount(array);
-    argumentArrayItem->bytesCount =
-      array->arrayMemberSize * argumentArrayItem->itemsCount;
-    argumentArrayItem->circularBuffer =
-      csoundCreateCircularBuffer(csound,
-                                 argumentArrayItem->itemsCount *
-                                 ringBufferItemsCount + 1,
-                                 array->arrayMemberSize);
-    csound->AuxAlloc(csound, argumentArrayItem->bytesCount,
-                     &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->bytesCount = array->arrayMemberSize * argumentArrayItem->itemsCount;
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound,
+                                                                   argumentArrayItem->itemsCount * ringBufferItemsCount + 1,
+                                                                   array->arrayMemberSize);
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
     argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
 }
 
-void WebSocketOpcode_allocateVariableArgument(MYFLT *argument,
-                                              OpcodeArgument *argumentArrayItem,
-                                              CSOUND *csound, int bytesCount)
+void WebSocketOpcode_allocateVariableArgument(MYFLT *argument, OpcodeArgument *argumentArrayItem, CSOUND *csound, int bytesCount)
 {
     argumentArrayItem->dataPointer = argument;
     argumentArrayItem->itemsCount = 1;
     argumentArrayItem->bytesCount = bytesCount;
-    argumentArrayItem->circularBuffer =
-      csoundCreateCircularBuffer(csound, ringBufferItemsCount + 1,
-                                 argumentArrayItem->bytesCount);
-    csound->AuxAlloc(csound, argumentArrayItem->bytesCount,
-                     &argumentArrayItem->auxillaryMemory);
+    argumentArrayItem->circularBuffer = csoundCreateCircularBuffer(csound, ringBufferItemsCount + 1, argumentArrayItem->bytesCount);
+    csound->AuxAlloc(csound, argumentArrayItem->bytesCount, &argumentArrayItem->auxillaryMemory);
     argumentArrayItem->readBuffer = argumentArrayItem->auxillaryMemory.auxp;
 }
 
 
-void WebSocketOpcode_initialiseArgumentsArray(CSOUND *csound,
-                                              WebSocketOpcode *self,
-                                              OpcodeArgument *argumentsArray,
-                                              size_t argumentsCount,
-                                              MYFLT **arguments,
-                                              bool areInputArguments)
+void WebSocketOpcode_initialiseArgumentsArray(CSOUND *csound, WebSocketOpcode *self, OpcodeArgument *argumentsArray,
+                                              size_t argumentsCount, MYFLT **arguments, bool areInputArguments)
 {
-    int i;
-    for (i = 0; i < argumentsCount; ++i) {
-
-      OpcodeArgument *argumentArrayItem = &argumentsArray[i];
-      argumentArrayItem->argumentType =
-        WebSocketOpcode_getArgumentType(csound, arguments[i]);
-      argumentArrayItem->name =
-        areInputArguments ? csound->GetInputArgName((void *)self, i + 1)
+    for (int i = 0; i < argumentsCount; ++i) {
+        
+        OpcodeArgument *argumentArrayItem = &argumentsArray[i];
+        argumentArrayItem->argumentPointer = arguments[i];
+        argumentArrayItem->argumentType = WebSocketOpcode_getArgumentType(csound, arguments[i]);
+        argumentArrayItem->name = areInputArguments ? csound->GetInputArgName((void *)self, i + 1)
         : csound->GetOutputArgName((void *)self, i);
-
-      switch (argumentsArray[i].argumentType) {
-
-      case IRATE_ARRAY:
-      case ARATE_ARRAY:
-      case KRATE_ARRAY: {
-
-        WebSocketOpcode_allocateArrayArgument(arguments[i],
-                                              argumentArrayItem, csound);
-        break;
-      }
-      case STRING_VAR: {
-
-        WebSocketOpcode_allocateStringArgument(arguments[i],
-                                               argumentArrayItem,
-                                               csound, areInputArguments);
-        break;
-      }
-      case ARATE_VAR: {
-
-        WebSocketOpcode_allocateVariableArgument(arguments[i],
-                                                 argumentArrayItem,
-                                                 csound,
-                                                 sizeof(MYFLT) *
-                                                 csound->GetKsmps(csound));
-        break;
-      }
-      case IRATE_VAR:
-      case KRATE_VAR: {
-
-        WebSocketOpcode_allocateVariableArgument(arguments[i],
-                                                 argumentArrayItem, csound,
-                                                 sizeof(MYFLT));
-        break;
-      }
-      default: {
-
-        csound->Die(csound,
-                    Str("websocket: error, incompatible argument "
-                        "detected\nExiting"));
-        break;
-      }
-      }
+        
+        switch (argumentsArray[i].argumentType) {
+                
+            case IRATE_ARRAY:
+            case ARATE_ARRAY:
+            case KRATE_ARRAY: {
+                
+                WebSocketOpcode_allocateArrayArgument(arguments[i], argumentArrayItem, csound);
+                break;
+            }
+            case STRING_VAR: {
+                
+                WebSocketOpcode_allocateStringArgument(arguments[i], argumentArrayItem, csound, areInputArguments);
+                break;
+            }
+            case ARATE_VAR: {
+                
+                WebSocketOpcode_allocateVariableArgument(arguments[i], argumentArrayItem, csound, sizeof(MYFLT) * csound->GetKsmps(csound));
+                break;
+            }
+            case IRATE_VAR:
+            case KRATE_VAR: {
+                
+                WebSocketOpcode_allocateVariableArgument(arguments[i], argumentArrayItem, csound, sizeof(MYFLT));
+                break;
+            }
+            default: {
+                
+                csound->Die(csound, "websocket: error, incompatible argument detected\nExiting");
+                break;
+            }
+        }
     }
 }
 
 void WebSocketOpcode_initialiseArguments(WebSocketOpcode *self, CSOUND *csound)
 {
-    self->inputArguments =
-      csound->Calloc(csound,
-                     sizeof(OpcodeArgument) * self->inputArgumentCount);
-    self->outputArguments =
-      csound->Calloc(csound, sizeof(OpcodeArgument) * self->outputArgumentCount);
-
+    self->inputArguments = csound->Calloc(csound, sizeof(OpcodeArgument) * self->inputArgumentCount);
+    self->outputArguments = csound->Calloc(csound, sizeof(OpcodeArgument) * self->outputArgumentCount);
+    
     WebSocketOpcode_initialiseArgumentsArray(csound, self, self->inputArguments,
                                              self->inputArgumentCount,
-                                             &self->arguments
-                                                 [self->outputArgumentCount + 1],
-                                             true);
+                                             &self->arguments[self->outputArgumentCount + 1], true);
     WebSocketOpcode_initialiseArgumentsArray(csound, self, self->outputArguments,
                                              self->outputArgumentCount,
                                              self->arguments, false);
 }
 
+
 void WebSocketOpcode_initialiseWebSocket(WebSocketOpcode *self, CSOUND *csound)
 {
     size_t argumentsCount = self->inputArgumentCount + self->outputArgumentCount;
-
+    
     self->webSocket = csound->Calloc(csound, sizeof(WebSocket));
-    self->webSocket->protocols =
-      csound->Calloc(csound,    //Last protocol is null
-                     sizeof(struct libwebsocket_protocols) * (argumentsCount + 1));
+    self->webSocket->protocols = csound->Calloc(csound, sizeof(struct lws_protocols) * (argumentsCount + 1)); //Last protocol is null
     size_t argumentIndex = 0;
-    int i;
-    for (i = 0; i < self->outputArgumentCount; ++i, ++argumentIndex) {
-
-      self->webSocket->protocols[argumentIndex].name =
-        self->outputArguments[i].name;
-      self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
-      self->webSocket->protocols[argumentIndex].per_session_data_size =
-        self->outputArguments[i].bytesCount;
+    
+    for (int i = 0; i < self->outputArgumentCount; ++i, ++argumentIndex) {
+        
+        self->webSocket->protocols[argumentIndex].name = self->outputArguments[i].name;
+        self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
+        self->webSocket->protocols[argumentIndex].id = (int)argumentIndex;
+        self->webSocket->protocols[argumentIndex].user = self;
+        self->webSocket->protocols[argumentIndex].per_session_data_size = sizeof(WebSocketOpcode *);
     }
-    for (i = 0; i < self->inputArgumentCount; ++i, ++argumentIndex) {
-
-      self->webSocket->protocols[argumentIndex].name = self->inputArguments[i].name;
-      self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
-      self->webSocket->protocols[argumentIndex].per_session_data_size =
-        self->inputArguments[i].bytesCount;
+    for (int i = 0; i < self->inputArgumentCount; ++i, ++argumentIndex) {
+        
+        self->webSocket->protocols[argumentIndex].name = self->inputArguments[i].name;
+        self->webSocket->protocols[argumentIndex].callback = Websocket_callback;
+        self->webSocket->protocols[argumentIndex].id = (int)argumentIndex;
+        self->webSocket->protocols[argumentIndex].user = self;
+        self->webSocket->protocols[argumentIndex].per_session_data_size = sizeof(WebSocketOpcode *);
     }
-
+    
     self->webSocket->info.port = *self->arguments[self->outputArgumentCount];
     self->webSocket->info.protocols = self->webSocket->protocols;
-    self->webSocket->info.extensions = libwebsocket_get_internal_extensions();
     self->webSocket->info.gid = -1;
     self->webSocket->info.uid = -1;
-    self->webSocket->info.user = self;
+    
     lws_set_log_level(LLL_ERR, NULL);
-    self->webSocket->context = libwebsocket_create_context(&self->webSocket->info);
-    self->webSocket->messageBuffer =
-      csound->Calloc(csound, LWS_SEND_BUFFER_PRE_PADDING +
-                     (sizeof(char) * writeBufferBytesCount) +
-                     LWS_SEND_BUFFER_POST_PADDING);
-
+    self->webSocket->context = lws_create_context(&self->webSocket->info);
+    self->webSocket->messageBuffer = csound->Calloc(csound, LWS_SEND_BUFFER_PRE_PADDING +
+                                                    (sizeof(char) * writeBufferBytesCount) +
+                                                    LWS_SEND_BUFFER_POST_PADDING);
     if (self->webSocket->context == NULL) {
-
-      csound->Die(csound,
-                  Str("websocket: could not initialise websocket, Exiting"));
+        
+        csound->Die(csound, "websocket: couldn't initialise websocket, Exiting");
     }
-
+    
+    
     self->isRunning = true;
-    self->webSocket->processThread =
-      csound->CreateThread(WebSocketOpcode_processThread, self);
+    self->webSocket->processThread = csound->CreateThread(WebSocketOpcode_processThread, self);
+    
+    
 }
 
 void WebSocketOpcode_sendInputArgumentData(CSOUND *csound, WebSocketOpcode *self)
 {
-    int i;
-    for (i = 0; i < self->inputArgumentCount; ++i) {
-
-      OpcodeArgument *currentArgument = &self->inputArguments[i];
-
-      if (currentArgument->iRateVarSent == true) {
-
-        continue;
-      }
-
-      int itemsWritten = csoundWriteCircularBuffer(csound,
-                                                   currentArgument->circularBuffer,
-                                                   currentArgument->dataPointer,
-                                                   currentArgument->itemsCount);
-
-      if (itemsWritten != currentArgument->itemsCount) {
-
-        csound->Message(csound,
-                        Str("websocket: variable %s data not sent,"
-                            "buffer overrrun\n"), currentArgument->name);
+    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+        
+        OpcodeArgument *currentArgument = &self->inputArguments[i];
+        
+        if (currentArgument->iRateVarSent == true) {
+            
+            continue;
+        }
+        
+        int itemsWritten = csoundWriteCircularBuffer(csound, currentArgument->circularBuffer,
+                                                     currentArgument->dataPointer, currentArgument->itemsCount);
+        
+        if (itemsWritten != currentArgument->itemsCount) {
+            
+            csound->Message(csound, "websocket: variable %s data not sent, buffer overrrun\n", currentArgument->name);
         }
     }
 }
 
-void WebSocketOpcode_receiveOutputArgumentData(CSOUND *csound,
-                                               WebSocketOpcode *self)
+void WebSocketOpcode_receiveOutputArgumentData(CSOUND *csound, WebSocketOpcode *self)
 {
-    int i;
-    for (i = 0; i < self->outputArgumentCount; ++i) {
-
-      OpcodeArgument *currentArgument = &self->outputArguments[i];
-
-      if (currentArgument->iRateVarSent == true) {
-
-        continue;
-      }
-
-      csoundReadCircularBuffer(csound, currentArgument->circularBuffer,
-                               currentArgument->dataPointer,
-                               currentArgument->itemsCount);
+    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+        
+        OpcodeArgument *currentArgument = &self->outputArguments[i];
+        
+        if (currentArgument->receivedNewData == true) {
+            
+            if (currentArgument->iRateVarSent == true) {
+                
+                continue;
+            }
+            
+            csoundReadCircularBuffer(csound, currentArgument->circularBuffer,
+                                     currentArgument->dataPointer, currentArgument->itemsCount);
+            
+            if (currentArgument->argumentType == STRING_VAR) {
+                
+                STRINGDAT *string = (STRINGDAT *)currentArgument->argumentPointer;
+                string->size = (int)strlen(currentArgument->dataPointer);
+            }
+            
+            currentArgument->receivedNewData = false;
+        }
+        
     }
 }
 
@@ -582,31 +511,31 @@ int WebSocketOpcode_finish(CSOUND *csound, void *opaqueReference)
 {
     WebSocketOpcode *self = opaqueReference;
     self->isRunning = false;
-
+    
     csound->JoinThread(self->webSocket->processThread);
-
-    libwebsocket_cancel_service(self->webSocket->context);
-    libwebsocket_context_destroy(self->webSocket->context);
-    int i;
-    for (i = 0; i < self->outputArgumentCount; ++i) {
-
-      csoundDestroyCircularBuffer(csound, self->outputArguments[i].circularBuffer);
+    
+    lws_cancel_service(self->webSocket->context);
+    lws_context_destroy(self->webSocket->context);
+    
+    for (size_t i = 0; i < self->outputArgumentCount; ++i) {
+        
+        csoundDestroyCircularBuffer(csound, self->outputArguments[i].circularBuffer);
     }
-    for (i = 0; i < self->inputArgumentCount; ++i) {
-
-      csoundDestroyCircularBuffer(csound, self->inputArguments[i].circularBuffer);
+    for (size_t i = 0; i < self->inputArgumentCount; ++i) {
+        
+        csoundDestroyCircularBuffer(csound, self->inputArguments[i].circularBuffer);
     }
-
+    
     csound->Free(csound, self->webSocket->protocols);
     csound->Free(csound, self->webSocket->messageBuffer);
     csound->Free(csound, self->webSocket);
     if (self->inputArgumentCount > 0) {
-
-      csound->Free(csound, self->inputArguments);
+        
+        csound->Free(csound, self->inputArguments);
     }
     if (self->outputArgumentCount > 0) {
-
-      csound->Free(csound, self->outputArguments);
+        
+        csound->Free(csound, self->outputArguments);
     }
     return OK;
 }
@@ -617,46 +546,48 @@ ArgumentType WebSocketOpcode_getArgumentType(CSOUND *csound, MYFLT *argument)
     const CS_TYPE *csoundType = csound->GetTypeForArg((void *)argument);
     const char *type = csoundType->varTypeName;
     ArgumentType argumentType = UNKNOWN;
-
+    
     if (strcmp("S", type) == 0) {
-
-      argumentType = STRING_VAR;
+        
+        argumentType = STRING_VAR;
     }
     else if (strcmp("a", type) == 0) {
-
-      argumentType = ARATE_VAR;
+        
+        argumentType = ARATE_VAR;
     }
     else if (strcmp("k", type) == 0) {
-
-      argumentType = KRATE_VAR;
+        
+        argumentType = KRATE_VAR;
     }
     else if (strcmp("i", type) == 0) {
-
-      argumentType = IRATE_VAR;
+        
+        argumentType = IRATE_VAR;
     }
     else if (strcmp("[", type) == 0) {
-
-      ARRAYDAT *array = (ARRAYDAT *)argument;
-
-      if (strcmp("k", array->arrayType->varTypeName) == 0) {
-
-        argumentType = KRATE_ARRAY;
-      }
-      else if (strcmp("a", array->arrayType->varTypeName) == 0) {
-
-        argumentType = ARATE_ARRAY;
-      }
-      else if (strcmp("i", array->arrayType->varTypeName) == 0) {
-
-        argumentType = IRATE_ARRAY;
-      }
+        
+        ARRAYDAT *array = (ARRAYDAT *)argument;
+        
+        if (strcmp("k", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = KRATE_ARRAY;
+        }
+        else if (strcmp("a", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = ARATE_ARRAY;
+        }
+        else if (strcmp("i", array->arrayType->varTypeName) == 0) {
+            
+            argumentType = IRATE_ARRAY;
+        }
     }
-
+    
+    
     return argumentType;
 }
 
 static OENTRY localops[] = {
-
+    
+    
     {
         .opname = "websocket",
         .dsblksiz = sizeof(WebSocketOpcode),
@@ -668,6 +599,5 @@ static OENTRY localops[] = {
         .aopadr = NULL
     }
 };
-
 
 LINKAGE

--- a/Opcodes/websockets/WebSocketOpcode.c
+++ b/Opcodes/websockets/WebSocketOpcode.c
@@ -1,10 +1,27 @@
-//
-//  WebSocketOpcode.c
-//  WebSocketOpcode
-//
-//  Created by Edward Costello on 10/05/2015.
-//  Copyright (c) 2015 Edward Costello. All rights reserved.
-//
+/*
+ WebSocketOpcode.c
+ WebSocketOpcode
+ 
+ Copyright (C) 2015, 2016
+ Edward Costello 
+ 
+ This file is part of Csound.
+ 
+ The Csound Library is free software; you can redistribute it
+ and/or modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ 
+ Csound is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with Csound; if not, write to the Free Software
+ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ 02111-1307 USA
+ */
 
 #import "WebSocketOpcode.h"
 #import <sys/param.h>


### PR DESCRIPTION
 Overloaded pvs2tab and tab2pvs so they can create and use split magnitude and phase arrays, e.g.

```csound-csd

<CsoundSynthesizer>
<CsOptions>
-odac -+rtaudio=CoreAudio
</CsOptions>
<CsInstruments>

sr = 44100
ksmps = 256
nchnls = 2
0dbfs  = 1

instr PVSIn

karr[] init 1026
kmags[] init 513
kfreqs[] init 513
kCurrentFrame init -1;

a1, a2 diskin2 "input.wav", 1
fsig1   pvsanal a1, 1024,ksmps,1024, 1
kframe  pvs2tab kmags, kfreqs, fsig1

if kframe != kCurrentFrame then

kCurrentFrame = kframe
hdf5write "pvssplit.h5", kmags, kfreqs

endif
endin


instr PVSOut

k1 init 0

kmags[][], kfreqs[][] hdf5read "pvssplit.h5", "kmags*", "kfreqs*"

kmagsrow[] getcol kmags, k1
kfreqsrow[] getcol kfreqs, k1

fsig1 tab2pvs kmagsrow, kfreqsrow
aOut pvsynth fsig1

k1 += 1

outs aOut, aOut
endin

</CsInstruments>
<CsScore>

i "PVSIn" 0 10
;i "PVSOut" 0 10

</CsScore>
</CsoundSynthesizer>
```

Also updated the websocket opcode to work with latest versions of the library