### PR TITLE
Fix format string attributes and usages to allow -Werror=format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,12 +456,6 @@ else()
     add_definitions("-DBETA")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-    add_definitions("-Wno-format")
-endif()
-
-
-
 #if(USE_DOUBLE)
 #    set(BUILD_PLUGINS_DIR ${BUILD_DIR}/plugins64)
 #else()
@@ -598,7 +592,7 @@ set(HEADERS_TO_CHECK
     unistd.h io.h fcntl.h stdint.h
     sys/time.h sys/types.h termios.h
     values.h winsock.h sys/socket.h
-    dirent.h )
+    dirent.h inttypes.h)
 
 foreach(header ${HEADERS_TO_CHECK})
     # Convert to uppercase and replace [./] with _
@@ -607,6 +601,11 @@ foreach(header ${HEADERS_TO_CHECK})
     string(REGEX REPLACE [./] "_" upper_header ${tmp})
     check_include_file(${header} HAVE_${upper_header})
 endforeach()
+
+if (NOT HAVE_INTTYPES_H)
+    message(FATAL_ERROR "Csound requires inttypes.h")
+endif()
+
 
 check_deps(USE_LRINT HAVE_LRINT)
 if(USE_LRINT)

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -29,6 +29,7 @@
 #include <math.h>
 #include <ctype.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "oload.h"
 #include "insert.h"
@@ -853,11 +854,11 @@ INSTRTXT *create_instrument(CSOUND *csound, TREE *root,
       int32 instrNum = (int32)root->left->value->value; /* Not used! */
 
       c = csound->Malloc(csound, 10); /* arbritrarily chosen number of digits */
-      snprintf(c, 10, "%ld", (long)instrNum);
+      snprintf(c, 10, "%"PRIi32, instrNum);
 
       if (PARSER_DEBUG)
         csound->Message(csound,
-                        Str("create_instrument: instr num %d\n"), instrNum);
+                        Str("create_instrument: instr num %"PRIi32"\n"), instrNum);
 
       ip->t.inlist->arg[0] = strsav_string(csound, engineState, c);
 
