### PR TITLE
small fixes for rtjack compilation on win32

### DIFF
--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -58,6 +58,11 @@ if(USE_JACK)
     # I am hardcoding it for MacOS
     set(JACK_HEADER  "jack/jack.h")
     endif()
+    if(WIN32)
+    # HLO: including the jack2 common source dir
+    # prevents "cannot open include file" errors
+    find_path(JACK_INCLUDE_PATH jack/jack.h)
+    endif()
 endif()
 if(USE_PULSEAUDIO)
     find_library(PULSEAUDIO_LIBRARY pulse)
@@ -214,6 +219,8 @@ if(USE_JACK)
         list(APPEND rtjack_LIBS
             ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
     elseif(WIN32)
+        check_deps(JACK_INCLUDE_PATH)
+        include_directories("${JACK_INCLUDE_PATH}")
         list(APPEND rtjack_LIBS
             ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
     else()

--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -52,7 +52,6 @@ if(USE_PORTMIDI)
 endif()
 if(USE_JACK)
     find_library(JACK_LIBRARY jack)
-    find_library(JACKDMP_LIBRARY jackdmp)
     check_include_file(jack/jack.h JACK_HEADER)
     if(APPLE)
     # VL: could not find a way to make check_include_file() work so
@@ -216,7 +215,7 @@ if(USE_JACK)
             ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
     elseif(WIN32)
         list(APPEND rtjack_LIBS
-            ${JACKDMP_LIBRARY} ${PTHREAD_LIBRARY})
+            ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
     else()
         list(APPEND rtjack_LIBS
             ${JACK_LIBRARY} ${PTHREAD_LIBRARY})


### PR DESCRIPTION
After long battle with jack2 on windows, I was able to make it run, and to be able to compile it, I needed to make minor changes to cmake and rtjack.c. But it wont run from the official jack2 installation, since it hasn't been updated since 2016. If someone really wants to use jack2 with windows and csound, I would recommend extracting the pre-built jack2 from http://users.notam02.no/~kjetism/radium/demos/windows64/?C=M;O=D there they distribute newer binaries with the same ABI. It's just a question of time when the jack developers make a new windows release and the errors from their current outdated release are fixed.