### PR TITLE
Update emugens,  band-enhanced additive synthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,5 @@ emscripten/dist-wasm
 
 # Alleged copyright violation.
 vst4cs/src
+
+compile_commands.json

--- a/Opcodes/emugens/.gitignore
+++ b/Opcodes/emugens/.gitignore
@@ -1,1 +1,0 @@
-compile_commands.json

--- a/Opcodes/emugens/.gitignore
+++ b/Opcodes/emugens/.gitignore
@@ -1,0 +1,1 @@
+compile_commands.json

--- a/Opcodes/emugens/beosc.c
+++ b/Opcodes/emugens/beosc.c
@@ -1,0 +1,1377 @@
+/*
+
+   beosc.c
+
+   beosc - Bandwidth enhanced oscillator
+   beadsynt - Bandwidth enhanced oscillator bank for additive synthesis
+
+   (C) 2017 Eduardo Moguillansky
+
+   The beosc library is free software; you can redistribute it
+   and/or modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the gab library; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA
+
+   beosc and beadsynt are based on the algorithm implemented by
+   Loris.
+
+   Loris is Copyright (c) 1999-2016 by Kelly Fitz and Lippold Haken
+
+*/
+
+/*
+
+  Overview
+
+  opcodes:
+
+  beosc: band-enhanced oscillator
+  beadsynt: band-enhanced additive synthesis (a bank of beosc)
+  tabrowlin: copy a row of a 2D-table to another table or to an array
+             (possibly selecting a slice and interpolating between two rows)
+  getrowlin: copy a row of a 2D-array to another array 
+             (possibly selecting a slice and interpolating between two rows)
+
+
+*/
+
+#include "csdl.h"
+
+// -------------------------------------------------------------------------
+
+#define UInt32toFlt(x) ((double)(x) * (1.0 / 4294967295.03125))
+
+#define unirand(c) ((MYFLT) UInt32toFlt(csoundRandMT(&((c)->randState_))))
+
+#define unirand2(cs,seed) ((MYFLT) (cs->Rand31(&seed)-1) / FL(2147483645.0))
+
+// 1 / 2pi
+#define RTWOPI 0.1591549430918953357688837634
+
+#define SAMPLE_ACCURATE \
+    uint32_t n, nsmps = CS_KSMPS;                                    \
+    MYFLT *out = p->out;                                             \
+    uint32_t offset = p->h.insdshead->ksmps_offset;                  \
+    uint32_t early  = p->h.insdshead->ksmps_no_end;                   \
+    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));   \
+    if (UNLIKELY(early)) {                                           \
+        nsmps -= early;                                                  \
+        memset(&out[nsmps], '\0', early*sizeof(MYFLT));                  \
+    }                                                                \
+
+#define MSG(m) (csound->Message(csound, Str(m)))
+#define MSGF(m, ...) (csound->Message(csound, Str(m), __VA_ARGS__))
+
+#define INITERR(m) (csound->InitError(csound, m))
+#define PERFERROR(m) (csound->PerfError(csound, &(p->h), "%s", m))
+
+
+/*
+
+  Helpers
+
+*/
+
+static inline float
+fastlog2 (float x) {
+    union { float f; uint32_t i; } vx = { x };
+    union { uint32_t i; float f; } mx = { (vx.i & 0x007FFFFF) | 0x3f000000 };
+    float y = vx.i;
+    y *= 1.1920928955078125e-7f;
+
+    return y - 124.22551499f
+           - 1.498030302f * mx.f
+           - 1.72587999f / (0.3520887068f + mx.f);
+}
+
+static inline float
+fastlogf (float x) {
+    return 0.69314718f * fastlog2 (x);
+}
+
+static inline MYFLT
+fastlog(MYFLT x) {
+    return FL(0.6931471805599453) * fastlog2(x);
+}
+
+
+// uniform noise, taken from csoundRand31, returns floats between 0-1
+static inline MYFLT
+FastRandFloat(uint32_t *seedptr) {
+    uint64_t tmp1;
+    uint32_t tmp2;
+    /* x = (742938285 * x) % 0x7FFFFFFF */
+    tmp1  = (uint64_t) ((int32_t) (*seedptr) * (int64_t) 742938285);
+    tmp2  = (uint32_t) tmp1 & (uint32_t) 0x7FFFFFFF;
+    tmp2 += (uint32_t) (tmp1 >> 31);
+    tmp2  = (tmp2 & (uint32_t) 0x7FFFFFFF) + (tmp2 >> 31);
+    (*seedptr) = tmp2;
+    return (MYFLT)(tmp2 - 1) / FL(2147483648.0);
+}
+
+
+/*
+
+  Gaussian Noise
+
+  gaussian_normal: the canonical implementation
+
+  gaussian_normal is used to calculate a table of gaussian numbers
+  which is then accessed using uniform noise. This renders an acceptable
+  result for our purpose, while reducing the performance cost to simple
+  uniform noise, without any logs or sqrts
+  
+*/
+
+typedef struct {
+    MYFLT gset;
+    int iset;
+    uint32_t seed;
+} GaussianState;
+
+static inline MYFLT
+gaussian_normal(GaussianState *gs) {
+    if(gs->iset) {
+        gs->iset = 0;
+        return gs->gset;
+    }
+    gs->iset = 1;
+    MYFLT v1 = FL(2.0) * FastRandFloat(&(gs->seed)) - FL(1.0);
+    MYFLT v2 = FL(2.0) * FastRandFloat(&(gs->seed)) - FL(1.0);
+    MYFLT r  = v1*v1 + v2*v2;
+    while(r >= 1.0) {
+        v1 = v2;
+        v2 = FL(2.0) * FastRandFloat(&(gs->seed)) - FL(1.0);
+        r  = v1*v1 + v2*v2;
+    }
+    MYFLT fac = r == FL(0) ? FL(0) : sqrt(FL(-2) * fastlog(r)/r);
+    gs->gset = v1*fac;
+    return v2*fac;
+}
+
+static MYFLT* gaussians = NULL;
+
+#define GAUSSIANS_SIZE 65536
+
+static void
+gaussians_init(uint32_t seed) {
+    GaussianState gs;
+    if(gaussians == NULL) {
+        uint32_t size = GAUSSIANS_SIZE;
+        uint32_t i;
+        gs.gset = 0;
+        gs.iset = 0;
+        gs.seed = seed;
+        MYFLT *g = malloc(sizeof(MYFLT)*size);
+        for(i=0; i<size; i++) {
+            g[i] = gaussian_normal(&gs);
+        }
+        gaussians = g;
+    }
+}
+
+#define GAUSSIANS_GET(seed) (gaussians[(uint32_t)(FastRandFloat(seed)*(GAUSSIANS_SIZE-1))])
+
+
+// from Opcodes/arrays.c, original name: tabensure.
+// This should be part of the API.
+
+static inline void
+arrayensure(CSOUND *csound, ARRAYDAT *p, int size) {
+    if (p->data==NULL || p->dimensions == 0 ||
+        (p->dimensions==1 && p->sizes[0] < size)) {
+        size_t ss;
+        if (p->data == NULL) {
+            CS_VARIABLE* var = p->arrayType->createVariable(csound, NULL);
+            p->arrayMemberSize = var->memBlockSize;
+        }
+        ss = p->arrayMemberSize*size;
+        if (p->data==NULL)
+            p->data = (MYFLT*)csound->Calloc(csound, ss);
+        else
+            p->data = (MYFLT*) csound->ReAlloc(csound, p->data, ss);
+        p->dimensions = 1;
+        p->sizes    = (int*)csound->Malloc(csound, sizeof(int));
+        p->sizes[0] = size;
+    }
+}
+
+
+/*
+
+   Integer phase oscillator with/without interpolation,
+   adapted from Supercollider. Not used now, included as
+   a reference
+
+ */
+
+#define xlobits 14
+#define xlobits1 13
+
+static inline float
+PhaseFrac(uint32_t inPhase) {
+    union { uint32_t itemp; float ftemp; } u;
+    u.itemp = 0x3F800000 | (0x007FFF80 & ((inPhase)<<7));
+    return u.ftemp - 1.f;
+}
+
+static inline float
+PhaseFrac1(uint32_t inPhase) {
+    union { uint32_t itemp; float ftemp; } u;
+    u.itemp = 0x3F800000 | (0x007FFF80 & ((inPhase)<<7));
+    return u.ftemp;
+}
+
+static inline MYFLT
+lookupi1(const MYFLT* table0, const MYFLT* table1,
+         int32_t pphase, int32_t lomask) {
+    MYFLT pfrac    = PhaseFrac(pphase);
+    uint32_t index = ((pphase >> xlobits1) & lomask);
+    MYFLT val1 = *(const MYFLT*)((const char*)table0 + index);
+    MYFLT val2 = *(const MYFLT*)((const char*)table1 + index);
+    MYFLT out  = val1 + (val2 - val1) * pfrac;
+    return out;
+}
+
+static inline MYFLT
+lookup(const MYFLT *table, int32_t phase, int32_t mask) {
+    uint32_t index = ((phase >> xlobits1) & mask);
+    return *(const MYFLT*)((const char*)table + index);
+}
+
+static inline MYFLT
+cs_lookupi(const MYFLT* ftbl, int32_t phs, int32_t lobits, int32_t lomask,
+           MYFLT lodiv) {
+    MYFLT fract = (MYFLT)((phs & lomask) * lodiv);
+    const MYFLT* ftbl0 = ftbl + (phs >> lobits);
+    MYFLT v1 = ftbl0[0];
+    return v1 + (ftbl0[1] - v1)*fract;
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/*
+
+    beosc
+
+    Band-Enhanced oscil, adapted from the supercollider port (BEOsc)
+    Loris original implementation uses gaussian normal noise,
+    the supercollider port uses uniform noise. I included
+    both implementations. Normal noise is generally more expensive, but this
+    implementation is efficient, using uniform noise reshaped
+    with a gaussian distribution
+
+    aout beosc xfreq, kbw [, ifn=-1, iphase=0, iflags=1 ]
+
+    xfreq: freq. of the oscillator
+    kbw: bandwidth of the oscillator (0=pure, 1=noise)
+    ifn: like oscil, default is -1, a sine wave.
+    iphase: like oscil, a float value between 0 - 2pi (default=0)
+    iflags: 0-1 = uniform or gaussian noise (default=gaussian)
+            +2  = table lookup with linear interpolation
+
+ */
+
+typedef struct {
+    OPDS h;
+    MYFLT *out, *xfreq, *kbw, *ifn, *iphs, *iflags;
+    MYFLT  lastfreq;
+    int32_t  phase;
+    int32_t  lomask;
+    MYFLT  cpstoinc, radtoinc;
+    FUNC * ftp;
+    MYFLT  x1, x2, x3; // MA
+    MYFLT  y1, y2, y3; // AR
+    int flags;
+    GaussianState gs;
+} BEOSC;
+
+static int
+beosc_init(CSOUND *csound, BEOSC *p) {
+    FUNC *ftp;
+    MYFLT sampledur = 1 / csound->GetSr(csound);
+    ftp = csound->FTFind(csound, p->ifn);
+    if (UNLIKELY(ftp == NULL))
+        return NOTOK;
+    p->ftp = ftp;
+    uint32_t tabsize = ftp->flen;
+    p->radtoinc = tabsize * (RTWOPI * 65536.);
+    p->cpstoinc = tabsize * sampledur * 65536;
+    p->lomask   = (tabsize - 1) << 3;
+    p->phase    = fabs(fmod(*p->iphs, TWOPI)) * p->radtoinc;
+    p->flags    = (int)(*p->iflags);
+    p->lastfreq = *p->xfreq;
+    p->gs.seed  = csound->GetRandomSeedFromTime();
+    p->gs.iset  = 0;
+    return OK;
+}
+
+static int
+beosc_kkiii(CSOUND *csound, BEOSC *p) {
+    SAMPLE_ACCURATE
+
+    FUNC *ftp     = p->ftp;
+    MYFLT freqin  = *p->xfreq;
+    MYFLT bwin    = *p->kbw;
+    MYFLT *table0 = ftp->ftable;
+    MYFLT *table1 = table0 + 1;
+
+    int32_t phase  = p->phase;
+    int32_t lomask = p->lomask;
+
+    int32_t phaseinc = (int32_t)(p->cpstoinc * freqin);
+
+    MYFLT x0,
+          x1 = p->x1,
+          x2 = p->x2,
+          x3 = p->x3,
+          y0,
+          y1 = p->y1,
+          y2 = p->y2,
+          y3 = p->y3;
+
+    // bw coefficients
+    MYFLT bw1 = sqrt( FL(1.0) - bwin );
+    MYFLT bw2 = sqrt( FL(2.0) * bwin );
+
+    uint32_t seed;
+    
+    switch (p->flags) {
+    case 0:    // uniform noise, no interp.
+        seed = p->gs.seed;
+        for (n=offset; n<nsmps; n++) {
+            x0 = x1; x1 = x2; x2 = x3;
+            // kelly uses 6. / GAIN
+            x3 = (FastRandFloat(&seed) * FL(2.0) - FL(1.0)) *
+                 FL(0.00012864661681256);
+            y0 = y1; y1 = y2; y2 = y3;
+            y3 = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                 (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookup(table0, phase, lomask)
+                     * (bw1 + ( y3 * bw2 ));
+            phase += phaseinc;
+        }
+        p->gs.seed = seed;
+        break;
+    case 1:     // gaussian noise, no interp
+        // gsptr = &(p->gs);
+        for (n=offset; n<nsmps; n++) {
+            x0 = x1; x1 = x2; x2 = x3;
+            // x3 = gaussian_normal(gsptr);
+            x3  = GAUSSIANS_GET(&seed);
+            x3 *= FL(0.00012864661681256);  // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookup(table0, phase, lomask) \
+                     * (bw1 + ( y3 * bw2 ));
+            phase += phaseinc;
+        }
+        break;
+    case 2:
+        seed = p->gs.seed;
+        for (n=offset; n<nsmps; n++) {
+            x0  = x1; x1 = x2; x2 = x3;
+            x3  = (FastRandFloat(&seed) * FL(2.0) - FL(1.0));
+            x3 *= FL(0.00012864661681256);  // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookupi1(table0, table1, phase, lomask)
+                     * (bw1 + ( y3 * bw2 ));
+            phase += phaseinc;
+        }
+        p->gs.seed = seed;
+        break;
+    case 3:    
+        for (n=offset; n<nsmps; n++) {
+            x0  = x1; x1 = x2; x2 = x3;
+            // x3  = gaussian_normal(gsptr);
+            x3  = GAUSSIANS_GET(&seed);
+            x3 *= FL(0.00012864661681256); // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookupi1(table0, table1, phase, lomask) \
+                     * (bw1 + ( y3 * bw2 ));
+            phase += phaseinc;
+        }
+        break;
+    }
+    p->phase = phase;
+    p->x1    = x1; p->x2 = x2; p->x3 = x3;
+    p->y1    = y1; p->y2 = y2; p->y3 = y3;
+    return OK;
+}
+
+static int
+beosc_akiii(CSOUND *csound, BEOSC *p) {
+    SAMPLE_ACCURATE
+
+    FUNC *ftp  = p->ftp;
+    MYFLT *freqptr = p->xfreq;
+    MYFLT bwin    = *p->kbw;
+    MYFLT *table0 = ftp->ftable;
+    MYFLT *table1 = table0 + 1;
+    // MYFLT noise;
+
+    int32_t phase  = p->phase;
+    int32_t lomask = p->lomask;
+
+    MYFLT x0,
+          x1 = p->x1,
+          x2 = p->x2,
+          x3 = p->x3,
+          y0,
+          y1 = p->y1,
+          y2 = p->y2,
+          y3 = p->y3;
+
+    // bw coefficients
+    MYFLT bw1 = sqrt( FL(1.0) - bwin );
+    MYFLT bw2 = sqrt( FL(2.0) * bwin );
+
+    uint32_t seed;
+
+    MYFLT freq,
+          cpstoinc = p->cpstoinc;
+
+    // GaussianState *gsptr;
+
+    switch (p->flags) {
+    case 0:    
+        seed = p->gs.seed;
+        for (n=offset; n<nsmps; n++) {
+            x0  = x1; x1 = x2; x2 = x3;
+            x3  = FastRandFloat(&seed) * FL(2.0) - FL(1.0);
+            x3 *= FL(0.00012864661681256); // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookup(table0, phase, lomask)
+                     * (bw1 + ( y3 * bw2 ));
+            freq   = freqptr[n];
+            phase += (int32_t)(cpstoinc * freq);
+        }
+        p->gs.seed = seed;
+        break;
+    case 1:     
+        for (n=offset; n<nsmps; n++) {
+            x0 = x1; x1 = x2; x2 = x3;
+            // x3 = gaussian_normal(gsptr);
+            x3  = GAUSSIANS_GET(&seed);
+            x3 *= FL(0.00012864661681256); // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookup(table0, phase, lomask) \
+                     * (bw1 + ( y3 * bw2 ));
+            freq   = freqptr[n];
+            phase += (int32_t)(cpstoinc * freq);
+        }
+        break;
+    case 2:    // + interp
+        seed = p->gs.seed;
+        for (n=offset; n<nsmps; n++) {
+            x0  = x1; x1 = x2; x2 = x3;
+            x3  = FastRandFloat(&seed) * FL(2.0) - FL(1.0);
+            x3 *= FL(0.00012864661681256); // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookupi1(table0, table1, phase, lomask)
+                     * (bw1 + ( y3 * bw2 ));
+            freq   = freqptr[n];
+            phase += (int32_t)(cpstoinc * freq);
+        }
+        p->gs.seed = seed;
+        break;
+    case 3:    // + interp
+        for (n=offset; n<nsmps; n++) {
+            x0 = x1; x1 = x2; x2 = x3;
+            // x3 = gaussian_normal(gsptr);
+            x3  = GAUSSIANS_GET(&seed);
+            x3 *= FL(0.00012864661681256); // kelly uses 6. / GAIN
+            y0  = y1; y1 = y2; y2 = y3;
+            y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                  (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+            out[n] = lookupi1(table0, table1, phase, lomask) \
+                     * (bw1 + ( y3 * bw2 ));
+            freq   = freqptr[n];
+            phase += (int32_t)(cpstoinc * freq);
+        }
+        break;
+    }
+
+    p->phase = phase;
+    p->x1    = x1; p->x2 = x2; p->x3 = x3;
+    p->y1    = y1; p->y2 = y2; p->y3 = y3;
+    return OK;
+}
+
+
+/*
+   ----------------------------------------------------------------
+
+   beadsynt - Band enhanced oscillator bank
+
+   aout   beadsynt ifreqfn, iampfn, ibwfn, icnt, kfreq=1, kbw=1, iwfn=-1, iphs=-1, iflags=0
+   aout   beadsynt kFreq[], kAmp[], kBw[], icnt, kfreq=1, kbw=1, iwfn=-1, iphs=-1, iflags=0
+
+   ifreqfn: a table containing frequencies for each oscillator.
+   iampfn:  a table containing amplitudes for each oscillator.
+   ibwfn:   a table containing bandwidths for each oscillator.
+   icnt:    number of oscillators. All three tables or arrays must be at least this big
+   kfreq:   frequency scaling, all frequencies are multiplied by this factor
+   kbw:     bandwidth scaling, bandwidths are multiplied by this factor
+   iwfn:    a table containing one wave cycle to be used for the oscillators.
+            -1 to use the default sine table
+   iphs:    Initial phase for the oscillators, indicated as follows:
+            *  -1: randomize phases
+            * 0-1: set the initial phase of all oscillators to this value
+            * >=1: the table number (an int) containing the initial phase
+                   for each oscillator (must contain at least icnt values)
+   iflags:  0-1  => noise type (0=uniform, 1=gaussian)
+            +2   => table lookup interpolation
+            +4   => freq interpolation
+
+   ----------------------------------------------------------------
+ */
+
+typedef struct {
+    MYFLT x1, x2, x3;
+    MYFLT y1, y2, y3;
+} FILTCOEFS;
+
+static void
+befilter_init(FILTCOEFS *filt) {
+    filt->x1 = 0;
+    filt->x2 = 0;
+    filt->x3 = 0;
+    filt->y1 = 0;
+    filt->y2 = 0;
+    filt->y3 = 0;
+}
+
+typedef struct {
+    OPDS h;
+    MYFLT *out;
+    void *ifreqtbl, *iamptbl, *ibwtbl;
+    MYFLT *icnt,  *iflags, *kfreq, *kbw, *ifn, *iphs;
+    GaussianState gs;
+    FUNC * ftp;
+    MYFLT *freqs;
+    MYFLT *amps;
+    MYFLT *bws;
+    int count;
+    int inerr;
+    AUXCH lphs;
+    AUXCH pamp;
+    AUXCH filtcoefs;
+    AUXCH pfreq;
+    MYFLT cpstoinc;
+    uint32_t seed;
+    int updatearrays;
+} BEADSYNT;
+
+
+static int32_t
+beadsynt_init_common(CSOUND *csound, BEADSYNT *p) {
+    FILTCOEFS *filtcoefs;
+    int32_t *lphs;
+    unsigned int c, count;
+
+    MYFLT iphs = *p->iphs;
+    MYFLT sr   = csound->GetSr(csound);
+    p->inerr = 0;
+    // corresponds to csound->sicvt. FMAXLEN depends on B64BIT being defined
+    p->cpstoinc = FMAXLEN / sr;
+    p->gs.seed  = p->seed = csound->GetRandomSeedFromTime();
+    p->gs.iset  = 0;  p->gs.gset = 0;
+    gaussians_init(csound->GetRandomSeedFromTime());
+
+    if (p->lphs.auxp==NULL || p->lphs.size < sizeof(int32_t)*count)
+        csound->AuxAlloc(csound, sizeof(int32_t)*count, &p->lphs);
+    lphs = (int32*)p->lphs.auxp;
+
+    if (iphs < 0) {
+        uint32_t seed = csound->GetRandomSeedFromTime();
+        for (c=0; c<count; c++) {
+            lphs[c] = (int32_t)(FastRandFloat(&seed) * FMAXLEN) & PHMASK;
+        }
+        // MSG(Str("beadsynt: init phase with random values\n"));
+    } else if (iphs <= 1) {   // between 0 and 1, use this number as phase
+        for (c=0; c<count; c++) {
+            lphs[c] = ((int32_t)(iphs * FMAXLEN)) & PHMASK;
+        }
+        // MSG(Str("beadsynt: init phase with fixed value\n"));
+    } else {  // iphs is the number of a table containing the phases
+        FUNC *phasetp = csound->FTFind(csound, p->iphs);
+        if (phasetp == NULL) {
+            p->inerr = 1;
+            return INITERR(Str("beadsynt: phasetable not found"));
+        }
+        for (c=0; c<count; c++) {
+            MYFLT ph = phasetp->ftable[c];
+            lphs[c] = ((int32_t)(ph * FMAXLEN)) & PHMASK;
+        }
+        // MSG(Str("beadsynt: init phase with func table\n"));
+    }
+
+    if (p->pamp.auxp==NULL || p->pamp.size < (uint32_t)(sizeof(MYFLT)*p->count))
+        csound->AuxAlloc(csound, sizeof(MYFLT)*p->count, &p->pamp);
+    else if (iphs >= 0)        /* AuxAlloc clear anyway */
+        memset(p->pamp.auxp, 0, sizeof(MYFLT)*p->count);
+
+    if (p->filtcoefs.auxp==NULL || p->filtcoefs.size < sizeof(FILTCOEFS)*count)
+        csound->AuxAlloc(csound, sizeof(FILTCOEFS)*count, &p->filtcoefs);
+    filtcoefs = (FILTCOEFS *)(p->filtcoefs.auxp);
+    for (c=0; c<count; c++) {
+        befilter_init(filtcoefs++);
+    }
+    // freq. interpolation
+    if ((int)*p->iflags & 4) {
+        if (p->pfreq.auxp==NULL ||
+            p->pfreq.size < (uint32_t)(sizeof(MYFLT)*p->count))
+            csound->AuxAlloc(csound, sizeof(MYFLT)*p->count, &p->pfreq);
+        // init freqs to current table contents
+        MYFLT *prevfreqs = (MYFLT*)p->pfreq.auxp;
+        MYFLT *freqs  = p->freqs;
+        MYFLT freqmul = *p->kfreq;
+        for (c=0; c<p->count; c++) {
+            prevfreqs[c] = freqs[c] * freqmul;
+        }
+    }
+    return OK;
+}
+
+static int32_t
+beadsynt_init(CSOUND *csound, BEADSYNT *p) {
+    FUNC *ftp;
+    int count = (int)*p->icnt;
+    p->inerr = 1;
+    p->ftp = ftp = csound->FTFind(csound, p->ifn);
+    if (ftp == NULL) {
+        return INITERR(Str("beadsynt: wavetable not found"));
+    }
+    ftp = csound->FTnp2Find(csound, (MYFLT *)p->iamptbl);
+    if (ftp == NULL) {
+        return INITERR("beadsynt: amptable not found!");
+    }
+    if( count < 0) {
+        // count not specified, set it to the length of the amps table
+        count = ftp->flen;
+    }
+    if (ftp->flen < count) {
+        return INITERR(Str("beadsynt: partial count > amptable size"));
+    }
+    p->amps = ftp->ftable;
+
+    ftp = csound->FTnp2Find(csound, (MYFLT *)p->ifreqtbl);
+    if (ftp == NULL) {
+        return INITERR(Str("beadsynt: freqtable not found!"));
+    }
+    if (ftp->flen < count) {
+        return INITERR(Str("beadsynt: partial count > freqtable size"));
+    }
+    p->freqs = ftp->ftable;
+
+    ftp = csound->FTnp2Find(csound, (MYFLT *)p->ibwtbl);
+    if (ftp == NULL) {
+        return INITERR(Str("beadsynt: bandwidth table not found"));
+    }
+    if (ftp->flen < count) {
+        return INITERR(Str("beadsynt: partial count > bandwidth size"));
+    }
+    p->bws = ftp->ftable;
+    p->updatearrays = 0;
+    p->inerr = 0;
+    p->count = count < 1 ? 1 : count;
+    
+    return beadsynt_init_common(csound, p);
+}
+
+static int32_t
+beadsynt_init_array(CSOUND *csound, BEADSYNT *p) {
+    FUNC *ftp;
+    p->ftp = ftp = csound->FTFind(csound, p->ifn);
+    if (ftp == NULL) {
+        p->inerr = 1;
+        return INITERR(Str("beadsynt: wavetable not found!"));
+    }
+
+    ARRAYDAT *ampsarr  = (ARRAYDAT *)p->iamptbl;
+    ARRAYDAT *freqsarr = (ARRAYDAT *)p->ifreqtbl;
+    ARRAYDAT *bwsarr   = (ARRAYDAT *)p->ibwtbl;
+    // check sizes and dimensions
+    if(ampsarr->dimensions != 1 || freqsarr->dimensions != 1 ||
+       bwsarr->dimensions != 1) {
+        return INITERR(Str("The arrays should have 1 dimension"));
+    }
+    
+    int count = (int)*p->icnt;
+    if (count < 0) {
+        // count not specified: set it to the size of the amps array
+        count = ampsarr->sizes[0];
+    }
+    p->count = count;
+    
+    if(ampsarr->sizes[0] < count) {
+        return INITERR(Str("Amplitudes array is too small"));
+    }
+    if(freqsarr->sizes[0] < count) {
+        return INITERR(Str("Frequencies array is too small"));
+    }
+    if(bwsarr->sizes[0] < count) {
+        return INITERR(Str("bandwidths array is too small"));
+    }
+
+    p->amps  = ampsarr->data;
+    p->freqs = freqsarr->data;
+    p->bws   = bwsarr->data;
+
+    p->updatearrays = 1;
+    return beadsynt_init_common(csound, p);
+}
+
+// FMAXLEN = MYFLT 0x40000000
+// PHMASK = 0x3fffffff
+
+static int32_t
+beadsynt_perf(CSOUND *csound, BEADSYNT *p) {
+    FUNC *ftp;
+    MYFLT *out, *ftpdata, *freqs, *amps, *bws, *prevamps, *prevfreqs;
+    MYFLT freq, freqmul, freqnow, freqinc;
+    MYFLT amp, ampnow, ampinc, bwmul, bwin, bw1, bw2;
+    MYFLT cpstoinc, sample, lodiv;
+    int32_t phs, inc, lobits, lomask;
+    int32_t *lphs;
+    int flags;
+    unsigned int c, count;
+    MYFLT x0, x1, x2, x3, y0, y1, y2, y3;
+    FILTCOEFS *coefs;
+    uint32_t seed,
+             offset = p->h.insdshead->ksmps_offset,
+             early = p->h.insdshead->ksmps_no_end;
+    uint32_t n, nsmps = CS_KSMPS;
+
+    if (UNLIKELY(p->inerr))
+        return INITERR(Str("beadsynt: not initialised"));
+
+    ftp = p->ftp;
+    ftpdata  = ftp->ftable;
+    lobits   = ftp->lobits;
+    lodiv    = ftp->lodiv;
+    lomask   = ftp->lomask;
+    cpstoinc = p->cpstoinc;
+    freqmul  = *p->kfreq;
+    bwmul    = *p->kbw;
+    count    = p->count;
+    out      = p->out;
+    flags    = (int)*p->iflags;
+
+    if(p->updatearrays) {
+        freqs = ((ARRAYDAT *)p->ifreqtbl)->data;
+        amps  = ((ARRAYDAT *)p->iamptbl)->data;
+        bws   = ((ARRAYDAT *)p->ibwtbl)->data;
+    } else {
+        freqs = p->freqs;
+        amps  = p->amps;
+        bws   = p->bws;
+    }
+
+    lphs = (int32*)p->lphs.auxp;
+    prevamps  = (MYFLT*)p->pamp.auxp;
+    prevfreqs = (MYFLT*)p->pfreq.auxp;
+
+    // clear output before adding partials
+    memset(out, 0, nsmps*sizeof(MYFLT));
+
+    if (UNLIKELY(early)) {
+        nsmps -= early;
+        memset(&out[nsmps], '\0', early*sizeof(MYFLT));
+    }
+
+    coefs = (FILTCOEFS *)(p->filtcoefs.auxp);
+    // GaussianState *gsptr = &(p->gs);
+    seed = p->seed;
+
+    for (c=0; c<count; c++) {
+        ampnow = prevamps[c];
+        amp    = amps[c];
+        if(ampnow == 0 && amp == 0) {
+            // skip silent partials
+            coefs++;
+            continue;
+        }
+        freq = freqs[c] * freqmul;
+        inc  = (int32_t) (freq * cpstoinc);
+        
+        bwin = bws[c] * bwmul;
+        bwin = bwin < 0 ? 0 : (bwin > 1 ? 1 : bwin);
+        bw1  = sqrt(FL(1.0) - bwin);
+        bw2  = sqrt(FL(2.0) * bwin);
+
+        phs    = lphs[c];
+        ampinc = (amp - ampnow) * CS_ONEDKSMPS;
+
+        if(LIKELY(bwin != 0)) {
+            x1 = coefs->x1; x2 = coefs->x2; x3 = coefs->x3;
+            y1 = coefs->y1; y2 = coefs->y2; y3 = coefs->y3;
+            switch(flags) {
+            // 0-1=uniform | gauss. noise,
+            //  +2=osc lookup with linear interp
+            //  +4=freq. interp
+            case 0:  // 000
+                for (n=offset; n<nsmps; n++) {
+                    x0  = x1; x1 = x2; x2 = x3;
+                    x3  = FastRandFloat(&seed) * FL(2) - FL(1);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample  = *(ftpdata + (phs >> lobits)) * ampnow;
+                    out[n] += sample * (bw1 + (y3*bw2));
+                    phs    += inc;
+                    phs    &= PHMASK;
+                    ampnow += ampinc;
+                }
+                break;
+            case 1:  // 001
+                for (n=offset; n<nsmps; n++) {
+                    x0 = x1; x1 = x2; x2 = x3;
+                    // x3 = gaussian_normal(gsptr);
+                    x3  = GAUSSIANS_GET(&seed);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample  = *(ftpdata + (phs >> lobits)) * ampnow;
+                    out[n] += sample * (bw1 + (y3*bw2));
+                    phs    += inc; phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                break;
+            case 2:  // 010
+                for (n=offset; n<nsmps; n++) {
+                    x0  = x1; x1 = x2; x2 = x3;
+                    x3  = FastRandFloat(&seed) * FL(2) - FL(1);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample =
+                        cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    out[n] += sample * (bw1 + (y3*bw2));
+                    phs    += inc; phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                break;
+            case 3:  // 011
+                // seed = p->gs.seed;
+                for (n=offset; n<nsmps; n++) {
+                    x0  = x1; x1 = x2; x2 = x3;
+                    x3  = GAUSSIANS_GET(&seed);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample =
+                        cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    out[n] += sample * (bw1 + (y3*bw2));
+                    phs    += inc; phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                break;
+            case 4:  // 100
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                // seed = p->gs.seed;
+                for (n=offset; n<nsmps; n++) {
+                    x0  = x1; x1 = x2; x2 = x3;
+                    x3  = FastRandFloat(&seed) * FL(2) - FL(1);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample   = *(ftpdata + (phs >> lobits)) * ampnow;
+                    out[n]  += sample * (bw1 + (y3*bw2));
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            case 5:  // 101
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                for (n=offset; n<nsmps; n++) {
+                    x0 = x1; x1 = x2; x2 = x3;
+                    // x3 = gaussian_normal(gsptr);
+                    x3  = GAUSSIANS_GET(&seed);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample   = *(ftpdata + (phs >> lobits)) * ampnow;
+                    out[n]  += sample * (bw1 + (y3*bw2));
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            case 6:  // 110
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                for (n=offset; n<nsmps; n++) {
+                    x0  = x1; x1 = x2; x2 = x3;
+                    x3  = FastRandFloat(&seed) * FL(2) - FL(1);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample =
+                        cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    out[n]  += sample * (bw1 + (y3*bw2));
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            case 7:  // 111
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                for (n=offset; n<nsmps; n++) {
+                    x0 = x1; x1 = x2; x2 = x3;
+                    // x3 = gaussian_normal(gsptr);
+                    x3  = GAUSSIANS_GET(&seed);
+                    x3 *= FL(0.00012864661681256);
+                    y0  = y1; y1 = y2; y2 = y3;
+                    y3  = (x0 + x3) + (FL(3) * (x1 + x2)) + (FL(0.9320209047) * y0) + \
+                          (FL(-2.8580608588) * y1) + (FL(2.9258684253) * y2);
+                    sample = cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    out[n]  += sample * (bw1 + (y3*bw2));
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            }
+            coefs->x1 = x1; coefs->x2 = x2; coefs->x3 = x3;
+            coefs->y1 = y1; coefs->y2 = y2; coefs->y3 = y3;
+        } else {
+            // simplified loops when there is no bw
+            switch(flags) {
+            case 0:  // 000
+            case 1:  // 001
+                for (n=offset; n<nsmps; n++) {
+                    out[n] += *(ftpdata + (phs >> lobits)) * ampnow;
+                    phs    += inc; phs &= PHMASK; ampnow += ampinc;
+                }
+                break;
+            case 2:  // 010
+            case 3:  // 011
+                for (n=offset; n<nsmps; n++) {
+                    out[n] +=
+                        cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    phs += inc; phs &= PHMASK; ampnow += ampinc;
+                }
+                break;
+            case 4:  // 100
+            case 5:  // 101
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                for (n=offset; n<nsmps; n++) {
+                    out[n]  += *(ftpdata + (phs >> lobits)) * ampnow;
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            case 6:  // 110
+            case 7:  // 111
+                freqnow = prevfreqs[c];
+                freqinc = (freq - freqnow) * CS_ONEDKSMPS;
+                for (n=offset; n<nsmps; n++) {
+                    out[n] +=
+                        cs_lookupi(ftpdata, phs, lobits, lomask, lodiv) * ampnow;
+                    freqnow += freqinc;
+                    phs    += (int32_t)(cpstoinc * freqnow); phs &= PHMASK;
+                    ampnow += ampinc;
+                }
+                prevfreqs[c] = freq;
+                break;
+            }
+        }
+        prevamps[c] = amp;
+        lphs[c] = phs;
+        coefs++;
+    }
+    p->seed = seed;
+    return OK;
+}
+
+/////////////////////////////////////////////////////
+
+
+/*
+
+    tabrowlin
+
+    Assuming a 2D table containing multiple rows of sampled streams
+    (for instance, the amplitudes of a set of oscilators, sampled at a
+    regular interval): extract one row of that data with linear
+    interpolation between adjacent rows (if row is not a whole number)
+
+    tabrowlin krow, ifnsrc, ifndest, inumcols, ioffset=0, istart=0, iend=0,
+       istep=1
+
+    kout[]  tabrowlin krow, ifnsrc, inumcols, ioffset=0, istart=0, iend=0, istep=1
+
+    If reading out of bounds a PerformanceError will be raised. Because we
+    interpolate between rows, the last row that can be read is
+
+    maxrow = (ftlen(ifnsrc)-ioffset)/inumcols - 2
+
+    krow     : the row to read (can be a fractional number, in which case interpolation
+               with the next row is performed)
+    ifnsrc   : index of the source table
+    ifndest  : index of the dest table
+    inumcols : the number of columns a row has, in the source table
+    ioffset  : an offset to where the data starts (used to skip a header, if present)
+    istart   : start index to read from the row
+    iend     : end index to read from the row (not inclusive)
+    istep    : step used to read the along the row
+
+    The use case is as follows: a bank of oscillators is driven by a table
+    containing the data. The bank has a fixed number of oscillators, each oscillator
+    is sampled regularly and for each instant, the frequency, amplitude and bandwidth
+    are recorded. All information is put into a table with following layout
+
+    row0: f0 amp0 bw0 f1 amp1 bw1 f2 amp2 bw2 ...
+    row1: f0 amp0 bw0 f1 amp1 bw1 f2 amp2 bw2 ...
+    ...
+
+    In order to get the frequency of the oscillators at any given time,
+    krow = ktime / ksampleperiod
+
+    Put the (interpolated) frequencies in another table
+
+    ioffset = 0
+    istart = 0
+    iend = 0
+    istep = 3
+    tabrowlin krow, ifnsrc, ifndest, inumoscil*istep, ioffset, istart, iend, istep 
+    
+ */
+
+typedef struct {
+    OPDS h;
+    MYFLT *krow, *ifnsrc, *ifndest, *inumcols, *ioffset, *istart, *iend, *istep;
+    MYFLT* tabsource;
+    MYFLT* tabdest;
+    MYFLT  maxrow;
+    int tabsourcelen;
+    int tabdestlen;
+    int end;
+} TABROWCOPY;
+
+// idx = ioffset + row * inumcols + n*step, while idx < iend
+
+static int32_t
+tabrowcopy_init(CSOUND* csound, TABROWCOPY* p){
+    FUNC* ftp;
+    if (UNLIKELY((ftp = csound->FTnp2Find(csound, p->ifnsrc)) == NULL))
+        return INITERR(Str("tabrowcopy: incorrect table number"));
+    p->tabsource    = ftp->ftable;
+    p->tabsourcelen = ftp->flen;
+    if (UNLIKELY((ftp = csound->FTnp2Find(csound, p->ifndest)) == NULL))
+        return INITERR(Str("tabrowcopy: incorrect table number"));
+    p->tabdest    = ftp->ftable;
+    p->tabdestlen = ftp->flen;
+
+    int end = *p->iend;
+    if(end > *p->inumcols)
+        return INITERR(Str("tabrowcopy: iend can't be bigger than numcols"));
+
+    if(end == 0)
+        end = *p->inumcols;
+
+    p->end = end;
+
+    int numcols_to_copy = (int)((end - *p->istart) / *p->istep);
+    if (numcols_to_copy > p->tabdestlen)
+        return INITERR(Str("tabrowcopy: Destination table too small"));
+
+    p->maxrow = (p->tabsourcelen - *p->ioffset) / *p->inumcols - FL(2);
+
+    MSGF(Str("tabrowcopy: Max. Row = %f \n"), p->maxrow);
+    return OK;
+}
+
+static int32_t
+tabrowcopyk(CSOUND* csound, TABROWCOPY* p) {
+    int i;
+    MYFLT x0, x1;
+    MYFLT row   = *p->krow;
+    int row0    = (int)row;
+    MYFLT delta = row - row0;
+    int numcols = *p->inumcols;
+    int offset  = *p->ioffset;
+    int start   = *p->istart;
+    int end  = p->end;
+    int step = *p->istep;
+    int tabsourcelen = p->tabsourcelen;
+
+    MYFLT* tabsource = p->tabsource;
+    MYFLT* tabdest   = p->tabdest;
+
+    int idx0 = offset + numcols * row0 + start;
+    int idx1 = idx0 + (end-start);
+    int j    = 0;
+
+    if(UNLIKELY(row < 0))
+        return PERFERROR(Str("tabrowcopy: krow can't be negative"));
+
+    if (LIKELY(delta != 0)) {
+        if (UNLIKELY(idx1+numcols >= tabsourcelen))
+            return PERFERROR(Str("tabrowcopy: tab off end"));
+        for (i=idx0; i<idx1; i+=step) {
+            x0 = tabsource[i];
+            x1 = tabsource[i + numcols];
+            tabdest[j++] = x0 + (x1-x0)*delta;
+        }
+    } else {
+        if (UNLIKELY(idx1 >= tabsourcelen))
+            return PERFERROR(Str("tabrowcopy: tab off end"));
+        for (i=idx0; i<idx1; i+=step) {
+            tabdest[j++] = tabsource[i];
+        }
+    }
+    return OK;
+}
+
+typedef struct {
+    OPDS h;
+    ARRAYDAT *outarr;
+    MYFLT *krow, *ifnsrc, *inumcols, *ioffset, *istart, *iend, *istep;
+    MYFLT* tabsource;
+    MYFLT  maxrow;
+    uint32_t tabsourcelen;
+    uint32_t end;
+    uint32_t numitems;
+} TABROWCOPYARR;
+
+static int32_t
+tabrowcopyarr_init(CSOUND *csound, TABROWCOPYARR *p) {
+    FUNC* ftp;
+    if (UNLIKELY((ftp = csound->FTnp2Find(csound, p->ifnsrc)) == NULL))
+        return INITERR(Str("tabrowlin: incorrect table number"));
+    p->tabsource = ftp->ftable;
+    p->tabsourcelen = ftp->flen;
+    uint32_t start = (uint32_t)*p->istart;
+    uint32_t end   = (uint32_t)*p->iend;
+    uint32_t step  = (uint32_t)*p->istep;
+    if(end > *p->inumcols)
+        return INITERR(Str("tabrowlin: iend can't be bigger than numcols"));
+    if(end == 0)
+        end = *p->inumcols;
+    if(end <= start) {
+        return INITERR(Str("tabrowlin: end must be bigger than start"));
+    }
+    p->end = end;
+    uint32_t numitems = (uint32_t)ceil((end - start) / (float)step);
+    if(numitems <= 0) {
+        return INITERR(Str("tabrowlin: no items to copy"));
+    }
+    arrayensure(csound, p->outarr, numitems);
+    p->numitems = numitems;
+    p->maxrow = (p->tabsourcelen - *p->ioffset) / *p->inumcols - FL(2);
+    return OK;
+}
+
+static int32_t
+tabrowcopyarr_k(CSOUND *csound, TABROWCOPYARR *p) {
+    uint32_t start = (uint32_t)*p->istart;
+    uint32_t end   = (uint32_t)p->end;
+    uint32_t step  = (uint32_t)*p->istep;
+    uint32_t offset = (uint32_t)*p->ioffset;
+    uint32_t numitems = (uint32_t)ceil((end - start) / (float)step);
+    uint32_t numcols = (uint32_t)*p->inumcols;
+    MYFLT row = *p->krow;
+    uint32_t row0 = (uint32_t)row;
+    MYFLT delta = row - row0;    
+    uint32_t tabsourcelen = p->tabsourcelen;
+    MYFLT *out = p->outarr->data;
+    MYFLT *tabsource = p->tabsource;
+    MYFLT x0, x1;
+    
+    if(UNLIKELY(row < 0)) {
+        return PERFERROR(Str("krow can't be negative"));
+    }
+    // TODO : check maxrow
+    uint32_t idx0 = offset + numcols * row0 + start;
+    uint32_t idx1 = idx0 + (end-start);
+    uint32_t i, j = 0;
+    if (LIKELY(delta != 0)) {
+        if (UNLIKELY(idx1+numcols >= tabsourcelen))
+            return PERFERROR(Str("tab off end"));
+        for (i=idx0; i<idx1; i+=step) {
+            x0 = tabsource[i];
+            x1 = tabsource[i + numcols];
+            out[j++] = x0 + (x1-x0)*delta;
+        }
+    } else {
+        if (UNLIKELY(idx1 >= tabsourcelen))
+            return PERFERROR(Str("tab off end"));
+        for (i=idx0; i<idx1; i+=step) {
+            out[j++] = tabsource[i];
+        }
+    }
+    return OK;
+}
+
+
+typedef struct {
+    OPDS h;
+    // kOut[] rowlin kMtrx[], krow, kstart=0, kend=0, kstep=1
+    ARRAYDAT *outarr, *inarr;
+    MYFLT *krow, *kstart, *kend, *kstep;
+    int numitems;
+} GETROWLIN;
+
+/*
+
+  getrowlin: the same as tabrowlin, but with arrays instead of tables
+
+  kOut[] getrowlin kMtrx[], krow, kstart=0, kend=0, kstep=1
+
+  Given a 2D array kMtrx, get a row of this array (possibly a slice [kstart:kend:kstep]).
+  If krow is not an integer, the values are the result of the interpolation between 
+  two rows
+
+*/
+
+static int32_t
+getrowlin_init(CSOUND *csound, GETROWLIN *p) {
+    int start = (int)*p->kstart;
+    int end   = (int)*p->kend;
+    int step  = (int)*p->kstep;
+    if (end < 1)
+        end = p->inarr->sizes[1];
+    int numitems = (int)ceil((end - start) / (float)step);
+
+    arrayensure(csound, p->outarr, numitems);
+    p->numitems = numitems;
+    return OK;
+}
+
+static int32_t
+getrowlin_k(CSOUND *csound, GETROWLIN *p) {
+    if(p->inarr->dimensions != 2)
+        return PERFERROR(Str("The input array should be a 2D array"));
+    int start = (int)*p->kstart;
+    int end   = (int)*p->kend;
+    int step  = (int)*p->kstep;
+    if (end <= 0) {
+        end = p->inarr->sizes[1];
+    }
+    int numitems = (int)ceil((end - start) / (float)step);
+    int numcols  = p->inarr->sizes[1];
+    if(numitems > numcols)
+        return PERFERROR(Str("Asked to read too many items from a row"));
+    if(numitems > p->numitems) {
+        arrayensure(csound, p->outarr, numitems);
+        p->numitems = numitems;
+    }
+    MYFLT row = *p->krow;
+    if(UNLIKELY(row < 0))
+        return PERFERROR(Str("getrowlin: krow can't be negative"));
+    if(UNLIKELY(row > p->inarr->sizes[0] - 2))
+        return PERFERROR(Str("getrowlin: exceeded maximum row"));
+    int row0    = (int)row;
+    MYFLT delta = row - row0;
+
+    MYFLT *out = p->outarr->data;
+    MYFLT *in  = p->inarr->data;
+
+    int idx0 = numcols * row0 + start;
+    int idx1 = idx0 + numitems;
+    MYFLT x0, x1;
+    int i, j = 0;
+    if (LIKELY(delta != 0))
+        for (i=idx0; i<idx1; i+=step) {
+            x0 = in[i];
+            x1 = in[i + numcols];
+            out[j++] = x0 + (x1-x0)*delta;
+        }
+    else
+        for (i=idx0; i<idx1; i+=step) {
+            out[j++] = in[i];
+        }
+    return OK;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+/*
+
+Input types:
+
+ * a, k, s, i, w, f,
+ * o (optional i-rate, default to 0), O optional krate=0
+ * p (opt, default to 1), P optional krate=1
+ * q (opt, 10),
+ * v(opt, 0.5),
+ * j(opt, -1), J optional krate=-1
+ * h(opt, 127),
+ * y (multiple inputs, a-type),
+ * z (multiple inputs, k-type),
+ * Z (multiple inputs, alternating k- and a-types),
+ * m (multiple inputs, i-type),
+ * M (multiple inputs, any type)
+ * n (multiple inputs, odd number of inputs, i-type).
+ * . anytype
+ * ? optional
+
+ */
+
+#define S(x)    sizeof(x)
+
+static OENTRY localops[] = {
+    // aout beosc xfreq, kbw, ifn=-1, iphase=0, iflags=1
+    {"beosc", S(BEOSC), 0, 5, "a", "kkjop", (SUBR)beosc_init, NULL, (SUBR)beosc_kkiii },
+    {"beosc", S(BEOSC), 0, 5, "a", "akjop", (SUBR)beosc_init, NULL, (SUBR)beosc_akiii },
+
+    // aout beadsynt ifreqft, iampft, ibwft, inumosc, iflags=1, kfreq=1, kbw=1, ifn=-1, iphs=-1
+    {"beadsynt", S(BEADSYNT), 0, 5, "a", "iiijpPPjj", (SUBR)beadsynt_init, NULL, (SUBR)beadsynt_perf },
+
+    // aout beadsynt kFreq[], kAmp[], kBw[], inumosc=-1, iflags=1, kfreq=1, kbw=1, ifn=-1, iphs=-1
+    {"beadsynt", S(BEADSYNT), 0, 5, "a", "k[]k[]k[]jpPPjj", (SUBR)beadsynt_init_array, NULL, (SUBR)beadsynt_perf },
+
+    // tabrowlin krow, ifnsrc, ifndest, inumcols, ioffset=0, istart=0, iend=0, istep=1
+    {"tabrowlin", S(TABROWCOPY), 0, 3, "", "kiiiooop",  (SUBR)tabrowcopy_init, (SUBR)tabrowcopyk },
+
+    // kOut[]  tabrowlin krow, ifnsrc, inumcols, ioffset=0, istart=0, iend=0, istep=1
+    {"getrowlin", S(TABROWCOPY), 0, 3, "k[]", "kiiooop", (SUBR)tabrowcopyarr_init, (SUBR)tabrowcopyarr_k},
+
+    // kOut[] getrowlin kMtrx[], krow, kstart=0, kend=0, kstep=1
+    {"getrowlin", S(TABROWCOPY), 0, 3, "k[]", "k[]kOOP",  (SUBR)getrowlin_init, (SUBR)getrowlin_k },
+};
+
+LINKAGE

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -24,7 +24,6 @@
 */
 
 #include <csdl.h>
-#include <math.h>
 
 #define SAMPLE_ACCURATE \
     uint32_t n, nsmps = CS_KSMPS;                                    \
@@ -233,7 +232,9 @@ lincos_perf(CSOUND *csound, LINLIN1 *p) {
     if (UNLIKELY(x0 == x1)) {
         return PERFERROR(Str("lincos: Division by zero"));
     }
-    MYFLT dx = ((x-x0) / (x1-x0)) * M_PI + M_PI;
+    // PI is defined in csoundCore.h, use that instead of M_PI from math.h, which
+    // is not defined in windows
+    MYFLT dx = ((x-x0) / (x1-x0)) * PI + PI;
     *p->kout = y0 + ((y1 - y0) * (1 + cos(dx)) / 2.0);
     return OK;
 }
@@ -433,7 +434,7 @@ static int32_t bpfxcos(CSOUND *csound, BPFX *p) {
         x1 = *data[i];
         y1 = *data[i+1];
         if( x <= x1 ) {
-            dx = ((x-x0) / (x1-x0)) * M_PI + M_PI;
+            dx = ((x-x0) / (x1-x0)) * PI + PI;
             *p->r = y0 + ((y1 - y0) * (1 + cos(dx)) / 2.0);
             return OK;
         }
@@ -528,7 +529,7 @@ static int32_t bpfarrcos(CSOUND *csound, BPFARR *p) {
                 x1 = *data[i];
                 y1 = *data[i+1];
                 if( x <= x1 ) {
-                    dx = ((x-x0) / (x1-x0)) * M_PI + M_PI;
+                    dx = ((x-x0) / (x1-x0)) * PI + PI;
                     out[idx] = y0 + ((y1 - y0) * (1 + cos(dx)) / 2.0);
                     break;
                 }

--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -28,34 +28,45 @@
 #define LOG001 FL(-6.907755278982137)
 #define CALCSLOPE(next,prev,nsmps) ((next - prev)/nsmps)
 
+#define SAMPLE_ACCURATE \
+    uint32_t n, nsmps = CS_KSMPS;                                    \
+    MYFLT *out = p->out;                                             \
+    uint32_t offset = p->h.insdshead->ksmps_offset;                  \
+    uint32_t early = p->h.insdshead->ksmps_no_end;                   \
+    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));   \
+    if (UNLIKELY(early)) {                                           \
+        nsmps -= early;                                              \
+        memset(&out[nsmps], '\0', early*sizeof(MYFLT));              \
+    }                                                                \
+
 /* #define ZXP(z) (*(z)++) */
 
-static inline MYFLT zapgremlins(MYFLT x)
-{
+static inline MYFLT
+zapgremlins(MYFLT x) {
     MYFLT absx = fabs(x);
     // very small numbers fail the first test, eliminating denormalized numbers
-    //    (zero also fails the first test, but that is OK since it returns zero.)
+    //    (zero also fails the first test, but that is OK since it returns
+    // zero.)
     // very large numbers fail the second test, eliminating infinities
     // Not-a-Numbers fail both tests and are eliminated.
     return (absx > (MYFLT)1e-15 && absx < (MYFLT)1e15) ? x : (MYFLT)0.0;
 }
 
-
-static inline MYFLT sc_wrap(MYFLT in, MYFLT lo, MYFLT hi) {
+static inline MYFLT
+sc_wrap(MYFLT in, MYFLT lo, MYFLT hi) {
     MYFLT range;
     // avoid the divide if possible
-    if (in >= hi) {
-      range = hi - lo;
-      in -= range;
-      if (in < hi) return in;
-    } else if (in < lo) {
-      range = hi - lo;
-      in += range;
-      if (in >= lo) return in;
+    if(in >= hi) {
+        range = hi - lo;
+        in -= range;
+        if (in < hi) return in;
+    } else if(in < lo) {
+        range = hi - lo;
+        in += range;
+        if(in >= lo) return in;
     } else return in;
 
     if (hi == lo) return lo;
-    // return in - range * floor((in - lo)/range);
     return in - range * FLOOR((in - lo) / range);
 }
 
@@ -70,35 +81,35 @@ static inline MYFLT sc_wrap(MYFLT in, MYFLT lo, MYFLT hi) {
   of a value. This is useful for smoothing out control signals.
 
   ksmooth = lag(kx, klagtime, [initialvalue=0])
-  asmooth = lag(ka, klagtime, [initialvalue=0])
+  asmooth = lag(ain, klagtime, [initialvalue=0])
 
 */
 
 typedef struct {
-  OPDS    h;
-  MYFLT   *out, *in, *lagtime, *first;
-  MYFLT   lag, b1, y1;
-  MYFLT   sr;
+    OPDS  h;
+    MYFLT *out, *in, *lagtime, *first;
+    MYFLT lag, b1, y1;
+    MYFLT sr;
 } LAG;
 
 static int32_t lagk_next(CSOUND *csound, LAG *p) {
-     IGN(csound);
+    IGN(csound);
     MYFLT lag = *p->lagtime;
-    MYFLT y0 = *p->in;
-    MYFLT y1 = p->y1;
+    MYFLT y0  = *p->in;
+    MYFLT y1  = p->y1;
     MYFLT b1;
     if (lag == p->lag) {
-      b1 = p->b1;
-      p->y1 = y1 = y0 + b1 * (y1 - y0);
-      *p->out = y1;
-      return OK;
+        b1 = p->b1;
+        p->y1   = y1 = y0 + b1 * (y1 - y0);
+        *p->out = y1;
+        return OK;
     } else {
-      // faust uses tau2pole = exp(-1 / (lag*sr))
-      b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
-      *p->out = y0 + b1 * (y1 - y0);
-      p->lag = lag;
-      p->b1 = b1;
-      return OK;
+        // faust uses tau2pole = exp(-1 / (lag*sr))
+        b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
+        *p->out = y0 + b1 * (y1 - y0);
+        p->lag = lag;
+        p->b1 = b1;
+        return OK;
     }
 }
 
@@ -122,66 +133,71 @@ static int32_t laga_init(CSOUND *csound, LAG *p) {
     return OK;
 }
 
+static int32_t
+laga_next(CSOUND *csound, LAG *p) {
+    IGN(csound);
 
-static int32_t laga_next(CSOUND *csound, LAG *p) {
-     IGN(csound);
-    uint32_t n, nsmps = CS_KSMPS;
-    MYFLT *in = p->in, *out = p->out;
+    SAMPLE_ACCURATE
+
+    MYFLT *in = p->in;
     MYFLT lag = *p->lagtime;
     MYFLT y1 = p->y1;
     MYFLT b1 = p->b1;
     MYFLT y0;
-    uint32_t offset = p->h.insdshead->ksmps_offset; // delayed onset
-    uint32_t early  = p->h.insdshead->ksmps_no_end; // early end of event
-    if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early))  {
-      nsmps -= early;
-      memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
-    }
+
     if (lag == p->lag) {
-      for (n=offset; n<nsmps; n++) {
-        y0 = in[n];
-        y1 = y0 + b1 * (y1 - y0);
-        out[n] = y1;
-      }
-      p->y1 = y1;
-      return OK;
+        for (n=offset; n<nsmps; n++) {
+            y0 = in[n];
+            y1 = y0 + b1 * (y1 - y0);
+            out[n] = y1;
+        }
+        p->y1 = y1;
+        return OK;
     } else {
-      // faust uses tau2pole = exp(-1 / (lag*sr))
-      p->b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
-      MYFLT b1_slope = CALCSLOPE(p->b1, b1, nsmps);
-      p->lag = lag;
-      for (n=offset; n<nsmps; n++) {
-        b1 += b1_slope;
-        y0 = in[n];
-        y1 = y0 + b1 * (y1 - y0);
-        out[n] = y1;
-      }
-      p->y1 = y1;
-      return OK;
+        // faust uses tau2pole = exp(-1 / (lag*sr))
+        p->b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
+        MYFLT b1_slope = CALCSLOPE(p->b1, b1, nsmps);
+        p->lag = lag;
+        for (n=offset; n<nsmps; n++) {
+            b1 += b1_slope;
+            y0  = in[n];
+            y1  = y0 + b1 * (y1 - y0);
+            out[n] = y1;
+        }
+        p->y1 = y1;
+        return OK;
     }
 }
 
 // ------------------------- LagUD ---------------------------
 
+/*
+
+  klagged lagud ksrc, klagtime_up, klagtime_down, initialvalue=0
+  alagged lagud asrc, klagtime_up, klagtime_down, initialvalue=0
+  
+*/
+
+
 typedef struct {
-  OPDS    h;
-  MYFLT   *out, *in, *lagtimeU, *lagtimeD, *first;
-  MYFLT   lagu, lagd, b1u, b1d, y1;
+    OPDS h;
+    MYFLT *out, *in, *lagtimeU, *lagtimeD, *first;
+    MYFLT  lagu, lagd, b1u, b1d, y1;
 } LagUD;
 
-static int32_t lagud_a(CSOUND *csound, LagUD *p) {
-    MYFLT
-      *out = p->out,
-      *in = p->in,
-      lagu = *p->lagtimeU,
-      lagd = *p->lagtimeD,
-      y1 = p->y1,
-      b1u = p->b1u,
-      b1d = p->b1d;
-    uint32_t offset = p->h.insdshead->ksmps_offset; // delayed onset
-    uint32_t early  = p->h.insdshead->ksmps_no_end; // early end of event
-    uint32_t n, nsmps = CS_KSMPS;
+
+static int32_t
+lagud_a(CSOUND *csound, LagUD *p) {
+    IGN(csound);
+
+    SAMPLE_ACCURATE
+
+    MYFLT *in  = p->in;
+    MYFLT lagu = *p->lagtimeU;
+    MYFLT lagd = *p->lagtimeD;
+    MYFLT y1   = p->y1;
+    MYFLT b1u  = p->b1u;
+    MYFLT b1d  = p->b1d;
 
     if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early))  {
@@ -189,139 +205,134 @@ static int32_t lagud_a(CSOUND *csound, LagUD *p) {
       memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
     }
     if ((lagu == p->lagu) && (lagd == p->lagd)) {
-      for (n=offset; n<nsmps; n++) {
-        MYFLT y0 = in[n];
-        if (y0 > y1)
-          y1 = y0 + b1u * (y1 - y0);
-        else
-          y1 = y0 + b1d * (y1 - y0);
-        out[n]= y1;
-      }
+        for (n=offset; n<nsmps; n++) {
+            MYFLT y0 = in[n];
+            if (y0 > y1)
+                y1 = y0 + b1u * (y1 - y0);
+            else
+                y1 = y0 + b1d * (y1 - y0);
+            out[n]= y1;
+        }
     } else {
-      MYFLT sr = csound->GetSr(csound);
-      // faust uses tau2pole = exp(-1 / (lag*sr))
-      p->b1u = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
-      MYFLT b1u_slope = CALCSLOPE(p->b1u, b1u, nsmps);
-      p->lagu = lagu;
-      p->b1d = lagd == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagd * sr));
-      MYFLT b1d_slope = CALCSLOPE(p->b1d, b1d, nsmps);
-      p->lagd = lagd;
-      for (n=offset; n<nsmps; n++) {
-        MYFLT y0 = in[n];
-        b1u += b1u_slope;
-        b1d += b1d_slope;
-        if (y0 > y1)
-          y1 = y0 + b1u * (y1-y0);
-        else
-          y1 = y0 + b1d * (y1-y0);
-        out[n] = y1;
-      }
+        MYFLT sr = csound->GetSr(csound);
+        // faust uses tau2pole = exp(-1 / (lag*sr))
+        p->b1u = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
+        MYFLT b1u_slope = CALCSLOPE(p->b1u, b1u, nsmps);
+        p->lagu = lagu;
+        p->b1d  = lagd == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagd * sr));
+        MYFLT b1d_slope = CALCSLOPE(p->b1d, b1d, nsmps);
+        p->lagd = lagd;
+        for (n=offset; n<nsmps; n++) {
+            MYFLT y0 = in[n];
+            b1u += b1u_slope;
+            b1d += b1d_slope;
+            if (y0 > y1)
+                y1 = y0 + b1u * (y1-y0);
+            else
+                y1 = y0 + b1d * (y1-y0);
+            out[n] = y1;
+        }
     }
     p->y1 = zapgremlins(y1);
     return OK;
 }
 
-static int32_t lagud_k(CSOUND *csound, LagUD *p) {
-    MYFLT
-      *in = p->in,
-      lagu = *p->lagtimeU,
-      lagd = *p->lagtimeD,
-      y1 = p->y1;
-
-    //uint32_t nsmps = CS_KSMPS;
+static int
+lagud_k(CSOUND *csound, LagUD *p) {
+    MYFLT *in  = p->in;
+    MYFLT lagu = *p->lagtimeU;
+    MYFLT lagd = *p->lagtimeD;
+    MYFLT y1   = p->y1;
 
     if ((lagu == p->lagu) && (lagd == p->lagd)) {
-      MYFLT y0 = *in;
-      if (y0 > y1)
-        p->y1 = y1 = y0 + p->b1u * (y1 - y0);
-      else
-        p->y1 = y1 = y0 + p->b1d * (y1 - y0);
-      *(p->out) = y1;
-
+        MYFLT y0 = *in;
+        if (y0 > y1)
+            p->y1 = y1 = y0 + p->b1u * (y1 - y0);
+        else
+            p->y1 = y1 = y0 + p->b1d * (y1 - y0);
+        *(p->out) = y1;
     } else {
-      MYFLT sr = csound->GetKr(csound);
-      // faust uses tau2pole = exp(-1 / (lag*sr)), sc uses log(0.01)
-      p->b1u = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
-      p->lagu = lagu;
-      p->b1d = lagd == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagd * sr));
-      p->lagd = lagd;
-      MYFLT y0 = *in;
-      if (y0 > y1)
-        y1 = y0 + p->b1u * (y1 - y0);
-      else
-        y1 = y0 + p->b1d * (y1 - y0);
-      *(p->out) = y1;
+        MYFLT sr = csound->GetKr(csound);
+        // faust uses tau2pole = exp(-1 / (lag*sr)), sc uses log(0.01)
+        p->b1u  = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
+        p->lagu = lagu;
+        p->b1d  = lagd == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagd * sr));
+        p->lagd = lagd;
+        MYFLT y0 = *in;
+        if (y0 > y1)
+            y1 = y0 + p->b1u * (y1 - y0);
+        else
+            y1 = y0 + p->b1d * (y1 - y0);
+        *(p->out) = y1;
     }
     p->y1 = y1;
     return OK;
 }
 
 static int32_t lagud_init(CSOUND *csound, LagUD *p) {
-     IGN(csound);
+    IGN(csound);
     p->lagu = -1;
     p->lagd = -1;
-    p->b1u = FL(0.0);
-    p->b1d = FL(0.0);
-    p->y1 = *p->first;
+    p->b1u  = FL(0.0);
+    p->b1d  = FL(0.0);
+    p->y1   = *p->first;
     return OK;
 }
 
-// ------------------ Trig -------------------------
-// trig(signal, duration)
-// Returns 1 for given duration whenever signal crosses from
-// non-positive to positiv
+/* ------------------ Trig -------------------------
 
+   Returns 1 for a given duration whenever signal crosses from non-positive to positive
+
+   kout    trig kin, kduration
+   aout    trig ain, kduration
+
+*/
 
 typedef struct {
-  OPDS    h;
-  MYFLT   *out, *in, *dur;
-  MYFLT   level, prevtrig;
-  int64_t counter;
+    OPDS h;
+    MYFLT *out, *in, *dur;
+    MYFLT  level, prevtrig;
+    long counter;
 } Trig;
 
-static int32_t trig_a(CSOUND *csound, Trig *p) {
-    MYFLT
-      *out = p->out,
-      *in = p->in;
-    MYFLT
-      dur = *p->dur,
-      sr = csound->GetSr(csound),
-      prevtrig = p->prevtrig,
-      level = p->level;
-    uint64_t counter = p->counter;
-    uint32_t offset = p->h.insdshead->ksmps_offset; // delayed onset
-    uint32_t early  = p->h.insdshead->ksmps_no_end; // early end of event
-    uint32_t n, nsmps = CS_KSMPS;
-    if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early))  {
-      nsmps -= early;
-      memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
-    }
-    for (n=offset; n<nsmps; n++) {
-      MYFLT curtrig = in[n];
-      MYFLT zout;
-      if (counter > 0) {
-        zout = --counter ? level : FL(0.0);
-      } else {
-        if (curtrig > FL(0.0) && prevtrig <= FL(0.0)) {
-          counter = (int64_t)(dur * sr + FL(0.5));
-          if (counter < 1) counter = 1;
-          level = curtrig;
-          zout = level;
+static int
+trig_a(CSOUND *csound, Trig *p) {
+
+    SAMPLE_ACCURATE
+
+    MYFLT *in = p->in;
+    MYFLT dur = *p->dur;
+    MYFLT sr = csound->GetSr(csound);
+    MYFLT prevtrig = p->prevtrig;
+    MYFLT level = p->level;
+    unsigned long counter = p->counter;
+
+    for(n=offset; n<nsmps; n++) {
+        MYFLT curtrig = in[n];
+        MYFLT zout;
+        if (counter > 0) {
+            zout = --counter ? level : FL(0.0);
         } else {
-          zout = FL(0.0);
+            if (curtrig > FL(0.0) && prevtrig <= FL(0.0)) {
+                counter = (long)(dur * sr + FL(0.5));
+                if (counter < 1) counter = 1;
+                level = curtrig;
+                zout  = level;
+            } else {
+                zout = FL(0.0);
+            }
         }
-      }
-      prevtrig = curtrig;
-      out[n] = zout;
+        prevtrig = curtrig;
+        out[n]   = zout;
     }
     p->prevtrig = prevtrig;
-    p->counter = counter;
-    p->level = level;
+    p->counter  = counter;
+    p->level    = level;
     return OK;
 }
 
-static int32_t trig_k(CSOUND *csound, Trig *p) {
+static int
+trig_k(CSOUND *csound, Trig *p) {
     MYFLT curtrig = *p->in;
     MYFLT dur = *p->dur;
     MYFLT kr = csound->GetKr(csound);
@@ -329,17 +340,17 @@ static int32_t trig_k(CSOUND *csound, Trig *p) {
     MYFLT level = p->level;
     uint64_t counter = p->counter;
     if (counter > 0) {
-      *p->out = --counter ? level : FL(0.0);
+        *p->out = --counter ? level : FL(0.0);
     } else {
-      if (curtrig > FL(0.0) && prevtrig <= FL(0.0)) {
-        counter = (int64_t)(dur * kr + FL(0.5));
-        if (counter < 1)
-          counter = 1;
-        level = curtrig;
-        *p->out = level;
-      } else {
-        *p->out = FL(0.0);
-      }
+        if (curtrig > FL(0.0) && prevtrig <= FL(0.0)) {
+            counter = (int64_t)(dur * kr + FL(0.5));
+            if (counter < 1)
+                counter = 1;
+            level   = curtrig;
+            *p->out = level;
+        } else {
+            *p->out = FL(0.0);
+        }
     }
     p->prevtrig = curtrig;
     p->counter = counter;
@@ -357,171 +368,175 @@ static int32_t trig_init(CSOUND *csound, Trig *p) {
 
 
 /*
+   Phasor
 
-  Phasor
+   kindex   sc_phasor  ktrig, krate, kstart, kend, kresetPos=kstart
+   aindex   sc_phasor  ktrig, krate, kstart, kend, kresetPos=kstart
+   aindex   sc_phasor  atrig, krate, kstart, kend, kresetPos=kstart
+   aindex   sc_phasor  atrig, arate, kstart, kend, kresetPos=kstart
+   
+   Phasor is a linear ramp between start and end values. When its trigger
+   input crosses from non-positive to positive, Phasor's output will jump
+   to its reset position. Upon reaching the end of its ramp Phasor will wrap
+   back to its start.
 
-  Phasor is a linear ramp between start and end values. When its trigger
-  input crosses from non-positive to positive, Phasor's output will jump
-  to its reset position. Upon reaching the end of its ramp Phasor will wrap
-  back to its start.
+   NOTE: N.B. Since end is defined as the wrap point, its value is never
+   actually output.
 
-  NOTE: N.B. Since end is defined as the wrap point, its value is never
-  actually output.
+   NOTE: If one wants Phasor to output a signal with frequency freq
+   oscillating between start and end, then the rate should be
+   (end - start) * freq / sr where sr is the sampling rate.
 
-  NOTE: If one wants Phasor to output a signal with frequency freq
-  oscillating between start and end, then the rate should be
-  (end - start) * freq / sr where sr is the sampling rate.
+   Phasor is commonly used as an index control.
 
-  Phasor is commonly used as an index control.
+   aindex phasor atrig, xrate, kstart, kend, kresetPos=kstart
+   kindex phasor ktrig, krate, kstart, kend, kresetPos=kstart
 
-  aindex phasor atrig, xrate, kstart, kend, kresetPos
-  kindex phasor ktrig, krate, kstart, kend, kresetPos
+   trig:     When triggered, jump to resetPos (default: 0, equivalent to start).
+   rate:     The amount of change per sample, i.e at a rate of 1 the value
+             of each sample will be 1 greater than the preceding sample.
+   start:    Start point of the ramp.
+   end:      End point of the ramp.
+   resetPos: The value to jump to upon receiving a trigger.
 
-  trig: When triggered, jump to resetPos (default: 0, equivalent to start).
-  rate: The amount of change per sample, i.e at a rate of 1 the value
-  of each sample will be 1 greater than the preceding sample.
-  start: Start point of the ramp.
-  end:   End point of the ramp.
-  resetPos: The value to jump to upon receiving a trigger.
 */
 
-
 typedef struct {
-  OPDS    h;
-  MYFLT   *out, *trig, *rate, *start, *end, *resetPos;
-  MYFLT   level, previn/*, resetk*/;
+    OPDS h;
+    MYFLT *out, *trig, *rate, *start, *end, *resetPos;
+    MYFLT level, previn;
 } Phasor;
 
 static int32_t phasor_init(CSOUND *csound, Phasor *p) {
-     IGN(csound);
+    IGN(csound);
     p->previn = 0;
     p->level = 0;
-    /* p->resetk = 1; */
     return OK;
 }
 
-/* static int32_t phasor_init0(CSOUND *csound, Phasor *p) { */
-/*     p->previn = 0; */
-/*     p->level = 0; */
-/*     p->resetk = 0; */
-/*     return OK; */
-/* } */
+static int32_t
+phasor_a_aa(CSOUND *csound, Phasor *p) {
+    IGN(csound);
 
-static int32_t phasor_aa(CSOUND *csound, Phasor *p) {
-     IGN(csound);
-    MYFLT *out  = p->out;
+    SAMPLE_ACCURATE
+
     MYFLT *in = p->trig;
     MYFLT *rate = p->rate;
     MYFLT start = *p->start;
-    MYFLT end   = *p->end;
-    //MYFLT resetPos = p->resetk ? (*p->resetPos) : 0;
+    MYFLT end = *p->end;
     MYFLT resetPos = *p->resetPos;
     MYFLT previn = p->previn;
     MYFLT level = p->level;
-    uint32_t offset = p->h.insdshead->ksmps_offset; // delayed onset
-    uint32_t early  = p->h.insdshead->ksmps_no_end; // early end of event
-    uint32_t n, nsmps = CS_KSMPS;
-    if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early))  {
-      nsmps -= early;
-      memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
+
+    for(n=offset; n<nsmps; n++) {
+        MYFLT curin = in[n];
+        MYFLT zrate = rate[n];
+        if (previn <= FL(0.0) && curin > FL(0.0)) {
+            MYFLT frac = FL(1) - previn/(curin-previn);
+            level = resetPos + frac * zrate;
+        }
+        out[n] = level;
+        level += zrate;
+        level = sc_wrap(level, start, end);
+        previn = curin;
     }
-    for (n=offset; n<nsmps; n++) {
-      MYFLT curin = in[n];
-      MYFLT zrate = rate[n];
-      if (previn <= FL(0.0) && curin > FL(0.0)) {
-        MYFLT frac = FL(1) - previn/(curin-previn);
-        level = resetPos + frac * zrate;
-      }
-      out[n] = level;
-      level += zrate;
-      level = sc_wrap(level, start, end);
-      previn = curin;
+    p->previn = previn;
+    p->level  = level;
+    return OK;
+}
+
+static int32_t
+phasor_a_ak(CSOUND *csound, Phasor *p) {
+    IGN(csound);
+    
+    SAMPLE_ACCURATE
+
+    MYFLT *in = p->trig;
+    MYFLT rate = *p->rate;
+    MYFLT start = *p->start;
+    MYFLT end = *p->end;
+    MYFLT resetPos = *p->resetPos;
+    MYFLT previn = p->previn;
+    MYFLT level = p->level;
+
+    for(n=offset; n<nsmps; n++) {
+        MYFLT curin = in[n];
+        if (previn <= FL(0.0) && curin > FL(0.0)) {
+            MYFLT frac = FL(1.0) - previn/(curin-previn);
+            level = resetPos + frac * rate;
+        }
+        out[n] = level;
+        level += rate;
+        level = sc_wrap(level, start, end);
+        previn = curin;
     }
     p->previn = previn;
     p->level = level;
     return OK;
 }
 
-static int32_t phasor_ak(CSOUND *csound, Phasor *p) {
-     IGN(csound);
-    MYFLT *out  = p->out;
-    MYFLT *in   = p->trig;
-    MYFLT rate  = *p->rate;
-    MYFLT start = *p->start;
-    MYFLT end   = *p->end;
+static int32_t
+phasor_a_kk(CSOUND *csound, Phasor *p) {
+    IGN(csound);
+    
+    SAMPLE_ACCURATE
+
+    MYFLT curin    = *p->trig;
+    MYFLT rate     = *p->rate;
+    MYFLT start    = *p->start;
+    MYFLT end      = *p->end;
     MYFLT resetPos = *p->resetPos;
-    //MYFLT resetPos = p->resetk ? (*p->resetPos) : 0;
-    MYFLT previn = p->previn;
-    MYFLT level = p->level;
-    uint32_t n;
-    uint32_t offset = p->h.insdshead->ksmps_offset; // delayed onset
-    uint32_t early  = p->h.insdshead->ksmps_no_end; // early end of event
-    uint32_t nsmps = CS_KSMPS;
-    if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early))  {
-      nsmps -= early;
-      memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
+    MYFLT previn   = p->previn;
+    MYFLT level    = p->level;
+    int trig = (previn <= FL(0.0)) && (curin > FL(0.0));
+    MYFLT frac = FL(1.0) - previn/(curin-previn);
+
+    for(n=offset; n<nsmps; n++) {
+        if (trig)
+            level = resetPos + frac * rate;
+        out[n] = level;
+        level += rate;
+        level  = sc_wrap(level, start, end);
     }
-    for (n=offset; n<nsmps; n++) { // Only calculate inside event
-      MYFLT curin = in[n];
-      if (previn <= FL(0.0) && curin > FL(0.0)) {
-        MYFLT frac = FL(1.0) - previn/(curin-previn);
-        level = resetPos + frac * rate;
-      }
-      out[n] = level;
-      level += rate;
-      level = sc_wrap(level, start, end);
-      previn = curin;
-    }
-    p->previn = previn;
-    p->level = level;
+    p->previn = curin;
+    p->level  = level;
     return OK;
 }
 
-static int32_t phasor_kk(CSOUND *csound, Phasor *p) {
-     IGN(csound);
-    MYFLT curin = *p->trig;
-    MYFLT rate  = *p->rate;
-    MYFLT start = *p->start;
-    MYFLT end   = *p->end;
+static int
+phasor_k_kk(CSOUND *csound, Phasor *p) {
+    MYFLT curin    = *p->trig;
+    MYFLT rate     = *p->rate;
+    MYFLT start    = *p->start;
+    MYFLT end      = *p->end;
     MYFLT resetPos = *p->resetPos;
-    //MYFLT resetPos = p->resetk ? (*p->resetPos) : 0;
-    MYFLT previn = p->previn;
-    MYFLT level = p->level;
+    MYFLT previn   = p->previn;
+    MYFLT level    = p->level;
 
     if (UNLIKELY(previn <= FL(0.0) && curin > FL(0.0))) {
-      level = resetPos;
+        level = resetPos;
     }
     level = sc_wrap(level, start, end);
     *p->out = level;
     level += rate;
     p->previn = curin;
     p->level = level;
-
     return OK;
 }
-
 
 #define S(x)    sizeof(x)
 
 static OENTRY localops[] = {
-  { "sc_lag", S(LAG),   0, 3,   "k", "kko",
-    (SUBR)lagk_init, (SUBR)lagk_next, NULL, NULL },
-  { "sc_lag", S(LAG),   0, 3,   "a", "ako",
-    (SUBR)laga_init, (SUBR)laga_next, NULL },
-  { "sc_lagud",   S(LagUD), 0, 3,   "k", "kkko", (SUBR)lagud_init, (SUBR)lagud_k },
-  { "sc_lagud",   S(LagUD), 0, 3,   "a", "akko",
-    (SUBR)lagud_init, (SUBR)lagud_a },
-  { "sc_trig",    S(Trig),  0, 3,   "k", "kk", (SUBR)trig_init, (SUBR)trig_k },
-  { "sc_trig",    S(Trig),  0, 3,   "a", "ak",
-    (SUBR)trig_init, (SUBR)trig_a },
-  { "sc_phasor",  S(Phasor),  0, 3,   "k", "kkkkO",
-    (SUBR)phasor_init, (SUBR)phasor_kk },
-  { "sc_phasor",  S(Phasor),  0, 3,   "a", "akkkO",
-    (SUBR)phasor_init, (SUBR)phasor_ak },
-  { "sc_phasor",  S(Phasor),  0, 3,   "a", "aakkO",
-    (SUBR)phasor_init, (SUBR)phasor_aa }
+    {"sc_lag",    S(LAG),    0, 3, "k", "kko",   (SUBR)lagk_init, (SUBR)lagk_next},
+    {"sc_lag",    S(LAG),    0, 5, "a", "ako",   (SUBR)laga_init, NULL, (SUBR)laga_next},
+    {"sc_lagud",  S(LagUD),  0, 3, "k", "kkko",  (SUBR)lagud_init, (SUBR)lagud_k },
+    {"sc_lagud",  S(LagUD),  0, 5, "a", "akko",  (SUBR)lagud_init, NULL, (SUBR)lagud_a },
+    {"sc_trig",   S(Trig),   0, 3, "k", "kk",    (SUBR)trig_init, (SUBR)trig_k },
+    {"sc_trig",   S(Trig),   0, 5, "a", "ak",    (SUBR)trig_init, NULL, (SUBR)trig_a },
+    {"sc_phasor", S(Phasor), 0, 3, "k", "kkkkO", (SUBR)phasor_init, (SUBR)phasor_k_kk },
+    {"sc_phasor", S(Phasor), 0, 5, "a", "akkkO", (SUBR)phasor_init, NULL, (SUBR)phasor_a_ak },
+    {"sc_phasor", S(Phasor), 0, 5, "a", "aakkO", (SUBR)phasor_init, NULL, (SUBR)phasor_a_aa },
+    {"sc_phasor", S(Phasor), 0, 5, "a", "kkkkO", (SUBR)phasor_init, NULL, (SUBR)phasor_a_kk }
 };
 
 LINKAGE


### PR DESCRIPTION
This PR updates emugens, fixing many bugs and adding new opcodes. It adds a new set of opcodes to implement band-enhanced additive synthesis, as implemented in loris, in csound.

## emugens

* `printarray`: print 1D and 2D arrays
* `tab2array`: copy a slice of a table (start, end, step) to an array
* `ftslice`: copy a slice of a table to another table
* `bpf`: breakpoint linear interpolation, now accepts unlimited number of breakpoints and accepts arrays
* `bpfcos`: similar to bpf, but with cosine interpolation
* `linlin`: accepts arrays, allows to make linear interpolation between arrays
* `lincos`: similar to linlin, with cosine interpolation
* or and and bitwise operation between two arrays

## beosc

* `beosc`: band enhanced oscillator, a port of BEOsc from supercollider, with added gaussian noise and linear interpolation
* `beadsynt`: a bank of band-enhanced oscillators, makes resynthesis of files analyzed via loris possible and efficient
* `getrowlin`: get a row from a 2D array, possibly a slice (giving start, end and step for the row), with linear interpolation between adjacent rows
* `tabrowlin`: the same but for a table

The band-enhanced opcodes are developed together with a python library (https://github.com/gesellkammer/loristrck) and set of scripts to analyze, filter and resynthesize soundfiles via partial tracking.

For an example of beadsynt, see https://github.com/gesellkammer/ugens/blob/master/beosc/examples/beadsynt3.csd