### PR TITLE
Pvs bin setter methods should be void on return

### DIFF
--- a/include/plugin.h
+++ b/include/plugin.h
@@ -404,11 +404,11 @@ public:
 
   /** set amplitude
    */
-  T amp(float a) { am = a; }
+  void amp(float a) { am = a; }
 
   /** set frequency
    */
-  T freq(float f) { fr = f; }
+  void freq(float f) { fr = f; }
 
   /** multiplication (unary)
    */


### PR DESCRIPTION
Control reaches end of non-void function for pvs bin setters