### PR TITLE
increase the maximum name length for the jack-client name

### DIFF
--- a/H/cs_jack.h
+++ b/H/cs_jack.h
@@ -21,7 +21,7 @@
     02110-1301 USA
 */
 
-#define MAX_NAME_LEN    32      /* for client and port name */
+#define MAX_NAME_LEN    256      /* for client and port name */
 
 typedef struct RtJackBuffer_ {
 #ifdef LINUX


### PR DESCRIPTION
32 characters is bit short amount for my use-case (I'm creating jack clients based on java classpath names). 256 should be a sensible maximum.