### PR TITLE
packages/gmm/PKGBUILD - dead links updated

### DIFF
--- a/mingw64/packages/gmm/PKGBUILD
+++ b/mingw64/packages/gmm/PKGBUILD
@@ -7,9 +7,9 @@ pkgrel=1
 pkgdesc="A generic C++ template library for sparse, dense and skyline matrices"
 arch=('i586' 'i686' 'x86_64')
 license=('LGPL')
-url="http://home.gna.org/getfem/gmm_intro"
-source=(http://download.gna.org/getfem/stable/gmm-${pkgver}.tar.gz)
-md5sums=('5706d23bf3bb6d06d3d7e5889cf8554d')
+url="http://download-mirror.savannah.gnu.org/releases/getfem/stable/"
+source=(http://download-mirror.savannah.gnu.org/releases/getfem/stable/gmm-${pkgver}.tar.gz)
+md5sums=('5706D23BF3BB6D06D3D7E5889CF8554D')
 
 build() {
 	cd $srcdir/gmm-${pkgver}


### PR DESCRIPTION
Because of gna.org server shutdown.

https://github.com/Boussau/PHYLDOG/issues/4