### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -479,7 +479,8 @@ static int32_t sprocess2(CSOUND *csound, DATASPACE *p)
 
           tmp_real = tmp_im = (MYFLT) 1e-20;
           for (i=2; i < N; i++) {
-            tmp_real += nwin[i]*nwin[i] + nwin[i+1]*nwin[i+1];
+            tmp_real += nwin[i]*nwin[i];
+            if (i+1 < N) tmp_real += nwin[i+1]*nwin[i+1];
             tmp_im += fwin[i]*fwin[i] + fwin[i+1]*fwin[i+1];
           }
           powrat = FL(20.0)*LOG10(tmp_real/tmp_im);


### PR DESCRIPTION
An array is accessed without checking that the subscript is in range.
```
 656 errors in context 2 of 2:
 Invalid read of size 8
    at 0x4FE5FE6: sprocess2 (pvlock.c:482)
    by 0x4E81882: kperf_nodebug (csound.c:1742)
    by 0x4E830ED: csoundPerform (csound.c:2265)
    by 0x109928: main (csound_main.c:328)
  Address 0x19dbd7f0 is 0 bytes after a block of size 16,416 alloc'd
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAA978: mcalloc (memalloc.c:113)
    by 0x4E87D5B: csoundAuxAlloc (auxfd.c:53)
    by 0x4FE5316: sinit2 (pvlock.c:348)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
```