### PR TITLE
Fix for Valgrind-reported memory leak

### DIFF
--- a/InOut/rtalsa.c
+++ b/InOut/rtalsa.c
@@ -1854,6 +1854,7 @@ int listAlsaSeq(CSOUND *csound, CS_MIDIDEVICE *list, int isOutput) {
         }
       }
     }
+    snd_seq_close(seq);
     return numdevs;
 }
 


### PR DESCRIPTION
`listAlsaSeq()` fails to close the handle returned from `snd_seq_open()`.
```
 30,528 (128 direct, 30,400 indirect) bytes in 1 blocks are definitely lost in loss record 124 of 125
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0xCDA5DD7: snd_seq_hw_open (seq_hw.c:485)
    by 0xCDA60A3: _snd_seq_hw_open (seq_hw.c:563)
    by 0xCDA63C8: snd_seq_open_conf (seq.c:918)
    by 0xCDA6725: snd_seq_open_noupdate (seq.c:939)
    by 0xCDA68A6: snd_seq_open (seq.c:984)
    by 0xFF573FC: listAlsaSeq (rtalsa.c:1827)
    by 0xFF57778: listDevicesM (rtalsa.c:1870)
    by 0x14FBF8: csoundGetMIDIDevList (csound.c:2906)
    by 0x14A4B1: test_dev_list (io_test.c:63)
    by 0x4E40D36: run_single_test.constprop.5 (TestRun.c:991)
    by 0x4E4106F: run_single_suite.constprop.4 (TestRun.c:876)
    by 0x4E413BD: CU_run_all_tests (TestRun.c:367)
    by 0x14B3A5: main (io_test.c:324)
```