### PR TITLE
Eliminate "//*" sequences interpreted as comment-block starts

### DIFF
--- a/Engine/csound_prs.lex
+++ b/Engine/csound_prs.lex
@@ -1693,7 +1693,7 @@ static int bodmas(CSOUND *csound, yyscan_t yyscanner, int* term)
           goto parseNumber;
         //        case '^':
         //type = 0;
-        //*++op = c; c = getscochar(csound, 1); break;
+        // *++op = c; c = getscochar(csound, 1); break;
         case '[':
           if (UNLIKELY(type)) {
             csound->Message(csound,

--- a/InOut/libmpadec/mpadec.c
+++ b/InOut/libmpadec/mpadec.c
@@ -416,7 +416,7 @@ mpadec_t mpadec_init(void)
     memset(mpa, 0, sizeof(struct mpadec_t));
     mpa->size = sizeof(struct mpadec_t);
     ch.t16 = 1;
-    //*((int16_t *)temp) = 1;
+    // *((int16_t *)temp) = 1;
     mpa->config.quality = MPADEC_CONFIG_FULL_QUALITY;
     mpa->config.mode = MPADEC_CONFIG_AUTO;
     mpa->config.format = MPADEC_CONFIG_16BIT;

--- a/InOut/widgets.cpp
+++ b/InOut/widgets.cpp
@@ -3489,7 +3489,7 @@ extern "C" {
       widgetGlobals->AddrSetValue.push_back(ADDR_SET_VALUE(0, 0, 0, (void *) o,
                                                  (void *) p,
                                                  widgetGlobals->currentSnapGroup));
-      //*p->ihandle = AddrValue.size()-1;
+      // *p->ihandle = AddrValue.size()-1;
       *p->ihandle = widgetGlobals->AddrSetValue.size()-1;
       return OK;
   }
@@ -3806,7 +3806,7 @@ extern "C" {
       widgetGlobals->AddrSetValue.push_back(ADDR_SET_VALUE(LIN_, 0, 0, (void *) w,
                                                 (void *) p,
                                                 widgetGlobals->currentSnapGroup));
-      //*p->ihandle = widgetGlobals->AddrSetValue.size()-1;
+      // *p->ihandle = widgetGlobals->AddrSetValue.size()-1;
       widgetGlobals->last_sldbnk = widgetGlobals->AddrSetValue.size()-1;  //gab
       return OK;
   }
@@ -4300,7 +4300,7 @@ extern "C" {
         }
       }
       o->resizable(o);
-      //*p->ix, *p->iy,
+      // *p->ix, *p->iy,
       o->size( (int)*p->iwidth, (int)*p->iheight);
       o->position((int)*p->ix, (int)*p->iy);
       o->align(FL_ALIGN_BOTTOM | FL_ALIGN_WRAP);
@@ -5148,7 +5148,7 @@ extern "C" {
       widgetGlobals->AddrSetValue.push_back(ADDR_SET_VALUE(LIN_, 0, 0, (void *) w,
                                                  (void *) p,
                                                  widgetGlobals->currentSnapGroup));
-      //*p->ihandle = widgetGlobals->AddrSetValue.size()-1;
+      // *p->ihandle = widgetGlobals->AddrSetValue.size()-1;
       widgetGlobals->last_sldbnk = widgetGlobals->AddrSetValue.size()-1;  //gab
 
       return OK;
@@ -5342,7 +5342,7 @@ extern "C" {
       widgetGlobals->AddrSetValue.push_back(ADDR_SET_VALUE(LIN_, 0, 0,
                                                  (void *) w, (void *) p,
                                                  widgetGlobals->currentSnapGroup));
-      //*p->ihandle = widgetGlobals->AddrSetValue.size()-1;
+      // *p->ihandle = widgetGlobals->AddrSetValue.size()-1;
       widgetGlobals->last_sldbnk = widgetGlobals->AddrSetValue.size()-1;  //gab
 
       return OK;

--- a/Opcodes/gab/hvs.c
+++ b/Opcodes/gab/hvs.c
@@ -431,7 +431,7 @@ static int32_t vphaseseg_set(CSOUND *csound, VPSEG *p)
                                  Str("vphaseseg: function invalid or missing"));
       if (LIKELY(dur > 0.0f)) {
         durtot+=dur;
-        segp->d = dur; //* ekr;
+        segp->d = dur; // ekr;
         segp->function = curfunc;
         segp->nxtfunction = nxtfunc;
         //segp->cnt = (int64_t) (segp->d + .5);

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -353,7 +353,7 @@ CS_NORETURN void dieu(CSOUND *csound, char *s, ...)
     va_start(args, s);
     csound->ErrMsgV(csound, Str("Csound Command ERROR:    "), s, args);
     va_end(args);
-    //***FIXME This code makes no sense
+    //// FIXME This code makes no sense
     /* if (csound->info_message_request == 0) { */
     /*   csound->info_message_request = 0; */
     /*   csound->LongJmp(csound, 1); */

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1398,7 +1398,7 @@ PUBLIC void csoundDestroy(CSOUND *csound)
       csoundDestroyMutex(csound->API_lock);
     }
     /* clear the pointer */
-    //*(csound->self) = NULL;
+    // *(csound->self) = NULL;
     free((void*) csound);
 }
 


### PR DESCRIPTION
This change addresses a relatively minor issue I've encountered: The use of the C++-style `//` comment marker, in conjunction with comment text that begins with an asterisk, can result in a `//*` sequence which at least two text editors ([GNU nano](https://www.nano-editor.org/), [NEdit](https://en.wikipedia.org/wiki/NEdit)) interpret as the start of a long C-style `/* ... */` comment block. This causes long sections of active code to appear commented-out.