### PR TITLE
Configures a default message string callback handler after csoundReset

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -3362,7 +3362,9 @@ PUBLIC void csoundReset(CSOUND *csound)
     }
 
     if (msgcallback_ != NULL) {
-      csoundSetMessageCallback(csound, msgcallback_);
+     csoundSetMessageCallback(csound, msgcallback_);
+    } else {
+     csoundSetMessageCallback(csound, csoundDefaultMessageCallback);
     }
     csound->printerrormessagesflag = (void*)1234;
     /* copysystem environment variables */

--- a/include/csound.h
+++ b/include/csound.h
@@ -1571,7 +1571,8 @@ extern "C" {
   /**
    * Sets an alternative function to be called by Csound to print an
    * informational message, using a less granular signature.
-   *  This callback can be set for --realtime mode
+   *  This callback can be set for --realtime mode.
+   *  This callback is cleared after csoundReset
    */
   PUBLIC void csoundSetMessageStringCallback(CSOUND *csound,
               void (*csoundMessageStrCallback)(CSOUND *csound,


### PR DESCRIPTION
After a call to csoundReset(), if the user have configured the csoundMessageStringCallback, a segmentation fault will occur because during the reset this callback pointer is clear, It doesn't happen when a default callback is configured.

the function csoundSetMessageStringCallback
```
PUBLIC void csoundSetMessageStringCallback(CSOUND *csound,
              void (*csoundMessageStrCallback)(CSOUND *csound,
                                            int attr,
                                            const char *str)) {

  if (csoundMessageStrCallback) {
    if(csound->message_string == NULL)
      csound->message_string = (char *) csound->Calloc(csound, MAX_MESSAGE_STR);
  csound->csoundMessageStringCallback = csoundMessageStrCallback;
  csound->csoundMessageCallback_ = NULL;
  }

}
```
assigns the callback pointer to the user's callback and also clear the csound's internal message pointer to NULL.
Also, after csoundReset the messageStringCallback's buffer is null, tha's why,  configuring only the messageStringCallback and then resetting the csound instance, a segmentation faults is triggered with the follow error message
```
#0 _IO_vsnprintf (string=0x0, maxlen=,
format=0x7ffff7b343d5 "0dBFS level = %.1f\n", args=0x7fffffffdaa8)
at vsnprintf.c:112
#1 0x00007ffff79119bc in csoundMessage () from /usr/lib/libcsound64.so.6.0
#2 0x00007ffff79156d9 in csoundReset () from /usr/lib/libcsound64.so.6.0
#3 0x0000555555554bc5 in main ()
```
All that, because the csound's message functions first check if  the csound->csoundMessageCallback_ is NULL,  and if it is NULL, they assume there is a messageStringCallback pointer already configured, like this:
```
PUBLIC void csoundMessage(CSOUND *csound, const char *format, ...)
{
    va_list args;
    va_start(args, format);
    if(csound->csoundMessageCallback_)
    csound->csoundMessageCallback_(csound, 0, format, args);
    else {
    vsnprintf(csound->message_string, MAX_MESSAGE_STR, format, args);
    csound->csoundMessageStringCallback(csound, 0, csound->message_string);
    }
    va_end(args);
}
```
and as I mentioned, the:
```
csound->message_string
```
and
```
csound->csoundMessageStringCallback
```
Are null after reset.

Well that was my understating about it. It could be fixed I guess in many ways. This PR contains two modifications:
* adding a else case when the callback pointer is evaluated in the csoundReset and if that pointer is null, assigns it to point to the default message callback.
* added a little note into the csoundSetMessageStringCallback documentation, indicating to the user that,  this callback is clear to NULL after reset.

You can test it with this test case:

```
#include <stdio.h>
#include <csound.h>

messages (CSOUND * csound, int attr, const char *message){
    printf("%s", message);
}

int main(int arg, char** argv) {

  csoundInitialize(CSOUNDINIT_NO_ATEXIT);

  CSOUND* csound = csoundCreate(NULL);

  csoundSetMessageStringCallback(csound, messages);

  csoundCompileCsd(csound, "test1.csd");  
  csoundStart(csound);
  csoundPerform(csound);

  printf(" calling for a new performance \n");

  csoundReset(csound);
  csoundCompileCsd(csound, "test1.csd");
  csoundStart(csound);

  csoundPerform(csound);

  csoundStop(csound);

  return 0;
}
```





