### PR TITLE
Fix segfault in "voice" opcode

### DIFF
--- a/Opcodes/singwave.c
+++ b/Opcodes/singwave.c
@@ -327,7 +327,7 @@ int32_t voicformset(CSOUND *csound, VOICF *p)
     MYFLT amp = (*p->amp)*AMP_RSCALE; /* Normalise */
     int32_t i;
 
-    if (UNLIKELY(make_SingWave(csound, &p->voiced, p->ifn, p->ivfn)==NOTOK))
+    if (UNLIKELY(make_SingWave(csound, &p->voiced, p->ifn, p->ivfn)!=OK))
       return NOTOK;
     Envelope_setRate(csound, &(p->voiced.envelope), FL(0.001));
     Envelope_setTarget(&(p->voiced.envelope), FL(0.0));


### PR DESCRIPTION
The `voicformset()` function incorrectly checks for an error condition, preventing it from bailing out when a function table is missing.

Specifically, `make_SingWave()` does not return `NOTOK` (i.e. -1) on error, but the return value of `csound->InitError()`, which is a non-negative error count. The intent, I believe, is better served by checking for non-equality to `OK` (zero).

The segfault can be reproduced by running this soak test...
```
csound -d -W -m0 -i /dev/null /path/to/csound/tests/soak/voice.csd -o ./voice.wav
```
...with a missing `impuls20.aiff` file.

FYI: I've run all the tests with all the non-score input files (like the aforementioned) deleted, and am happy to report that this was the only segfault observed. The only new memory leak reported by Valgrind was in the "include" test, but as that one occurred deep inside `csound_prslex.c` and appears non-trivial to resolve, I think it can be allowed to slide.