### PR TITLE
Fix for Valgrind-reported memory leak

### DIFF
--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -264,6 +264,18 @@ struct SignalFlowGraphState {
   ~SignalFlowGraphState() {}
   void clear() {
     LockGuard guard(csound, signal_flow_ports_lock);
+
+    for (std::vector<std::vector<std::vector<Outleta *> *> *>::iterator it = aoutletVectors.begin(), end = aoutletVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<std::vector<Outletk *> *> *>::iterator it = koutletVectors.begin(), end = koutletVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<std::vector<Outletf *> *> *>::iterator it = foutletVectors.begin(), end = foutletVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<std::vector<Outletv *> *> *>::iterator it = voutletVectors.begin(), end = voutletVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<std::vector<Outletkid *> *> *>::iterator it = kidoutletVectors.begin(), end = kidoutletVectors.end(); it != end; it++)
+      delete *it;
+
     aoutletsForSourceOutletIds.clear();
     ainletsForSinkInletIds.clear();
     aoutletVectors.clear();


### PR DESCRIPTION
`sfg_globals->aoutletvectors` and `sfg_globals->koutletVectors` contain un-deleted objects prior to being cleared.
```
 208 (144 direct, 64 indirect) bytes in 6 blocks are definitely lost in loss record 10 of 18
    at 0x4C3041F: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x18B41240: csound::Inleta::init(CSOUND_*) (signalflowgraph.cpp:365)
    by 0x18B4A9AF: csound::OpcodeBase<csound::Inleta>::init_(CSOUND_*, void*) (OpcodeBase.hpp:129)
    by 0x4E9D3D4: init_pass (insert.c:116)
    by 0x4E9ED2A: insert_event (insert.c:472)
    by 0x4E9DF7D: insert (insert.c:298)
    by 0x4EAFF65: process_score_event (musmon.c:829)
    by 0x4EB0432: process_rt_event (musmon.c:926)
    by 0x4EB11E1: sensevents (musmon.c:1136)
    by 0x4E82F76: csoundPerform (csound.c:2245)
    by 0x109928: main (csound_main.c:328)
```