### PR TITLE
Add an opcode "errormsg" 

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2273,7 +2273,11 @@ strstrip(CSOUND *csound, STR1_1 *p) {
 
 /* errormsg
  *
- * errormsg "mymsg", Skind="error"       ; k-rate
+ * errormsg Smsg
+ * errormsg Skind, Smsg
+ *
+ * errormsg "my error message"
+ * errormsg "warning", "this is only a warning, event will keep running"
  *
  * Skind can be "error", "warning" or "info"
  * If "error", (the default) a performance error is thrown, which will delete the current event
@@ -2292,54 +2296,58 @@ enum Errorkind_t { ERRORMSG_ERROR, ERRORMSG_WARNING, ERRORMSG_INFO};
 
 typedef struct {
     OPDS h;
-    STRINGDAT *Smsg;
-    STRINGDAT *Skind;
+    STRINGDAT *S1;
+    STRINGDAT *S2;
     enum Errorkind_t kind;
     int warning_done;
+    int which;
 } ERRORMSG;
 
 
 static int32_t errormsg_init(CSOUND *csound, ERRORMSG *p) {
     IGN(csound);
-    if(!strcmp(p->Skind->data, "error"))
+    if(!strcmp(p->S1->data, "error"))
         p->kind = ERRORMSG_ERROR;
-    else if(!strcmp(p->Skind->data, "warning"))
+    else if(!strcmp(p->S1->data, "warning"))
         p->kind = ERRORMSG_WARNING;
-    else if(!strcmp(p->Skind->data, "info"))
+    else if(!strcmp(p->S1->data, "info"))
         p->kind = ERRORMSG_INFO;
     else
         return csound->InitError(csound, "Unknown type");
     p->warning_done = 0;   // default: mark message as "error"
+    p->which = 1;
     return OK;
 }
 
 static int32_t errormsg_init0(CSOUND *csound, ERRORMSG *p) {
     IGN(csound);
     p->kind = ERRORMSG_ERROR;
+    p->which = 0;
     return OK;
 }
 
 static int32_t errormsg_perf(CSOUND *csound, ERRORMSG *p) {
     char *name;
     INSDS *ip;
+    char *msg = p->which == 0 ? p->S1->data : p->S2->data;
 
     switch(p->kind) {
     case ERRORMSG_ERROR:
-        return csound->PerfError(csound, &(p->h), "%s\n", p->Smsg->data);
+        return csound->PerfError(csound, &(p->h), "%s\n", msg);
     case ERRORMSG_WARNING:
         if(p->warning_done)
             return OK;
         ip = p->h.insdshead;
         name = (ip->instr->insname != NULL) ? ip->instr->insname : "";
         csound->Warning(csound, "Warning from instr %d (%s), line %d\n    %s\n",
-                          ip->insno, name, p->h.optext->t.linenum, p->Smsg->data);
+                          ip->insno, name, p->h.optext->t.linenum, msg);
         p->warning_done = 1;
         return OK;
     case ERRORMSG_INFO:
         ip = p->h.insdshead;
         name = (ip->instr->insname != NULL) ? ip->instr->insname : "";
         csound->Warning(csound, "Info from instr %d (%s), line %d\n    %s\n",
-                          ip->insno, name, p->h.optext->t.linenum, p->Smsg->data);
+                          ip->insno, name, p->h.optext->t.linenum, msg);
         return OK;
     }
 }


### PR DESCRIPTION
This PR adds the opcode `errormsg`, which allows the user to throw an error from its own code. By default it throws a PerfError, which stops the current event. Two other error kinds are defined: a "warning", which prints a warning in the console only once, and "info", which prints a warning every cycle.

```csound

if kcondition == 1 then
    errormsg "An error has occurred!"
    ; this is the same as errormsg, "error", ...
elseif kcondition == 2 then
    errormsg "warning", "This is just a warning"
endif
```

`errormsg` works only at k-time. If needed, an i-variant can be added (maybe as `errormsg_i`)

NB: another name for this opcode might be `perferror`, and an init variant could then be "initerror", following the csound API. 