### PR TITLE
Fix for Valgrind-reported jump/move dep on uninitialised values

### DIFF
--- a/Opcodes/syncgrain.c
+++ b/Opcodes/syncgrain.c
@@ -438,6 +438,7 @@ static int32_t filegrain_init(CSOUND *csound, filegrain *p)
                        (p->dataframes+1)*sizeof(MYFLT)*p->nChannels, &p->buffer);
 
     buffer = (MYFLT *) p->buffer.auxp;
+    memset(&sfinfo, '\0', sizeof(sfinfo)); /* for Valgrind */
     /* open file and read the first block using *p->ioff */
     fd = csound->FileOpen2(csound, &(p->sf), CSFILE_SND_R, fname, &sfinfo,
                             "SFDIR;SSDIR", CSFTYPE_UNKNOWN_AUDIO, 0);


### PR DESCRIPTION
A stack-allocated struct needs zeroing out before use.
```
 5 errors in context 1 of 2:
 Conditional jump or move depends on uninitialised value(s)
    at 0x5A031A7: psf_open_file (sndfile.c:2935)
    by 0x4E8CBEF: csoundFileOpenWithType (envvar.c:1104)
    by 0x50A80A8: filegrain_init (syncgrain.c:442)
    by 0x4E9D4B6: init_pass (insert.c:117)
    by 0x4E9EE8C: insert_event (insert.c:479)
    by 0x4E9E0DF: insert (insert.c:305)
    by 0x4EB0227: process_score_event (musmon.c:833)
    by 0x4EB0D61: sensevents (musmon.c:1042)
    by 0x4E83031: csoundPerform (csound.c:2255)
    by 0x109928: main (csound_main.c:328)
  Uninitialised value was created by a stack allocation
    at 0x50A7D37: filegrain_init (syncgrain.c:404)
```