### PR TITLE
Fix python test case runner for Windows

### DIFF
--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -161,7 +161,10 @@ def runTest():
     tests += udoTests
 
     output = ""
-    tempfile = "/tmp/csound_test_output.txt"
+    if(os.name == 'nt'):
+    	tempfile = "/csound_test_output.txt"
+    else:
+    	tempfile = "/tmp/csound_test_output.txt"
     if(os.sep == '/' and os.name == 'nt'):
         tempfile = 'csound_test_output.txt'
     counter = 1
@@ -177,7 +180,7 @@ def runTest():
         expectedResult = (len(t) == 3) and 1 or 0
 
         if(os.sep == '\\' or os.name == 'nt'):
-            executable = (csoundExecutable == "") and "..\csound.exe" or csoundExecutable
+            executable = (csoundExecutable == "") and "csound.exe" or csoundExecutable
             command = "%s %s %s %s 2> %s"%(executable, parserType, runArgs, filename, tempfile)
             print command
             retVal = os.system(command)


### PR DESCRIPTION
@kunstmusik Could you take a look and see if this is suitable or not? 

This changes worked for me locally and all tests were passing. Would be nice to have appveyor run these tests after each build if possible.