### PR TITLE
Module['print'] no longer available

### DIFF
--- a/Emscripten/src/CsoundObj.js
+++ b/Emscripten/src/CsoundObj.js
@@ -287,6 +287,7 @@ class CsoundObj {
         let that = this;
 
         if (navigator.getUserMedia === null) {
+            console.log("Audio Input not supported in this browser");
             audioInputCallback(false);
         } else {
             let onSuccess = function(stream) {
@@ -296,6 +297,7 @@ class CsoundObj {
 
             let onFailure = function(error) {
                 that.microphoneNode = null;
+                console.log("Could not initialise audio input, error:" + error);
                 audioInputCallback(false);
             };
             navigator.getUserMedia({
@@ -323,6 +325,7 @@ class CsoundObj {
         };
 
         const midiFail = function(error) {
+            console.log("MIDI failed to start, error:" + error);
             if (midiInputCallback) {
                 midiInputCallback(false);
             }
@@ -332,6 +335,7 @@ class CsoundObj {
         if (navigator.requestMIDIAccess) {
             navigator.requestMIDIAccess().then(midiSuccess, midiFail);
         } else {
+            console.log("MIDI not supported in this browser");
             if (midiInputCallback) {
                 midiInputCallback(false);
             }

--- a/Emscripten/src/CsoundObj.js
+++ b/Emscripten/src/CsoundObj.js
@@ -287,7 +287,6 @@ class CsoundObj {
         let that = this;
 
         if (navigator.getUserMedia === null) {
-            //Module['print']("Audio Input not supported in this browser");
             audioInputCallback(false);
         } else {
             let onSuccess = function(stream) {
@@ -298,7 +297,6 @@ class CsoundObj {
             let onFailure = function(error) {
                 that.microphoneNode = null;
                 audioInputCallback(false);
-                //Module['print']("Could not initialise audio input, error:" + error);
             };
             navigator.getUserMedia({
                 audio: true, 
@@ -325,8 +323,6 @@ class CsoundObj {
         };
 
         const midiFail = function(error) {
-
-            Module['print']("MIDI failed to start, error:" + error);
             if (midiInputCallback) {
                 midiInputCallback(false);
             }
@@ -336,7 +332,6 @@ class CsoundObj {
         if (navigator.requestMIDIAccess) {
             navigator.requestMIDIAccess().then(midiSuccess, midiFail);
         } else {
-            Module['print']("MIDI not supported in this browser");
             if (midiInputCallback) {
                 midiInputCallback(false);
             }

--- a/Emscripten/src/csound.js
+++ b/Emscripten/src/csound.js
@@ -57,7 +57,6 @@ Csound = function() {
                 CsoundObj.importScripts(path).then(() => {
                     console.log("loaded WASM runtime");
                     csound.Csound = new CsoundObj();
-                    csound.Csound.enableMidiInput(undefined);
                     csound.module = true;
                     if (typeof window.handleMessage !== 'undefined') { 
                         console.log = console.warn = function(mess) {


### PR DESCRIPTION
Module['print'] is no longer available in CsoundObj.js and all references should be removed