### PR TITLE
Remove packages for code that has been moved out

### DIFF
--- a/installer/windows/csound6_x64_github.iss
+++ b/installer/windows/csound6_x64_github.iss
@@ -179,13 +179,9 @@ Source: "{#ReleaseDir}\deprecated.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: igno
 Source: "{#ReleaseDir}\stdutil.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 
 Source: "{#ReleaseDir}\lfsr.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-;Source: "{#ReleaseDir}\iconv-2.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-;Source: "{#ReleaseDir}\intl-8.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\liblo.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-;Source: "{#ReleaseDir}\pcre.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\portaudio.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\portmidi.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-;Source: "{#ReleaseDir}\zlib1.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 
 Source: "include\*.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
 Source: "include\*.hpp"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
@@ -196,7 +192,6 @@ Source: "interfaces\*.py"; DestDir: "{#APP_BIN}"; Flags: ignoreversion;  Compone
 Source: "examples\*.*"; DestDir: "{#APP_EXAMPLES}"; Excludes: "*.wav *.html"; Flags: ignoreversion recursesubdirs;  Components: core
 Source: "samples\*.*"; DestDir: "{#APP_SAMPLES}"; Flags: ignoreversion recursesubdirs;  Components: core
 
-Source: "build\vcpkg_installed\x64-windows-csound\share\libstk\rawwaves\*.*"; DestDir: "{#APP_SAMPLES}"; Flags: ignoreversion recursesubdirs;  Components: core
 Source: "{#BuildRoot}\include\float-version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
 Source: "{#BuildRoot}\include\version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
 Source: "{#ManualSourceDir}\*.*"; DestDir: "{#APP_MANUAL}"; Flags: ignoreversion recursesubdirs; Components: core

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,20 +4,18 @@
     "version-string": "6.16.2",
     "builtin-baseline": "70033dbb31527fb3e69654731f540f59c87787f9",
     "dependencies": [
-        "eigen3",
-        "fltk",
         "zlib",
-        "libflac",
-        "libogg",
-        "libvorbis",
-        "libsndfile",
         "libsamplerate",
         "portmidi",
         "portaudio",
         "liblo",
-        "hdf5",
-        "dirent",
-        "libstk",
-        "fluidsynth"
+        {
+            "name": "dirent",
+            "platform": "windows"
+        },
+        {
+            "name": "libsndfile",
+            "features": ["external-libs"]
+        }
     ]
 }


### PR DESCRIPTION
Since we moved some opcodes out into the external plugins repo, we were still installing some VCPKGs which slows the build down a fair bit. Can safely remove them now.