### PR TITLE
lisp cffi bindings: fix dylib name

### DIFF
--- a/interfaces/csound.lisp
+++ b/interfaces/csound.lisp
@@ -76,7 +76,7 @@
         :csoundReadScore
         ))
 (cffi:define-foreign-library libcsound64
-    (:darwin "libcsound64.dylib")
+    (:darwin "libcsnd6.dylib")
     (:unix "libcsound64.so")
     (:windows "csound64.dll")
     (t (:default "libcsound64")))

--- a/interfaces/lisp-swig.sh
+++ b/interfaces/lisp-swig.sh
@@ -6,7 +6,7 @@ swig -DUSE_DOUBLE  -cffi -module lcsound -v -nocwrap -swig-lisp -generate-typede
 #   (:use :common-lisp :cffi))
 #(in-package :csound)
 #(cffi:define-foreign-library libcsound64
-#    (:darwin "libcsound64.dylib")
+#    (:darwin "libcsnd6.dylib")
 #    (:unix "libcsound64.so")
 #    (:windows "csound64.dll")
 #    (t (:default "libcsound64")))


### PR DESCRIPTION
I tested only to the point that I can load the dylib now.