### PR TITLE
Fix to cmake Xcode Generator for recent xcode projects. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,8 +409,8 @@ message(STATUS "Building for OSX")
   endif()
 
   if(CMAKE_OSX_SYSROOT AND NOT CMAKE_OSX_SYSROOT MATCHES ".*OSX10.6.*")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)
-    message(STATUS "OSX: Setting Deployment Target to 10.7")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+    message(STATUS "OSX: Setting Deployment Target to 10.9")
   endif()
 
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_VECLIB")


### PR DESCRIPTION
Currently, builds for multiple targets in the generated XCode project fail because of misconfiguration in the generated targets. The generated targets all have libstdc++ as the default c++ lib for llvm, and we want libc++. 

One workaround - and I'd assume this won't introduce any issues - is to up the the target version as suggested by XCode's warnings. I upped target version to 10.9 for generated Xcode project. Targeting a lower version causes llvm to default to using libstdc++ instead of libc++, and not have C++11 features on by default, which breaks some subprojects using inline namespaces - nicely outlined here:

https://stackoverflow.com/questions/12542971/using-libstdc-compiled-libraries-with-clang-stdlib-libc