### PR TITLE
Set CS_FRAMEWORK_DEST as CMake cache entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(EXECUTABLE_INSTALL_DIR "bin")
 set(LOCALE_INSTALL_DIR "share/locale")
 set(HEADER_INSTALL_DIR "include/csound")
 
-set(CS_FRAMEWORK_DEST "~/Library/Frameworks")
+set(CS_FRAMEWORK_DEST "~/Library/Frameworks" CACHE PATH "Csound framework path")
 include(TestBigEndian)
 include(CheckFunctionExists)
 include(CheckIncludeFile)


### PR DESCRIPTION
This should allow `CS_FRAMEWORK_DEST` to be specified when building Csound, for example:

```sh
cmake -DCS_FRAMEWORK_DEST:PATH=/usr/local/Frameworks ../csound
```

This issue [came up](https://github.com/Homebrew/homebrew-core/pull/36061#issuecomment-484457838) in my pull request to add Csound to [homebrew-core](https://github.com/Homebrew/homebrew-core).

This pull request uses `~/Library/Frameworks` as the default path (since that’s what it was before), but I should mention that [Apple discourages](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Tasks/InstallingFrameworks.html) installing frameworks there.