### PR TITLE
optional parameter for GEN20, 9

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -1313,8 +1313,8 @@ static int gen20(FGDATA *ff, FUNC *ftp)
           ft[i] = FL(1.0);
         return OK;
     case 9:                     /* Sinc */
-        arg = TWOPI / ff->flen;
-        for (i = 0, x = -PI ; i < ((int) ff->flen >> 1) ; i++, x += arg)
+        arg = TWOPI * varian / ff->flen;
+        for (i = 0, x = -PI * varian; i < ((int) ff->flen >> 1) ; i++, x += arg)
           ft[i] = (MYFLT) (xarg * sin(x) / x);
         ft[i++] = (MYFLT) xarg;
         for (x = arg ; i <= (int) ff->flen ; i++, x += arg)


### PR DESCRIPTION
the sinc function is currently set to a fixed range from -pi to +pi.
the proposed change adds an optional multiplier for the x-range (1 by default).
so  `f1   0   4096   -20   9   1` would result in the current behaviour, whereas `f1   0   4096   -20   9   1 3` would generate a sinc function from -3pi to +3pi.

i tested the change and it seems to work.  i don't understand why there is no check in the code for x=0.  perhaps someone can review.

once it is merged, i can add it to the manual.  i also have new figures for https://csound.com/docs/manual/MiscWindows.html.