### PR TITLE
Modified Hash Table implementation to expand on load

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -144,7 +144,7 @@ static void free_opcode_table(CSOUND* csound) {
     CS_HASH_TABLE_ITEM* bucket;
     CONS_CELL* head;
 
-    for (i = 0; i < HASH_SIZE; i++) {
+    for (i = 0; i < csound->opcodes->table_size; i++) {
       bucket = csound->opcodes->buckets[i];
 
       while (bucket != NULL) {

--- a/include/csound_data_structures.h
+++ b/include/csound_data_structures.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define HASH_SIZE 4099
-
 typedef struct _cons {
     void* value; // should be car, but using value
     struct _cons* next; // should be cdr, but to follow csound
@@ -43,7 +41,9 @@ typedef struct _cs_hash_bucket_item {
 } CS_HASH_TABLE_ITEM;
 
 typedef struct _cs_hash_table {
-    CS_HASH_TABLE_ITEM* buckets[HASH_SIZE];
+    int table_size;
+    int count;
+    CS_HASH_TABLE_ITEM** buckets;
 } CS_HASH_TABLE;
 
 /* FUNCTIONS FOR CONS CELL */


### PR DESCRIPTION
Modified hash table to expand hash table buckets based on load and load factor. Performance compared to prior implementation should be about equal on small loads and much improved on higher loads. 