### PR TITLE
webaudio improvement on develop branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ if(NOT MSVC)
   find_library(PTHREAD_LIBRARY pthread)
 
   if(NOT PTHREAD_LIBRARY)
-      message(FATAL_ERROR "Csound requires the pthread library")
+      message(STATUS "Csound requires the pthread library")
   endif()
 
   set(CMAKE_REQUIRED_INCLUDES pthread.h)

--- a/H/csGblMtx.h
+++ b/H/csGblMtx.h
@@ -53,7 +53,7 @@ void csoundUnLock() {
 extern "C" {
   #endif
 
-static INIT_ONCE g_InitOnce = INIT_ONCE_STATIC_INIT;
+static INIT_ONCE g_InitOnce = INIT_ONCE_STATIC_INIT; 
 static CRITICAL_SECTION* csound_global_lock;
 
 static BOOL CALLBACK InitHandleFunction ( PINIT_ONCE InitOnce, PVOID Parameter,
@@ -62,13 +62,13 @@ static BOOL CALLBACK InitHandleFunction ( PINIT_ONCE InitOnce, PVOID Parameter,
     CRITICAL_SECTION* cs = (CRITICAL_SECTION*) malloc(sizeof(CRITICAL_SECTION));
     InitializeCriticalSection(cs);
     *lpContext = cs;
-    return 1;
+	return 1;
 }
 
 
 
 void csoundLock() {
-    BOOL status;
+    BOOL status; 
     CRITICAL_SECTION* cs;
 
     status = InitOnceExecuteOnce(&g_InitOnce, InitHandleFunction, NULL, &cs);
@@ -79,7 +79,7 @@ void csoundLock() {
 
 void csoundUnLock() {
 
-    BOOL status;
+    BOOL status; 
     CRITICAL_SECTION* cs;
 
     status = InitOnceExecuteOnce(&g_InitOnce, InitHandleFunction, NULL, &cs);
@@ -93,8 +93,23 @@ void csoundUnLock() {
 }
 #endif
 
+#else /* END WIN32 */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#endif /* END WIN32 */
+void csoundLock() {
+}
+
+void csoundUnLock() {
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
 
 
 #endif      /* CSOUND_CSGBLMTX_H */
+

--- a/OOps/midiops.c
+++ b/OOps/midiops.c
@@ -25,6 +25,7 @@
 #include "csoundCore.h"                                 /*      MIDIOPS.C   */
 #include "midiops.h"
 #include <math.h>
+#include <time.h>
 #include "namedins.h"           /* IV - Oct 31 2002 */
 
 #define dv127   (FL(1.0)/FL(127.0))

--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -18,11 +18,13 @@ emcc -s LINKABLE=1 ../src/FileList.c -Iinclude -o FileList.bc
 
 
 # build_libcsound.js.sh
-emcc -O3  --post-js ../src/CsoundObj.js --post-js ../src/FileList.js -s LINKABLE=1 -s VERBOSE=1 -s RESERVED_FUNCTION_POINTERS=1 -s  EXPORTED_FUNCTIONS="['_CsoundObj_new', '_CsoundObj_compileCSD', '_CsoundObj_render', '_CsoundObj_evaluateCode', '_CsoundObj_readScore', '_CsoundObj_getOutputBuffer', '_CsoundObj_getControlChannel', '_CsoundObj_setControlChannel', '_CsoundObj_getInputBuffer', '_CsoundObj_getKsmps', '_CsoundObj_performKsmps' , '_CsoundObj_reset', '_CsoundObj_getInputChannelCount', '_CsoundObj_getOutputChannelCount', '_CsoundObj_getTableLength', '_CsoundObj_getTable','_CsoundObj_getZerodBFS', '_CsoundObj_pushMidiMessage', '_CsoundObj_setMidiCallbacks', '_CsoundObj_setOutputChannelCallback', '_FileList_new', '_FileList_delete', '_FileList_getFileCount', '_FileList_getFileNameString', '_FileList_getFileNameLength']"  CsoundObj.bc FileList.bc libcsound.a ../deps/libsndfile-1.0.25/src/.libs/libsndfile.a -o libcsound.js
+emcc -O3 -s LINKABLE=1 -s RESERVED_FUNCTION_POINTERS=1 -s EXPORTED_FUNCTIONS="['_strlen', '_CsoundObj_new', '_CsoundObj_compileCSD', '_CsoundObj_render', '_CsoundObj_evaluateCode', '_CsoundObj_readScore', '_CsoundObj_getOutputBuffer', '_CsoundObj_getControlChannel', '_CsoundObj_setControlChannel', '_CsoundObj_getInputBuffer', '_CsoundObj_getKsmps', '_CsoundObj_performKsmps' , '_CsoundObj_reset', '_CsoundObj_getInputChannelCount', '_CsoundObj_getOutputChannelCount', '_CsoundObj_getTableLength', '_CsoundObj_getTable','_CsoundObj_getZerodBFS', '_CsoundObj_pushMidiMessage', '_CsoundObj_setMidiCallbacks', '_CsoundObj_setOutputChannelCallback', '_FileList_new', '_FileList_delete', '_FileList_getFileCount', '_FileList_getFileNameString', '_FileList_getFileNameLength']"  CsoundObj.bc FileList.bc libcsound.a ../deps/libsndfile-1.0.25/src/.libs/libsndfile.a -o libcsound.js
 
 
 cd ..
 rm -rf dist
 mkdir dist
 cp build/libcsound.js dist/
+cp src/*.js dist/
 cp build/libcsound.js.mem dist/
+

--- a/emscripten/examples/javascripts/ConsolePanel.js
+++ b/emscripten/examples/javascripts/ConsolePanel.js
@@ -35,7 +35,7 @@ define('ConsolePanel', ["ace/ace"], function(ace) {
 		editor.setShowPrintMargin(false); 
 		editor.renderer.setShowGutter(false);
 		editor.setHighlightActiveLine(false);
-		//editor.$blockScrolling = Infinity;
+		editor.$blockScrolling = Infinity;
 		editor.renderer.$cursorLayer.element.style.opacity = 0;
 
 		var clearConsoleButton = document.getElementById("ClearConsoleButton");

--- a/emscripten/examples/javascripts/main.js
+++ b/emscripten/examples/javascripts/main.js
@@ -25,14 +25,16 @@ require.config({
 
 	},
 	paths: {
-		ace: "ace",
-		"jquery" : "jquery",
+		"ace"       : "ace",
+		"jquery"    : "jquery",
 		"bootstrap" :  "bootstrap.min" ,
-		"libcsound":"libcsound"	
+		"libcsound" : "libcsound",
+        "CsoundObj" : "CsoundObj",
+        "FileList"  : "FileList"
 	}
 });
 
-require(["jquery", "bootstrap", "libcsound", "InputPanel", "ConsolePanel", "FileManager", "FilePanel", "HelpPanel", "EditorPanel"], main);
+require(["jquery", "bootstrap", "libcsound", "CsoundObj", "FileList", "InputPanel", "ConsolePanel", "FileManager", "FilePanel", "HelpPanel", "EditorPanel"], main);
 
 
 function main() {

--- a/emscripten/src/CsoundObj.c
+++ b/emscripten/src/CsoundObj.c
@@ -43,7 +43,6 @@ typedef struct  {
 typedef struct _CsoundObj
 {
 	CSOUND *csound;
-	uint32_t frameCount;
 	uint32_t zerodBFS;
 	MidiCallbackData *midiCallbackData;
 } CsoundObj;
@@ -51,7 +50,7 @@ typedef struct _CsoundObj
 CsoundObj *CsoundObj_new()
 {
 	CsoundObj *self = calloc(1, sizeof(CsoundObj));
-	self->frameCount = 256;
+	//self->frameCount = 256;
 	self->csound = csoundCreate(self);
 	csoundSetHostImplementedAudioIO(self->csound, 1, 0);
 
@@ -64,23 +63,12 @@ void CsoundObj_compileCSD(CsoundObj *self,
 		char *filePath,
 		uint32_t samplerate)
 {
-	char samplerateArgument[20] = {0};
-	char controlrateArgument[20] = {0};
-	char bufferSizeArgument[20] = {0};
-	double controlRate = (double)samplerate/(double)self->frameCount;
-	sprintf((char *)&samplerateArgument, "-r %d", samplerate);
-	sprintf((char *)&controlrateArgument, "-k %f", controlRate);
-	sprintf((char *)&bufferSizeArgument, "-b %d", 256);
-
-	char *argv[5] = {
+	char *argv[2] = {
 		"csound",
-		samplerateArgument,
-		controlrateArgument,
-		bufferSizeArgument,
 		filePath
 	};
 
-	int result = csoundCompile(self->csound, 5, argv);
+	int result = csoundCompile(self->csound, 2, argv);
 
 	if (result != 0) {
 


### PR DESCRIPTION
The webaudio buffer is decoupled for ksmps. Every call to _performKsmps yields ksmps samples. This function is called repeatedly until enough samples are gathered to entirely fill the webaudio buffer. The last csound samples are preserved and used to fill the next first samples of the next webaudio buffer