### PR TITLE
Fix Valgrind-reported invalid read

### DIFF
--- a/tests/c/csound_message_buffer_test.c
+++ b/tests/c/csound_message_buffer_test.c
@@ -54,8 +54,8 @@ void test_buffer_run(void)
     while (csoundGetMessageCnt(csound)) {
         const char * msg = csoundGetFirstMessage(csound);
         CU_ASSERT_PTR_NOT_NULL(msg);
-        csoundPopFirstMessage(csound);
         printf("CSOUND MESSAGE: %s", msg);
+        csoundPopFirstMessage(csound);
     }
 
     csoundCleanup(csound);


### PR DESCRIPTION
`test_buffer_run()` pops a message before printing it, when it should be doing the reverse.
```
 410 errors in context 6 of 6:
 Invalid read of size 1
    at 0x4C33384: strlen (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x5D624D2: vfprintf (vfprintf.c:1643)
    by 0x5D6367F: buffered_vfprintf (vfprintf.c:2329)
    by 0x5D60725: vfprintf (vfprintf.c:1301)
    by 0x5D69F25: printf (printf.c:33)
    by 0x14A35A: test_buffer_run (csound_message_buffer_test.c:58)
    by 0x4E40D36: run_single_test.constprop.5 (TestRun.c:991)
    by 0x4E4106F: run_single_suite.constprop.4 (TestRun.c:876)
    by 0x4E413BD: CU_run_all_tests (TestRun.c:367)
    by 0x14A43E: main (csound_message_buffer_test.c:93)
  Address 0xc7a99cd is 13 bytes inside a block of size 45 free'd
    at 0x4C30FDB: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x1518CD: csoundPopFirstMessage (csound.c:4319)
    by 0x14A342: test_buffer_run (csound_message_buffer_test.c:57)
    by 0x4E40D36: run_single_test.constprop.5 (TestRun.c:991)
    by 0x4E4106F: run_single_suite.constprop.4 (TestRun.c:876)
    by 0x4E413BD: CU_run_all_tests (TestRun.c:367)
    by 0x14A43E: main (csound_message_buffer_test.c:93)
  Block was alloc'd at
    at 0x4C2FDAF: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x151AD9: csoundMessageBufferCallback_1_ (csound.c:4384)
    by 0x14DBE1: csoundMessage (csound.c:2560)
    by 0x105CDA54: csoundModuleInit (rtalsa.c:1909)
    by 0x22FB82: csoundInitModule (csmodule.c:609)
    by 0x22FD3D: csoundInitModules (csmodule.c:664)
    by 0x231F9C: csoundStart (main.c:459)
    by 0x14A2E6: test_buffer_run (csound_message_buffer_test.c:50)
    by 0x4E40D36: run_single_test.constprop.5 (TestRun.c:991)
    by 0x4E4106F: run_single_suite.constprop.4 (TestRun.c:876)
    by 0x4E413BD: CU_run_all_tests (TestRun.c:367)
    by 0x14A43E: main (csound_message_buffer_test.c:93)
```