### PR TITLE
printf: add the possibility to always print by setting the trigger to -1

### DIFF
--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -583,8 +583,6 @@ int32_t printf_opcode_set(CSOUND *csound, PRINTF_OP *p)
 int32_t printf_opcode_perf(CSOUND *csound, PRINTF_OP *p)
 {
     MYFLT ktrig = *p->ktrig;
-    if (ktrig == FL(-1.0))
-      return (printf_opcode_(csound, p));
     if (ktrig == p->prv_ktrig)
       return OK;
     p->prv_ktrig = ktrig;

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -582,10 +582,13 @@ int32_t printf_opcode_set(CSOUND *csound, PRINTF_OP *p)
 
 int32_t printf_opcode_perf(CSOUND *csound, PRINTF_OP *p)
 {
-    if (*p->ktrig == p->prv_ktrig)
+    MYFLT ktrig = *p->ktrig;
+    if (ktrig == FL(-1.0))
+      return (printf_opcode_(csound, p));
+    if (ktrig == p->prv_ktrig)
       return OK;
-    p->prv_ktrig = *p->ktrig;
-    if (p->prv_ktrig > FL(0.0))
+    p->prv_ktrig = ktrig;
+    if (ktrig > FL(0.0))
       return (printf_opcode_(csound, p));
     return OK;
 }

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2272,13 +2272,13 @@ strstrip(CSOUND *csound, STR1_1 *p) {
 
 
 /*
- * echo
+ * println
  *
  * The same as printf but without a trigger
  *
- * echo Sfmt, xvar1, [xvar2, ...]
+ * println Sfmt, xvar1, [xvar2, ...]
  *
- * echo "foo bar %s: %k,", Skey, kvalue
+ * println "foo bar %s: %k,", Skey, kvalue
  *
  */
 
@@ -2292,10 +2292,10 @@ typedef struct {
     int fmtlen;
     STRINGDAT buf;
     STRINGDAT strseg;
-} ECHO;
+} PRINTLN;
 
 
-int32_t echo_reset(CSOUND *csound, ECHO *p) {
+int32_t println_reset(CSOUND *csound, PRINTLN *p) {
     if(p->buf.data != NULL && p->allocatedBuf) {
         csound->Free(csound, p->buf.data);
         p->buf.data = NULL;
@@ -2311,7 +2311,7 @@ int32_t echo_reset(CSOUND *csound, ECHO *p) {
 }
 
 
-int32_t echo_init(CSOUND *csound, ECHO *p) {
+int32_t println_init(CSOUND *csound, PRINTLN *p) {
     int32_t bufsize = 2048;
     int32_t fmtlen = strlen(p->sfmt->data);
     int32_t numVals = (int32_t)p->INOCOUNT - 1;
@@ -2330,7 +2330,7 @@ int32_t echo_init(CSOUND *csound, ECHO *p) {
             p->strseg.data = csound->ReAlloc(csound, p->strseg.data, maxSegmentSize);
         p->strseg.size = maxSegmentSize;
         p->allocatedBuf = 1;
-        csound->RegisterResetCallback(csound, p, (int32_t(*)(CSOUND*, void*))(echo_reset));
+        csound->RegisterResetCallback(csound, p, (int32_t(*)(CSOUND*, void*))(println_reset));
     } else {
         p->allocatedBuf = 0;
     }
@@ -2353,7 +2353,7 @@ int32_t echo_init(CSOUND *csound, ECHO *p) {
 // Memory is actually never allocated here
 static int32_t
 sprintf_opcode_(CSOUND *csound,
-                ECHO *p,          /* opcode data structure pointer       */
+                PRINTLN *p,          /* opcode data structure pointer       */
                 STRINGDAT *str,   /* pointer to space for output string  */
                 const char *fmt,  /* format string                       */
                 int fmtlen,       /* length of format string             */
@@ -2390,7 +2390,7 @@ sprintf_opcode_(CSOUND *csound,
 
     while (1) {
         if (UNLIKELY(i >= strsegsize)) {
-            csound->Warning(csound, "%s", "echo: Allocating memory");
+            csound->Warning(csound, "%s", "println: Allocating memory");
             strsegsize *= 2;
             p->strseg.data = strseg = csound->ReAlloc(csound, strseg, strsegsize);
             p->strseg.size = strsegsize;
@@ -2448,7 +2448,7 @@ sprintf_opcode_(CSOUND *csound,
                 if ((((STRINGDAT*)parm)->size+strlen(strseg)) >= (uint32_t)maxChars) {
                     int32_t offs = outstring - str->data;
                     int newsize = str->size  + ((STRINGDAT*)parm)->size + strlen(strseg);
-                    csound->Warning(csound, "%s", Str("echo: Allocating extra memory for output string"));
+                    csound->Warning(csound, "%s", Str("println: Allocating extra memory for output string"));
                     str->data = csound->ReAlloc(csound, str->data, newsize);
                     if(str->data == NULL){
                         return PERFERR(Str("memory allocation failure"));
@@ -2493,7 +2493,7 @@ sprintf_opcode_(CSOUND *csound,
     return OK;
 }
 
-int32_t echo_perf(CSOUND *csound, ECHO *p) {
+int32_t println_perf(CSOUND *csound, PRINTLN *p) {
     int32_t err = sprintf_opcode_(csound, p, &p->buf, (char*)p->sfmt->data, p->fmtlen,
                                   &(p->args[0]), (int32_t)p->INOCOUNT - 1, 0);
     if(err!=OK)
@@ -2669,7 +2669,7 @@ static OENTRY localops[] = {
       (SUBR)lastcycle_init, (SUBR)lastcycle},
     { "strstrip.i_side", S(STR1_1), 0, 1, "S", "SS", (SUBR)stripside},
     { "strstrip.i", S(STR1_1), 0, 1, "S", "S", (SUBR)strstrip},
-    { "echo", S(ECHO), 0, 3, "", "S*", (SUBR)echo_init, (SUBR)echo_perf}
+    { "println", S(PRINTLN), 0, 3, "", "S*", (SUBR)println_init, (SUBR)println_perf}
 
 };
 

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2345,8 +2345,11 @@ int32_t println_init(CSOUND *csound, PRINTLN *p) {
 }
 
 
-#define IS_AUDIO_ARG(x) (csound->GetTypeForArg(x) == &CS_VAR_TYPE_A)
-#define IS_STRING_ARG(x) (csound->GetTypeForArg(x) == &CS_VAR_TYPE_S)
+// #define IS_AUDIO_ARG(x) (csound->GetTypeForArg(x) == &CS_VAR_TYPE_A)
+#define IS_AUDIO_ARG(x) (!strcmp("a", csound->GetTypeForArg(x)->varTypeName))
+
+// #define IS_STRING_ARG(x) (csound->GetTypeForArg(x) == &CS_VAR_TYPE_S)
+#define IS_STRING_ARG(x) (!strcmp("S", csound->GetTypeForArg(x)->varTypeName))
 
 
 // This is taken from OOps/str_ops.c, with minor modifications to adapt it to plugin API
@@ -2373,9 +2376,8 @@ sprintf_opcode_(CSOUND *csound,
     const char *fmtend = fmt+(fmtlen-0);
 
     for (i = 0; i < numVals; i++) {
-        if (UNLIKELY(IS_AUDIO_ARG(kvals[i]))) {
+        if(UNLIKELY( IS_AUDIO_ARG(kvals[i])) )
             return PERFERR(Str("a-rate argument not allowed"));
-        }
     }
 
     if (UNLIKELY((int32_t) ((OPDS*) p)->optext->t.inArgCount > 31)){
@@ -2669,7 +2671,7 @@ static OENTRY localops[] = {
       (SUBR)lastcycle_init, (SUBR)lastcycle},
     { "strstrip.i_side", S(STR1_1), 0, 1, "S", "SS", (SUBR)stripside},
     { "strstrip.i", S(STR1_1), 0, 1, "S", "S", (SUBR)strstrip},
-    { "println", S(PRINTLN), 0, 3, "", "S*", (SUBR)println_init, (SUBR)println_perf}
+    { "println", S(PRINTLN), 0, 3, "", "SN", (SUBR)println_init, (SUBR)println_perf}
 
 };
 

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2273,7 +2273,11 @@ strstrip(CSOUND *csound, STR1_1 *p) {
 
 /* errormsg
  *
- * errormsg "mymsg", Skind="error"       ; k-rate
+ * errormsg Smsg
+ * errormsg Skind, Smsg
+ *
+ * errormsg "my error message"
+ * errormsg "warning", "this is only a warning, event will keep running"
  *
  * Skind can be "error", "warning" or "info"
  * If "error", (the default) a performance error is thrown, which will delete the current event
@@ -2292,54 +2296,58 @@ enum Errorkind_t { ERRORMSG_ERROR, ERRORMSG_WARNING, ERRORMSG_INFO};
 
 typedef struct {
     OPDS h;
-    STRINGDAT *Smsg;
-    STRINGDAT *Skind;
+    STRINGDAT *S1;
+    STRINGDAT *S2;
     enum Errorkind_t kind;
     int warning_done;
+    int which;
 } ERRORMSG;
 
 
 static int32_t errormsg_init(CSOUND *csound, ERRORMSG *p) {
     IGN(csound);
-    if(!strcmp(p->Skind->data, "error"))
+    if(!strcmp(p->S1->data, "error"))
         p->kind = ERRORMSG_ERROR;
-    else if(!strcmp(p->Skind->data, "warning"))
+    else if(!strcmp(p->S1->data, "warning"))
         p->kind = ERRORMSG_WARNING;
-    else if(!strcmp(p->Skind->data, "info"))
+    else if(!strcmp(p->S1->data, "info"))
         p->kind = ERRORMSG_INFO;
     else
         return csound->InitError(csound, "Unknown type");
     p->warning_done = 0;   // default: mark message as "error"
+    p->which = 1;
     return OK;
 }
 
 static int32_t errormsg_init0(CSOUND *csound, ERRORMSG *p) {
     IGN(csound);
     p->kind = ERRORMSG_ERROR;
+    p->which = 0;
     return OK;
 }
 
 static int32_t errormsg_perf(CSOUND *csound, ERRORMSG *p) {
     char *name;
     INSDS *ip;
+    char *msg = p->which == 0 ? p->S1->data : p->S2->data;
 
     switch(p->kind) {
     case ERRORMSG_ERROR:
-        return csound->PerfError(csound, &(p->h), "%s\n", p->Smsg->data);
+        return csound->PerfError(csound, &(p->h), "%s\n", msg);
     case ERRORMSG_WARNING:
         if(p->warning_done)
             return OK;
         ip = p->h.insdshead;
         name = (ip->instr->insname != NULL) ? ip->instr->insname : "";
         csound->Warning(csound, "Warning from instr %d (%s), line %d\n    %s\n",
-                          ip->insno, name, p->h.optext->t.linenum, p->Smsg->data);
+                          ip->insno, name, p->h.optext->t.linenum, msg);
         p->warning_done = 1;
         return OK;
     case ERRORMSG_INFO:
         ip = p->h.insdshead;
         name = (ip->instr->insname != NULL) ? ip->instr->insname : "";
         csound->Warning(csound, "Info from instr %d (%s), line %d\n    %s\n",
-                          ip->insno, name, p->h.optext->t.linenum, p->Smsg->data);
+                          ip->insno, name, p->h.optext->t.linenum, msg);
         return OK;
     }
 }


### PR DESCRIPTION
When using printf inside an if clause it would be convenient to always execute the printing

```csound
if kval == 1 then
  ; code here
  printf "k1: %f\n", timeinstk(), k1
endif
```
With this PR, setting the trigger to -1 forces printf to print

```csound
if kval == 1 then
  ; code here
  printf "k1: %f\n", -1, k1
endif
```
