### PR TITLE
generating types.d.ts out of jsdoc

### DIFF
--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -60,6 +60,7 @@
     "build:release:prod": "cross-env BUILD_TARGET=release_prod rollup -c --environment production",
     "build:release": "yarn build:release:dev && yarn build:release:prod",
     "build:readme": "node --experimental-modules script/generate-readme.mjs > README.md",
+    "build:index": "jsdoc -t node_modules/tsd-jsdoc/dist -r src -d .",
     "test:ci": "node tests/selenium_runner.js",
     "test:open": "http-server ./tests -c-1 --no-dotfiles"
   },
@@ -100,7 +101,8 @@
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-pluginutils": "^2.8.2",
-    "selenium-webdriver": "^4.0.0-alpha.8"
+    "selenium-webdriver": "^4.0.0-alpha.8",
+    "tsd-jsdoc": "^2.5.0"
   },
   "dependencies": {
     "@wasmer/wasi": "^0.12.0",

--- a/wasm/browser/src/modules/attributes.js
+++ b/wasm/browser/src/modules/attributes.js
@@ -15,8 +15,7 @@ import { curry } from "ramda";
  * Returns the sample rate from Csound instance
  * @async
  * @function
- * @name getSr
- * @memberof CsoundObj
+ * @name CsoundObj#getSr
  * @return {Promise.<number>}
  */
 export const csoundGetSr = curry((wasm, csound) => wasm.exports.csoundGetSr(csound));
@@ -27,8 +26,7 @@ csoundGetSr.toString = () => "getSr = async () => Number;";
  * Returns the control rate from Csound instance
  * @async
  * @function
- * @name getKr
- * @memberof CsoundObj
+ * @name CsoundObj#getKr
  * @return {Promise.<number>}
  */
 export const csoundGetKr = curry((wasm, csound) => wasm.exports.csoundGetKr(csound));
@@ -39,8 +37,7 @@ csoundGetKr.toString = () => "getKr = async () => Number;";
  * Returns the ksmps value (kr/sr) from Csound instance
  * @async
  * @function
- * @name getKsmps
- * @memberof CsoundObj
+ * @name CsoundObj#getKsmps
  * @return {Promise.<number>}
  */
 export const csoundGetKsmps = curry((wasm, csound) => wasm.exports.csoundGetKsmps(csound));
@@ -51,8 +48,7 @@ csoundGetKsmps.toString = () => "getKsmps = async () => Number;";
  * Returns the number of output channels from Csound instance
  * @async
  * @function
- * @name getNchnls
- * @memberof CsoundObj
+ * @name CsoundObj#getNchnls
  * @return {Promise.<number>}
  */
 export const csoundGetNchnls = curry((wasm, csound) => wasm.exports.csoundGetNchnls(csound));
@@ -63,8 +59,7 @@ csoundGetNchnls.toString = () => "getNchnls = async () => Number;";
  * Returns the number of input channels from Csound instance
  * @async
  * @function
- * @name getNchnlsInput
- * @memberof CsoundObj
+ * @name CsoundObj#getNchnlsInput
  * @return {Promise.<number>}
  */
 export const csoundGetNchnlsInput = curry((wasm, csound) =>
@@ -77,8 +72,7 @@ csoundGetNchnlsInput.toString = () => "getNchnlsInput = async () => Number;";
  * Returns the value of csoundGet0dBFS
  * @async
  * @function
- * @name get0dBFS
- * @memberof CsoundObj
+ * @name CsoundObj#get0dBFS
  * @return {Promise.<number>}
  */
 export const csoundGet0dBFS = curry((wasm, csound) => wasm.exports.csoundGet0dBFS(csound));
@@ -89,8 +83,7 @@ csoundGet0dBFS.toString = () => "get0dBFS = async () => Number;";
  * Returns the A4 frequency reference
  * @async
  * @function
- * @name getA4
- * @memberof CsoundObj
+ * @name CsoundObj#getA4
  * @return {Promise.<number>}
  */
 export const csoundGetA4 = curry((wasm, csound) => wasm.exports.csoundGetA4(csound));
@@ -101,8 +94,7 @@ csoundGetA4.toString = () => "getA4 = async () => Number;";
  * Return the current performance time in samples
  * @async
  * @function
- * @name getCurrentTimeSamples
- * @memberof CsoundObj
+ * @name CsoundObj#getCurrentTimeSamples
  * @return {Promise.<number>}
  */
 export const csoundGetCurrentTimeSamples = curry((wasm, csound) =>
@@ -115,8 +107,7 @@ csoundGetCurrentTimeSamples.toString = () => "getCurrentTimeSamples = async () =
  * Return the size of MYFLT in number of bytes
  * @async
  * @function
- * @name getSizeOfMYFLT
- * @memberof CsoundObj
+ * @name CsoundObj#getSizeOfMYFLT
  * @return {Promise.<number>}
  */
 export const csoundGetSizeOfMYFLT = curry((wasm, csound) =>
@@ -134,7 +125,7 @@ csoundGetSizeOfMYFLT.toString = () => "getSizeOfMYFLT = async () => Number;";
  * no spaces are allowed in the string.
  * @async
  * @function
- * @name setOption
+ * @name CsoundObj#setOption
  * @memberof CsoundObj
  * @param {string} option
  * @return {Promise.<number>}
@@ -159,7 +150,7 @@ csoundSetOption.toString = () => "setOption = async (option) => Number;";
  * performance has started.
  * @async
  * @function
- * @name setParams
+ * @name CsoundObj#setParams
  * @memberof CsoundObj
  * @param {CSOUND_PARAMS} csoundParams - csoundParams object
  * @return {Promise.<undefined>}
@@ -176,7 +167,7 @@ csoundSetParams.toString = () => "setParams = async (csoundParams) => undefined;
  * in a CSOUND_PARAMS structure.
  * @async
  * @function
- * @name getParams
+ * @name CsoundObj#getParams
  * @memberof CsoundObj
  * @return {Promise.<CSOUND_PARAMS>} - CSOUND_PARAMS object
  */
@@ -199,7 +190,7 @@ csoundGetParams.toString = () => "getParams = async () => CSOUND_PARAMS;";
  * Anything different to 0 means true.
  * @async
  * @function
- * @name getDebug
+ * @name CsoundObj#getDebug
  * @memberof CsoundObj
  * @return {Promise.<number>}
  */
@@ -211,7 +202,7 @@ csoundGetDebug.toString = () => "getDebug = async () => Number;";
  * Return the size of MYFLT in number of bytes
  * @async
  * @function
- * @name setDebug
+ * @name CsoundObj#setDebug
  * @memberof CsoundObj
  * @param {number} debug
  * @return {Promise.<undefined>}

--- a/wasm/browser/src/modules/control-events.js
+++ b/wasm/browser/src/modules/control-events.js
@@ -10,8 +10,7 @@ import { freeStringPtr, ptr2string, string2ptr } from "@utils/string-pointers";
  * without any pre-process parsing
  * @async
  * @function
- * @name inputMessage
- * @memberof CsoundObj
+ * @name CsoundObj#inputMessage
  * @param {string} scoreEvent
  * @return {Promise.<number>}
  */
@@ -29,8 +28,7 @@ csoundInputMessage.toString = () => "inputMessage = async (scoreEvent) => Number
  * without any pre-process parsing
  * @async
  * @function
- * @name inputMessageAsync
- * @memberof CsoundObj
+ * @name CsoundObj#inputMessageAsync
  * @param {string} scoreEvent
  * @return {Promise.<number>}
  */
@@ -49,8 +47,7 @@ csoundInputMessageAsync.toString = () => "inputMessageAsync = async (scoreEvent)
  * or accessing the channel is stored in it.
  * @async
  * @function
- * @name getControlChannel
- * @memberof CsoundObj
+ * @name CsoundObj#getControlChannel
  * @param {string} channelName
  * @return {Promise.<undefined>}
  */
@@ -67,8 +64,7 @@ csoundGetControlChannel.toString = () => "getControlChannel = async (channelName
  * Sets the value of control channel identified by channelName
  * @async
  * @function
- * @name setControlChannel
- * @memberof CsoundObj
+ * @name CsoundObj#setControlChannel
  * @param {string} channelName
  * @param {number} value
  * @return {Promise.<undefined>}
@@ -85,8 +81,7 @@ csoundSetControlChannel.toString = () => "setControlChannel = async (channelName
  * Retrieves the string channel identified by channelName
  * @async
  * @function
- * @name getStringChannel
- * @memberof CsoundObj
+ * @name CsoundObj#getStringChannel
  * @param {string} channelName
  * @return {Promise.<undefined>}
  */
@@ -106,8 +101,7 @@ csoundGetStringChannel.toString = () => "getStringChannel = async (channelName) 
  * Sets the string channel value identified by channelName
  * @async
  * @function
- * @name setStringChannel
- * @memberof CsoundObj
+ * @name CsoundObj#setStringChannel
  * @param {string} channelName
  * @param {string} value
  * @return {Promise.<undefined>}

--- a/wasm/browser/src/modules/csoundObj.js
+++ b/wasm/browser/src/modules/csoundObj.js
@@ -1,0 +1,3 @@
+/**
+ * @interface CsoundObj
+*/

--- a/wasm/browser/src/modules/general-io.js
+++ b/wasm/browser/src/modules/general-io.js
@@ -9,8 +9,7 @@ import { trimNull } from "@utils/trim-null";
 /**
  * Returns the audio output name (-o)
  * @function
- * @name getOutputName
- * @memberof CsoundObj
+ * @name CsoundObj#getOutputName
  * @return {Promise.<string>}
  */
 export const csoundGetOutputName = (wasm) => (csound) => {
@@ -25,8 +24,7 @@ csoundGetOutputName.toString = () => "getOutputName = async () => String;";
 /**
  * Returns the audio input name (-i)
  * @function
- * @name getInputName
- * @memberof CsoundObj
+ * @name CsoundObj#getInputName
  * @return {Promise.<string>}
  */
 export const csoundGetInputName = (wasm) => (csound) => {

--- a/wasm/browser/src/modules/instantiation.js
+++ b/wasm/browser/src/modules/instantiation.js
@@ -16,8 +16,7 @@ csoundCreate.toString = () => "create = async () => undefined;";
  * Destroys an instance of Csound and frees memory
  * @async
  * @function
- * @name destroy
- * @memberof CsoundObj
+ * @name CsoundObj#destroy
  * @return {Promise.<undefined>}
  */
 export const csoundDestroy = (wasm) => (csound) => wasm.exports.csoundDestroy(csound);
@@ -28,8 +27,7 @@ csoundDestroy.toString = () => "destroy = async () => undefined;";
  * Returns the API version as int
  * @async
  * @function
- * @name getAPIVersion
- * @memberof CsoundObj
+ * @name CsoundObj#getAPIVersion
  * @return {Promise.<number>}
  */
 export const csoundGetAPIVersion = (wasm) => () => wasm.exports.csoundGetAPIVersion();
@@ -40,8 +38,7 @@ csoundGetAPIVersion.toString = () => "getAPIVersion = async () => Number;";
  * Returns the Csound version as int
  * @async
  * @function
- * @name getVersion
- * @memberof CsoundObj
+ * @name CsoundObj#getVersion
  * @return {Promise.<number>}
  */
 export const csoundGetVersion = (wasm) => () => wasm.exports.csoundGetVersion();
@@ -56,8 +53,8 @@ csoundGetVersion.toString = () => "getVersion = async () => Number;";
  * sets signal handlers and atexit() callbacks.
  * @async
  * @function
- * @name initialize
- * @memberof CsoundObj
+ * @name CsoundObj#initialize
+
  * @return {Promise.<number>} - Return value is zero on success,
  *     positive if initialisation was done already, and negative on error.
  */

--- a/wasm/browser/src/modules/performance.js
+++ b/wasm/browser/src/modules/performance.js
@@ -9,8 +9,7 @@ import { freeStringPtr, string2ptr } from "@utils/string-pointers";
  * Parses a csound orchestra string
  * @async
  * @function
- * @name parseOrc
- * @memberof CsoundObj
+ * @name CsoundObj#parseOrc
  * @param {string} orc
  * @return {Promise.<object>}
  */
@@ -22,8 +21,7 @@ csoundParseOrc.toString = () => "parseOrc = async (orchestra) => Object;";
  * Compiles AST tree
  * @async
  * @function
- * @name compileTree
- * @memberof CsoundObj
+ * @name CsoundObj#compileTree
  * @param {object} tree
  * @return {Promise.<number>}
  */
@@ -39,8 +37,7 @@ csoundCompileTree.toString = () => "compileTree = async (tree) => Number;";
  * Compiles a csound orchestra string
  * @async
  * @function
- * @name compileOrc
- * @memberof CsoundObj
+ * @name CsoundObj#compileOrc
  * @param {string} orc
  * @return {Promise.<number>}
  */
@@ -57,8 +54,7 @@ csoundCompileOrc.toString = () => "compileOrc = async (orchestra) => Number;";
  * Compiles a csound orchestra string
  * @async
  * @function
- * @name evalCode
- * @memberof CsoundObj
+ * @name CsoundObj#evalCode
  * @param {string} orc
  * @return {Promise.<number>}
  */
@@ -81,8 +77,7 @@ csoundEvalCode.toString = () => "csoundEvalCode = async (orchestra) => Number;";
  * Prepares Csound for performance
  * @async
  * @function
- * @name start
- * @memberof CsoundObj
+ * @name CsoundObj#start
  * @return {Promise.<number>}
  */
 export const csoundStart = (wasm) => (csound) => wasm.exports.csoundStartWasi(csound);
@@ -96,8 +91,7 @@ csoundStart.toString = () => "start = async () => Number;";
  * Compiles a Csound input file but does not perform it.
  * @async
  * @function
- * @name compileCsd
- * @memberof CsoundObj
+ * @name CsoundObj#compileCsd
  * @param {string} path
  * @return {Promise.<number>}
  */
@@ -115,8 +109,7 @@ csoundCompileCsd.toString = () => "compileCsd = async (path) => Number;";
  * Compiles a CSD string but does not perform it.
  * @async
  * @function
- * @name compileCsdText
- * @memberof CsoundObj
+ * @name CsoundObj#compileCsdText
  * @param {string} orc
  * @return {Promise.<number>}
  */
@@ -133,8 +126,7 @@ csoundCompileCsdText.toString = () => "compileCsdText = async (csoundDocument) =
  * Performs(plays) audio until end is reached
  * @async
  * @function
- * @name perform
- * @memberof CsoundObj
+ * @name CsoundObj#perform
  * @return {Promise.<number>}
  */
 export const csoundPerform = (wasm) => (csound) => wasm.exports.csoundPerform(csound);
@@ -145,8 +137,7 @@ csoundPerform.toString = () => "perform = async () => Number;";
  * Performs(plays) 1 ksmps worth of sample(s)
  * @async
  * @function
- * @name performKsmps
- * @memberof CsoundObj
+ * @name CsoundObj#performKsmps
  * @return {Promise.<number>}
  */
 export const csoundPerformKsmps = (wasm) => (csound) => wasm.exports.csoundPerformKsmpsWasi(csound);
@@ -157,8 +148,7 @@ csoundPerformKsmps.toString = () => "performKsmps = async (csound) => Number;";
  * Performs(plays) 1 buffer worth of audio
  * @async
  * @function
- * @name performBuffer
- * @memberof CsoundObj
+ * @name CsoundObj#performBuffer
  * @return {Promise.<number>}
  */
 export const csoundPerformBuffer = (wasm) => (csound) => wasm.exports.csoundPerformBuffer(csound);
@@ -169,8 +159,7 @@ csoundPerformBuffer.toString = () => "performBuffer = async (csound) => Number;"
  * Stops a csoundPerform
  * @async
  * @function
- * @name stop
- * @memberof CsoundObj
+ * @name CsoundObj#stop
  * @return {Promise.<undefined>}
  */
 export const csoundStop = (wasm) => (csound) => wasm.exports.csoundStop(csound);
@@ -182,8 +171,7 @@ csoundStop.toString = () => "stop = async () => undefined;";
  * and closes audio and MIDI devices.
  * @async
  * @function
- * @name cleanup
- * @memberof CsoundObj
+ * @name CsoundObj#cleanup
  * @return {Promise.<number>}
  */
 export const csoundCleanup = (wasm) => (csound) => wasm.exports.csoundCleanup(csound);
@@ -195,8 +183,7 @@ csoundCleanup.toString = () => "cleanup = async () => Number;";
  * and closes audio and MIDI devices.
  * @async
  * @function
- * @name reset
- * @memberof CsoundObj
+ * @name CsoundObj#reset
  * @return {Promise.<number>}
  */
 export const csoundReset = (wasm) => (csound) => wasm.exports.csoundResetWasi(csound);

--- a/wasm/browser/src/modules/rtaudio.js
+++ b/wasm/browser/src/modules/rtaudio.js
@@ -7,8 +7,7 @@
  * Returns the number of samples in Csound's input buffer.
  * @async
  * @function
- * @name getInputBufferSize
- * @memberof CsoundObj
+ * @name CsoundObj#getInputBufferSize
  * @return {Promise.<number>}
  */
 export const csoundGetInputBufferSize = (wasm) => (csound) =>
@@ -20,8 +19,7 @@ csoundGetInputBufferSize.toString = () => "getInputBufferSize = async () => Numb
  * Returns the number of samples in Csound's output buffer.
  * @async
  * @function
- * @name getOutputBufferSize
- * @memberof CsoundObj
+ * @name CsoundObj#getOutputBufferSize
  * @return {Promise.<number>}
  */
 export const csoundGetOutputBufferSize = (wasm) => (csound) =>
@@ -33,8 +31,7 @@ csoundGetOutputBufferSize.toString = () => "getOutputBufferSize = async () => Nu
  * Returns the address of the Csound audio input buffer.
  * @async
  * @function
- * @name getInputBuffer
- * @memberof CsoundObj
+ * @name CsoundObj#getInputBuffer
  * @return {Promise.<number>}
  */
 export const csoundGetInputBuffer = (wasm) => (csound) => wasm.exports.csoundGetInputBuffer(csound);
@@ -45,8 +42,7 @@ csoundGetInputBuffer.toString = () => "getInputBuffer = async () => Number;";
  * Returns the address of the Csound audio output buffer.
  * @async
  * @function
- * @name getOutputBuffer
- * @memberof CsoundObj
+ * @name CsoundObj#getOutputBuffer
  * @return {Promise.<number>}
  */
 export const csoundGetOutputBuffer = (wasm) => (csound) =>
@@ -59,8 +55,7 @@ csoundGetOutputBuffer.toString = () => "getOutputBuffer = async () => Number;";
  * Enables external software to write audio into Csound before calling csoundPerformKsmps.
  * @async
  * @function
- * @name getSpin
- * @memberof CsoundObj
+ * @name CsoundObj#getSpin
  * @return {Promise.<number>}
  */
 export const csoundGetSpin = (wasm) => (csound) => wasm.exports.csoundGetSpin(csound);
@@ -71,8 +66,8 @@ csoundGetSpin.toString = () => "getSpin = async (csound) => Number;";
  * Returns the address of the Csound audio output working buffer (spout).
  * Enables external software to read audio from Csound after calling csoundPerformKsmps.
  * @async
- * @function getSpout
- * @memberof CsoundObj
+ * @function
+ * @name CsoundObj#getSpout
  * @return {Promise.<number>}
  */
 export const csoundGetSpout = (wasm) => (csound) => wasm.exports.csoundGetSpout(csound);

--- a/wasm/browser/src/modules/rtmidi.js
+++ b/wasm/browser/src/modules/rtmidi.js
@@ -16,8 +16,7 @@ export const csoundSetMidiCallbacks = (wasm) => (csound) => {
  * (isOutput=1 for out devices, 0 for in devices).
  * @async
  * @function
- * @name getMIDIDevList
- * @memberof CsoundObj
+ * @name CsoundObj#getMIDIDevList
  * @param {number} isOutput
  * @return {Promise.<CS_MIDIDEVICE>}
  */
@@ -45,8 +44,7 @@ csoundGetMIDIDevList.toString = () => "getMIDIDevList = async (isOutput) => Obje
  * (isOutput=1 for out devices, 0 for in devices).
  * @async
  * @function
- * @name getRtMidiName
- * @memberof CsoundObj
+ * @name CsoundObj#getRtMidiName
  * @return {Promise.<string>}
  */
 export const csoundGetRtMidiName = (wasm) => (csound) => {
@@ -75,8 +73,7 @@ export const _isRequestingRtMidiInput = (wasm) => (csound) => {
  * in the range of 0 to 127.
  * @async
  * @function
- * @name midiMessage
- * @memberof CsoundObj
+ * @name CsoundObj#midiMessage
  * @param {number} midi status value
  * @param {number} midi data1
  * @param {number} midi data2

--- a/wasm/browser/src/modules/score-handling.js
+++ b/wasm/browser/src/modules/score-handling.js
@@ -10,8 +10,7 @@ import { freeStringPtr, string2ptr } from "@utils/string-pointers";
  * independently of real-time MIDI events
  * @async
  * @function
- * @name isScorePending
- * @memberof CsoundObj
+ * @name CsoundObj#isScorePending
  * @return {Promise.<number>}
  */
 export const csoundIsScorePending = (wasm) => (csound) => wasm.exports.csoundIsScorePending(csound);
@@ -27,8 +26,7 @@ csoundIsScorePending.toString = () => "isScorePending = async () => Number;";
  * or to play the Csound instruments live.
  * @async
  * @function
- * @name setScorePending
- * @memberof CsoundObj
+ * @name CsoundObj#setScorePending
  * @param {number} pending
  * @return {Promise.<undefined>}
  */
@@ -42,8 +40,7 @@ csoundSetScorePending.toString = () => "setScorePending = async (pending) => Num
  * with the new score events being added to the currently scheduled ones.
  * @async
  * @function
- * @name readScore
- * @memberof CsoundObj
+ * @name CsoundObj#readScore
  * @param {string} score
  * @return {Promise.<undefined>}
  */
@@ -60,8 +57,7 @@ csoundReadScore.toString = () => "readScore = async (score) => Number;";
  * Returns the current score time in seconds since the beginning of performance.
  * @async
  * @function
- * @name getScoreTime
- * @memberof CsoundObj
+ * @name CsoundObj#getScoreTime
  * @return {Promise.<number>}
  */
 export const csoundGetScoreTime = (wasm) => (csound) => wasm.exports.csoundGetScoreTime(csound);
@@ -72,8 +68,7 @@ csoundGetScoreTime.toString = () => "getScoreTime = async () => Number;";
  * Returns the score time beginning at which score events will actually immediately be performed
  * @async
  * @function
- * @name getScoreOffsetSeconds
- * @memberof CsoundObj
+ * @name CsoundObj#getScoreOffsetSeconds
  * @return {Promise.<number>}
  */
 export const csoundGetScoreOffsetSeconds = (wasm) => (csound) =>
@@ -91,8 +86,7 @@ csoundGetScoreOffsetSeconds.toString = () => "getScoreOffsetSeconds = async () =
  * or to synchronize other events with the Csound score.
  * @async
  * @function
- * @name setScoreOffsetSeconds
- * @memberof CsoundObj
+ * @name CsoundObj#setScoreOffsetSeconds
  * @param {number} time
  * @return {Promise.<number>}
  */
@@ -105,8 +99,7 @@ csoundSetScoreOffsetSeconds.toString = () => "setScoreOffsetSeconds = async () =
  * Rewinds a compiled Csound score to the time specified with csoundObj.setScoreOffsetSeconds().
  * @async
  * @function
- * @name rewindScore
- * @memberof CsoundObj
+ * @name CsoundObj#rewindScore
  * @return {Promise.<number>}
  */
 export const csoundRewindScore = (wasm) => (csound) => wasm.exports.csoundRewindScore(csound);

--- a/wasm/browser/src/modules/table.js
+++ b/wasm/browser/src/modules/table.js
@@ -10,8 +10,7 @@ import { uint2String } from "@utils/text-encoders";
  * or -1 if the table does not exist.
  * @async
  * @function
- * @name tableLength
- * @memberof CsoundObj
+ * @name CsoundObj#tableLength
  * @param {string} tableNum
  * @return {Promise.<number>}
  */
@@ -25,8 +24,7 @@ csoundTableLength.toString = () => "tableLength = async (tableNum) => Number;";
  * The table number and index are assumed to be valid.
  * @async
  * @function
- * @name tableGet
- * @memberof CsoundObj
+ * @name CsoundObj#tableGet
  * @param {string} tableNum
  * @param {string} tableIndex
  * @return {Promise.<number>}
@@ -41,8 +39,7 @@ csoundTableGet.toString = () => "tableGet = async (tableNum, tableIndex) => Numb
  * The table number and index are assumed to be valid.
  * @async
  * @function
- * @name tableSet
- * @memberof CsoundObj
+ * @name CsoundObj#tableSet
  * @param {string} tableNum
  * @param {string} tableIndex
  * @param {string} value
@@ -60,8 +57,7 @@ csoundTableSet.toString = () => "tableSet = async (tableNum, tableIndex, value) 
  * The table number and index are assumed to be valid.
  * @async
  * @function
- * @name tableCopyIn
- * @memberof CsoundObj
+ * @name CsoundObj#tableCopyIn
  * @param {string} tableNum
  * @param {string} tableIndex
  * @param {Array<number>|ArrayLike<number>} array
@@ -83,8 +79,7 @@ csoundTableCopyIn.toString = () => "tableCopyIn = async (tableNum, float64Array)
  * it returns undefined.
  * @async
  * @function
- * @name tableCopyOut
- * @memberof CsoundObj
+ * @name CsoundObj#tableCopyOut
  * @param {string} tableNum
  * @return {Promise.<Float64Array|undefined>}
  */
@@ -103,12 +98,11 @@ export const csoundTableCopyOut = (wasm) => (csound, tableNumber) => {
 csoundTableCopyOut.toString = () => "tableCopyOut = async (tableNum) => ?Float64Array;";
 
 /**
- * @name getTable
+ * @name CsoundObj#getTable
  * @alias csoundTableCopyOut
  * @async
  * @function
- * @name getTable
- * @memberof CsoundObj
+ * @name CsoundObj#getTable
  * @param {string} tableNum
  * @return {Promise.<Float64Array|undefined>}
  */
@@ -121,8 +115,7 @@ csoundGetTable.toString = csoundTableCopyOut.toString;
  * it returns undefined.
  * @async
  * @function
- * @name getTableArgs
- * @memberof CsoundObj
+ * @name CsoundObj#getTableArgs
  * @param {string} tableNum
  * @return {Promise.<Float64Array|undefined>}
  */
@@ -145,8 +138,7 @@ csoundGetTableArgs.toString = () => "getTableArgs = async (tableNum) => ?Float64
  * Otherwise it returns 0.
  * @async
  * @function
- * @name isNamedGEN
- * @memberof CsoundObj
+ * @name CsoundObj#isNamedGEN
  * @param {string} tableNum
  * @return {Promise.<number>}
  */
@@ -162,8 +154,7 @@ csoundIsNamedGEN.toString = () => "isNamedGEN = async (tableNum) => number;";
  * return undefined.
  * @async
  * @function
- * @name getNamedGEN
- * @memberof CsoundObj
+ * @name CsoundObj#getNamedGEN
  * @param {string} tableNum
  * @return {Promise.<string|undefined>}
  */

--- a/wasm/browser/yarn.lock
+++ b/wasm/browser/yarn.lock
@@ -3393,6 +3393,13 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tsd-jsdoc@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tsd-jsdoc/-/tsd-jsdoc-2.5.0.tgz#0677aa952e1a8e3ebbb5bcf7d6e2f0301d71e151"
+  integrity sha512-80fcJLAiUeerg4xPftp+iEEKWUjJjHk9AvcHwJqA8Zw0R4oASdu3kT/plE/Zj19QUTz8KupyOX25zStlNJjS9g==
+  dependencies:
+    typescript "^3.2.1"
+
 tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
@@ -3414,6 +3421,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+typescript@^3.2.1:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
using tsd-jsdoc it is possible to create .d.ts out of csound JSDoc in src/modules.

TODO: upgrade tsd-jsdoc to generate ES6 style functions `inputMessage: (scoreEvent: string) => Promise<number>;` instead of `function inputMessage(scoreEvent: string): Promise<number>;`