### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -284,11 +284,12 @@ static int Load_File_(CSOUND *csound, const char *filnam,
     fseek(f, 0L, SEEK_SET);
     if (UNLIKELY(*len < 1L))
       goto err_return;
-    *allocp = csound->Malloc(csound, (size_t) (*len)); /*   alloc as reqd     */
+    *allocp = csound->Malloc(csound, (size_t) (*len + 1)); /*   alloc as reqd     */
     if (UNLIKELY(fread(*allocp, (size_t) 1,     /*   read file in      */
                        (size_t) (*len), f) != (size_t) (*len)))
       goto err_return;
     fclose(f);                                  /*   and close it      */
+    (*allocp)[*len] = '\0';                     /*   add sentinel      */
     return 0;                                   /*   return 0 for OK   */
  err_return:
     if (*allocp != NULL) {


### PR DESCRIPTION
`Load_File_()` should add a trailing null to the buffer so that string reads of the content do not walk off the end.
```
 2368 errors in context 1 of 1:
 Invalid read of size 1
    at 0x4C37E04: rawmemchr (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x5697351: _IO_str_init_static_internal (strops.c:41)
    by 0x568878C: vsscanf (iovsscanf.c:40)
    by 0x56821A3: sscanf (sscanf.c:32)
    by 0x16CF059A: scsnux_init_ (scansynx.c:354)
    by 0x16CF0F44: scsnux_init_S (scansynx.c:478)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
  Address 0x19d1526b is 0 bytes after a block of size 1,659 alloc'd
    at 0x4C2FDAF: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAA7FF: mmalloc (memalloc.c:75)
    by 0x4EABC68: Load_File_ (memfiles.c:287)
    by 0x4EABEA7: ldmemfile2withCB (memfiles.c:356)
    by 0x16CF0346: scsnux_init_ (scansynx.c:315)
    by 0x16CF0F44: scsnux_init_S (scansynx.c:478)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
```