### PR TITLE
Fix for various Valgrind-reported memory leaks

### DIFF
--- a/tests/c/csound_debugger_test.c
+++ b/tests/c/csound_debugger_test.c
@@ -27,6 +27,7 @@ void test_debugger_init(void)
     csoundCreateMessageBuffer(csound, 0);
     csoundDebuggerInit(csound);
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -41,6 +42,7 @@ void test_add_bkpt(void)
     csoundSetInstrumentBreakpoint(csound, 1.1, 0);
     csoundClearBreakpoints(csound);
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -59,6 +61,7 @@ void test_add_callback(void)
     csoundDebuggerInit(csound);
     csoundSetBreakpointCallback(csound, brkpt_cb, NULL);
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -81,6 +84,7 @@ void test_breakpoint_once(void)
     CU_ASSERT(break_count == 1);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -121,6 +125,7 @@ void test_breakpoint_remove(void)
     CU_ASSERT(break_count == 1);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -153,6 +158,7 @@ void test_variables(void)
     csoundPerformKsmps(csound);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -180,6 +186,7 @@ void test_bkpt_instrument(void)
     csoundPerformKsmps(csound);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -221,6 +228,7 @@ void test_line_breakpoint_add_remove(void)
     csoundPerformKsmps(csound);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
     CU_ASSERT_EQUAL(count, 2);
 }
@@ -290,8 +298,7 @@ void test_line_breakpoint(void)
     CU_ASSERT_EQUAL(count, 3);
 
     csoundDebuggerClean(csound);
-
-
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 
     CU_ASSERT_EQUAL(count, 3);
@@ -365,6 +372,7 @@ void test_line_breakpoint_orc_file(void)
 
     csoundDebuggerClean(csound);
     CU_ASSERT_EQUAL(count, 2);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -379,6 +387,7 @@ void test_no_callback(void)
     csoundPerformKsmps(csound);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
 }
 
@@ -494,6 +503,7 @@ void test_next(void)
     csoundPerformKsmps(csound);
 
     csoundDebuggerClean(csound);
+    csoundDestroyMessageBuffer(csound);
     csoundDestroy(csound);
     CU_ASSERT_EQUAL(count, 5);
 }


### PR DESCRIPTION
Several functions in `csound_debugger_test.c` fail to call `csoundDestroyMessageBuffer()`.

Typical example:
```
 40 bytes in 1 blocks are indirectly lost in loss record 98 of 244
    at 0x4C2FDAF: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x5248F64: csoundCreateMutex (threads.c:478)
    by 0x50964B9: csoundCreateMessageBuffer (csound.c:4240)
    by 0x109286: test_debugger_init (csound_debugger_test.c:27)
    by 0x4E40D36: run_single_test.constprop.5 (TestRun.c:991)
    by 0x4E4106F: run_single_suite.constprop.4 (TestRun.c:876)
    by 0x4E413BD: CU_run_all_tests (TestRun.c:367)
    by 0x10AE33: main (csound_debugger_test.c:547)
```