### PR TITLE
dont try to find libsndfile includes on msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,8 +549,8 @@ find_package(SWIG)
 find_package(VSTSDK2X)
 
 
-# TODO should this work for MSVC also?
-if(WIN32)
+# LIBSNDFILE_LIBRARY and SNDFILE_H_PATH flags are enough for MSVC
+if(WIN32 AND NOT MSVC)
   find_library(FLAC_LIB NAMES FLAC flac)
   find_library(OGG_LIB ogg)
   find_library(SPEEX_LIB speex)


### PR DESCRIPTION
With this change, cmake works directly with the source-tree using MSVC. This is my command which I used to test #1151 there was also some doubt about this written in the comments, so I hope the new comments clarify this TODO/question.

```
cmake ..\ -G "Visual Studio 15 2017 Win64" -DUSE_DOUBLE=1 -DUSE_JACK=1 -DBUILD_JACK_OPCODES=0 -DCMAKE_BUILD_TYPE="Rel" -DCMAKE_INSTALL_PREFIX="dist" -DJACK_LIB="C:\Users\User\Downloads\radium_64bit_windows-5.9.65-demo\radium_64bit_windows-5.9.65-demo\bin\jack_local\libjack64.lib" -DJACK_LIBRARY="C:\Users\User\Downloads\radium_64bit_windows-5.9.65-demo\radium_64bit_windows-5.9.65-demo\bin\jack_local\libjack64.lib" -DJACK_INCLUDE_PATH="C:\Users\User\Documents\jack2\common" -DLIBSNDFILE_LIBRARY="C:\Program Files\Mega-Nerd\libsndfile\lib\libsndfile-1.lib" -DSNDFILE_H_PATH="C:\Program Files\Mega-Nerd\libsndfile\include" -DBISON_EXECUTABLE="..\..\..\Downloads\win_flex_bison-latest\win_bison.exe" -DFLEX_EXECUTABLE="C:\Users\User\Downloads\win_flex_bison-latest\win_flex.exe"
cmake --build .
```