### PR TITLE
Copy tests/soak/nsliders.tk to builddir to fix three tests

### DIFF
--- a/tests/soak/CMakeLists.txt
+++ b/tests/soak/CMakeLists.txt
@@ -1,3 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
 add_custom_target(soak ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runtests.py --csound-executable=${CMAKE_BINARY_DIR}/csound --opcode6dir64=${CMAKE_BINARY_DIR} --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
+
+# needed by checkbox, flashtxt, setctrl
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nsliders.tk DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The `checkbox`, `flashtxt`, and `setctrl` tests need this file in the current directory in order to complete successfully, and now that tests can run in a separate builddir (PR #1467), this will ensure the file continues to be accessible in that scenario.

----

(Now that the big test PR is done, I'm focusing on individual tests.)

As a completely separate aside, by the way, the following tests fail due to `fox.wav` not being present in `tests/soak/`:
```
poscil3-file.csd
pvsftr.csd
pvslock.csd
pvstanal.csd
vpow_i-2.csd
```