### PR TITLE
Fix typescript declarations

### DIFF
--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -63,7 +63,7 @@ declare interface CsoundObj {
     /**
      * Alias for removeListener()
      */
-    off(eventName: PublicEvents, listener: EventEmitter.EventListener<PublicEvents, any>) => EventEmitter;
+    off: (eventName: PublicEvents, listener: EventEmitter.EventListener<PublicEvents, any>) => EventEmitter;
     /**
      * Adds the listener to the end of the listeners array for the event named eventName.
      * No checks are made to see if the listener has already been added.
@@ -91,7 +91,7 @@ declare interface CsoundObj {
     /**
      * Removes the specified listener from the listener array for the event named eventName.
      */
-    removeListener: (eventName: PublicEvents,  listener: EventEmitter.EventListener<PublicEvents, any>)) => EventEmitter;
+    removeListener: (eventName: PublicEvents,  listener: EventEmitter.EventListener<PublicEvents, any>) => EventEmitter;
     /**
      * The in-browser filesystem based on nodejs's
      * built-in module "fs"


### PR DESCRIPTION
There are 2 issues in the `index.d.ts` declarations causing the following TypeScript errors:
```
ERROR in [...]/csound-browser/index.d.ts
66:90-92
[tsl] ERROR in [...]/csound-browser/index.d.ts(66,91)
      TS1005: ':' expected.

ERROR in [...]/csound-browser/index.d.ts
94:103-104
[tsl] ERROR in [...]/csound-browser/index.d.ts(94,104)
      TS1005: '=>' expected.

ERROR in [...]/csound-browser/index.d.ts
94:105-107
[tsl] ERROR in [...]/csound-browser/index.d.ts(94,106)
      TS1131: Property or signature expected.
```
This change fixes the declarations so TypeScript compiles without error.