### PR TITLE
Fix invalid pointer dereference

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -1605,7 +1605,7 @@ static int gen27(FGDATA *ff, FUNC *ftp)
 static int gen28(FGDATA *ff, FUNC *ftp)
 {
     CSOUND  *csound = ff->csound;
-    MYFLT   *fp = ftp->ftable, *finp;
+    MYFLT   *fp, *finp;
     int     seglen, resolution = 100;
     FILE    *filp;
     void    *fd;


### PR DESCRIPTION
The `ftp` pointer passed in to `gen28()` does not appear to be valid in some cases, and in any event, dereferencing it early serves no purpose as the `fp` variable is not used before being assigned a new value.
```
 1 errors in context 1 of 1:
 Invalid read of size 8
    at 0x4E953E5: gen28 (fgens.c:1608)
    by 0x4E8F6BB: hfgens (fgens.c:236)
    by 0x4EB0A54: process_score_event (musmon.c:841)
    by 0x4EB1518: sensevents (musmon.c:1038)
    by 0x4E83036: csoundPerform (csound.c:2243)
    by 0x109953: main (csound_main.c:328)
  Address 0x42d8 is not stack'd, malloc'd or (recently) free'd
```