### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/psynth.c
+++ b/Opcodes/psynth.c
@@ -1107,7 +1107,7 @@ static int32_t trcross_process(CSOUND *csound, _PSCROSS *p)
       if (bal < 0)
         bal = FL(0.0);
       if (mode < 1)
-        for (i = 0; framein2[i + 3] != -1 && i < end; i += 4)
+        for (i = 0; i < end && framein2[i + 3] != -1; i += 4)
           max = framein2[i] > max ? framein2[i] : max;
 
       for (i = 0; id != -1 && i < end; i += 4, id = (int32_t) framein1[i + 3]) {


### PR DESCRIPTION
An array subscript should be checked before, not after, the array access.
```
 2 errors in context 1 of 1:
 Invalid read of size 4
    at 0x50DA67D: trcross_process (psynth.c:1110)
    by 0x4E81882: kperf_nodebug (csound.c:1742)
    by 0x4E830ED: csoundPerform (csound.c:2265)
    by 0x109928: main (csound_main.c:328)
  Address 0x19d683dc is 12 bytes after a block of size 16,432 alloc'd
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAA978: mcalloc (memalloc.c:113)
    by 0x4E87D5B: csoundAuxAlloc (auxfd.c:53)
    by 0x50D4247: partials_init (partials.c:157)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
```