### PR TITLE
Stop writing out of bounds of buffer allocated in `allocFloatArray`

### DIFF
--- a/wasm/src/csound_wasm.c
+++ b/wasm/src/csound_wasm.c
@@ -67,9 +67,7 @@ void freeCsoundParams(CSOUND_PARAMS* ptr) {
 __attribute__((used))
 double* allocFloatArray(int length) {
   double *ptr = NULL;
-  ptr = malloc((length * sizeof(double)) + 1);
-  // NULL Terminate
-  ptr[length * sizeof(double)] = '\0';
+  ptr = malloc(length * sizeof(double));
   return ptr;
 }
 


### PR DESCRIPTION
The `allocFloatArray` function currently allocates the bytes needed to hold the given number of doubles, plus 1 byte for a null terminator. When setting the null terminator byte, the index into the array is calculated incorrectly and ends up zeroing out a byte outside of the allocated buffer. This causes WASM errors to be displayed in the console and causes occasional pops and clicks in the audio output.

This change fixes the issue by not adding a null terminator in `allocFloatArray` since it is not needed.