### PR TITLE
Fix for Valgrind-reported invalid reads

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1858,6 +1858,8 @@ static inline void process_debug_buffers(CSOUND *csound, csdebug_data_t *data)
         while (n) {
           if (n->line == bkpt_node->line && n->instr == bkpt_node->instr) {
             prev->next = n->next;
+            if (data->cur_bkpt == n)
+              data->cur_bkpt = n->next;
             csound->Free(csound, n); /* TODO this should be moved from kperf to a
                         non-realtime context */
             n = prev->next;
@@ -1932,7 +1934,7 @@ int kperf_debug(CSOUND *csound)
       }
       if (command == CSDEBUG_CMD_CONTINUE &&
           data->status == CSDEBUG_STATUS_STOPPED) {
-        if (data->cur_bkpt->skip <= 2) data->cur_bkpt->count = 2;
+        if (data->cur_bkpt && data->cur_bkpt->skip <= 2) data->cur_bkpt->count = 2;
         data->status = CSDEBUG_STATUS_RUNNING;
         if (data->debug_instr_ptr) {
           /* if not NULL, resume from last active */


### PR DESCRIPTION
In `process_debug_buffers()`, the `data->cur_bkpt` pointer is not updated when the record it references is freed.

In `kperf_debug()`, `data->cur_bkpt` is not NULL-checked before being dereferenced.

(Note: These changes eliminate the Valgrind errors, but may need further elaboration to yield correct debugging behavior. Please review carefully.)

```
 1 errors in context 10 of 22:
 Invalid read of size 4
    at 0x509013D: kperf_debug (csound.c:1935)
    by 0x5090AF8: csoundPerformKsmps (csound.c:2142)
    by 0x10AB30: test_next (csound_debugger_test.c:477)
    by 0x4E3FD36: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E4006F: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E403BD: CU_run_all_tests (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x10AE33: main (csound_debugger_test.c:537)
  Address 0x19ea8750 is 48 bytes inside a block of size 72 free'd
    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x50B87E9: mfree (memalloc.c:173)
    by 0x508FDCE: process_debug_buffers (csound.c:1861)
    by 0x509000D: kperf_debug (csound.c:1909)
    by 0x5090AF8: csoundPerformKsmps (csound.c:2142)
    by 0x10AB30: test_next (csound_debugger_test.c:477)
    by 0x4E3FD36: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E4006F: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E403BD: CU_run_all_tests (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x10AE33: main (csound_debugger_test.c:537)
  Block was alloc'd at
    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x50B8441: mmalloc (memalloc.c:75)
    by 0x523AE42: csoundSetInstrumentBreakpoint (csdebug.c:151)
    by 0x10AA3F: test_next (csound_debugger_test.c:455)
    by 0x4E3FD36: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E4006F: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E403BD: CU_run_all_tests (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x10AE33: main (csound_debugger_test.c:537)
```