### PR TITLE
error when using pvs2tab with sliding PVS

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -2675,6 +2675,9 @@ int32_t pvs2tab_init(CSOUND *csound, PVS2TAB_T *p)
                    (p->fsig->format == PVS_AMP_PHASE))))
     return csound->InitError(csound, Str("pvs2tab: signal format "
                                          "must be amp-phase or amp-freq."));
+    if (UNLIKELY(p->fsig->sliding))
+        return csound->InitError(csound, Str("pvs2tab: cannot use sliding PVS"));
+    
   if (LIKELY(p->ans->data)) return OK;
   return csound->InitError(csound, Str("array-variable not initialised"));
 }
@@ -2703,7 +2706,10 @@ int32_t pvs2tabsplit_init(CSOUND *csound, PVS2TABSPLIT_T *p)
                    (p->fsig->format == PVS_AMP_PHASE))))
     return csound->InitError(csound, Str("pvs2tab: signal format "
                                          "must be amp-phase or amp-freq."));
-
+    
+    if (UNLIKELY(p->fsig->sliding))
+        return csound->InitError(csound, Str("pvs2tab: cannot use sliding PVS"));
+    
   if (LIKELY(p->mags->data) && LIKELY(p->freqs->data))
     return OK;
 


### PR DESCRIPTION
If you're using sliding PVS and try to use pvs2tab at the same time then the fsig data points to uninitialised data and this get's copied into the target array(s).

There also doesn't seem to be any indication if csound has switched to using sliding PVS, which I think I ran into because the overlap was smaller than ksmps.