### PR TITLE
Add channel count to list_audio_devices 

### DIFF
--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -1863,9 +1863,15 @@ static void list_audio_devices(CSOUND *csound, int output){
       csound->MessageS(csound, CSOUNDMSG_STDOUT,
                        Str("%d audio input devices\n"), n);
     csoundGetAudioDevList(csound,devs,output);
-    for (i=0; i < n; i++)
-      csound->Message(csound, " %d: %s (%s)\n",
-                      i, devs[i].device_id, devs[i].device_name);
+    for (i=0; i < n; i++) {
+      int nchnls = devs[i].max_nchnls;
+      if(nchnls > 0)
+        csound->Message(csound, " %d: %s (%s) [ch:%d]\n",
+                        i, devs[i].device_id, devs[i].device_name, nchnls);
+      else
+        csound->Message(csound, " %d: %s (%s)\n",
+                        i, devs[i].device_id, devs[i].device_name);
+    }
     csound->Free(csound, devs);
 }
 


### PR DESCRIPTION
When csound is called with the flag --devices it lists the input/output devices. This PR adds the number of channels for each device to the list whenever this information is made available by the backend. This allows frontends to query audio devices as seen by csound for all audio backends (up to now this information was listed only by the portaudio modules, now it would be extended to all audio modules) as long as this information is provided/available to the backend