### PR TITLE
CoreAudio fix for nchnls mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,10 @@ CMakeLists.txt.user
 
 # emacs autosaved files
 \#*\#
+
+
+# cmake / doxygen 
+CMakeDoxy*
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Doxyfile

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -1115,6 +1115,8 @@ OENTRY opcodlst_1[] = {
     (SUBR) chnclear_opcode_init, (SUBR) notinit_opcode_stub },
   { "chn_k",       S(CHN_OPCODE_K),    _CW, 1,      "",             "SiooooooooN",
     (SUBR) chn_k_opcode_init, NULL, NULL                  },
+  { "chn_k",       S(CHN_OPCODE_K),    _CW, 1,      "",             "SSooooooooN",
+    (SUBR) chn_k_opcode_init_S, NULL, NULL},
   { "chn_a",       S(CHN_OPCODE),      _CW, 1,      "",             "Si",
     (SUBR) chn_a_opcode_init, NULL, NULL                  },
   { "chn_S",       S(CHN_OPCODE),      _CW, 1,      "",             "Si",

--- a/H/bus.h
+++ b/H/bus.h
@@ -195,6 +195,7 @@ int32_t     chnset_opcode_perf_S(CSOUND *, CHNGET *);
 int32_t     chnmix_opcode_init(CSOUND *, CHNGET *);
 int32_t     chnclear_opcode_init(CSOUND *, CHNCLEAR *);
 int32_t     chn_k_opcode_init(CSOUND *, CHN_OPCODE_K *);
+int32_t     chn_k_opcode_init_S(CSOUND *, CHN_OPCODE_K *);
 int32_t     chn_a_opcode_init(CSOUND *, CHN_OPCODE *);
 int32_t     chn_S_opcode_init(CSOUND *, CHN_OPCODE *);
 int32_t     chnexport_opcode_init(CSOUND *, CHNEXPORT_OPCODE *);

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -288,7 +288,14 @@ int AuHAL_open(CSOUND *csound, const csRtAudioParams * parm,
       prop.mSelector = kAudioHardwarePropertyDevices;
       if (isInput) {
         for(i=0; (unsigned int)  i < devnos; i++) {
-          if((unsigned int) devinfo[i].indevnum == devnum) CoreAudioDev = i;
+          if((unsigned int) devinfo[i].indevnum == devnum) {
+          	if(devinfo[i].inchannels < parm->nChannels) {
+          		csound->Warning(csound, 
+          			Str("Device has not enough channels (%d, requested %d)"),
+          			devinfo[i].inchannels, parm->nChannels)
+          	}
+          	CoreAudioDev = i;
+          }
         }
         if (LIKELY(CoreAudioDev >= 0)) {
           prop.mSelector = kAudioHardwarePropertyDefaultInputDevice;

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -289,8 +289,8 @@ int AuHAL_open(CSOUND *csound, const csRtAudioParams * parm,
       if (isInput) {
         for(i=0; (unsigned int)  i < devnos; i++) {
           if((unsigned int) devinfo[i].indevnum == devnum) {
-          	CoreAudioDev = i;
-          	break;
+            CoreAudioDev = i;
+            break;
           }
         }
         if (LIKELY(CoreAudioDev >= 0)) {
@@ -324,25 +324,25 @@ int AuHAL_open(CSOUND *csound, const csRtAudioParams * parm,
           if(isInput) {
             if(devinfo[i].inchannels < parm->nChannels) {
               csound->ErrorMsg(csound, 
-            		           Str(" *** CoreAudio: Device has not enough" 
-            		               " inputs (%d, requested %d)\n"), 
-            		           devinfo[i].inchannels, parm->nChannels);
+                               Str(" *** CoreAudio: Device has not enough" 
+                                   " inputs (%d, requested %d)\n"), 
+                               devinfo[i].inchannels, parm->nChannels);
               return -1;
             } 
-          	ADC_channels(csound, devinfo[i].inchannels);
+            ADC_channels(csound, devinfo[i].inchannels);
           } 
           else {
-          	if(devinfo[i].outchannels < parm->nChannels) {
-          	  csound->ErrorMsg(csound, 
-          	            	   Str(" *** CoreAudio: Device has not enough"
-          	            	       " outputs (%d, requested %d)\n"), 
-          	            	   devinfo[i].outchannels, parm->nChannels);
-			  return -1;
+            if(devinfo[i].outchannels < parm->nChannels) {
+              csound->ErrorMsg(csound, 
+                               Str(" *** CoreAudio: Device has not enough"
+                                   " outputs (%d, requested %d)\n"), 
+                               devinfo[i].outchannels, parm->nChannels);
+              return -1;
             }
-          	DAC_channels(csound, devinfo[i].outchannels);
-		  }
+            DAC_channels(csound, devinfo[i].outchannels);
+          }
         }
-    }	
+    }   
 
     csound->Free(csound,sysdevs);
     csound->Free(csound,devinfo);

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -320,30 +320,29 @@ int AuHAL_open(CSOUND *csound, const csRtAudioParams * parm,
     }
 
     for(i=0; (unsigned int)  i < devnos; i++) {
-        if(sysdevs[i] == dev){
-          if(isInput) {
-            if(devinfo[i].inchannels < parm->nChannels) {
-              csound->ErrorMsg(csound, 
-                               Str(" *** CoreAudio: Device has not enough" 
-                                   " inputs (%d, requested %d)\n"), 
-                               devinfo[i].inchannels, parm->nChannels);
-              return -1;
-            } 
-            ADC_channels(csound, devinfo[i].inchannels);
+      if(sysdevs[i] == dev){
+        if(isInput) {
+          if(devinfo[i].inchannels < parm->nChannels) {
+            csound->ErrorMsg(csound, 
+                             Str(" *** CoreAudio: Device has not enough" 
+                                 " inputs (%d, requested %d)\n"), 
+                             devinfo[i].inchannels, parm->nChannels);
+            return -1;
           } 
-          else {
-            if(devinfo[i].outchannels < parm->nChannels) {
-              csound->ErrorMsg(csound, 
-                               Str(" *** CoreAudio: Device has not enough"
-                                   " outputs (%d, requested %d)\n"), 
-                               devinfo[i].outchannels, parm->nChannels);
-              return -1;
-            }
-            DAC_channels(csound, devinfo[i].outchannels);
+          ADC_channels(csound, devinfo[i].inchannels);
+        } 
+        else {
+          if(devinfo[i].outchannels < parm->nChannels) {
+            csound->ErrorMsg(csound, 
+                             Str(" *** CoreAudio: Device has not enough"
+                                 " outputs (%d, requested %d)\n"), 
+                             devinfo[i].outchannels, parm->nChannels);
+            return -1;
           }
+          DAC_channels(csound, devinfo[i].outchannels);
         }
+      }
     }   
-
     csound->Free(csound,sysdevs);
     csound->Free(csound,devinfo);
 

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -834,7 +834,7 @@ LIBA(acosa,ACOS)
 LIBA(atana,ATAN)
 LIBA(sinha,SINH)
 LIBA(cosha,COSH)
-LIBA(tanha,TANH)
+LIBA(tanha,TAN)
 LIBA(log10a,LOG10)
 LIBA(log2a,LOG2)
 

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -834,7 +834,7 @@ LIBA(acosa,ACOS)
 LIBA(atana,ATAN)
 LIBA(sinha,SINH)
 LIBA(cosha,COSH)
-LIBA(tanha,TAN)
+LIBA(tanha,TANH)
 LIBA(log10a,LOG10)
 LIBA(log2a,LOG2)
 

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -1656,7 +1656,7 @@ int32_t inch_opcode1(CSOUND *csound, INCH1 *p)
     ch = MYFLT2LRND(*p->ch);
     if (UNLIKELY(ch > (uint32_t)csound->inchnls)) {
       if (p->init)
-        csound->Message(csound, Str("Input channel %d too large; ignored"), ch);
+        csound->Message(csound, Str("Input channel %d too large; ignored\n"), ch);
       memset(p->ar, 0, sizeof(MYFLT)*nsmps);
       p->init = 0;
       //        return OK;

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1585,13 +1585,13 @@ int32_t chn_k_opcode_init_S(CSOUND *csound, CHN_OPCODE_K *p)
 {
     STRINGDAT *smode = (STRINGDAT *)p->imode;
     int32_t mode;
-    if(!strcmp("rw", smode->data)) {
+    if(!strcmp("rw", smode->data))
         mode = 3;
-    } else if(!strcmp("r", smode->data)) {
+    else if(!strcmp("r", smode->data))
         mode = 1;
-    } else if(!strcmp("w", smode->data)) {
+    else if(!strcmp("w", smode->data))
         mode = 2;
-    } else
+    else
         return csound->InitError(csound, Str("invalid mode, should be r, w, rw"));
     return chn_k_opcode_init_(csound, p, mode);
 }

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1524,16 +1524,16 @@ int32_t chnset_opcode_perf_S(CSOUND* csound, CHNGET* p)
 
 /* declare control channel, optionally with special parameters */
 
-int32_t chn_k_opcode_init(CSOUND *csound, CHN_OPCODE_K *p)
+int32_t chn_k_opcode_init_(CSOUND *csound, CHN_OPCODE_K *p, int mode)
 {
     MYFLT *dummy;
-    int32_t   type, mode, err;
+    int32_t   type, err;
     controlChannelHints_t hints;
     hints.attributes = NULL;
     hints.max = hints.min = hints.dflt = FL(0.0);
     hints.x = hints.y = hints.height = hints.width = 0;
 
-    mode = (int32_t)MYFLT2LRND(*(p->imode));
+    // mode = (int32_t)MYFLT2LRND(*(p->imode));
     if (UNLIKELY(mode < 1 || mode > 3))
         return csound->InitError(csound, Str("invalid mode parameter"));
     type = CSOUND_CONTROL_CHANNEL;
@@ -1574,6 +1574,28 @@ int32_t chn_k_opcode_init(CSOUND *csound, CHN_OPCODE_K *p)
         return print_chn_err(p, err);
     return csound->InitError(csound, Str("invalid channel parameters"));
 }
+
+int32_t chn_k_opcode_init(CSOUND *csound, CHN_OPCODE_K *p)
+{
+    int32_t mode = (int32_t)MYFLT2LRND(*(p->imode));
+    return chn_k_opcode_init_(csound, p, mode);
+}
+
+int32_t chn_k_opcode_init_S(CSOUND *csound, CHN_OPCODE_K *p)
+{
+    STRINGDAT *smode = (STRINGDAT *)p->imode;
+    int32_t mode;
+    if(!strcmp("rw", smode->data)) {
+        mode = 3;
+    } else if(!strcmp("r", smode->data)) {
+        mode = 1;
+    } else if(!strcmp("w", smode->data)) {
+        mode = 2;
+    } else
+        return csound->InitError(csound, Str("invalid mode, should be r, w, rw"));
+    return chn_k_opcode_init_(csound, p, mode);
+}
+
 
 /* declare audio channel */
 

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -3967,7 +3967,41 @@ int32_t deinterleave_perf (CSOUND *csound, INTERL *p) {
     return OK;
 }
 
+static int32 taninv2_A(CSOUND* csound, TABARITH* p)
+{
+    ARRAYDAT* ans = p->ans;
+    ARRAYDAT* aa = p->left;
+    ARRAYDAT* bb = p->right;
+    int i, j, k;
+    if (csound->mode == 1 && tabarithset(csound, p)!=OK)
+                             return NOTOK;
+    k = 0;
+    for (i=0; i<ans->dimensions; i++) {
+      for (j=0; j<aa->sizes[i]; j++) {
+        ans->data[k] = ATAN2(aa->data[k], bb->data[k]);
+        k++;
+      }
+    }
+    return OK;
+}
 
+static int32 taninv2_Aa(CSOUND* csound, TABARITH* p)
+{
+    ARRAYDAT* ans = p->ans;
+    ARRAYDAT* aa = p->left;
+    ARRAYDAT* bb = p->right;
+    int i, j, k;
+    uint32_t m;
+    k = 0;
+    for (i=0; i<ans->dimensions; i++) {
+      for (j=0; j<aa->sizes[i]; j++)
+        for (m=0; m<csound->ksmps; m++) {
+          ans->data[k] = ATAN2(aa->data[k], bb->data[k]);
+          k++;
+        }
+    }
+    return OK;
+}
 
 
 // reverse, scramble, mirror, stutter, rotate, ...
@@ -4343,7 +4377,10 @@ static OENTRY arrayvars_localops[] =
     {"deinterleave", sizeof(INTERL), 0, 1, "i[]i[]","i[]",
      (SUBR)deinterleave_i},
     {"deinterleave", sizeof(INTERL), 0, 1, "k[]k[]","k[]",
-     (SUBR)deinterleave_i, (SUBR)deinterleave_perf}
+     (SUBR)deinterleave_i, (SUBR)deinterleave_perf},
+    { "taninv2.Ai", sizeof(TABARITH), 0, 1, "i[]", "i[]i[]", (SUBR)taninv2_A  },
+    { "taninv2.Ak", sizeof(TABARITH), 0, 2, "k[]", "k[]k[]", (SUBR)tabarithset, (SUBR)taninv2_A  },
+    { "taninv2.Aa", sizeof(TABARITH), 0, 2, "a[]", "a[]a[]", (SUBR)tabarithset, (SUBR)taninv2_Aa  }
   };
 
 LINKAGE_BUILTIN(arrayvars_localops)


### PR DESCRIPTION
In macOS, when using coreaudio (auhal) as the backend, a mismatch in nchnls and the actual number of channels of the device will lead to csound hanging if nchnls > device channels. This PR fixes this issue by checking that device channels >= nchnls, and fails if this is not the case. This behaviour is similar to what portaudio does under the same circumstances. 
This fixes similar issues reported to csoundqt, where csoundqt would hang waiting for csound's audio thread to join when stopping a performance. 
