### PR TITLE
Add a user folder to the paths searched for plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,14 +368,27 @@ if(APPLE)
 
     add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${CS_FRAMEWORK_FULL_PATH}\"")
     set(DEFAULT_OPCODEDIR ${CS_FRAMEWORK_FULL_PATH})
+
+    # dir relative to $HOME
+    set(DEFAULT_USER_PLUGINDIR "Library/csound/${APIVERSION}/plugins64")
+    add_definitions("-DCS_DEFAULT_USER_PLUGINDIR=\"${DEFAULT_USER_PLUGINDIR}\"")
+endif()
+
+if(LINUX)
+    set(DEFAULT_OPCODEDIR "${PLUGIN_INSTALL_DIR}")
+    add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${DEFAULT_OPCODEDIR}\"")
+    set(DEFAULT_USER_PLUGINDIR ".local/lib/csound/${APIVERSION}/plugins64")
+    add_definitions("-DCS_DEFAULT_USER_PLUGINDIR=\"${DEFAULT_USER_PLUGINDIR}\"")
+endif()
+
+if(WIN32)
+    # dir relaive to %LOCALAPPDATA%
+    set(DEFAULT_USER_PLUGINDIR "csound/${APIVERSION}/plugins64")
+    add_definitions("-DCS_DEFAULT_USER_PLUGINDIR=\"${DEFAULT_USER_PLUGINDIR}\"")
 endif()
 
 if(BUILD_RELEASE)
     add_definitions("-D_CSOUND_RELEASE_")
-    if(LINUX)
-        set(DEFAULT_OPCODEDIR "${PLUGIN_INSTALL_DIR}")
-        add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${DEFAULT_OPCODEDIR}\"")
-    endif()
 else()
     add_definitions("-DBETA")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ endif()
 if(LINUX)
     set(DEFAULT_OPCODEDIR "${PLUGIN_INSTALL_DIR}")
     add_definitions("-DCS_DEFAULT_PLUGINDIR=\"${DEFAULT_OPCODEDIR}\"")
+    # dir relative to $HOME
     set(DEFAULT_USER_PLUGINDIR ".local/lib/csound/${APIVERSION}/plugins64")
     add_definitions("-DCS_DEFAULT_USER_PLUGINDIR=\"${DEFAULT_USER_PLUGINDIR}\"")
 endif()

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -469,7 +469,7 @@ int csoundLoadModules(CSOUND *csound)
     int pos = strlen(dname);
     int prefixlen = strlen(prefix);
     if(pos + prefixlen + 2 > _buflen - 1) {
-      csound->Message(csound, "plugins search path two long\n");
+      csound->Message(csound, "plugins search path too long\n");
     } else {
       strncpy(opcode_paths_buf, dname, _buflen-1);
       opcode_paths_buf[pos++] = sep;

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -488,7 +488,8 @@ int csoundLoadModules(CSOUND *csound)
       dname = csound->opcodedir;
       csound->Message(csound, "OPCODEDIR overridden to %s \n", dname);
     } else {
-      csound->Message(csound, "Plugins search path: %s\n", dname);
+      if(UNLIKELY(csound->oparms->odebug))
+        csound->Message(csound, "Plugins search path: %s\n", dname);
 
     }
 


### PR DESCRIPTION
This is a draft implementing #1249. It includes a new define in the cmake file, "CS_DEFAULT_USER_PLUGINDIR", which is a relative path to a folder within the users home directory. In linux and mac the prefix is $HOME, in windows it is %LOCALAPPDATA%. This is defined in the cmake file because we need access there to APIVERSION. 

In csmodule.c we add the user dir to the search path if this macro is defined. If the user defines OPCODE6DIR64, the path
given there overrides everything, including the user plugins dir. 