### PR TITLE
Make test suite compatible with Python 3

### DIFF
--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 
 if(MSVC) 
-  add_custom_target(csdtests python test.py --csound-executable=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/csound --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/
+  add_custom_target(csdtests python3 test.py --csound-executable=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/csound --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 else()
-  add_custom_target(csdtests python test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
+  add_custom_target(csdtests python3 test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Csound Test Suite
 # By Steven Yi <stevenyi at gmail dot com>
@@ -7,7 +7,7 @@ import os
 import sys
 
 from testUI import TestApplication
-from Tkinter import *
+from tkinter import *
 
 parserType = ""
 showUIatClose = False
@@ -43,15 +43,15 @@ def showHelp():
     
     """
 
-    print message
+    print(message)
 
 def runTest():
     runArgs = "-nd"# "-Wdo test.wav"
 
     if (parserType == "--old-parser"):
-        print "Testing with old parser"
+        print("Testing with old parser")
     else:
-        print "Testing with new parser"
+        print("Testing with new parser")
 
     tests = [
         ["test1.csd", "Simple Test, Single Channel"],
@@ -178,12 +178,12 @@ def runTest():
         if(os.sep == '\\' or os.name == 'nt'):
             executable = (csoundExecutable == "") and "..\csound.exe" or csoundExecutable
             command = "%s %s %s %s 2> %s"%(executable, parserType, runArgs, filename, tempfile)
-            print command
+            print(command)
             retVal = os.system(command)
         else:
             executable = (csoundExecutable == "") and "../../csound" or csoundExecutable
             command = "%s %s %s %s 2> %s"%(executable, parserType, runArgs, filename, tempfile)
-            print command
+            print(command)
             retVal = os.system(command)
   
         out = ""
@@ -196,7 +196,7 @@ def runTest():
 
         out += "Test %i: %s (%s)\n\tReturn Code: %i\tExpected: %d\n"%(counter, desc, filename, retVal, expectedResult
 )
-        print out
+        print(out)
         output += "%s\n"%("=" * 80)
         output += "Test %i: %s (%s)\nReturn Code: %i\n"%(counter, desc, filename, retVal)
         output += "%s\n\n"%("=" * 80)
@@ -216,10 +216,10 @@ def runTest():
         output += "\n\n"
         counter += 1
 
-#    print output
+#    print(output)
 
-    print "%s\n\n"%("=" * 80)
-    print "Tests Passed: %i\nTests Failed: %i\n"%(testPass, testFail)
+    print("%s\n\n"%("=" * 80))
+    print("Tests Passed: %i\nTests Failed: %i\n"%(testPass, testFail))
 
 
     f = open("results.txt", "w")
@@ -241,10 +241,10 @@ if __name__ == "__main__":
                 parserType = "--old-parser"
             elif arg.startswith("--csound-executable="):
                 csoundExecutable = arg[20:]
-                print csoundExecutable
+                print(csoundExecutable)
             elif arg.startswith("--opcode6dir64="):
                 os.environ['OPCODE6DIR64'] = arg[15:]
-                print os.environ['OPCODE6DIR64'] 
+                print(os.environ['OPCODE6DIR64'])
     results = runTest()
     if (showUIatClose):
         showUI(results)

--- a/tests/commandline/testCsoundCatalog.py
+++ b/tests/commandline/testCsoundCatalog.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, fnmatch
 
 SRC_DIR="/Users/stevenyi/Desktop/Csound Catalog/"
-print SRC_DIR
+print(SRC_DIR)
 
 matches = []
 for root, dirnames, filenames in os.walk(SRC_DIR):
@@ -21,7 +21,7 @@ total = len(matches)
 for orc in matches:
   ex = csoundCommand % (orc, orc[:-3] + 'sco', outputFile)
   retVal = os.system(ex)
-  print orc, '\t', retVal
+  print(orc, '\t', retVal)
   if retVal != 0:
     output += "=======================\n"
     output += "%s\t%s\n"%(orc, retVal) 
@@ -40,4 +40,4 @@ f.write(output)
 f.flush()
 f.close()
 
-print "\nTESTS COMPLETE:\n\tSUCCESS\t%d\n\tFAIL\t%d\n\tTOTAL\t%d"%(success, fail, total)
+print("\nTESTS COMPLETE:\n\tSUCCESS\t%d\n\tFAIL\t%d\n\tTOTAL\t%d"%(success, fail, total))

--- a/tests/commandline/testCsoundManual.py
+++ b/tests/commandline/testCsoundManual.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, fnmatch
 
 SRC_DIR="../../manual/examples/"
-print SRC_DIR
+print(SRC_DIR)
 
 matches = []
 for root, dirnames, filenames in os.walk(SRC_DIR):
@@ -40,4 +40,4 @@ f.write(output)
 f.flush()
 f.close()
 
-print "\nTESTS COMPLETE:\n\tSUCCESS\t%d\n\tFAIL\t%d\n\tTOTAL\t%d"%(success, fail, total)
+print("\nTESTS COMPLETE:\n\tSUCCESS\t%d\n\tFAIL\t%d\n\tTOTAL\t%d"%(success, fail, total))

--- a/tests/commandline/testUI.py
+++ b/tests/commandline/testUI.py
@@ -1,4 +1,4 @@
-from Tkinter import *
+from tkinter import *
 
 class TestApplication(Frame):
     def selectTest(self):

--- a/tests/python/test_all.py
+++ b/tests/python/test_all.py
@@ -1,4 +1,4 @@
-import Tkinter
+import tkinter
 
 # UI that shows all other tests
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-add_custom_target(regression python test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
+add_custom_target(regression python3 test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/regression/test.py
+++ b/tests/regression/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Csound6 Regresson Test Suite
 # By Steven Yi<stevenyi at gmail dot com>John ffitch
@@ -7,7 +7,7 @@ import os
 import sys
 
 from testUI import TestApplication
-from Tkinter import *
+from tkinter import *
 
 showUIatClose = False
 csoundExecutable = ""
@@ -32,7 +32,7 @@ def showHelp():
     are written to results.txt file.
     """
 
-    print message
+    print(message)
 
 def runTest():
     runArgs = "-Wd -n"
@@ -96,12 +96,12 @@ def runTest():
         if(os.sep == '\\'):
             executable = (csoundExecutable == "") and "..\..\csound.exe" or csoundExecutable
             command = "%s %s %s 2> %s"%(executable, runArgs, filename, tempfile)
-            print command
+            print(command)
             retVal = os.system(command)
         else:
             executable = (csoundExecutable == "") and "../../csound" or csoundExecutable
             command = "%s %s %s 2> %s"%(executable, runArgs, filename, tempfile)
-            print command
+            print(command)
             retVal = os.system(command)
 
         out = ""
@@ -114,7 +114,7 @@ def runTest():
 
         out += "Test %i: %s (%s)\n\tReturn Code: %i\tExpected: %d\n"%(counter, desc, filename, retVal, expectedResult
 )
-        print out
+        print(out)
         output += "%s\n"%("=" * 80)
         output += "Test %i: %s (%s)\nReturn Code: %i\n"%(counter, desc, filename, retVal)
         output += "%s\n\n"%("=" * 80)
@@ -134,10 +134,10 @@ def runTest():
         output += "\n\n"
         counter += 1
 
-#    print output
+#    print(output)
 
-    print "%s\n\n"%("=" * 80)
-    print "Tests Passed: %i\nTests Failed: %i\n"%(retVals.tests_passsed, retVals.tests_failed)
+    print("%s\n\n"%("=" * 80))
+    print("Tests Passed: %i\nTests Failed: %i\n"%(retVals.tests_passsed, retVals.tests_failed))
 
 
     f = open("results.txt", "w")
@@ -166,10 +166,10 @@ if __name__ == "__main__":
                 showUIatClose = True
             elif arg.startswith("--csound-executable="):
                 csoundExecutable = arg[20:]
-                print csoundExecutable
+                print(csoundExecutable)
             elif arg.startswith("--opcode6dir64="):
                 os.environ['OPCODE6DIR64'] = arg[15:]
-                print os.environ['OPCODE6DIR64']
+                print(os.environ['OPCODE6DIR64'])
     results = runTest()
     if (showUIatClose):
         showUI(results)

--- a/tests/regression/testUI.py
+++ b/tests/regression/testUI.py
@@ -1,4 +1,4 @@
-from Tkinter import *
+from tkinter import *
 
 class TestApplication(Frame):
     def selectTest(self):

--- a/tests/soak/CMakeLists.txt
+++ b/tests/soak/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-add_custom_target(soak python runtests.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
+add_custom_target(soak python3 runtests.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/soak/runtests.py
+++ b/tests/soak/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import os
 import sys
@@ -1029,10 +1029,10 @@ testFiles = [
 if len(sys.argv) == 2:
     csound = sys.argv[1]
 else:
-    print "Testing git version"
+    print("Testing git version")
 
 
-print "Using Csound Command: " + csound    
+print("Using Csound Command: " + csound)
 
 try:
     os.remove("Old_Output")
@@ -1056,16 +1056,16 @@ for filename in testFiles:
   
     md5sumCommand = "md5sum -b %s.wav >> CheckSums"%filename
 
-    print csCommand
+    print(csCommand)
     os.system(csCommand)
     os.system(md5sumCommand)
 
     try:
         os.remove(filename + ".wav")
     except OSError:
-        print "Error: %s.wav was not generated"%filename
+        print("Error: %s.wav was not generated"%filename)
     
-print "********Comparing checksums"
+print("********Comparing checksums")
 os.system("diff CheckSums SAFESums")
-print "********Comparing output"
+print("********Comparing output")
 os.system("diff Output Old_Output")

--- a/tests/soak/xx.py
+++ b/tests/soak/xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import os
 import sys
@@ -15,7 +15,7 @@ testFiles = [
 if len(sys.argv) == 2:
     csound = sys.argv[1]
 else:
-    print "Testing git version"
+    print("Testing git version")
 
 
 print "Using Csound Command: " + csound    
@@ -50,10 +50,10 @@ for filename in testFiles:
     try:
         os.remove(filename + ".wav")
     except OSError:
-        print "Error: %s.wav was not generated"%filename
+        print("Error: %s.wav was not generated"%filename)
     
-print "********Comparing checksums"
+print("********Comparing checksums")
 os.system("diff CheckSumsX SAFESumsX")
-print "********Comparing output"
+print("********Comparing output")
 os.system("sed -e /Elapsed/d < OutputX > OutputX1")
 os.system("diff OutputX1 Old_OutputX | grep -v Elapsed")


### PR DESCRIPTION
* Invoke Python as `python3` instead of `python` (the latter is usually Python2)

* Use `#!/usr/bin/env python3` shebang line consistently

* Tkinter is [now named](https://docs.python.org/2/library/tkinter.html) `tkinter` (lower case) in Python 3

* Convert all `print foo` statements to `print(foo)`