### PR TITLE
#1542.

### DIFF
--- a/include/csound.hpp
+++ b/include/csound.hpp
@@ -928,6 +928,12 @@ public:
   {
     return csoundGetInputName(csound);
   }
+  virtual void SetAudioChannel(const char *name, MYFLT *samples) {
+    csoundSetAudioChannel(csound, name, samples);
+  }
+  virtual MYFLT SystemSr(MYFLT value) {
+    return csoundSystemSr(csound, value);
+  }
 };
 
 class CsoundThreadLock {


### PR DESCRIPTION
Noticed a few inconsistencies between Csound.hpp and csound.h, which are fixed in this PR. There may be more inconsistencies.

Two changes add missing virtual methods at the end of the csound.hpp declaration. These should not cause any breakage.

One change removes an (unused) return value from Csound::SetDebug. This would be a breaking change if anybody was using this return value, but I'm not aware of anybody actually using this return value.