### PR TITLE
FLTK widget colour updates during performance

### DIFF
--- a/InOut/widgets.cpp
+++ b/InOut/widgets.cpp
@@ -3149,6 +3149,7 @@ extern "C" {
                                (int) *p->green,
                                (int) *p->blue);
       o->color(color);
+      o->redraw();
       return OK;
   }
 
@@ -3160,6 +3161,7 @@ extern "C" {
       Fl_Widget *o = (Fl_Widget *) v.WidgAddress;
       int color = fl_rgb_color((int) *p->red, (int) *p->green, (int) *p->blue);
       o->selection_color(color);
+      o->redraw();
       return OK;
   }
 
@@ -3171,6 +3173,7 @@ extern "C" {
       Fl_Widget *o = (Fl_Widget *) v.WidgAddress;
       int color = fl_rgb_color((int) *p->red, (int) *p->green, (int) *p->blue);
       o->labelcolor(color);
+      o->window()->redraw();
       return OK;
   }
 


### PR DESCRIPTION
At the moment FLsetColor, FLsetColor2 and FLsetTextColor only work at initialisation. These additions allow widget colours to be changed after the panel has been created/during performance by calling the relevant redraw function.