### PR TITLE
Use the overloaded Scope::log(float*)

### DIFF
--- a/Bela/BelaCsound.cpp
+++ b/Bela/BelaCsound.cpp
@@ -286,7 +286,7 @@ void render(BelaContext *context, void *Data)
         channel[i].samples[frmcount] = analogRead(context,k,i);
 	analogWriteOnce(context,k,i,ochannel[i].samples[frmcount]);
       }
-      scope.log(schannel.samples[frmcount]);
+      scope.log(&schannel.samples[frmcount]);
     }
     gCsData.res = res;
     gCsData.count = count;


### PR DESCRIPTION
as this is a) more efficient b) less unlikely to be discontinued in the future.

This assume that `schannel.samples[frmcount]` is a `float`, and so we take its address instead.