### PR TITLE
fix bug in named_instr_assign_numbers

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1180,16 +1180,26 @@ void named_instr_assign_numbers(CSOUND *csound, ENGINE_STATE *engineState) {
 
   while (--insno_priority > -3) {
     if (insno_priority == -2) {
-
+      int found = 0;
       /* check both this state & current state */
       if(engineState->maxinsno > csound->engineState.maxinsno) {
-          num = engineState->maxinsno;
-          while (engineState->instrtxtp[num] && --num);
+        for(num=engineState->maxinsno; num > csound->engineState.maxinsno; num--) {
+          if(engineState->instrtxtp[num]) {
+            found = 1;
+            break;
+          }
+        }
       } else {
-          num = csound->engineState.maxinsno;
-          while (!csound->engineState.instrtxtp[num] && --num);
+        for(num=csound->engineState.maxinsno; num > engineState->maxinsno; num--) {
+          if(csound->engineState.instrtxtp[num]) {
+            found = 1;
+            break;
+          }
+        }
       }
-
+      if(!found) {
+        while(!engineState->instrtxtp[num] && !csound->engineState.instrtxtp[num] && --num);
+      }
     }
     for (inm = inm_first; inm; inm = inm->next) {
       INSTRNAME *temp = (INSTRNAME *)inm->name;

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1180,17 +1180,15 @@ void named_instr_assign_numbers(CSOUND *csound, ENGINE_STATE *engineState) {
 
   while (--insno_priority > -3) {
     if (insno_priority == -2) {
-      /* check both this state & current state */
-      num = engineState->maxinsno >
-        csound->engineState.maxinsno ?
-        engineState->maxinsno :
-        csound->engineState.maxinsno; /* find last used instr number */
 
       /* check both this state & current state */
-      while ((!engineState->instrtxtp[num] ||
-              !csound->engineState.instrtxtp[num]) &&
-             --num)
-        ;
+      if(engineState->maxinsno > csound->engineState.maxinsno) {
+          num = engineState->maxinsno;
+          while (engineState->instrtxtp[num] && --num);
+      } else {
+          num = csound->engineState.maxinsno;
+          while (!csound->engineState.instrtxtp[num] && --num);
+      }
 
     }
     for (inm = inm_first; inm; inm = inm->next) {
@@ -1221,23 +1219,23 @@ void named_instr_assign_numbers(CSOUND *csound, ENGINE_STATE *engineState) {
             engineState->instrtxtp[m] = NULL;
         }
         inum = num;
-      } else
+
+      } else {
         inum = no; // else use existing number
+      }
       /* hack: "name" actually points to the corresponding INSTRNAME */
       inm2 = (INSTRNAME *)(inm->name); /* entry in the table */
 
       inm2->instno = (int32)inum;
       engineState->instrtxtp[inum] = inm2->ip;
 
-      //if(&csound->engineState == engineState) {
-        /* print message only after merge */
-       if (UNLIKELY((csound->oparms->odebug) || (csound->oparms->msglevel > 0)))
+      if (UNLIKELY((csound->oparms->odebug) || (csound->oparms->msglevel > 0)))
         csound->Message(csound, Str("instr %s uses instrument number %d\n"),
                         inm2->name, inum);
-       //}
     }
   }
   /* clear temporary chains */
+
   inm = inm_first;
   while (inm) {
     INSTRNAME *nxtinm = inm->next;


### PR DESCRIPTION
This fixes a very nasty bug where adding a new named instr after a high numbered instr would result in a crash. 