### PR TITLE
Fix for Valgrind-reported invalid read

### DIFF
--- a/Opcodes/sndwarp.c
+++ b/Opcodes/sndwarp.c
@@ -339,7 +339,10 @@ static int32_t sndwarpst(CSOUND *csound, SNDWARPST *p)
         frm10 = *(ftpSamp->ftable + (base * 2));
         frm11 = *(ftpSamp->ftable + ((base+1)*2));
         frm20 = *(ftpSamp->ftable + (base*2)+1);
-        frm21 = *(ftpSamp->ftable + (((base+1)*2)+1));
+        if (((base+1)*2)+1 < ftpSamp->flen + 1)
+          frm21 = *(ftpSamp->ftable + (((base+1)*2)+1));
+        else
+          frm21 = FL(0.0);
         if (frac != FL(0.0)) {
           r1[n] += ((frm10 + frac*(frm11-frm10)) * windowamp) * *amp;
           r2[n] += ((frm20 + frac*(frm21-frm20)) * windowamp) * *amp;


### PR DESCRIPTION
A function table array is accessed without checking its size.
```
 2052279 errors in context 1 of 1:
 Invalid read of size 8
    at 0x509FC13: sndwarpst (sndwarp.c:342)
    by 0x4E81882: kperf_nodebug (csound.c:1742)
    by 0x4E830ED: csoundPerform (csound.c:2265)
    by 0x109928: main (csound_main.c:328)
  Address 0x19d262f8 is 0 bytes after a block of size 524,328 alloc'd
    at 0x4C32185: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4EAA978: mcalloc (memalloc.c:113)
    by 0x4E98D27: ftalloc (fgens.c:2384)
    by 0x4E8F44B: hfgens (fgens.c:275)
    by 0x4EB0296: process_score_event (musmon.c:845)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
```