### PR TITLE
new opcode ftset

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1505,14 +1505,14 @@ static int32_t
 ftset_k(CSOUND *csound, FTSET *p) {
     int tabnum = (int)(*p->tabnum);
     FUNC *tab;
-    if(tabnum != p->lastTabnum) {
+    if(UNLIKELY(tabnum != p->lastTabnum)) {
         tab = csound->FTnp2Finde(csound, p->tabnum);
         if(UNLIKELY(tab == NULL))
             return PERFERRF(Str("Table %d not found"), tabnum);
         p->tab = tab;
         p->lastTabnum = tabnum;
     } else {
-        if(p->tab == NULL)
+        if(UNLIKELY(p->tab == NULL))
             return PERFERR(Str("Table not set"));
         tab = p->tab;
     }
@@ -1523,8 +1523,8 @@ ftset_k(CSOUND *csound, FTSET *p) {
     int32_t step = (int32_t)*p->kstep;
     MYFLT value = *p->value;
 
-    if(end < 0)
-        end += tab->flen+1;
+    if(end <= 0)
+        end += tab->flen;
     else if(end > tablen)
         end = tablen;
 
@@ -1895,7 +1895,7 @@ static int32_t arrprint(CSOUND *csound, ARRAYDAT *arr,
                                      " %s\n", (char*)currline);
                 }
                 charswritten = 0;
-                startidx = i;
+                startidx = i+1;
             }
         }
         if (charswritten > 0) {
@@ -2049,7 +2049,7 @@ static int handle_negative_idx(uint32_t *out, int32_t idx, uint32_t length) {
 static int32_t
 ftprint_perf(CSOUND *csound, FTPRINT *p) {
     int32_t trig = (int32_t)*p->ktrig;
-    if(trig == 0 || (trig == p->lasttrig))
+    if(trig == 0 || (trig > 0 && trig == p->lasttrig))
         return OK;
     p->lasttrig = trig;
     FUNC *ftp = p->ftp;
@@ -2087,7 +2087,7 @@ ftprint_perf(CSOUND *csound, FTPRINT *p) {
             currline[charswritten++] = '\0';
             csound->MessageS(csound, CSOUNDMSG_ORCH,
                              " %3d: %s\n", startidx, currline);
-            startidx = i;
+            startidx = i+step;
             elemsprinted = 0;
             charswritten = 0;
         }
@@ -2727,8 +2727,8 @@ static OENTRY localops[] = {
       (SUBR)tabslice_init, (SUBR)tabslice_k},
 
 
-    { "ftset.k", S(FTSET), 0, 3, "", "kkOJP", (SUBR)ftset_init, (SUBR)ftset_k },
-    { "ftset.i", S(FTSET), 0, 3, "", "iiojp", (SUBR)ftset_i },
+    { "ftset.k", S(FTSET), 0, 3, "", "kkOOP", (SUBR)ftset_init, (SUBR)ftset_k },
+    { "ftset.i", S(FTSET), 0, 3, "", "iioop", (SUBR)ftset_i },
 
     { "tab2array", S(TAB2ARRAY), TR, 3, "k[]", "iOOP",
       (SUBR)tab2array_init, (SUBR)tab2array_k},

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1523,27 +1523,28 @@ ftset_k(CSOUND *csound, FTSET *p) {
     int32_t step = (int32_t)*p->kstep;
     MYFLT value = *p->value;
 
-    if(end <= 0)
-        end += tab->flen;
+    if(end < 0)
+        end += tab->flen+1;
     else if(end > tablen)
         end = tablen;
 
     if(step == 1 && value == 0) {
         // special case: clear the table, use memset
-        memset(data + start, 0, end - start);
+        memset(data + start, '\0', sizeof(MYFLT) * (end - start));
         return OK;
     }
 
-    int32_t numitems = (int32_t) (ceil((end - start) / (float)step));
-    if (numitems > tablen)
-        numitems = tablen;
-
-    for(int i=0; i<numitems; i+=step) {
+    for(int i=start; i<end; i+=step) {
         data[i] = value;
     }
     return OK;
 }
 
+static int32_t
+ftset_i(CSOUND *csound, FTSET *p) {
+    ftset_init(csound, p);
+    return ftset_k(csound, p);
+}
 
 /*
 
@@ -2023,6 +2024,7 @@ ftprint_init(CSOUND *csound, FTPRINT *p) {
         p->numcols = 10;
     p->ftp = csound->FTnp2Finde(csound, p->ifn);
     int32_t trig = (int32_t)*p->ktrig;
+
     if (trig > 0) {
         ftprint_perf(csound, p);
     }
@@ -2724,7 +2726,9 @@ static OENTRY localops[] = {
     { "ftslice", S(TABSLICE),  TB, 3, "", "iiOOP",
       (SUBR)tabslice_init, (SUBR)tabslice_k},
 
-    { "ftset.k", S(FTSET), 0, 3, "", "kkOOP", (SUBR)ftset_init, (SUBR)ftset_k },
+
+    { "ftset.k", S(FTSET), 0, 3, "", "kkOJP", (SUBR)ftset_init, (SUBR)ftset_k },
+    { "ftset.i", S(FTSET), 0, 3, "", "iiojp", (SUBR)ftset_i },
 
     { "tab2array", S(TAB2ARRAY), TR, 3, "k[]", "iOOP",
       (SUBR)tab2array_init, (SUBR)tab2array_k},


### PR DESCRIPTION
this PR adds a new opcode ftset, which enables to set a table or a slice of it to a particular value

    ftset ktable, kvalue, kstart=0, kend=-1, kstep=1

* ktable: the table to modify
* kvalue: the value to set
* kstart: (optional, defaults to 0) start index
* kend: negative numbers count from the end, -1 being equal to the length of the table (same slicing strategy as python's)
* kstep: step value of the slice. 


```csound

ftset gitable, 0   ; clear the table, set all elements to 0
ftset gitable, 1, 10, 20 ; set elements between 10 and 20 (exclusive) to 1
ftset gitable, 0, 0, -5, 2; clear all elements between 0 and 5 before the end with a step of 2

```
`ftset` works at perf-time if any argument is a k-rate variable, otherwise it works at i-time. 

