### PR TITLE
Fix printarray

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1454,17 +1454,15 @@ arrayprint_init(CSOUND *csound, ARRAYPRINTK *p) {
 }
 
 
-#define MESSAGES(fmt, s) (csound->MessageS(csound, CSOUNDMSG_ORCH, fmt, (char*)s))
 #define ARRPRINT_SEP (csound->MessageS(csound, CSOUNDMSG_ORCH, "\n"))
-
+#define ARRPRINT_MAXLINE 1024
 
 static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *data,
                             int dim0, int dim1, const char *label) {
     MYFLT *in = data;
     int32_t i, j, startidx;
     const uint32_t linelength = print_linelength;
-    const int MAXLINE = 1024;
-    char currline[MAXLINE];
+    char currline[ARRPRINT_MAXLINE];
     uint32_t charswritten = 0;
     if(label != NULL) {
         MESSAGES("%s\n", label);
@@ -1499,14 +1497,14 @@ static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *da
                 }
                 else {
                     currline[charswritten+1] = '\0';
-                    MESSAGES("%s\n", currline);
+                    csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline)
                     charswritten = 0;
                 }
                 in++;
             }
             if (charswritten > 0) {
                 currline[charswritten] = '\0';
-                MESSAGES("%s\n", currline);
+                csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline)
                 charswritten = 0;
             }
         }

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1465,7 +1465,7 @@ static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *da
     char currline[ARRPRINT_MAXLINE];
     uint32_t charswritten = 0;
     if(label != NULL) {
-        MESSAGES("%s\n", label);
+        csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char *)label);
     }
     switch(dims) {
     case 1:
@@ -1497,14 +1497,14 @@ static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *da
                 }
                 else {
                     currline[charswritten+1] = '\0';
-                    csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline)
+                    csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline);
                     charswritten = 0;
                 }
                 in++;
             }
             if (charswritten > 0) {
                 currline[charswritten] = '\0';
-                csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline)
+                csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char*)currline);
                 charswritten = 0;
             }
         }

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1464,28 +1464,39 @@ static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *da
     const uint32_t linelength = print_linelength;
     char currline[ARRPRINT_MAXLINE];
     uint32_t charswritten = 0;
+    int32_t showidx = 0;
     if(label != NULL) {
         csound->MessageS(csound, CSOUNDMSG_ORCH, "%s\n", (char *)label);
     }
     switch(dims) {
     case 1:
         startidx = 0;
+        if (dim0 > 100) {
+            showidx = 1;
+        }
         for(i=0; i<dim0; i++) {
             charswritten += sprintf(currline+charswritten, fmt, in[i]);
             if(charswritten < linelength) {
                 currline[charswritten++] = ' ';
             } else {
                 currline[charswritten+1] = '\0';
-                csound->MessageS(csound, CSOUNDMSG_ORCH, " %3d: %s\n", startidx, (char*)currline);
+                if (showidx) {
+                    csound->MessageS(csound, CSOUNDMSG_ORCH, " %3d: %s\n", startidx, (char*)currline);
+                } else {
+                    csound->MessageS(csound, CSOUNDMSG_ORCH, " %s\n", (char*)currline);
+                }
                 charswritten = 0;
                 startidx = i;
             }
         }
         if (charswritten > 0) {
             currline[charswritten] = '\0';
-            csound->MessageS(csound, CSOUNDMSG_ORCH, " %3d: %s\n", startidx, (char*)currline);
+            if (showidx) {
+                csound->MessageS(csound, CSOUNDMSG_ORCH, " %3d: %s\n", startidx, (char*)currline);
+            } else {
+                csound->MessageS(csound, CSOUNDMSG_ORCH, " %s\n", (char*)currline);
+            }
         }
-        ARRPRINT_SEP;
         break;
     case 2:
         for(i=0; i<dim0; i++) {
@@ -1508,9 +1519,9 @@ static inline void arrprint(CSOUND *csound, const char *fmt, int dims, MYFLT *da
                 charswritten = 0;
             }
         }
-        ARRPRINT_SEP;
         break;
     }
+    // ARRPRINT_SEP;
 }
 
 


### PR DESCRIPTION
This PR removes a newline after printing an array, limits printing of index for 1D arrays to arrays bigger than a certain limit (now 100)

The 1 "bug" reported in #1095 can't be fixed with the given implementation, which passes the format to sprintf and thus will not work with %d or %i. It is in my opinion questionable if these formats should be allowed since there are no integers in csound. The desired result can be achieved by passing `%.0f` as format