### PR TITLE
Fix for Valgrind-reported memory leak

### DIFF
--- a/InOut/widgets.cpp
+++ b/InOut/widgets.cpp
@@ -108,6 +108,7 @@ int widget_reset(CSOUND *csound, void *pp)
     WIDGET_GLOBALS *widgetGlobals =
       (WIDGET_GLOBALS *)csound->QueryGlobalVariable(csound, "WIDGET_GLOBALS");
     if (widgetGlobals != NULL) {
+      widgetGlobals->AddrSetValue.~vector<ADDR_SET_VALUE>();
       widgetGlobals->AddrStack.~vector<ADDR_STACK>();
       widgetGlobals->allocatedStrings.~vector<char*>();
       widgetGlobals->fl_windows.~vector<PANELS>();


### PR DESCRIPTION
`widget_reset()` fails to clear `widgetGlobals->AddrSetValue`.
```
 224 bytes in 1 blocks are definitely lost in loss record 211 of 333
    at 0x4C3041F: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x168D10FF: __gnu_cxx::new_allocator<ADDR_SET_VALUE>::allocate(unsigned long, void const*) (new_allocator.h:111)
    by 0x168CF8F5: std::allocator_traits<std::allocator<ADDR_SET_VALUE> >::allocate(std::allocator<ADDR_SET_VALUE>&, unsigned long) (alloc_traits.h:436)
    by 0x168CD4AF: std::_Vector_base<ADDR_SET_VALUE, std::allocator<ADDR_SET_VALUE> >::_M_allocate(unsigned long) (stl_vector.h:172)
    by 0x168CF07D: void std::vector<ADDR_SET_VALUE, std::allocator<ADDR_SET_VALUE> >::_M_realloc_insert<ADDR_SET_VALUE>(__gnu_cxx::__normal_iterator<ADDR_SET_VALUE*, std::vector<ADDR_SET_VALUE, std::allocator<ADDR_SET_VALUE> > >, ADDR_SET_VALUE&&) (vector.tcc:406)
    by 0x168CC8A7: void std::vector<ADDR_SET_VALUE, std::allocator<ADDR_SET_VALUE> >::emplace_back<ADDR_SET_VALUE>(ADDR_SET_VALUE&&) (vector.tcc:105)
    by 0x168C95A5: std::vector<ADDR_SET_VALUE, std::allocator<ADDR_SET_VALUE> >::push_back(ADDR_SET_VALUE&&) (stl_vector.h:954)
    by 0x168BD424: fl_joystick (widgets.cpp:3927)
    by 0x4E9DC05: init0 (insert.c:249)
    by 0x4EADD54: musmon (musmon.c:313)
    by 0x5033D63: csoundStart (main.c:549)
    by 0x5033DA7: csoundCompile (main.c:556)
    by 0x109913: main (csound_main.c:326)
```