### PR TITLE
Implement stack size more correctly and change it from 32mb to 128mb

### DIFF
--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -7,8 +7,8 @@ import { dlinit } from "@root/dlinit";
 import { csoundWasiJsMessageCallback, initFS } from "@root/filesystem/worker-fs";
 import { logWasmModule as log } from "@root/logger";
 
-const BYTES_PER_MB = 1048576;
 const PAGE_SIZE = 65536;
+const PAGES_PER_MB = 16; // 1048576 bytes per MB / PAGE_SIZE
 
 const assertPluginExports = (pluginInstance) => {
   if (
@@ -145,7 +145,15 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
     return accumulator_;
   }, []);
 
-  const fixedMemoryBase = 512;
+  // The `fixedMemoryBase` is equivalent to the stack size. Note that the stack size grows down towards the code
+  // section. This means that if the stack overflows then it will write over the Csound and plugin code which will
+  // cause all kinds of strange behavior including errors that make no sense, no output of sound, or sound output will
+  // be horrendously loud static and garbage sounds.
+  //
+  // TODO: Investigate using the --stack-first linker flag to move the stack to the beginning of memory so it doesn't
+  // write over anything if it overflows.
+  //
+  const fixedMemoryBase = 128 * PAGES_PER_MB;
   const initialMemory = Math.ceil((memorySize + memoryAlign) / PAGE_SIZE);
   const pluginsMemory = Math.ceil(
     withPlugins.reduce(
@@ -153,18 +161,20 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
       0,
     ) / PAGE_SIZE,
   );
-  const stackSize = 4 * BYTES_PER_MB / PAGE_SIZE;
-  const totalInitialMemory = initialMemory + pluginsMemory + fixedMemoryBase + stackSize;
 
+  const totalInitialMemory = initialMemory + pluginsMemory + fixedMemoryBase;
+
+  // Request a max of 1gb of memory so devices use less CPU when growing memory. This has a noticeable effect on low-
+  // powered devices like the Oculus Quest 2.
   const memory = new WebAssembly.Memory({
-    initial: totalInitialMemory,
+    initial: totalInitialMemory, maximum: 1024 * PAGES_PER_MB
   });
 
   const table = new WebAssembly.Table({ initial: tableSize + 1, element: "anyfunc" });
 
   const stackPointer = new WebAssembly.Global(
     { value: "i32", mutable: true },
-    (totalInitialMemory - stackSize) * PAGE_SIZE,
+    totalInitialMemory * PAGE_SIZE,
   );
   const heapBase = new WebAssembly.Global(
     { value: "i32", mutable: true },

--- a/wasm/src/csound_wasm.c
+++ b/wasm/src/csound_wasm.c
@@ -67,9 +67,7 @@ void freeCsoundParams(CSOUND_PARAMS* ptr) {
 __attribute__((used))
 double* allocFloatArray(int length) {
   double *ptr = NULL;
-  ptr = malloc((length * sizeof(double)) + 1);
-  // NULL Terminate
-  ptr[length * sizeof(double)] = '\0';
+  ptr = malloc(length * sizeof(double));
   return ptr;
 }
 


### PR DESCRIPTION
After investigating the issue PR https://github.com/csound/csound/pull/1518 tried to fix, I learned that the WASM stack grows down into the code section of memory, not up into the heap! This change adjusts the memory setup accordingly, increasing the stack from 32mb (512 * 64k for each page) to 128mb, to accommodate large .csd files.

This change also sets the `WebAssembly.Memory` `maximum` argument to 1gb so low-powered devices use less CPU when dynamically growing the heap. This has a noticeable effect in the Oculus Quest 2 browser.