### PR TITLE
Set CMAKE_INSTALL_RPATH on Unix to avoid run-time linker errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,14 @@ TEST_BIG_ENDIAN(BIG_ENDIAN)
 
 SET(BUILD_SHARED_LIBS ON)
 
+if(UNIX)
+    if(USE_LIB64)
+        SET(CMAKE_INSTALL_RPATH "$ORIGIN/../lib64")
+    else()
+        SET(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+    endif()
+endif()
+
 ## HEADER/LIBRARY/OTHER CHECKS ##
 
 # First, required stuff


### PR DESCRIPTION
Currently, if I build Csound on Linux (or Unix generally) and install it in a non-system location, and then attempt to run it, I get this error:
```
$ /tmp/csound-install/bin/csound --help
/tmp/csound-install/bin/csound: error while loading shared libraries: libcsound64.so.6.0: cannot open shared object file: No such file or directory
```
In order for the executable to work, I have to (for example) set `LD_LIBRARY_PATH=/tmp/csound-install/lib` in my environment, so that the run-time linker knows where to look for the Csound shared libraries that the executable requires.

This change sets `CMAKE_INSTALL_RPATH` in Unix builds so that executables and shared libraries are built with [RPATH](https://www.lekensteyn.nl/rpath.html) support, and thus have run-time linker paths embedded directly into the compiled artifacts themselves.

This change additionally makes use of the `$ORIGIN` token rather than setting a hard-coded absolute path. This allows the whole install tree to be moved to a different location, without complaint from the run-time linker.