### PR TITLE
increase MAXLINE to 8192

### DIFF
--- a/Opcodes/date.c
+++ b/Opcodes/date.c
@@ -133,7 +133,7 @@ static int32_t getcurdir(CSOUND *csound, GETCWD *p)
 }
 
 #ifndef MAXLINE
-#define MAXLINE 1024
+#define MAXLINE 8192
 #endif
 
 typedef struct {


### PR DESCRIPTION
i ran into issues in reading long lines from het.  and as far as i see, this would coincide with the limit in fprints as set in fout.c, line 1284.