### PR TITLE
Fix Homebrew link in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -98,9 +98,9 @@ describe what you will need to do to use Homebrew to install Csound 6.
 
 -   Xcode Command-Line Tools
 
--   Homebrew - [http://www.brew.sh][2]
+-   Homebrew - [https://brew.sh][2]
 
-[2]: <http://www.brew.sh>
+[2]: <https://brew.sh>
 
 #### Installing Homebrew 
 


### PR DESCRIPTION
The current link to Homebrew (http://www.brew.sh) in the build instructions is broken. This change updates it.