### PR TITLE
fix dirname/filename mismatch in plugindir_envvar

### DIFF
--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -505,7 +505,7 @@ int csoundLoadModules(CSOUND *csound)
         csoundWarning(csound, Str("Library %s omitted\n"), fname);
         continue;
       }
-      snprintf(buf, 1024, "%s%c%s", dname, DIRSEP, fname);
+      snprintf(buf, 1024, "%s%c%s", dname1, DIRSEP, fname);
       if (UNLIKELY(csound->oparms->odebug)) {
         csoundMessage(csound, Str("Loading '%s'\n"), buf);
        }


### PR DESCRIPTION
There's something strange about `OPCODE6DIR64` on my linux, this is more of a ticket with a suggestion (this PR) how I fixed it. If I add `export OPCODE6DIR64=/dir/a:/dir/b` then csound will complain that an .so file located in `/dir/b` is missing in `/dir/a`. Plus it's strange that if this global variable is empty, like it is all of the time on my computer, csound works fine, and as soon as I give it a value, it complains about alsa module is not found (and jack if it's set), but will not complain about any other missing opcode and `csound -z` works fine and the .csd compiles with many opcodes on a dummy module.

ps. I discovered this as I discovered the best hidden secret in csound so far, compiling faust .dsp to csound .so file. It works and I'm super excited about this :P, just need to have a seperate plugins directory since NixOs distro is based on immutability for system packages.