### PR TITLE
Fix for HDF5 1.12.0

### DIFF
--- a/Opcodes/hdf5/CMakeLists.txt
+++ b/Opcodes/hdf5/CMakeLists.txt
@@ -4,6 +4,15 @@ if(BUILD_HDF5_OPCODES)
     find_package(HDF5)
 
     if(HDF5_FOUND)
+        # split version string, as cmake doesn't do this automatically
+        string(REPLACE "." ";" VERSION_LIST ${HDF5_VERSION})
+        list(GET VERSION_LIST 0 HDF5_VERSION_MAJOR)
+        list(GET VERSION_LIST 1 HDF5_VERSION_MINOR)
+        list(GET VERSION_LIST 2 HDF5_VERSION_PATCH)
+        # add definitions so we can use them in the preprocessor
+        ADD_DEFINITIONS(-DHDF5_VERSION_MAJOR=${HDF5_VERSION_MAJOR})
+        ADD_DEFINITIONS(-DHDF5_VERSION_MINOR=${HDF5_VERSION_MINOR})
+        ADD_DEFINITIONS(-DHDF5_VERSION_PATCH=${HDF5_VERSION_PATCH})
         if(MSVC)
             make_plugin(hdf5ops HDF5IO.c)
             target_include_directories(hdf5ops PRIVATE ${HDF5_INCLUDE_DIRS})

--- a/Opcodes/hdf5/HDF5IO.c
+++ b/Opcodes/hdf5/HDF5IO.c
@@ -229,7 +229,11 @@ void HDF5IO_readStringAttribute(CSOUND *csound, HDF5File *self,
 {
     hid_t dataSetID = H5Dopen2(self->fileHandle, datasetName, H5P_DEFAULT);
     H5O_info_t oinfo;
+#if HDF5_VERSION_MAJOR == 1 && HDF5_VERSION_MINOR >= 12
+    HDF5ERROR(H5Oget_info1(dataSetID, &oinfo));
+#else
     HDF5ERROR(H5Oget_info(dataSetID, &oinfo));
+#endif
     hid_t attributeID = H5Aopen_by_idx(dataSetID, ".", H5_INDEX_CRT_ORDER,
                                        H5_ITER_INC, 0, H5P_DEFAULT, H5P_DEFAULT);
     HDF5ERROR(attributeID);


### PR DESCRIPTION
Opcodes/hdf5/HDF5IO.c:
The HDF5 update to 1.12.0 introduced breaking API changes [1]
Particularly H5Oget_info() got removed.
Instead H5Oget_info1() can be called, which provides the same
signature.
For HDF5 prior to 1.12.0 the call to H5Oget_info() remains.

Closes #1313

[1] https://portal.hdfgroup.org/display/HDF5/API+Compatibility+Reports+for+1.12