### PR TITLE
Fix for Valgrind-reported jump/move deps on uninitialised value

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -145,6 +145,7 @@ int hfgens(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp, int mode)
       csound->genmax = GENMAX + 1;
     }
     msg_enabled = csound->oparms->msglevel & 7;
+    memset(&ff, 0, sizeof(ff)); /* for Valgrind */
     ff.csound = csound;
     memcpy((char*) &(ff.e), (char*) evtblkp,
            (size_t) ((char*) &(evtblkp->p[2]) - (char*) evtblkp));


### PR DESCRIPTION
The uninitialised variables occur in the `FGDATA` struct.
```
 1 errors in context 2 of 8:
 Conditional jump or move depends on uninitialised value(s)
    at 0x4E9756A: ftresdisp (fgens.c:2302)
    by 0x4E8E4F1: hfgens (fgens.c:295)
    by 0x4EAEEB8: process_score_event (musmon.c:841)
    by 0x4EAF983: sensevents (musmon.c:1038)
    by 0x4E81F18: csoundPerform (csound.c:2243)
    by 0x10992C: main (csound_main.c:328)
  Uninitialised value was created by a stack allocation
    at 0x4E8D7DD: hfgens (fgens.c:134)

[...]

 44096 errors in context 8 of 8:
 Conditional jump or move depends on uninitialised value(s)
    at 0x4EBD3DC: spoutsf (libsnd.c:83)
    by 0x4E80AE7: kperf_nodebug (csound.c:1790)
    by 0x4E81FD4: csoundPerform (csound.c:2253)
    by 0x10992C: main (csound_main.c:328)
  Uninitialised value was created by a stack allocation
    at 0x4E8D7DD: hfgens (fgens.c:134)
```