### PR TITLE
Increase stack size to prevent heap corruption

### DIFF
--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -152,7 +152,8 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
       0,
     ) / PAGE_SIZE,
   );
-  const totalInitialMemory = initialMemory + pluginsMemory + fixedMemoryBase;
+  const stackSize = 4 * 1024 / 64
+  const totalInitialMemory = initialMemory + pluginsMemory + fixedMemoryBase + stackSize;
 
   const memory = new WebAssembly.Memory({
     initial: totalInitialMemory,
@@ -162,7 +163,7 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
 
   const stackPointer = new WebAssembly.Global(
     { value: "i32", mutable: true },
-    totalInitialMemory * PAGE_SIZE,
+    (totalInitialMemory - stackSize) * PAGE_SIZE,
   );
   const heapBase = new WebAssembly.Global(
     { value: "i32", mutable: true },

--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -7,6 +7,7 @@ import { dlinit } from "@root/dlinit";
 import { csoundWasiJsMessageCallback, initFS } from "@root/filesystem/worker-fs";
 import { logWasmModule as log } from "@root/logger";
 
+const BYTES_PER_MB = 1048576;
 const PAGE_SIZE = 65536;
 
 const assertPluginExports = (pluginInstance) => {
@@ -152,7 +153,7 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
       0,
     ) / PAGE_SIZE,
   );
-  const stackSize = 4 * 1024 / 64
+  const stackSize = 4 * BYTES_PER_MB / PAGE_SIZE;
   const totalInitialMemory = initialMemory + pluginsMemory + fixedMemoryBase + stackSize;
 
   const memory = new WebAssembly.Memory({


### PR DESCRIPTION
I ran into an issue when using Csound WASM in the Oculus Quest 2 browser with large .csd files. The stack appears to be expanding into the memory used as the heap. This causes strange error messages to be reported by the browser and/or Csound depending on how much of the heap gets corrupted.

This change fixes the issue by reserving 4mb of memory for the stack. It is maybe not the most correct fix, but it works.