### PR TITLE
Fix for leaked file pointer

### DIFF
--- a/Opcodes/cpumeter.c
+++ b/Opcodes/cpumeter.c
@@ -95,6 +95,7 @@ int32_t cpupercent_init(CSOUND *csound, CPUMETER* p)
     p->cpus = (CPU_t *) p->cpu_a.auxp;
     k = cpupercent_renew(csound, p);
     p->cnt = (p->trig = (int32_t)(*p->itrig * csound->GetSr(csound)));
+    csoundCreateFileHandle(csound, &p->fp, CSFILE_STD, "/proc/stat");
     return k;
 }
 


### PR DESCRIPTION
`cpupercent_init()` calls `fopen()` on `/proc/stat`, but never closes it.
Create a Csound file handle so it is closed on program exit.
```
 552 bytes in 1 blocks are still reachable in loss record 4 of 8
    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x5B73E49: __fopen_internal (iofopen.c:65)
    by 0x5B73E49: fopen@@GLIBC_2.2.5 (iofopen.c:89)
    by 0x30F617: cpupercent_init (cpumeter.c:78)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
```