### PR TITLE
Fixed issue when linking csbeats

### DIFF
--- a/Frontends/beats/main.c
+++ b/Frontends/beats/main.c
@@ -27,7 +27,7 @@
 #include "beats.h"
 
 FILE *myout;
-FILE *yyin;
+extern FILE *yyin;
 int debug = 0;
 
 double pt[13] = { 8.1757989156,  8.6619572180,  9.1770239974,  9.7227182413,


### PR DESCRIPTION
Building with `-fno-common` results in the following linking error:

```
make[2]: Entering directory '/tmp/csound_build.kxkz47/csound-develop/build'
[ 79%] Linking C executable ../csbeats
/bin/ld: CMakeFiles/csbeats.dir/beatslex.yy.c.o:(.bss+0x20): multiple definition of `yyin'; CMakeFiles/csbeats.dir/beats/main.c.o:(.bss+0x10): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [Frontends/CMakeFiles/csbeats.dir/build.make:127: csbeats] Error 1
make[2]: Leaving directory '/tmp/csound_build.kxkz47/csound-develop/build'
```

Declaring `yyin` as `extern` makes sure that this variable is resolved correctly by the linker.