### PR TITLE
perfThread: wait the recording thread before waiting for the performance thread

### DIFF
--- a/interfaces/csPerfThread.cpp
+++ b/interfaces/csPerfThread.cpp
@@ -676,14 +676,14 @@ int CsoundPerformanceThread::Join()
     int retval;
     retval = status;
 
-    if (perfThread) {
-      retval = csoundJoinThread(perfThread);
-      perfThread = (void*) 0;
-    }
     if (recordData.running) {
         recordData.running = false;
         csoundCondSignal(recordData.condvar);
         csoundJoinThread(recordData.thread);
+    }
+    if (perfThread) {
+      retval = csoundJoinThread(perfThread);
+      perfThread = (void*) 0;
     }
 
     // delete any pending messages


### PR DESCRIPTION
If we don't tell the recording thread to stop, we might enter a deadlock as the perf thread waits for the record
thread but it has not been stopped yet.

Fixes #1103