### PR TITLE
AudioWorklet output channel fix + MIDI support

### DIFF
--- a/Emscripten/src/CsoundNode.js
+++ b/Emscripten/src/CsoundNode.js
@@ -52,9 +52,6 @@ class CsoundNode extends AudioWorkletNode {
      */
     constructor(context, options) {
         options = options || {};
-        options.numberOfInputs  = 1;
-        options.numberOfOutputs = 2;
-        options.channelCount = 2;
         
         super(context, 'Csound', options);
 
@@ -309,7 +306,8 @@ class CsoundNodeFactory {
     static createNode(inputChannelCount=1, outputChannelCount=2) {
         var options = {};
         options.numberOfInputs  = inputChannelCount;
-        options.numberOfOutputs  = outputChannelCount;
+        options.numberOfOutputs = 1;
+        options.outputChannelCount = [ outputChannelCount ];
         return new CsoundNode(CSOUND_AUDIO_CONTEXT, options);
     }
 }

--- a/Emscripten/src/CsoundObj.js
+++ b/Emscripten/src/CsoundObj.js
@@ -307,6 +307,43 @@ class CsoundObj {
         }
     }
 
+    enableMidiInput(midiInputCallback) {
+        const that = this;
+        const handleMidiInput = function(event) {
+            that.midiMessage(event.data[0], event.data[1], event.data[2]);
+            //console.log("midievent: " + event.data[0] + ", " + event.data[1] + ", " + event.data[2]);
+        };
+        const midiSuccess = function(midiInterface) {
+
+            const inputs = midiInterface.inputs.values();
+
+            for (let input = inputs.next(); input && !input.done; input = inputs.next()) {
+                input = input.value;
+                input.onmidimessage = handleMidiInput;
+            }
+            if (midiInputCallback) {
+                midiInputCallback(true);
+            }
+        };
+
+        const midiFail = function(error) {
+
+            Module['print']("MIDI failed to start, error:" + error);
+            if (midiInputCallback) {
+                midiInputCallback(false);
+            }
+        };
+
+
+        if (navigator.requestMIDIAccess) {
+            navigator.requestMIDIAccess().then(midiSuccess, midiFail);
+        } else {
+            Module['print']("MIDI not supported in this browser");
+            if (midiInputCallback) {
+                midiInputCallback(false);
+            }
+        }
+    }
     
     /** 
      * This static method is used to asynchronously setup the Csound

--- a/Emscripten/src/CsoundProcessor.js
+++ b/Emscripten/src/CsoundProcessor.js
@@ -104,7 +104,7 @@ class CsoundProcessor extends AudioWorkletProcessor {
         Csound.setOption(csObj, "-+rtmidi=null");
         Csound.setOption(csObj, "--sample-rate="+sampleRate);  
         Csound.prepareRT(csObj);
-        this.nchnls = options.numberOfOutputs;
+        this.nchnls = options.outputChannelCount[0];
         this.nchnls_i = options.numberOfInputs;
         Csound.setOption(csObj, "--nchnls=" + this.nchnls);
         Csound.setOption(csObj, "--nchnls_i=" + this.nchnls_i); 

--- a/Emscripten/src/csound.js
+++ b/Emscripten/src/csound.js
@@ -57,8 +57,7 @@ Csound = function() {
                 CsoundObj.importScripts(path).then(() => {
                     console.log("loaded WASM runtime");
                     csound.Csound = new CsoundObj();
-                    // csound.Csound.setOption("-M0");
-                    // csound.Csound.setMidiCallbacks();
+                    csound.Csound.enableMidiInput(undefined);
                     csound.module = true;
                     if (typeof window.handleMessage !== 'undefined') { 
                         console.log = console.warn = function(mess) {


### PR DESCRIPTION
In AudioWorkletNode each input and output can have multiple channels. The number of channels in an output is specified in options.outputChannelCount per output. In Csound we only have one output, which can contain multiple channels. Now my stereo tobias.csd works. 

Midi support fix