### PR TITLE
fix slicearray for StringArrays

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -4262,7 +4262,7 @@ static OENTRY arrayvars_localops[] =
       (SUBR) tabslice, (SUBR) tabslice, NULL },
     { "slicearray.a", sizeof(TABSLICE), 0, 2, "a[]", "a[]iip",
       (SUBR) tabslice, (SUBR) tabslice, NULL },
-    { "slicearray.S", sizeof(TABSLICE), 0, 2, "S[]", "S[]iip",
+    { "slicearray.S", sizeof(TABSLICE), 0, 1, "S[]", "S[]iip",
       (SUBR) tabslice, (SUBR) tabslice, NULL },
     { "slicearray_i", sizeof(TABSLICE), 0, 1, ".[]", "i[]iip",
       (SUBR) tabslice, NULL },


### PR DESCRIPTION
Running the csd I posted in the ticket I wrote in #1388 I get

```
new alloc for instr SUCCESS:
iArr2[0] is 1
iArr2[1] is 2
iArr2[2] is 3
new alloc for instr FAIL:
incorrect value for SArr2[0]
incorrect value for SArr2[1]
incorrect value for SArr2[2]
```

applying this change I get

```
new alloc for instr SUCCESS:
iArr2[0] is 1
iArr2[1] is 2
iArr2[2] is 3
new alloc for instr FAIL:
SArr2[0] is "1"
SArr2[1] is "2"
SArr2[2] is "3"
```