### PR TITLE
Csound6 branch: Fix for windows build

### DIFF
--- a/InOut/libmpadec/layer1.c
+++ b/InOut/libmpadec/layer1.c
@@ -24,7 +24,7 @@
 extern const uint32_t bitmask[17];
 extern alloc_table_t *alloc_tables[5];
 
-extern unsigned getbits(mpadec_t mpadec, int n);
+extern unsigned mpa_getbits(mpadec_t mpadec, int n);
 extern uint16_t update_crc(uint16_t init, uint8_t *buf, int length);
 
 static void I_decode_bitalloc(mpadec_t mpadec, uint8_t *bit_alloc,

--- a/InOut/libmpadec/layer2.c
+++ b/InOut/libmpadec/layer2.c
@@ -24,7 +24,7 @@
 extern const uint32_t bitmask[17];
 extern alloc_table_t *alloc_tables[5];
 
-extern unsigned getbits(mpadec_t mpadec, int n);
+extern unsigned mpa_getbits(mpadec_t mpadec, int n);
 extern uint16_t update_crc(uint16_t init, uint8_t *buf, int length);
 
 static void II_decode_bitalloc(mpadec_t mpadec, uint8_t *bit_alloc,

--- a/InOut/libmpadec/layer3.c
+++ b/InOut/libmpadec/layer3.c
@@ -31,7 +31,7 @@ extern const MYFLT tfcos12[3];
 extern const MYFLT cs[8];
 extern const MYFLT ca[8];
 
-extern uint32_t getbits(mpadec_t mpadec, unsigned n);
+extern uint32_t mpa_getbits(mpadec_t mpadec, unsigned n);
 extern uint16_t update_crc(uint16_t init, uint8_t *buf, int length);
 
 static int decode_layer3_sideinfo(mpadec_t mpadec)

--- a/InOut/libmpadec/mpadec.c
+++ b/InOut/libmpadec/mpadec.c
@@ -33,7 +33,7 @@ const uint32_t bitmask[17] = {
 const int32_t frequency_table[9] = {
   44100, 48000, 32000, 22050, 24000, 16000, 11025, 12000, 8000 };
 
-const int16_t bitrate_table[2][3][16] = {
+const int16_t mpa_bitrate_table[2][3][16] = {
   { { 0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 560 },
     { 0, 32, 48, 56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, 384, 448 },
     { 0, 32, 40, 48,  56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, 384 } },
@@ -47,7 +47,7 @@ extern void decode_layer1(mpadec_t mpadec, uint8_t *buffer);
 extern void decode_layer2(mpadec_t mpadec, uint8_t *buffer);
 extern void decode_layer3(mpadec_t mpadec, uint8_t *buffer);
 
-uint32_t getbits(mpadec_t mpadec, unsigned n)
+uint32_t mpa_getbits(mpadec_t mpadec, unsigned n)
 {
     register struct mpadec_t *mpa = (struct mpadec_t *)mpadec;
 
@@ -143,7 +143,7 @@ static int decode_header(mpadec_t mpadec, uint32_t header)
     } else mpa->frame.LSF = mpa->frame.MPEG25 = TRUE;
     mpa->frame.layer = (uint8_t)layer;
     mpa->frame.bitrate_index = bridx;
-    mpa->frame.bitrate = bitrate_table[mpa->frame.LSF][layer - 1][bridx];
+    mpa->frame.bitrate = mpa_bitrate_table[mpa->frame.LSF][layer - 1][bridx];
     mpa->frame.frequency_index = (fridx += 3*(mpa->frame.LSF + mpa->frame.MPEG25));
     mpa->frame.frequency = frequency_table[fridx];
     mpa->frame.decoded_frequency = mpa->frame.frequency >> mpa->config.quality;

--- a/InOut/libmpadec/mpadec_internal.h
+++ b/InOut/libmpadec/mpadec_internal.h
@@ -210,6 +210,6 @@ struct mpadec2_t {
 
 #define GETBITS(n) ((mpa->bits_left >= (uint8_t)(n)) \
                     ? ((mpa->bit_buffer >> (mpa->bits_left -= \
-                       (uint8_t)(n))) & bitmask[n]) : getbits(mpa, n))
+                       (uint8_t)(n))) & bitmask[n]) : mpa_getbits(mpa, n))
 
 #endif

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -3491,7 +3491,7 @@ int32_t perf_rfftmult(CSOUND *csound, FFT *p) {
 void csoundComplexFFTnp2(CSOUND *csound, MYFLT *buf, int32_t FFTsize);
 void csoundInverseComplexFFTnp2(CSOUND *csound, MYFLT *buf, int32_t FFTsize);
 
-int32_t init_fft(CSOUND *csound, FFT *p) {
+int32_t initialise_fft(CSOUND *csound, FFT *p) {
   int32_t   N2 = p->in->sizes[0];
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
@@ -3512,7 +3512,7 @@ int32_t perf_fft(CSOUND *csound, FFT *p) {
 }
 
 int32_t fft_i(CSOUND *csound, FFT *p) {
-  if (init_fft(csound,p) == OK)
+  if (initialise_fft(csound,p) == OK)
     return perf_fft(csound, p);
   else return NOTOK;
 }
@@ -4734,7 +4734,7 @@ static OENTRY arrayvars_localops[] =
     {"cmplxprod", sizeof(FFT), 0, 3, "k[]","k[]k[]",
      (SUBR) init_rfftmult, (SUBR) perf_rfftmult, NULL},
     {"fft", sizeof(FFT), 0, 3, "k[]","k[]",
-     (SUBR) init_fft, (SUBR) perf_fft, NULL},
+     (SUBR) initialise_fft, (SUBR) perf_fft, NULL},
     {"fft", sizeof(FFT), 0, 1, "i[]","i[]",
      (SUBR) fft_i, NULL, NULL},
     {"fftinv", sizeof(FFT), 0, 3, "k[]","k[]",


### PR DESCRIPTION
Some symbols were clashing in the build as we are using static libs. Renamed some of the CS ones to be different from internal libmp3lame (or whatever it is). 