### PR TITLE
Fix build of libstdutil an Android

### DIFF
--- a/Android/pluginlibs/libstdutil/jni/Android.mk
+++ b/Android/pluginlibs/libstdutil/jni/Android.mk
@@ -34,7 +34,7 @@ $(CSOUND_SRC_ROOT)/util/sndinfo.c \
 $(CSOUND_SRC_ROOT)/util/srconv.c \
 $(CSOUND_SRC_ROOT)/util/std_util.c \
 $(CSOUND_SRC_ROOT)/util/xtrct.c \
-$(CSOUND_SRC_ROOT)/SDIF/sdif.c
+$(CSOUND_SRC_ROOT)/util/SDIF/sdif.c
 
 LOCAL_LDLIBS += -ldl
 


### PR DESCRIPTION
libstdutil doesn't build for Android because of a wrong (moved?) place for sdif.c.