### PR TITLE
packages/musicxml/PKGBUILD

### DIFF
--- a/mingw64/packages/musicxml/PKGBUILD
+++ b/mingw64/packages/musicxml/PKGBUILD
@@ -19,12 +19,12 @@ pkgver() {
 }
 
 build() {
-    cd "$srcdir/$pkgname/cmake"
+    cd "$srcdir/$pkgname/build"
     cmake -DCMAKE_INSTALL_PREFIX:PATH="${pkgdir}${MINGW_PREFIX}" -G "Unix Makefiles"
     make
 }
 
 package() {
-    cd "$srcdir/$pkgname/cmake"
+    cd "$srcdir/$pkgname/build"
     make prefix="${pkgdir}${MINGW_PREFIX}" install
 }


### PR DESCRIPTION
I think this change is neccesary, CMakeLists is now in a folder named build (instead of cmake). Old command (**cd "$srcdir/$pkgname/cmake"**) gives me the next error sequence:

```
/csound/mingw64/packages/musicxml
$ makepkg-mingw -f
==> Creando el paquete: libmusicxml-git 244.b0bf6b53-1 (sá.,  8 de sep. de 2018 16:39:09)
==> Comprobando dependencias mientras se ejecuta...
==> Comprobando dependencias mientras se compila...
==> Recibiendo las fuentes...
  -> Clonando libmusicxml-git del repositorio git...
Clonando en un repositorio vacío '/home/Dani/csound/mingw64/packages/musicxml/libmusicxml-git'...
remote: Counting objects: 31335, done.
remote: Compressing objects: 100% (349/349), done.
remote: Total 31335 (delta 307), reused 390 (delta 197), pack-reused 30786
Recibiendo objetos: 100% (31335/31335), 19.08 MiB | 1003.00 KiB/s, listo.
Resolviendo deltas: 100% (25566/25566), listo.
==> Validando los archivos source con md5sums...
    libmusicxml-git ... Omitido
==> Extrayendo las fuentes...
  -> Creando copia de trabajo de libmusicxml-git del repositorio git...
Clonando en 'libmusicxml-git'...
hecho.
==> Iniciando pkgver()...
==> Iniciando build()...
/home/Dani/csound/mingw64/packages/musicxml/PKGBUILD: línea 22: cd: /home/Dani/csound/mingw64/packages/musicxml/src/libmusicxml-git/cmake: No such file or director                                               y
==> ERROR: Se produjo un fallo en build().
    Cancelando...
```