### PR TITLE
Fix `tableCopyIn` typescript declaration

### DIFF
--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -374,9 +374,8 @@ declare interface CsoundObj {
      * Copy the contents of an Array or TypedArray from javascript into a given csound table.
      * The table number is assumed to be valid, and the table needs to have sufficient space
      * to receive all the array contents.
-     * The table number and index are assumed to be valid.
      */
-    tableCopyIn: (tableNum: string, tableIndex: string, array: number[] | ArrayLike<number>) => Promise<undefined>;
+    tableCopyIn: (tableNum: string, array: number[] | ArrayLike<number>) => Promise<undefined>;
     /**
      * Copies the contents of a table from csound into Float64Array.
      * The returns a Float64Array if the table exists, otherwise


### PR DESCRIPTION
Calling `tableCopyIn` from typescript fails silently because it is declared with a `tableIndex: string` argument that does not exist in the corresponding javascript function. This change fixes the issue by removing the `tableIndex: string` argument.