### PR TITLE
fix bug in GEN20,8

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -1310,7 +1310,7 @@ static int gen20(FGDATA *ff, FUNC *ftp)
       }
     case 8:                     /* Rectangular */
         for (i = 0; i <= (int) ff->flen ; i++)
-          ft[i] = FL(1.0);
+          ft[i] = FL(xarg);
         return OK;
     case 9:                     /* Sinc */
         arg = TWOPI * varian / ff->flen;


### PR DESCRIPTION
gen20, 8 always returned 1 as value for the rectangle window, for instance in
`i0 ftgen 8, 0, 8192, -20, 8, .1`
i think this fixes it.