### PR TITLE
fixed setcol

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -4014,8 +4014,8 @@ int32_t set_cols_perf(CSOUND *csound, FFT *p) {
                                  Str("Error: New column too short\n"));
 
 
-    int32_t j,i,len =  p->out->sizes[0];
-    for (j=0,i=start; j < len; i+=len+1, j++)
+    int32_t j,i,row = p->out->sizes[1], col = p->out->sizes[0];
+    for (j=0,i=start; j < col; i+=row, j++)
         p->out->data[i] = p->in->data[j];
     return OK;
 }
@@ -4029,8 +4029,8 @@ int32_t set_cols_i(CSOUND *csound, FFT *p) {
     if (UNLIKELY(p->in->dimensions != 1 || p->in->sizes[0]<p->out->sizes[0]))
       return csound->InitError(csound, "%s",
                                  Str("Error: New column too short\n"));
-    int32_t j,i,len =  p->out->sizes[0];
-    for (j=0,i=start; j < len; i+=len+1, j++)
+    int32_t j,i,row = p->out->sizes[1], col = p->out->sizes[0];
+    for (j=0,i=start; j < col; i+=row, j++)
         p->out->data[i] = p->in->data[j];
     return OK;
 }


### PR DESCRIPTION
there was an issue with `setcol` where it used the wrong dimention length to jump through the array, causing it to give incorrect results. it was incrementing by length of column to get to the same column one row down. I made it increment by row, and fixed the loop to loop through the length of column. I found this issue when I was playing in this file: https://github.com/tomara-x/witches/blob/main/test/2dArr.csd

hopefully I'm doing this whole build/push/pull request stuff correctly