### PR TITLE
Allow aftertouch to be init to 0

### DIFF
--- a/InOut/midirecv.c
+++ b/InOut/midirecv.c
@@ -174,8 +174,10 @@ static void sustsoff(CSOUND *csound, MCHNBLK *chn)
 
 void midi_ctl_reset(CSOUND *csound, int16 chan)
 {
+    OPARMS  *O = csound->oparms;
     MCHNBLK *chn;
     int     i;
+    int     aftouchInit
 
     chn = csound->m_chnbp[chan];
     for (i = 1; i <= 135; i++)                  /* from ctlr 1 to ctlr 128 */
@@ -192,9 +194,13 @@ void midi_ctl_reset(CSOUND *csound, int16 chan)
     chn->pbensens = FL(2.0);                    /*   pitch bend range */
     chn->datenabl = 0;
     /* reset aftertouch to max value - added by Istvan Varga, May 2002 */
-    chn->aftouch = FL(127.0);
+    if (O->aft_zero)
+      aftouchInit = 0;
+    else
+      aftouchInit = 127;
+    chn->aftouch = FL(aftouchInit);
     for (i = 0; i < 128; i++)
-      chn->polyaft[i] = FL(127.0);
+      chn->polyaft[i] = FL(aftouchInit);
     /* controller 64 has just been set to zero: terminate any held notes */
     if (chn->ksuscnt && !MGLOB(rawControllerMode))
       sustsoff(csound, chn);

--- a/InOut/midirecv.c
+++ b/InOut/midirecv.c
@@ -177,7 +177,7 @@ void midi_ctl_reset(CSOUND *csound, int16 chan)
     OPARMS  *O = csound->oparms;
     MCHNBLK *chn;
     int     i;
-    int     aftouchInit
+    int     aftouchInit;
 
     chn = csound->m_chnbp[chan];
     for (i = 1; i <= 135; i++)                  /* from ctlr 1 to ctlr 128 */

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -1179,6 +1179,10 @@ static int decode_long(CSOUND *csound, char *s, int argc, char **argv)
       csound->info_message_request = 1;
       return 1;
     }
+    else if (!(strcmp(s, "aft-zero"))){
+      O->aft_zero = 1;
+      return 1;
+    }
 
     csoundErrorMsg(csound, Str("unknown long option: '--%s'"), s);
     return 0;

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -258,6 +258,7 @@ typedef struct CORFIL {
     int     ksmps_override;
     int     fft_lib;
     int     echo;
+    int     aft_zero;
   } OPARMS;
 
   typedef struct arglst {


### PR DESCRIPTION
Addition of `--aft-zero` flag to Csound to allow aftertouch to be init to 0. Without `--aft-zero` flag set the value of aftertouch is default to 127 (current behaviour).