### PR TITLE
Do not ignore return value of setuid

### DIFF
--- a/Frontends/csound/sched.c
+++ b/Frontends/csound/sched.c
@@ -170,7 +170,10 @@ int set_rt_priority(int argc, const char **argv)
     }
 
     if (rtmode != 7) {          /* all the above are required to enable */
-      ignore_value(setuid(getuid()));         /* error: give up root privileges */
+      if (setuid(getuid()) < 0) {	/* error: give up root privileges */
+        err_msg("csound: Could not drop privileges");
+        return -1;
+      }
       if (rtmode & 1) {
         err_msg("csound: --sched requires -d and either -o dac or -o devaudio");
         return -1;
@@ -226,7 +229,10 @@ int set_rt_priority(int argc, const char **argv)
       }
     }
     /* give up root privileges */
-    ignore_value(setuid(getuid()));
+    if (setuid(getuid()) < 0) {
+   	err_msg("csound: Could not drop privileges");
+      return -1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Ignoring the return value of setuid might lead to a security issue.

Since the csound_main.c creates log files after invoking set_rt_priority,
if setuid fails, these files would be owned by root.
