### PR TITLE
Fix Valgrind-reported jump/move dep on uninitialised values

### DIFF
--- a/OOps/ugrw1.c
+++ b/OOps/ugrw1.c
@@ -566,6 +566,7 @@ int32_t printsset(CSOUND *csound, PRINTS *p)
     pk.ptime = &ptime;
     printksset(csound, &pk);
     memset(string,0,8192);
+    memset(pk.txtstring,0,sizeof(pk.txtstring));
     if (sprints(string, pk.txtstring, p->kvals, p->INOCOUNT-1)==NOTOK)
         return
           csound->InitError(csound,


### PR DESCRIPTION
```
 1 errors in context 1 of 1:
 Conditional jump or move depends on uninitialised value(s)
    at 0x223FD8: sprints (ugrw1.c:448)
    by 0x224460: printsset (ugrw1.c:569)
    by 0x1674F2: init_pass (insert.c:116)
    by 0x168E48: insert_event (insert.c:472)
    by 0x16809B: insert (insert.c:298)
    by 0x17A083: process_score_event (musmon.c:829)
    by 0x17ABBD: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
  Uninitialised value was created by a stack allocation
    at 0x224351: printsset (ugrw1.c:559)
```