### PR TITLE
Fix for Valgrind-reported leaked file handle

### DIFF
--- a/interfaces/csPerfThread.cpp
+++ b/interfaces/csPerfThread.cpp
@@ -221,6 +221,13 @@ public:
       return 0;
     }
     ~CsPerfThreadMsg_Record() {
+        CsoundPerformanceThreadMessage::lockRecord();
+        recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
+        if (recordData->sfile) {
+            sf_close((SNDFILE *) recordData->sfile);
+            recordData->sfile = NULL;
+        }
+        CsoundPerformanceThreadMessage::unlockRecord();
     }
 private:
     std::string filename;
@@ -239,7 +246,10 @@ public:
       if (recordData->running) {
           recordData->running = false;
           csoundJoinThread(recordData->thread);
-          sf_close((SNDFILE *) recordData->sfile);
+          if (recordData->sfile) {
+            sf_close((SNDFILE *) recordData->sfile);
+            recordData->sfile = NULL;
+          }
       }
 
       CsoundPerformanceThreadMessage::unlockRecord();


### PR DESCRIPTION
The `CsPerfThreadMsg_Record` destructor does not close the `sfile` handle that was opened in the constructor. The handle is closed in `CsPerfThreadMsg_StopRecord::run()`, but this does not appear to happen in the "testPerfThread" test case.

(The `sfile` handle is set to `NULL` after closing in both instances to prevent it from being potentially closed a second time.)
```
 13,520 (12,736 direct, 784 indirect) bytes in 1 blocks are definitely lost in loss record 14 of 16
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x621135F: psf_allocate (common.c:43)
    by 0x61E1097: sf_open (sndfile.c:331)
    by 0x50817B0: CsPerfThreadMsg_Record::CsPerfThreadMsg_Record(CsoundPerformanceThread*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int) (csPerfThread.cpp:202)
    by 0x5080A54: CsoundPerformanceThread::Record(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int) (csPerfThread.cpp:666)
    by 0x10FDED: test_record() (perfthread_test.cpp:70)
    by 0x4E40D36: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E4106F: ??? (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x4E413BD: CU_run_all_tests (in /usr/lib/x86_64-linux-gnu/libcunit.so.1.0.1)
    by 0x10FFD8: main (perfthread_test.cpp:117)
```