### PR TITLE
Ensure that widget_reset() is called on reset

### DIFF
--- a/InOut/winFLTK.c
+++ b/InOut/winFLTK.c
@@ -100,7 +100,6 @@ PUBLIC int csoundModuleInit(CSOUND *csound)
           csound->SetKillGraphCallback(csound, KillGraph_FLTK);
           csound->SetExitGraphCallback(csound, ExitGraph_FLTK);
            /* seemed to crash, but not anymore... */
-          csound->RegisterResetCallback(csound, NULL, widget_reset);
           csound->Message(csound, "graph init...\n");
 
         }
@@ -141,7 +140,9 @@ PUBLIC int csoundModuleInit(CSOUND *csound)
       }
     }
 
+    csound->RegisterResetCallback(csound, NULL, widget_reset);
     widget_init(csound);
+
     return 0;
 }
 


### PR DESCRIPTION
One thing I noticed in my testing is that some Csound invocations that use FLTK widgets were leaking memory, because the `widget_reset()` function (in which said memory is freed) was not being called.

I tracked this down to the `csoundModuleInit()` function in `InOut/winFLTK.c`. The problem appears to be that the `csound->RegisterResetCallback()` call that hooks in `widget_reset()` was not being called, even though the `widget_init()` call was.

Looking at the code, it is notable that the first call occurs only if a number of conditions are satisfied, whereas the second one occurs in the (likely) absence of errors. This appears incorrect---either both calls should happen (ideally together), or neither. This change moves the first call to the same place as the second. It compiles cleanly, and has a neutral-to-positive effect on Valgrind results for all existing tests.

The tests specifically affected by this are following two:
```
csound -d -W -m0 -i /dev/null /path/to/csound/tests/soak/crossfm.csd -o ./crossfm.wav
csound -d -W -m0 -i /dev/null /path/to/csound/tests/soak/noise-2.csd -o ./noise-2.wav
```

Note that this change is a minimal fix, but perhaps more lines (comment? "graph init" message? other callbacks?) should be moved down in the same way.