### PR TITLE
new opcode filereadmeta: reads metadata from a soundfile

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -26,6 +26,8 @@
 #include "arrays.h"
 #include "emugens_common.h"
 #include <ctype.h>
+#include "sndfile.h"
+
 
 #define SAMPLE_ACCURATE \
     uint32_t n, nsmps = CS_KSMPS;                                    \
@@ -2955,6 +2957,120 @@ int32_t printsk_perf(CSOUND *csound, PRINTLN *p) {
 }
 
 
+/* sfreadmeta
+ *
+ */
+
+// Sstr sndfilemeta "sndfile.wav", Skey
+typedef struct {
+    OPDS h;
+    STRINGDAT *sout;
+    STRINGDAT *sndfile;
+    STRINGDAT *key;
+} SFREADMETA;
+
+
+static int sf_string_to_type(const char *key) {
+    int str_type;
+    if(!strcmp(key, "comment"))
+        str_type = SF_STR_COMMENT;
+    else if(!strcmp(key, "title"))
+        str_type = SF_STR_TITLE;
+    else if(!strcmp(key, "artist"))
+        str_type = SF_STR_ARTIST;
+    else if(!strcmp(key, "album"))
+        str_type = SF_STR_ALBUM;
+    else if(!strcmp(key, "tracknumber"))
+        str_type = SF_STR_TRACKNUMBER;
+    else if(!strcmp(key, "software"))
+        str_type = SF_STR_SOFTWARE;
+    else {
+        str_type = 0;
+    }
+    return str_type;
+}
+
+static const char * sf_strtype_to_string(int str_type) {
+    switch(str_type) {
+    case SF_STR_COMMENT:
+        return "comment";
+    case SF_STR_TITLE:
+        return "title";
+    case SF_STR_ARTIST:
+        return "artist";
+    case SF_STR_ALBUM:
+        return "album";
+    case SF_STR_TRACKNUMBER:
+        return "tracknumber";
+    default:
+        return NULL;
+    }
+}
+
+static int32_t sfreadmeta_i(CSOUND *csound, SFREADMETA *p) {
+    SNDFILE *file;
+    SF_INFO sfinfo;
+
+    char *key = p->key->data;
+    int str_type = sf_string_to_type(key);
+    if(str_type == 0)
+        return INITERRF("Key not supported: %s", key);
+
+    if ((file = sf_open (p->sndfile->data, SFM_READ, &sfinfo)) == NULL) {
+        return INITERRF("Error: Not able to open input file %s.\n", p->sndfile->data);
+    }
+    const char *svalue = sf_get_string(file, str_type);
+    if(svalue == NULL) {
+        stringdat_clear(csound, p->sout);
+        return OK;
+    }
+    size_t slen = strlen(svalue);
+    stringdat_copy_cstr(csound, p->sout, svalue, slen);
+    return OK;
+}
+
+
+typedef struct {
+    OPDS h;
+    ARRAYDAT *skeys;
+    ARRAYDAT *svalues;
+    STRINGDAT *sndfile;
+} SFREADMETA_SS;
+
+static int32_t sfreadmeta_ss(CSOUND *csound, SFREADMETA_SS *p) {
+    SNDFILE *file;
+    SF_INFO sfinfo;
+    const char *skey, *svalue;
+    if ((file = sf_open (p->sndfile->data, SFM_READ, &sfinfo)) == NULL) {
+        return INITERRF("Error: Not able to open input file %s.\n", p->sndfile->data);
+    }
+    // first, count number of key:value pairs
+    int numpairs = 0;
+
+    for(int str_type=SF_STR_FIRST; str_type<SF_STR_LAST; str_type++) {
+        if(sf_get_string(file, str_type) != NULL)
+            numpairs++;
+    }
+    tabinit(csound, p->skeys, numpairs);
+    tabinit(csound, p->svalues, numpairs);
+    STRINGDAT *keys = (STRINGDAT *)p->skeys->data;
+    STRINGDAT *values = (STRINGDAT *)p->svalues->data;
+    size_t i=0;
+    for(int str_type=SF_STR_FIRST; str_type<SF_STR_LAST; str_type++) {
+        svalue = sf_get_string(file, str_type);
+        if(svalue == NULL)
+            continue;
+        skey = sf_strtype_to_string(str_type);
+        if(skey == NULL)
+            continue;
+        stringdat_copy_cstr(csound, &keys[i], skey, strlen(skey));
+        stringdat_copy_cstr(csound, &values[i], svalue, strlen(svalue));
+        i++;
+    }
+    return OK;
+}
+
+
 /*
 
    Input types:
@@ -3139,7 +3255,10 @@ static OENTRY localops[] = {
     { "println", S(PRINTLN), 0, 3, "", "SN",
       (SUBR)println_init, (SUBR)println_perf},
     { "printsk", S(PRINTLN), 0, 3, "", "SN",
-      (SUBR)printsk_init, (SUBR)printsk_perf}
+      (SUBR)printsk_init, (SUBR)printsk_perf},
+    { "filereadmeta.i", S(SFREADMETA), 0, 1, "S", "SS", (SUBR)sfreadmeta_i},
+    { "filereadmeta.i", S(SFREADMETA_SS), 0, 1, "S[]S[]", "S", (SUBR)sfreadmeta_ss},
+
 };
 
 LINKAGE

--- a/Opcodes/emugens/emugens_common.h
+++ b/Opcodes/emugens/emugens_common.h
@@ -106,4 +106,51 @@ int em_isinfornan(MYFLT d) {
 }
 
 
+unsigned long next_power_of_two(unsigned long v) {
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v++;
+    return v;
+}
+
+
+// like strncpy but really makes sure that the dest str is 0 terminated
+// dest should have allocated at least n+1
+static inline
+void strncpy0(char *dest, const char *src, size_t n) {
+    strncpy(dest, src, n);
+    dest[n] = '\0';
+}
+
+
+// make sure that the out string has enough allocated space to hold
+// a string of `size` chars (the \0 should be taken into account)
+// This can be run only at init time
+static void
+string_ensure(CSOUND *csound, STRINGDAT *s, size_t size) {
+    if (s->size >= (int)size)
+        return;
+    size = next_power_of_two(size);
+    s->data = csound->ReAlloc(csound, s->data, size);
+    s->size = (int)size;
+}
+
+
+static void
+stringdat_copy_cstr(CSOUND *csound, STRINGDAT *dest, const char *src, size_t len) {
+    string_ensure(csound, dest, len+1);
+    strncpy0(dest->data, src, len);
+}
+
+
+static void
+stringdat_clear(CSOUND *csound, STRINGDAT *s) {
+    string_ensure(csound, s, 1);
+    s->data[0] = '\0';
+}
+
 #endif


### PR DESCRIPTION
# filereadmeta

Reads metadata from a soundfile via libsndfile. Can read the value of a specific key, or read all key:value pairs. 

```csound

Svalue filereadmeta Ssndfile_path, Skey
Skeys[], Spairs[] filereadmeta Ssndfile

```