### PR TITLE
Fix for various Valgrind-reported memory leaks

### DIFF
--- a/Top/threads.c
+++ b/Top/threads.c
@@ -205,6 +205,7 @@ PUBLIC uintptr_t csoundJoinThread(void *thread)
     if(thread == NULL) return 0;
     pthreadReturnValue = pthread_join(*pthread,
                                       &threadRoutineReturnValue);
+    free(pthread);
     if (pthreadReturnValue) {
         return (uintptr_t) ((intptr_t) pthreadReturnValue);
     } else {
@@ -556,6 +557,11 @@ PUBLIC void csoundCondSignal(void* condVar) {
         pthread_cond_signal(condVar);
 }
 
+PUBLIC void csoundDestroyCondVar(void* condVar) {
+        pthread_cond_destroy((pthread_cond_t*)condVar);
+        free(condVar);
+}
+
 /* ------------------------------------------------------------------------ */
 
 #elif defined(WIN32)
@@ -781,6 +787,11 @@ PUBLIC void csoundCondSignal(void* condVar) {
     WakeConditionVariable(cv);
 }
 
+PUBLIC void csoundDestroyCondVar(void* condVar) {
+    memset(condVar, '\0', sizeof(CONDITION_VARIABLE));
+    free(condVar);
+}
+
 // REMOVE FOLLOWING BARRIER DEFINITION WINDOWS SUPPORT LIMITED to WIN 8.1+
 typedef struct barrier {
     CRITICAL_SECTION* mut;
@@ -958,6 +969,10 @@ PUBLIC void csoundCondWait(void* condVar, void* mutex) {
 
 PUBLIC void csoundCondSignal(void* condVar) {
     // notImplementedWarning_("csoundCreateCondSignal");
+}
+
+PUBLIC void csoundDestroyCondVar(void* condVar) {
+    // notImplementedWarning_("csoundDestroyCondVar");
 }
 
 PUBLIC long csoundRunCommand(const char * const *argv, int noWait) {

--- a/include/csound.h
+++ b/include/csound.h
@@ -2250,6 +2250,9 @@ extern "C" {
   /** Signals a conditional variable */
   PUBLIC void csoundCondSignal(void* condVar);
 
+  /** Destroys a conditional variable */
+  PUBLIC void csoundDestroyCondVar(void* condVar);
+
   /**
    * Waits for at least the specified number of milliseconds,
    * yielding the CPU to other threads.

--- a/interfaces/csPerfThread.cpp
+++ b/interfaces/csPerfThread.cpp
@@ -595,7 +595,12 @@ CsoundPerformanceThread::~CsoundPerformanceThread()
     }
     if (recordLock) {
         csoundDestroyMutex(recordLock);
-
+    }
+    if (recordData.mutex) {
+        csoundDestroyMutex(recordData.mutex);
+    }
+    if (recordData.condvar) {
+        csoundDestroyCondVar(recordData.condvar);
     }
 }
 


### PR DESCRIPTION
`csoundJoinThread()` does not `free()` the small bit of memory `malloc()`'ed in `csoundCreateThread()` to hold the `pthread_t` object.

The `CsoundPerformanceThread` destructor does not free the mutex and condition variable created toward the end of `CsoundPerformanceThread::csPerfThread_constructor()`.

A new library function is needed to destroy a condition variable.