### PR TITLE
fix fluidsynth version check; added channel info for listDevices for portaudio

### DIFF
--- a/InOut/rtpa.c
+++ b/InOut/rtpa.c
@@ -127,8 +127,8 @@ int listDevices(CSOUND *csound, CS_AUDIODEVICE *list, int isOutput){
         if ((isOutput && dev_info->maxOutputChannels > 0) ||
             (!isOutput && dev_info->maxInputChannels > 0)) {
           //strncpy(list[j].device_name, dev_info->name, 63);
-          snprintf(list[j].device_name, 63, "%s [%s]",
-                   dev_info->name, api_info->name);
+          snprintf(list[j].device_name, 63, "%s [%s, %d in, %d out]",
+                   dev_info->name, api_info->name, dev_info->maxInputChannels, dev_info->maxOutputChannels);
           if (isOutput) {
             snprintf(tmp, 256, "dac%d", j);
           } else {

--- a/Opcodes/fluidOpcodes/fluidOpcodes.cpp
+++ b/Opcodes/fluidOpcodes/fluidOpcodes.cpp
@@ -119,7 +119,7 @@ public:
       result =
           csound->InitError(csound, "%s", Str("error allocating fluid engine\n"));
     } else {
-#if (FLUIDSYNTH_VERSION_MAJOR >= 2)
+#if (FLUIDSYNTH_VERSION_MAJOR >= 2 && FLUIDSYNTH_VERSION_MINOR >= 3)
       // TODO: Change -1 to a configurable FX group?
       fluid_synth_chorus_on(fluidSynth, -1, chorusEnabled);
       fluid_synth_reverb_on(fluidSynth, -1, reverbEnabled);


### PR DESCRIPTION
This PR fixes a version guard for fluidsynth. The deprecation happened seems to have been introduced in version 2.1.3, so just checking against major version causes a compilation error in many systems with versions prior to that.

This PR also includes a small modification to listDevices for portaudio, where the max. channel count for input and output is added to the device name in order to make it available for printing or when listing devices in csoundqt. Similar changes could be implemented also for other backends for which that makes sense (alsa)