### PR TITLE
Fix for Valgrind-reported jump/move deps on uninitialised value

### DIFF
--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -1227,7 +1227,7 @@ void *csoundCreateFileHandle(CSOUND *csound,
       return NULL;
     nbytes += (int) strlen(fullName);
     /* allocate file structure */
-    p = (CSFILE*) csound->Malloc(csound, (size_t) nbytes);
+    p = (CSFILE*) csound->Calloc(csound, (size_t) nbytes);
     if (p == NULL)
       return NULL;
     p->nxt = (CSFILE*) csound->open_files;


### PR DESCRIPTION
The uninitialised variable is `async_flag` in the `CSFILE` struct.

Rather than initialising this explicitly in `csoundCreateFileHandle()`, just use `csound->Calloc()` to allocate the struct, in case other fields end up in a similar scenario.
```
 Conditional jump or move depends on uninitialised value(s)
    at 0x157E9F: csoundFileClose (envvar.c:1286)
    by 0x15814C: close_all_files (envvar.c:1354)
    by 0x1500F9: reset (csound.c:3248)
    by 0x14B95F: csoundDestroy (csound.c:1385)
    by 0x14A566: main (csound_main.c:332)
  Uninitialised value was created by a heap allocation
    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x17468C: mmalloc (memalloc.c:75)
    by 0x157CF9: csoundCreateFileHandle (envvar.c:1230)
    by 0x30F96F: cpupercent_init (cpumeter.c:98)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
```