### PR TITLE
Swift 4 update, added Accelerate to linked frameworks in examples projects

### DIFF
--- a/iOS/Csound iOS Obj-C Examples/Csound iOS Examples.xcodeproj/project.pbxproj
+++ b/iOS/Csound iOS Obj-C Examples/Csound iOS Examples.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2499965020A60882002B6ED8 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2499964F20A6087C002B6ED8 /* Accelerate.framework */; };
 		249B1A441E2FBB1F004F6566 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 249B1A431E2FBB1F004F6566 /* Assets.xcassets */; };
 		249B1A4A1E2FD95E004F6566 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 249B1A491E2FD95E004F6566 /* LaunchScreen.storyboard */; };
 		24D727291E33F9F400CEC022 /* csdStorage in Resources */ = {isa = PBXBuildFile; fileRef = 24D727281E33F9F400CEC022 /* csdStorage */; };
@@ -92,6 +93,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2499964F20A6087C002B6ED8 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		249B1A431E2FBB1F004F6566 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		249B1A491E2FD95E004F6566 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		24D727281E33F9F400CEC022 /* csdStorage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = csdStorage; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2499965020A60882002B6ED8 /* Accelerate.framework in Frameworks */,
 				F604B21618288A9E00C7C552 /* libcsound.a in Frameworks */,
 				F6B647D014D353D2005F786B /* libsndfile.a in Frameworks */,
 			);
@@ -250,6 +253,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2499964E20A6087C002B6ED8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2499964F20A6087C002B6ED8 /* Accelerate.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		C41F0A941973612A00997479 /* ConsoleOutput */ = {
 			isa = PBXGroup;
 			children = (
@@ -335,6 +346,7 @@
 				F6B6477C14D353D2005F786B /* csound-iOS */,
 				F6B6466314D348E5005F786B /* Csound iOS Examples */,
 				F6B6465A14D348E5005F786B /* Products */,
+				2499964E20A6087C002B6ED8 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -652,7 +664,7 @@
 		F6B6465014D348E4005F786B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0910;
 				TargetAttributes = {
 					F6B6465814D348E5005F786B = {
 						DevelopmentTeam = AH2WVU4222;
@@ -818,12 +830,18 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -864,12 +882,18 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples.xcodeproj/project.pbxproj
+++ b/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		244DC51F1EDF741600216C1B /* CsoundVirtualKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244DC51E1EDF741600216C1B /* CsoundVirtualKeyboard.swift */; };
 		244DC5211EDF743800216C1B /* Waveview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244DC5201EDF743800216C1B /* Waveview.swift */; };
 		244DC5231EDF746100216C1B /* LevelMeterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 244DC5221EDF746100216C1B /* LevelMeterView.swift */; };
+		2499964D20A60800002B6ED8 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2499964C20A607FC002B6ED8 /* Accelerate.framework */; };
 		24BF2D561EDD13870091F04E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BF2D551EDD13870091F04E /* AppDelegate.swift */; };
 		24BF2D581EDD13870091F04E /* MasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BF2D571EDD13870091F04E /* MasterViewController.swift */; };
 		24BF2D5D1EDD13870091F04E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24BF2D5B1EDD13870091F04E /* Main.storyboard */; };
@@ -125,6 +126,7 @@
 		244DC51E1EDF741600216C1B /* CsoundVirtualKeyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CsoundVirtualKeyboard.swift; sourceTree = "<group>"; };
 		244DC5201EDF743800216C1B /* Waveview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Waveview.swift; sourceTree = "<group>"; };
 		244DC5221EDF746100216C1B /* LevelMeterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LevelMeterView.swift; sourceTree = "<group>"; };
+		2499964C20A607FC002B6ED8 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		24BF2D521EDD13870091F04E /* Csound iOS SwiftExamples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Csound iOS SwiftExamples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		24BF2D551EDD13870091F04E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		24BF2D571EDD13870091F04E /* MasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterViewController.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2499964D20A60800002B6ED8 /* Accelerate.framework in Frameworks */,
 				24BF2DE11EDD15190091F04E /* libcsound.a in Frameworks */,
 				24BF2DE21EDD15190091F04E /* libsndfile.a in Frameworks */,
 			);
@@ -224,11 +227,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2499964B20A607FC002B6ED8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2499964C20A607FC002B6ED8 /* Accelerate.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		24BF2D491EDD13870091F04E = {
 			isa = PBXGroup;
 			children = (
 				24BF2D541EDD13870091F04E /* Csound iOS SwiftExamples */,
 				24BF2D531EDD13870091F04E /* Products */,
+				2499964B20A607FC002B6ED8 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -587,13 +599,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 0910;
 				ORGANIZATIONNAME = "Nikhil Singh";
 				TargetAttributes = {
 					24BF2D511EDD13870091F04E = {
 						CreatedOnToolsVersion = 8.3.2;
 						DevelopmentTeam = AH2WVU4222;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -733,7 +745,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -741,7 +755,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -785,7 +803,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -793,7 +813,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -836,7 +860,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.csound.Csound-iOS-SwiftExamples";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -857,7 +882,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.csound.Csound-iOS-SwiftExamples";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/ConsoleOutputViewController.swift
+++ b/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/ConsoleOutputViewController.swift
@@ -40,7 +40,7 @@ class ConsoleOutputViewController: BaseCsoundViewController {
     private var csdListVC: UIViewController?
     
     // This method is called by CsoundObj() to output console messages
-    func messageCallback(_ infoObj: NSValue) {
+    @objc func messageCallback(_ infoObj: NSValue) {
         var info = Message()    // Create instance of Message (a C Struct)
         infoObj.getValue(&info) // Store the infoObj value in Message
         let message = UnsafeMutablePointer<Int8>.allocate(capacity: 1024) // Create an empty C-String

--- a/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/ControlKnob.swift
+++ b/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/ControlKnob.swift
@@ -124,7 +124,7 @@ extension ControlKnob: CsoundBinding {
         addTarget(self, action: #selector(updateChannelValue(_:)), for: .valueChanged)
     }
     
-    func updateChannelValue(_ sender: ControlKnob) {
+    @objc func updateChannelValue(_ sender: ControlKnob) {
         channelValue = sender._value
     }
     


### PR DESCRIPTION
Minor update to Swift 4 and Xcode's newest recommended settings, and adding Accelerate to the linked frameworks in the example projects so that users don't have to.