### PR TITLE
Fix Valgrind-reported invalid reads

### DIFF
--- a/Opcodes/bilbar.c
+++ b/Opcodes/bilbar.c
@@ -306,6 +306,7 @@ int32_t init_pp(CSOUND *csound, CSPP *p)
       csound->AuxAlloc(csound,
                        3*((1+(N+5))*NS+p->rattle_num+p->rubber_num)*sizeof(MYFLT),
                        &p->auxch);
+      c = (double *)p->auxch.auxp;
       p->s0 = (MYFLT*)p->auxch.auxp;
       p->s1 = &p->s0[NS];
       p->hammer_force = &p->s1[NS];


### PR DESCRIPTION
The code fails to take into account that memory pointed to by a local variable may have moved.
```
 3 errors in context 4 of 4:
 Invalid read of size 8
    at 0x2701EA: init_pp (bilbar.c:315)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
  Address 0xc269420 is 32 bytes inside a block of size 56 free'd
    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x174A34: mfree (memalloc.c:173)
    by 0x152936: csoundAuxAlloc (auxfd.c:44)
    by 0x27002D: init_pp (bilbar.c:306)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
  Block was alloc'd at
    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x174805: mcalloc (memalloc.c:113)
    by 0x152988: csoundAuxAlloc (auxfd.c:53)
    by 0x26FC61: init_pp (bilbar.c:277)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
```