### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/sndloop.c
+++ b/Opcodes/sndloop.c
@@ -306,6 +306,9 @@ static int32_t flooper_init(CSOUND *csound, flooper *p)
     int32 len, i, nchnls;
 
     p->sfunc = csound->FTnp2Finde(csound, p->ifn) ;  /* function table */
+    if (UNLIKELY(p->sfunc==NULL)) {
+      return csound->InitError(csound,Str("function table not found\n"));
+    }
     cfds = (int32) (*(p->cfd)*p->sfunc->gen01args.sample_rate);
     starts = (int32) (*(p->start)*p->sfunc->gen01args.sample_rate);
     durs = (int32)  (*(p->dur)*p->sfunc->gen01args.sample_rate);
@@ -315,9 +318,6 @@ static int32_t flooper_init(CSOUND *csound, flooper *p)
                                Str("crossfade longer than loop duration\n"));
 
     inc =  FL(1.0)/cfds;    /* inc/dec */
-    if (UNLIKELY(p->sfunc==NULL)) {
-      return csound->InitError(csound,Str("function table not found\n"));
-    }
     tab = p->sfunc->ftable,  /* func table pointer */
     len = p->sfunc->flen;    /* function table length */
     nchnls = p->sfunc->nchanls;


### PR DESCRIPTION
Code checks for a null function table, but not soon enough.
```
 1 errors in context 1 of 1:
 Invalid read of size 8
    at 0x37FDC3: flooper_init (sndloop.c:309)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
  Address 0x3ed0 is not stack'd, malloc'd or (recently) free'd
```