### PR TITLE
fix timeinstk and timeinsts to match timek and times

### DIFF
--- a/OOps/ugrw1.c
+++ b/OOps/ugrw1.c
@@ -107,7 +107,7 @@ int32_t instimset(CSOUND *csound, RDTIME *p)
 int32_t instimek(CSOUND *csound, RDTIME *p)
 {
     IGN(csound);
-    *p->rslt = (MYFLT) (CS_KCNT - p->instartk);
+    *p->rslt = (MYFLT) (CS_KCNT - p->instartk - 1);
     return OK;
 }
 
@@ -119,7 +119,7 @@ int32_t instimek(CSOUND *csound, RDTIME *p)
 int32_t instimes(CSOUND *csound, RDTIME *p)
 {
     IGN(csound);
-    *p->rslt = (MYFLT) (CS_KCNT - p->instartk) * CS_ONEDKR;
+    *p->rslt = (MYFLT) (CS_KCNT - p->instartk - 1) * CS_ONEDKR;
     return OK;
 }
 


### PR DESCRIPTION
This PR adapts timeinstk and timeinsts to actually return the elapsed cycles and elapsed time of an event and makes  them conform to the global time given by timek and times.

At the moment timeinstk and timeinsts differ from timek by one cycle, even if the instrument is run at logical time 0. 

```csound
instr 1
	kcycle = timek()
	kcycleinstr = timeinstk()
	println "kcycle: %d, kcycleinstr: %d", kcycle, kcycleinstr
	ktime = times()
	ktimeinstr = timeinsts()
	println "ktime: %f, ktypeinstr: %f", ktime, ktimeinstr
	turnoff
endin

schedule 1, 0, 1
```

The manual page for timeinstk should also be modified to reflect this change. The same modification can be applied to the develop branch (csound7)
