### PR TITLE
fix setcols

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -3600,7 +3600,7 @@ int32_t set_cols_perf(CSOUND *csound, FFT *p) {
 
 
     int32_t j,i,len =  p->out->sizes[0];
-    for (j=0,i=start; j < len; i+=len, j++)
+    for (j=0,i=start; j < len; i+=len+1, j++)
         p->out->data[i] = p->in->data[j];
     return OK;
 }
@@ -3612,7 +3612,7 @@ int32_t set_cols_i(CSOUND *csound, FFT *p) {
         return csound->InitError(csound, "%s",
                                  Str("Error: index out of range\n"));
     int32_t j,i,len =  p->out->sizes[0];
-    for (j=0,i=start-1; j < len; i+=len+1, j++)
+    for (j=0,i=start; j < len; i+=len+1, j++)
         p->out->data[i] = p->in->data[j];
     return OK;
 }


### PR DESCRIPTION
i think this is correct now.  example:

instr 1
iArr[][] init 3, 4
iCol[] fillarray 1,2,3
printarray iArr, "%d", "array at start:"
iArr setcol iCol, 3
printarray iArr, "%d", "array after setcol:"
endin
schedule(1,0,0)

instr 2
kArr[][] init 3, 4
kCol[] fillarray 1,2,3
printarray kArr, 1, "%d", "array at start:"
kArr setcol kCol, 3
printarray kArr, 1, "%d", "array after setcol:"
turnoff
endin
schedule(2,0,1)

what is missing: error message if desired column does not exist, e.g.
iArr setcol iCol, 3