### PR TITLE
Fix for Valgrind-reported use of uninitialised value

### DIFF
--- a/Engine/csound_pre.lex
+++ b/Engine/csound_pre.lex
@@ -409,6 +409,7 @@ QNAN            "qnan"[ \t]*\(
                        PARM->lstack[++PARM->depth] =
                          (strchr(mm->body,'\n') ?file_to_int(csound, mname) : 63);
                        yy_scan_string(mm->body, yyscanner);
+                       csound_preset_lineno(0, yyscanner); /* for Valgrind */
                      }
                    }
                  }


### PR DESCRIPTION
The uninitialised variable at issue is `yy_bs_lineno` in the `YY_BUFFER_STATE` struct.

This solution (explicitly resetting the line number) was suggested in https://stackoverflow.com/questions/59754253/ .
```
 128 errors in context 6 of 6:
 Use of uninitialised value of size 8
    at 0x565E86B: _itoa_word (_itoa.c:179)
    by 0x5661F0D: vfprintf (vfprintf.c:1642)
    by 0x56876D0: vsprintf (iovsprintf.c:42)
    by 0x566B093: sprintf (sprintf.c:32)
    by 0x5121D35: csound_pre_line (csound_pre.lex:1421)
    by 0x5118F0B: csound_prelex (csound_pre.lex:187)
    by 0x5135B11: csoundParseOrc (new_orc_parser.c:197)
    by 0x5133EA1: csoundCompileOrcInternal (csound_orc_compile.c:1932)
    by 0x5031EA5: csoundCompileArgs (main.c:306)
    by 0x5032B6A: csoundCompile (main.c:554)
    by 0x109917: main (csound_main.c:326)
  Uninitialised value was created by a heap allocation
    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x511E3CB: csound_prealloc (csound_prelex.c:3421)
    by 0x511DB75: csound_pre_scan_buffer (csound_prelex.c:3022)
    by 0x511DD1A: csound_pre_scan_bytes (csound_prelex.c:3080)
    by 0x511DC58: csound_pre_scan_string (csound_prelex.c:3052)
    by 0x511A407: csound_prelex (csound_pre.lex:411)
    by 0x5135B11: csoundParseOrc (new_orc_parser.c:197)
    by 0x5133EA1: csoundCompileOrcInternal (csound_orc_compile.c:1932)
    by 0x5031EA5: csoundCompileArgs (main.c:306)
    by 0x5032B6A: csoundCompile (main.c:554)
    by 0x109917: main (csound_main.c:326)
```