### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/partials.c
+++ b/Opcodes/partials.c
@@ -285,7 +285,7 @@ static void Analysis(CSOUND * csound, _PARTS * p)
     /* loop to the end of tracks (indicate by the 0'd bins)
        find continuation tracks */
 
-    for (j = 0; oldbins[prev + j] != 0.f && j < maxtracks; j++) {
+    for (j = 0; j < maxtracks && oldbins[prev + j] != 0.f; j++) {
 
       foundcont = 0;
 


### PR DESCRIPTION
An array subscript should be checked before, not after, the array access.
```
 6 errors in context 1 of 1:
 Invalid read of size 8
    at 0x50D519A: Analysis (partials.c:288)
    by 0x50D5969: partials_process (partials.c:443)
    by 0x4E81882: kperf_nodebug (csound.c:1742)
    by 0x4E830ED: csoundPerform (csound.c:2265)
    by 0x109928: main (csound_main.c:328)
  Address 0x19ce9200 is 0 bytes after a block of size 8,032 alloc'd
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAA978: mcalloc (memalloc.c:113)
    by 0x4E87D5B: csoundAuxAlloc (auxfd.c:53)
    by 0x50D4052: partials_init (partials.c:135)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
```