### PR TITLE
Fix Valgrind-reported jump/move dep on uninitialised values

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -1621,9 +1621,9 @@ static int gen28(FGDATA *ff, FUNC *ftp)
     if (UNLIKELY(fd == NULL))
       goto gen28err1;
 
-    x = (MYFLT*)csound->Malloc(csound,arraysize*sizeof(MYFLT));
-    y = (MYFLT*)csound->Malloc(csound,arraysize*sizeof(MYFLT));
-    z = (MYFLT*)csound->Malloc(csound,arraysize*sizeof(MYFLT));
+    x = (MYFLT*)csound->Calloc(csound,arraysize*sizeof(MYFLT));
+    y = (MYFLT*)csound->Calloc(csound,arraysize*sizeof(MYFLT));
+    z = (MYFLT*)csound->Calloc(csound,arraysize*sizeof(MYFLT));
 #if defined(USE_DOUBLE)
     while (fscanf( filp, "%lf%lf%lf", &z[i], &x[i], &y[i])!= EOF)
 #else


### PR DESCRIPTION
```
 878964 errors in context 76 of 76:
 Conditional jump or move depends on uninitialised value(s)
    at 0x4EBF4E4: spoutsf (libsnd.c:83)
    by 0x4E81A9A: kperf_nodebug (csound.c:1790)
    by 0x4E830FE: csoundPerform (csound.c:2253)
    by 0x109953: main (csound_main.c:328)
  Uninitialised value was created by a heap allocation
    at 0x4C2FDAF: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAAE3D: mmalloc (memalloc.c:75)
    by 0x4E954EC: gen28 (fgens.c:1625)
    by 0x4E8F6BB: hfgens (fgens.c:236)
    by 0x4EB0A44: process_score_event (musmon.c:841)
    by 0x4EB1508: sensevents (musmon.c:1038)
    by 0x4E83036: csoundPerform (csound.c:2243)
    by 0x109953: main (csound_main.c:328)
```