### PR TITLE
Let syntax-check-only return an error if syntax failed

### DIFF
--- a/Top/main.c
+++ b/Top/main.c
@@ -164,6 +164,7 @@ PUBLIC int csoundCompileArgs(CSOUND *csound, int argc, const char **argv)
     volatile int     csdFound = 0;
     volatile int ac = argc;
     char    *fileDir;
+    int     compiledOk = 0;
 
 
     if ((n = setjmp(csound->exitjmp)) != 0) {
@@ -322,6 +323,9 @@ PUBLIC int csoundCompileArgs(CSOUND *csound, int argc, const char **argv)
                                       "Csound will start with no instruments"));
        }
     }
+    else {
+      compiledOk = 1;
+    }
     csound->modules_loaded = 1;
 
     s = csoundQueryGlobalVariable(csound, "_RTMIDI");
@@ -384,7 +388,10 @@ PUBLIC int csoundCompileArgs(CSOUND *csound, int argc, const char **argv)
     print_benchmark_info(csound, Str("end of score sort"));
     if (O->syntaxCheckOnly) {
       csound->Message(csound, Str("Syntax check completed.\n"));
-      return CSOUND_EXITJMP_SUCCESS;
+      // return CSOUND_EXITJMP_SUCCESS;
+      if (compiledOk)
+          return CSOUND_EXITJMP_SUCCESS;
+      return CSOUND_ERROR;
     }
     return CSOUND_SUCCESS;
 }


### PR DESCRIPTION
When csound is called with --syntax-check-only it always returns CSOUND_EXITJMP_SUCCESS. With this PR the function csoundCompile will return an error code (CSOUND_ERROR) if called with that flag and parsing failed. 
This allows frontends like CsoundQt to check syntax of a csd without running it and prevent a series of crashes were a failed compilation should not be carried further.