### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/gab/vectorial.c
+++ b/Opcodes/gab/vectorial.c
@@ -46,6 +46,9 @@ static int32_t mtable_i(CSOUND *csound,MTABLEI *p)
       int64_t indx = (int64_t) fndx;
       MYFLT fract = fndx - indx;
       for (j=0; j < nargs; j++) {
+        if (UNLIKELY((indx + 1) * nargs + j >= ftp->flen + 1)) {
+          return csound->InitError(csound, Str("vtablei: reading past end of table"));
+        }
         v1 = table[indx * nargs + j];
         v2 = table[(indx + 1) * nargs + j];
         **out++ = v1 + (v2 - v1) * fract;


### PR DESCRIPTION
Code does not check for a read past the end of an array.

(Note: Please double-check my array-index check)
```
 9 errors in context 2 of 2:
 Invalid read of size 8
    at 0x34C998: mtable_i (vectorial.c:50)
    by 0x167507: init_pass (insert.c:116)
    by 0x168E5D: insert_event (insert.c:472)
    by 0x1680B0: insert (insert.c:298)
    by 0x17A098: process_score_event (musmon.c:829)
    by 0x17A565: process_rt_event (musmon.c:926)
    by 0x17B314: sensevents (musmon.c:1136)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
  Address 0xc28bb88 is 0 bytes after a block of size 296 alloc'd
    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x174805: mcalloc (memalloc.c:113)
    by 0x162D9F: ftalloc (fgens.c:2379)
    by 0x159568: hfgens (fgens.c:275)
    by 0x17A107: process_score_event (musmon.c:841)
    by 0x17ABD2: sensevents (musmon.c:1038)
    by 0x14DC5E: csoundPerform (csound.c:2243)
    by 0x14A548: main (csound_main.c:328)
```