### PR TITLE
Fix for Valgrind-reported invalid reads

### DIFF
--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -175,6 +175,8 @@ static int32_t sprocess1(CSOUND *csound, DATASPACE *p)
         double tim;
         double resamp;
         ft = csound->FTnp2Finde(csound,p->knum);
+        if (UNLIKELY(ft==NULL))
+          return csound->PerfError(csound, &(p->h), Str("function table not found"));
         resamp = ft->gen01args.sample_rate/CS_ESR;
         pitch *= resamp;
         tab = ft->ftable;
@@ -390,6 +392,8 @@ static int32_t sprocess2(CSOUND *csound, DATASPACE *p)
       if (cnt == hsize) {
         double resamp;
         ft = csound->FTnp2Finde(csound,p->knum);
+        if (UNLIKELY(ft==NULL))
+          return csound->PerfError(csound, &(p->h), Str("function table not found"));
         resamp = ft->gen01args.sample_rate/CS_ESR;
         pitch *= resamp;
         time  *= resamp;


### PR DESCRIPTION
Code does not check for a null function table.
```
 1 errors in context 1 of 1:
 Invalid read of size 8
    at 0x2E3CC2: sprocess1 (pvlock.c:178)
    by 0x14C51E: kperf_nodebug (csound.c:1735)
    by 0x14DD1A: csoundPerform (csound.c:2253)
    by 0x14A548: main (csound_main.c:328)
  Address 0x3ed0 is not stack'd, malloc'd or (recently) free'd

[...]

 1 errors in context 1 of 1:
 Invalid read of size 8
    at 0x2E5026: sprocess2 (pvlock.c:393)
    by 0x14C51E: kperf_nodebug (csound.c:1735)
    by 0x14DD1A: csoundPerform (csound.c:2253)
    by 0x14A548: main (csound_main.c:328)
  Address 0x3ed0 is not stack'd, malloc'd or (recently) free'd
```