@@ -1055,7 +1056,7 @@ int named_instr_alloc(CSOUND *csound, char *s, INSTRTXT *ip,
       /* redefinition does not raise an error now, just a warning */
        if (UNLIKELY(csound->oparms->odebug))
          csound->Warning(csound,
-                         Str("instr %d redefined, replacing previous definition"),
+                         Str("instr %"PRIi32" redefined, replacing previous definition"),
                          inm->instno);
       /* here we should move the old instrument definition into a deadpool
          which will be checked for active instances and freed when there are no
@@ -1211,7 +1212,7 @@ void insert_instrtxt(CSOUND *csound, INSTRTXT *instrtxt,
       if (!merge) synterr(csound, Str("instr %d redefined\n"), instrNum);
       if (UNLIKELY(instrNum && csound->oparms->odebug))
         csound->Warning(csound,
-                        Str("instr %d redefined, replacing previous definition"),
+                        Str("instr %"PRIi32" redefined, replacing previous definition"),
                         instrNum);
       /* inherit active & maxalloc flags */
         instrtxt->active = engineState->instrtxtp[instrNum]->active;

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -28,6 +28,7 @@
 #include "csound_orc_expressions.h"
 #include "csound_type_system.h"
 #include "csound_orc_semantics.h"
+#include <inttypes.h>
 
 extern char argtyp2(char *);
 extern void print_tree(CSOUND *, char *, TREE *);
@@ -828,7 +829,7 @@ static TREE *create_synthetic_ident(CSOUND *csound, int32 count)
     char *label = (char *)csound->Calloc(csound, 20);
     ORCTOKEN *token;
 
-    snprintf(label,20, "__synthetic_%ld", (long)count);
+    snprintf(label, 20, "__synthetic_%"PRIi32, count);
     if (UNLIKELY(PARSER_DEBUG))
       csound->Message(csound, "Creating Synthetic T_IDENT: %s\n", label);
     token = make_token(csound, label);
@@ -841,7 +842,7 @@ static TREE *create_synthetic_label(CSOUND *csound, int32 count)
 {
     char *label = (char *)csound->Calloc(csound, 20);
     ORCTOKEN *token;
-    snprintf(label, 20, "__synthetic_%ld:", (long)count);
+    snprintf(label, 20, "__synthetic_%"PRIi32, count);
     if (UNLIKELY(PARSER_DEBUG))
       csound->Message(csound, "Creating Synthetic label: %s\n", label);
     token = make_label(csound, label);

--- a/Engine/csound_pre.lex
+++ b/Engine/csound_pre.lex
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include "csoundCore.h"
 #include "corfile.h"
+#include <inttypes.h>
 #define YY_DECL int yylex (CSOUND *csound, yyscan_t yyscanner)
 static void comment(yyscan_t);
 static void do_comment(yyscan_t);
@@ -739,7 +740,7 @@ void do_include(CSOUND *csound, int term, yyscan_t yyscanner)
       uint8_t n = file_to_int(csound, buffer);
       char bb[128];
       PARM->lstack[PARM->depth] = n;
-      sprintf(bb, "#source %llu\n", PARM->locn = make_location(PARM));
+      sprintf(bb, "#source %"PRIu64"\n", PARM->locn = make_location(PARM));
       PARM->llocn = PARM->locn;
       corfile_puts(csound, bb, csound->expanded_orc);
     }
@@ -1212,7 +1213,7 @@ void cs_init_omacros(CSOUND *csound, PRE_PARM *qq, NAMES *nn)
       if (p == NULL)
         p = s + strlen(s);
       if (csound->oparms->msglevel & 7)
-        csound->Message(csound, Str("Macro definition for %*s\n"), (int) (p - s), s);
+        csound->Message(csound, Str("Macro definition for %*s\n"), (int)(p - s), s);
       s = strchr(s, ':') + 1;                   /* skip arg bit */
       if (UNLIKELY(s == NULL || s >= p)) {
         csound->Die(csound, Str("Invalid macro name for --omacro"));
@@ -1270,7 +1271,7 @@ void csound_pre_line(CSOUND *csound, CORFIL* cf, void *yyscanner)
       uint64_t llocn = PARM->llocn;
       if (UNLIKELY(locn != llocn)) {
         char bb[80];
-        sprintf(bb, "#source %llu\n", locn);
+        sprintf(bb, "#source %"PRIu64"\n", locn);
         corfile_puts(csound, bb, cf);
       }
       PARM->llocn = locn;

--- a/Engine/csound_prs.lex
+++ b/Engine/csound_prs.lex
@@ -1334,7 +1334,7 @@ void cs_init_smacros(CSOUND *csound, PRS_PARM *qq, NAMES *nn)
       if (p == NULL)
         p = s + strlen(s);
       if (UNLIKELY(csound->oparms->msglevel & 7))
-        csound->Message(csound, Str("Macro definition for %*s\n"), (int) (p - s), s);
+        csound->Message(csound, Str("Macro definition for %*s\n"), (int)(p - s), s);
       s = strchr(s, ':') + 1;                   /* skip arg bit */
       if (UNLIKELY(s == NULL || s >= p)) {
         csound->Die(csound, Str("Invalid macro name for --smacro"));

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -33,6 +33,7 @@
 #include "interlocks.h"
 #include "csound_type_system.h"
 #include "csound_standard_types.h"
+#include <inttypes.h>
 
 static  void    showallocs(CSOUND *);
 static  void    deact(CSOUND *, INSDS *);
@@ -302,10 +303,10 @@ int insert_event(CSOUND *csound, int insno, EVTBLK *newevtp)
   if (UNLIKELY(O->odebug)) {
     char *name = csound->engineState.instrtxtp[insno]->insname;
     if (UNLIKELY(name))
-      csound->Message(csound, Str("activating instr %s at %lld\n"),
+        csound->Message(csound, Str("activating instr %s at %"PRIi64"\n"),
                       name, csound->icurTime);
     else
-      csound->Message(csound, Str("activating instr %d at %lld\n"),
+        csound->Message(csound, Str("activating instr %d at %"PRIi64"\n"),
                       insno, csound->icurTime);
   }
   csound->inerrcnt = 0;

--- a/Engine/memalloc.c
+++ b/Engine/memalloc.c
@@ -55,7 +55,7 @@ typedef struct memAllocBlock_s {
 
 static void memdie(CSOUND *csound, size_t nbytes)
 {
-    csound->ErrorMsg(csound, Str("memory allocate failure for %zu"),
+    csound->ErrorMsg(csound, Str("memory allocate failure for %zd"),
                              nbytes);
     csound->LongJmp(csound, CSOUND_MEMORY);
 }

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -31,6 +31,7 @@
 #include "namedins.h"
 #include <sndfile.h>
 #include <string.h>
+#include <inttypes.h>
 
 static int Load_Het_File_(CSOUND *csound, const char *filnam,
                           char **allocp, int32 *len)
@@ -554,8 +555,8 @@ int PVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE *p)
 
     /* link into PVOC-EX memfile chain */
     csound->pvx_memfiles = pp;
-    csound->Message(csound, Str("file %s (%d bytes) loaded into memory\n"),
-                            fname, (int32) mem_wanted);
+    csound->Message(csound, Str("file %s (%"PRIi32" bytes) loaded into memory\n"),
+                            fname, mem_wanted);
 
     memcpy(p, pp, sizeof(PVOCEX_MEMFILE));
     return 0;
@@ -675,10 +676,10 @@ SNDMEMFILE *csoundLoadSoundFile(CSOUND *csound, const char *fileName, void *sfi)
     }
     p->data[p->nFrames] = 0.0f;
     csound->FileClose(csound, fd);
-    csound->Message(csound, Str("File '%s' (sr = %d Hz, %d channel(s), %lld "
+    csound->Message(csound, Str("File '%s' (sr = %d Hz, %d channel(s), %ld"
                                 "sample frames) loaded into memory\n"),
-                            p->fullName, (int) sfinfo->samplerate,
-                            (int) sfinfo->channels,
+                            p->fullName, sfinfo->samplerate,
+                            sfinfo->channels,
                             sfinfo->frames);
 
     /* link into database */

--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -24,6 +24,7 @@
 #include "csoundCore.h"                             /*   SREAD.C     */
 #include <math.h>      /* for fabs() */
 #include <ctype.h>
+#include <inttypes.h>
 #include "namedins.h"           /* IV - Oct 31 2002 */
 #include "corfile.h"
 #include "Engine/score_param.h"
@@ -1164,7 +1165,7 @@ int sread(CSOUND *csound)       /*  called from main,  reads from SCOREIN   */
           STA(names)[j].line = STA(str)->line;
           //printf("line-%d\n",STA(names)[j].line);
           if (csound->oparms->msglevel & TIMEMSG)
-            csound->Message(csound,Str("%d: %s position %d\n"),
+            csound->Message(csound,Str("%d: %s position %"PRIi32"\n"),
                             j, STA(names)[j].name,
                             STA(names)[j].posit);
           STA(op) = getop(csound);

--- a/InOut/FL_graph.cpp
+++ b/InOut/FL_graph.cpp
@@ -34,6 +34,7 @@
 #include "csdl.h"
 #include "cwindow.h"
 #include "winFLTK.h"
+#include <inttypes.h>
 
 #define NUMOFWINDOWS (30)
 #define XINIT    10      /* set default window location */
@@ -125,14 +126,14 @@ void graph_box::draw()
       if (!win)
         return;
       MYFLT       *fdata = win->fdata;
-      long        npts   = win->npts;
+      int32       npts   = win->npts;
       char        *msg   = win->caption;
       short       win_x, win_y,        win_h;     /* window rect */
       short       gra_x, gra_y, gra_w, gra_h;     /* graph rect is inset */
       short       y_axis;
       int         lsegs, pts_pls;
       int         pol;
-      char        string[80];
+      char        string[400];
 
       pol  = win->polarity;
 
@@ -204,9 +205,9 @@ void graph_box::draw()
         fl_line(win_x+w()/2, win_y, win_x+w()/2, win_y+win_h);
       }
       if (pol != NEGPOL)
-        sprintf(string, "%s  %ld points, max %5.3f", msg, npts, win->oabsmax);
+      sprintf(string, "%s  %" PRIi32 " points, max %5.3f", msg, npts, win->oabsmax);
       else
-        sprintf(string, "%s  %ld points, max %5.3f", msg, npts, win->max);
+      sprintf(string, "%s  %" PRIi32 " points, max %5.3f", msg, npts, win->max);
 
       ST(form)->label(string);
     }

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -25,6 +25,7 @@
 #include "soundio.h"
 #include <stdlib.h>
 #include <time.h>
+#include <inttypes.h>
 
 #ifdef HAVE_SYS_TYPES_H
 # include <sys/types.h>
@@ -942,12 +943,12 @@ void sfcloseout(CSOUND *csound)
  report:
     if (STA(pipdevout) == 2) {
       csound->Message(csound,
-                      Str("%d %d sample blks of %lu-bit floats written to %s\n"),
+                      Str("%"PRIi32" %d sample blks of %lu-bit floats written to %s\n"),
                       csound->nrecs, O->outbufsamps,
                       sizeof(MYFLT)*8, STA(sfoutname));
     }
     else {
-      csound->Message(csound, Str("%d %d sample blks of %s written to %s"),
+      csound->Message(csound, Str("%"PRIi32" %d sample blks of %s written to %s"),
                       O->outbufsamps, O->outbufsamps * O->sfsampsize,
                       getstrformat(O->outformat), STA(sfoutname));
       if (O->sfheader == 0)

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -25,6 +25,7 @@
 #include "soundio.h"
 #include "diskin2.h"
 #include <math.h>
+#include <inttypes.h>
 
 typedef struct DISKIN_INST_ {
   CSOUND *csound;
@@ -467,7 +468,7 @@ static int diskin2_init_(CSOUND *csound, DISKIN2 *p, int stringname)
       if (UNLIKELY((csound->oparms_.msglevel & 7) == 7)) {
         csound->Message(csound, Str("diskin2: opened (asynchronously) '%s':\n"
                                     "         %d Hz, %d channel(s), "
-                                    "%lld sample frames\n"),
+                                    "%ld sample frames\n"),
                         csound->GetFileName(fd),
                         sfinfo.samplerate, sfinfo.channels,
                         sfinfo.frames);
@@ -481,7 +482,7 @@ static int diskin2_init_(CSOUND *csound, DISKIN2 *p, int stringname)
       if (UNLIKELY((csound->oparms_.msglevel & 7) == 7)) {
         csound->Message(csound, Str("diskin2: opened '%s':\n"
                                     "         %d Hz, %d channel(s), "
-                                    "%lld sample frames\n"),
+                                    "%ld sample frames\n"),
                         csound->GetFileName(fd),
                         sfinfo.samplerate, sfinfo.channels,
                         sfinfo.frames);
@@ -1741,7 +1742,7 @@ static int diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p, int stringname)
       if (UNLIKELY((csound->oparms_.msglevel & 7) == 7)) {
         csound->Message(csound, Str("diskin2: opened (asynchronously) '%s':\n"
                                     "         %d Hz, %d channel(s), "
-                                    "%lld sample frames\n"),
+                                    "%ld sample frames\n"),
                         csound->GetFileName(fd),
                         sfinfo.samplerate, sfinfo.channels,
                         sfinfo.frames);
@@ -1755,7 +1756,7 @@ static int diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p, int stringname)
       if (UNLIKELY((csound->oparms_.msglevel & 7) == 7)) {
         csound->Message(csound, Str("diskin2: opened '%s':\n"
                                     "         %d Hz, %d channel(s), "
-                                    "%lld sample frames\n"),
+                                    "%ld sample frames\n"),
                         csound->GetFileName(fd),
                         sfinfo.samplerate, sfinfo.channels,
                         sfinfo.frames);

--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -24,6 +24,7 @@
 #include "csoundCore.h"         /*                      UGENS4.C        */
 #include "ugens4.h"
 #include <math.h>
+#include <inttypes.h>
 
 /* The branch prediction slows it down!! */
 
@@ -469,7 +470,7 @@ int rndset(CSOUND *csound, RAND *p)
       if (*p->iseed > FL(1.0)) {    /* As manual suggest seed in range [0,1] */
         uint32 seed;         /* I reinterpret >1 as a time seed */
         seed = csound->GetRandomSeedFromTime();
-        csound->Warning(csound, Str("Seeding from current time %u\n"), seed);
+        csound->Warning(csound, Str("Seeding from current time %"PRIu32"\n"), seed);
         if (!p->new) {
           p->rand = (int32) (seed & 0xFFFFUL);
         }
@@ -580,7 +581,7 @@ int rhset(CSOUND *csound, RANDH *p)
       if (*p->iseed > FL(1.0)) {    /* As manual suggest sseed in range [0,1] */
         uint32 seed;         /* I reinterpret >1 as a time seed */
         seed = csound->GetRandomSeedFromTime();
-        csound->Warning(csound, Str("Seeding from current time %u\n"), seed);
+        csound->Warning(csound, Str("Seeding from current time %"PRIu32"\n"), seed);
         if (!p->new) {
           p->rand = (int32) (seed & 0xFFFFUL);
           p->num1 = (MYFLT) ((int16) p->rand) * DV32768;
@@ -686,7 +687,7 @@ int riset(CSOUND *csound, RANDI *p)
       if (*p->iseed > FL(1.0)) { /* As manual suggest sseed in range [0,1] */
         uint32 seed;             /* I reinterpret >1 as a time seed */
         seed = csound->GetRandomSeedFromTime();
-        csound->Warning(csound, Str("Seeding from current time %u\n"), seed);
+        csound->Warning(csound, Str("Seeding from current time %"PRIu32"\n"), seed);
         if (!p->new) {
           int16 rand = (int16)seed;
 /*           int16 ss = rand; */

--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -24,6 +24,7 @@
 #include "csoundCore.h"         /*                      UGENS5.C        */
 #include "ugens5.h"
 #include <math.h>
+#include <inttypes.h>
 
 /*
  * LPC storage slots
@@ -680,7 +681,7 @@ int lprdset_(CSOUND *csound, LPREAD *p, int stringname)
     p->lastfram16 = (((totvals - p->nvals) / p->nvals) << 16) - 1;
     if (UNLIKELY(csound->oparms->odebug))
       csound->Message(csound, Str(
-                 "npoles %d, nvals %d, totvals %d, lastfram16 = %x\n"),
+                 "npoles %"PRIi32", nvals %"PRIi32", totvals %"PRIi32", lastfram16 = %"PRIi32"x\n"),
              p->npoles, p->nvals, totvals, p->lastfram16);
  lpend:
     p->lastmsg = 0;

--- a/Opcodes/fareyseq.c
+++ b/Opcodes/fareyseq.c
@@ -250,12 +250,12 @@ int tablefilter (CSOUND *csound, TABFILT *p)
     if (UNLIKELY((*p->dft < 1) || (*p->sft < 1))) {
       return csound->PerfError(csound, p->h.insdshead,
                                Str("Farey: Table no. < 1 dft=%.2f  sft=%.2f"),
-                               *p->dft, *p->sft);
+                               (float)*p->dft, (float)*p->sft);
     }
     if (UNLIKELY((*p->ftype < 1))) {
       return csound->PerfError(csound, p->h.insdshead,
                                Str("Farey: Filter type < 1 ftype=%.2f"),
-                               *p->ftype);
+                               (float)*p->ftype);
     }
 
 
@@ -304,8 +304,7 @@ int tableifilter (CSOUND *csound, TABFILT *p)
     }
     if (UNLIKELY((*p->ftype < 1))) {
       return csound->PerfError(csound, p->h.insdshead,
-                               Str("Farey: Filter type < 1 ftype=%.2f"),
-                               *p->ftype);
+                               Str("Farey: Filter type < 1"));
     }
 
     /* Check each table number in turn.  */

--- a/Opcodes/gab/vectorial.c
+++ b/Opcodes/gab/vectorial.c
@@ -25,6 +25,7 @@
 #include "interlocks.h"
 #include "vectorial.h"
 #include <math.h>
+#include <inttypes.h>
 
 static int mtable_i(CSOUND *csound,MTABLEI *p)
 {
@@ -1904,7 +1905,7 @@ static int vrandh_set(CSOUND *csound,VRANDH *p)
           p->rand = (int32) (seed % 0x7FFFFFFEUL) + 1L;
         }
         csound->Message(csound,
-                        Str("vrandh: Seeding from current time %u\n"),
+                        Str("vrandh: Seeding from current time %" PRIu32 "\n"),
                         seed);
       }
       else {
@@ -2004,7 +2005,7 @@ static int vrandi_set(CSOUND *csound,VRANDI *p)
           p->rand = (int32) (seed % 0x7FFFFFFEUL) + 1L;
         }
         csound->Message(csound,
-                        Str("vrandi: Seeding from current time %u\n"), seed);
+                        Str("vrandi: Seeding from current time %" PRIu32 "\n"), seed);
       }
       else {
         if (*p->isize == 0)

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -31,6 +31,7 @@
 #include "spectra.h"
 #include "pitch.h"
 #include "uggab.h"
+#include <inttypes.h>
 
 #define STARTING  1
 #define PLAYING   2
@@ -1420,7 +1421,7 @@ int GardnerPink_init(CSOUND *csound, PINKISH *p)
       /* Warn if user tried but failed to give sensible number */
       if (UNLIKELY(*p->iparam1 != FL(0.0)))
         csound->Warning(csound, Str("pinkish: Gardner method requires 4-%d bands. "
-                                    "Default %d substituted for %d.\n"),
+                                    "Default %"PRIi32" substituted for %d.\n"),
                         GRD_MAX_RANDOM_ROWS, p->grd_NumRows,
                         (int) *p->iparam1);
     }

--- a/Opcodes/spectra.c
+++ b/Opcodes/spectra.c
@@ -29,6 +29,7 @@
 #include "spectra.h"
 #include "pitch.h"
 #include "uggab.h"
+#include <inttypes.h>
 
 #define LOGTWO  (0.69314718056)
 
@@ -187,7 +188,7 @@ int spectset(CSOUND *csound, SPECTRUM *p)
         octp->endp = fltp;  minr *= 2;
       }
       csound->Warning(csound, Str("\t%d oct analysis window "
-                                  "delay = %d samples (%d msecs)\n"),
+                                  "delay = %"PRIi32" samples (%d msecs)\n"),
                               nocts, bufsiz, (int)(bufsiz*1000/dwnp->srate));
       if (p->disprd) {                      /* if display requested, */
         totsize = totsamps * sizeof(MYFLT); /*  alloc an equiv local */

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -26,6 +26,7 @@
 #include "convolve.h"
 #include "ugens9.h"
 #include "soundio.h"
+#include <inttypes.h>
 
 static int cvset_(CSOUND *csound, CONVOLVE *p, int stringname)
 {
@@ -60,7 +61,7 @@ static int cvset_(CSOUND *csound, CONVOLVE *p, int stringname)
     cvh = (CVSTRUCT *)mfp->beginp;
     if (UNLIKELY(cvh->magic != CVMAGIC)) {
       return csound->InitError(csound,
-                               Str("%s not a CONVOLVE file (magic %d)"),
+                               Str("%s not a CONVOLVE file (magic %"PRIi32")"),
                                cvfilnam, cvh->magic);
     }
 
@@ -107,7 +108,7 @@ static int cvset_(CSOUND *csound, CONVOLVE *p, int stringname)
     if (UNLIKELY(cvh->dataFormat != CVMYFLT)) {
       return csound->InitError(csound,
                                Str("unsupported CONVOLVE data "
-                                   "format %d in %s"),
+                                   "format %"PRIi32" in %s"),
                                cvh->dataFormat, cvfilnam);
     }
 

--- a/include/text.h
+++ b/include/text.h
@@ -113,7 +113,7 @@ extern "C" {
 #endif
   void init_getstring(void*);
   PUBLIC char *csoundLocalizeString(const char *s)
-     __attribute__ ((format (printf, 1,0)));
+     __attribute__ ((format_arg (1)));
   PUBLIC char* cs_strtok_r(char* str, char* sep, char** lasts);
   PUBLIC double cs_strtod(char* nptr, char** endptr);
   PUBLIC int cs_sprintf(char *str, const char *format, ...);


### PR DESCRIPTION

Disabling format errors is bad, as introducing such errors is easy. Lets allow using `-Wformat` and `-Werror=format`.


Maybe even enable `-Wformat` by default?