### PR TITLE
Update of the testing facility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ find_package(FAUST)
 find_package(Java)
 find_package(JNI)
 find_package(MUSICXML)
+find_package(Python)
 find_package(VSTSDK2X)
 
 #if(MUSICXML_FOUND)

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -56,26 +56,22 @@ add_test(NAME testCircularBuffer
 #add_executable(testCscore cscore_tests.c)
 #target_link_libraries(testCscore ${CSOUNDLIB} ${CUNIT_LIBRARY} pthread)
 #add_test(NAME testCscore
-#        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/c/
 #        COMMAND $<TARGET_FILE:testCscore> ${CMAKE_SOURCE_DIR}/tests/c/ -arg2 ${TEST_ARGS})
 
 add_executable(testPerfThread perfthread_test.cpp)
 target_link_libraries(testPerfThread ${CSOUNDLIB} ${CUNIT_LIBRARY} pthread libcsnd6)
 add_test(NAME testPerfThread
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/c/
         COMMAND $<TARGET_FILE:testPerfThread> ${CMAKE_SOURCE_DIR}/tests/c/ -arg2 ${TEST_ARGS})
 
 add_executable(testDebugger csound_debugger_test.c)
 target_link_libraries(testDebugger ${CSOUNDLIB} ${CUNIT_LIBRARY} pthread libcsnd6)
 add_test(NAME testDebugger
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/c/
         COMMAND $<TARGET_FILE:testDebugger> ${CMAKE_SOURCE_DIR}/tests/c/ -arg2 ${TEST_ARGS})
 
 
 add_executable(testEngine engine_test.c)
 target_link_libraries(testEngine ${CSOUNDLIB} ${CUNIT_LIBRARY} pthread)
 add_test(NAME testEngine
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/c/
         COMMAND $<TARGET_FILE:testEngine> ${CMAKE_SOURCE_DIR}/tests/c/
 	-arg2 ${TEST_ARGS})
 
@@ -83,7 +79,6 @@ add_executable(testServer server_test.cpp)
 target_link_libraries(testServer ${CSOUNDLIB} ${CUNIT_LIBRARY} pthread
 libcsnd6)
 add_test(NAME testServer
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/c/
         COMMAND $<TARGET_FILE:testServer> ${CMAKE_SOURCE_DIR}/tests/c/ -arg2 ${TEST_ARGS})
 
 

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
-if(MSVC) 
-  add_custom_target(csdtests python test.py --csound-executable=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/csound --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+if(MSVC)
+  add_custom_target(csdtests ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py --csound-executable=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/csound --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
 else()
-  add_custom_target(csdtests python test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_custom_target(csdtests ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR} --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Csound Test Suite
 # By Steven Yi <stevenyi at gmail dot com>
@@ -19,6 +19,7 @@ parserType = ""
 showUIatClose = False
 ##csoundExecutable = r"C:/Users/new/csound-csound6-git/csound.exe "
 csoundExecutable =""
+sourceDirectory = "."
 
 class Test:
     def __init__(self, fileName, description, expected=True):
@@ -169,7 +170,7 @@ def runTest():
     tests += udoTests
 
     output = ""
-    tempfile = 'csound_test_output.txt' if (os.name == 'nt') else '/tmp/csound_test_output.txt'
+    tempfile = 'csound_test_output.txt'
     counter = 1
 
     retVals = []
@@ -184,14 +185,17 @@ def runTest():
 
         if(os.sep == '\\' or os.name == 'nt'):
             executable = (csoundExecutable == "") and "..\csound.exe" or csoundExecutable
-            command = "%s %s %s %s 2> %s"%(executable, parserType, runArgs, filename, tempfile)
+            command = "%s %s %s %s/%s 2> %s"%(executable, parserType, runArgs, sourceDirectory, filename, tempfile)
             print(command)
             retVal = os.system(command)
         else:
             executable = (csoundExecutable == "") and "../../csound" or csoundExecutable
-            command = "%s %s %s %s 2> %s"%(executable, parserType, runArgs, filename, tempfile)
+            command = "%s %s %s %s/%s 2> %s"%(executable, parserType, runArgs, sourceDirectory, filename, tempfile)
             print(command)
             retVal = os.system(command)
+
+        if hasattr(os, 'WIFEXITED') and os.WIFEXITED(retVal):
+            retVal = os.WEXITSTATUS(retVal)
 
         out = ""
         if (retVal == 0) == (expectedResult == 0):
@@ -252,6 +256,8 @@ if __name__ == "__main__":
             elif arg.startswith("--opcode6dir64="):
                 os.environ['OPCODE6DIR64'] = arg[15:]
                 print(os.environ['OPCODE6DIR64'])
+            elif arg.startswith("--source-dir="):
+                sourceDirectory = arg[13:]
     results = runTest()
     if (showUIatClose):
         showUI(results)

--- a/tests/python/test_all.py
+++ b/tests/python/test_all.py
@@ -1,4 +1,9 @@
-import Tkinter
+try:
+    # Python 3
+    from tkinter import *
+except:
+    # Python 2
+    from Tkinter import *
 
 # UI that shows all other tests
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,5 +1,3 @@
 cmake_minimum_required(VERSION 2.8)
 
-add_custom_target(regression python test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
+add_custom_target(regression ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR} --source-dir=${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/regression/test.py
+++ b/tests/regression/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Csound6 Regresson Test Suite
 # By Steven Yi<stevenyi at gmail dot com>John ffitch
@@ -7,10 +7,17 @@ import os
 import sys
 
 from testUI import TestApplication
-from Tkinter import *
+
+try:
+    # Python 3
+    from tkinter import *
+except:
+    # Python 2
+    from Tkinter import *
 
 showUIatClose = False
 csoundExecutable = ""
+sourceDirectory = "."
 
 class Test:
     def __init__(self, fileName, description, expected=True):
@@ -32,7 +39,7 @@ def showHelp():
     are written to results.txt file.
     """
 
-    print message
+    print(message)
 
 def runTest():
     runArgs = "-Wd -n"
@@ -84,7 +91,7 @@ def runTest():
     ]
 
     output = ""
-    tempfile = "/tmp/csound_test_output.txt"
+    tempfile = "csound_test_output.txt"
     counter = 1
 
     retVals = TestResults()
@@ -97,13 +104,16 @@ def runTest():
         if(os.sep == '\\'):
             executable = (csoundExecutable == "") and "..\..\csound.exe" or csoundExecutable
             command = "%s %s %s 2> %s"%(executable, runArgs, filename, tempfile)
-            print command
+            print(command)
             retVal = os.system(command)
         else:
             executable = (csoundExecutable == "") and "../../csound" or csoundExecutable
-            command = "%s %s %s 2> %s"%(executable, runArgs, filename, tempfile)
-            print command
+            command = "%s %s %s/%s 2> %s"%(executable, runArgs, sourceDirectory, filename, tempfile)
+            print(command)
             retVal = os.system(command)
+
+        if hasattr(os, 'WIFEXITED') and os.WIFEXITED(retVal):
+            retVal = os.WEXITSTATUS(retVal)
 
         out = ""
         if (retVal == 0) == (expectedResult == 0):
@@ -115,7 +125,7 @@ def runTest():
 
         out += "Test %i: %s (%s)\n\tReturn Code: %i\tExpected: %d\n"%(counter, desc, filename, retVal, expectedResult
 )
-        print out
+        print(out)
         output += "%s\n"%("=" * 80)
         output += "Test %i: %s (%s)\nReturn Code: %i\n"%(counter, desc, filename, retVal)
         output += "%s\n\n"%("=" * 80)
@@ -135,10 +145,10 @@ def runTest():
         output += "\n\n"
         counter += 1
 
-#    print output
+#    print(output)
 
-    print "%s\n\n"%("=" * 80)
-    print "Tests Passed: %i\nTests Failed: %i\n"%(retVals.tests_passsed, retVals.tests_failed)
+    print("%s\n\n"%("=" * 80))
+    print("Tests Passed: %i\nTests Failed: %i\n"%(retVals.tests_passsed, retVals.tests_failed))
 
 
     f = open("results.txt", "w")
@@ -167,10 +177,12 @@ if __name__ == "__main__":
                 showUIatClose = True
             elif arg.startswith("--csound-executable="):
                 csoundExecutable = arg[20:]
-                print csoundExecutable
+                print(csoundExecutable)
             elif arg.startswith("--opcode6dir64="):
                 os.environ['OPCODE6DIR64'] = arg[15:]
-                print os.environ['OPCODE6DIR64']
+                print(os.environ['OPCODE6DIR64'])
+            elif arg.startswith("--source-dir="):
+                sourceDirectory = arg[13:]
     results = runTest()
     if (showUIatClose):
         showUI(results)

--- a/tests/regression/testUI.py
+++ b/tests/regression/testUI.py
@@ -1,4 +1,9 @@
-from Tkinter import *
+try:
+    # Python 3
+    from tkinter import *
+except:
+    # Python 2
+    from Tkinter import *
 
 class TestApplication(Frame):
     def selectTest(self):

--- a/tests/soak/CMakeLists.txt
+++ b/tests/soak/CMakeLists.txt
@@ -1,5 +1,3 @@
 cmake_minimum_required(VERSION 2.8)
 
-add_custom_target(soak python runtests.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR}
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
+add_custom_target(soak ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR} --source-dir=${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/soak/runtests.py
+++ b/tests/soak/runtests.py
@@ -1,10 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys
 
 csound = "../../csound"
 flags = "-d -W -m0"
+source_dir = "."
 
 testFiles = [
 "0dbfs",
@@ -1026,13 +1027,21 @@ testFiles = [
 "zkwm",
 ]
 
-if len(sys.argv) == 2:
-    csound = sys.argv[1]
-else:
-    print "Testing git version"
+if(len(sys.argv) > 1):
+    for arg in sys.argv:
+        if (arg == "--help"):
+            showHelp()
+            sys.exit(0)
+        elif arg.startswith("--csound-executable="):
+            csound = arg[20:]
+        elif arg.startswith("--opcode6dir64="):
+            os.environ['OPCODE6DIR64'] = arg[15:]
+            print("OPCODE6DIR64 = " + os.environ['OPCODE6DIR64'])
+        elif arg.startswith("--source-dir="):
+            source_dir = arg[13:]
+            print("source dir = " + source_dir)
 
-
-print "Using Csound Command: " + csound    
+print("Using Csound Command: " + csound)
 
 try:
     os.remove("Old_Output")
@@ -1051,21 +1060,21 @@ except OSError:
 
 for filename in testFiles:
 
-    replaceText = (csound, flags, filename, filename)
-    csCommand = "%s %s %s.csd -o ./%s.wav >> Output 2>&1"%replaceText
+    replaceText = (csound, flags, source_dir, filename, filename)
+    csCommand = "%s %s %s/%s.csd -o ./%s.wav >> Output 2>&1"%replaceText
   
     md5sumCommand = "md5sum -b %s.wav >> CheckSums"%filename
 
-    print csCommand
+    print(csCommand)
     os.system(csCommand)
     os.system(md5sumCommand)
 
     try:
         os.remove(filename + ".wav")
     except OSError:
-        print "Error: %s.wav was not generated"%filename
+        print("Error: %s.wav was not generated"%filename)
     
-print "********Comparing checksums"
-os.system("diff CheckSums SAFESums")
-print "********Comparing output"
+print("********Comparing checksums")
+os.system("diff CheckSums %s/Sample_CheckSums"%source_dir)
+print("********Comparing output")
 os.system("diff Output Old_Output")

--- a/tests/soak/xx.py
+++ b/tests/soak/xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys
@@ -15,10 +15,10 @@ testFiles = [
 if len(sys.argv) == 2:
     csound = sys.argv[1]
 else:
-    print "Testing git version"
+    print("Testing git version")
 
 
-print "Using Csound Command: " + csound    
+print("Using Csound Command: " + csound)
 
 try:
     os.remove("Old_OutputX")
@@ -43,17 +43,17 @@ for filename in testFiles:
   
     md5sumCommand = "md5sum -b %s.wav >> CheckSumsX"%filename
 
-    print csCommand
+    print(csCommand)
     os.system(csCommand)
     os.system(md5sumCommand)
 
     try:
         os.remove(filename + ".wav")
     except OSError:
-        print "Error: %s.wav was not generated"%filename
+        print("Error: %s.wav was not generated"%filename)
     
-print "********Comparing checksums"
+print("********Comparing checksums")
 os.system("diff CheckSumsX SAFESumsX")
-print "********Comparing output"
+print("********Comparing output")
 os.system("sed -e /Elapsed/d < OutputX > OutputX1")
 os.system("diff OutputX1 Old_OutputX | grep -v Elapsed")


### PR DESCRIPTION
I've been sitting on these changes for a while, making use of them in my own testing. The main goals are (1) allow the test suite to run on Python 3 without losing support for Python 2, and (2) run the tests in the build tree, so that the source tree doesn't get polluted with test outputs.

Commit message body follows:

* Make scripts compatible with both Python 2 and 3

* Detect at configuration time the available Python interpreter

* Make tests run in the build tree, not in the source tree

* Don't write files directly into `/tmp`

* Use proper exit status value from `os.system()`