### PR TITLE
reverted changes intimeinstk/timeinsts, new replacement opcodes

### DIFF
--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -740,14 +740,29 @@ OENTRY opcodlst_1[] = {
     (SUBR)table3rkt_audio          },
   { "inz",    S(IOZ),    ZW, 2,   "",   "k",  NULL,   (SUBR)inz  },
   { "outz",   S(IOZ),ZR|IR,  2,   "",   "k",    NULL,   (SUBR)outz },
-  { "timek.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)timek,   NULL,  NULL },
-  { "times.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)timesr,  NULL,  NULL },
+
   { "timek.k",  S(RDTIME),0, 2,  "k",  "",     NULL,    (SUBR)timek, NULL },
+  { "timek.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)timek,   NULL,  NULL },
+
   { "times.k",  S(RDTIME),0, 2,  "k",  "",     NULL,    (SUBR)timesr,NULL },
+  { "times.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)timesr,  NULL,  NULL },
+
+  { "elapsedcycles.k",  S(RDTIME),0, 2,  "k",  "",     NULL,    (SUBR)elapsedcycles, NULL },
+  { "elapsedcycles.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)elapsedcycles,   NULL,  NULL },
+
+  { "elapsedtime.k",  S(RDTIME),0, 2,  "k",  "",     NULL,    (SUBR)elapsedtime,NULL },
+  { "elapsedtime.i", S(RDTIME),0, 1,   "i",  "",     (SUBR)elapsedtime,  NULL,  NULL },
+
   { "timeinstk", S(RDTIME),0, 3, "k",  "",
     (SUBR)instimset, (SUBR)instimek, NULL },
   { "timeinsts", S(RDTIME),0, 3, "k",  "",
     (SUBR)instimset, (SUBR)instimes, NULL },
+
+  { "eventcycles", S(RDTIME),0, 3, "k",  "",
+    (SUBR)instimset, (SUBR)eventcycles, NULL },
+  { "eventtime", S(RDTIME),0, 3, "k",  "",
+    (SUBR)instimset, (SUBR)eventtime, NULL },
+
   { "peak.k",  S(PEAK),0,   2,   "k",  "k",    NULL,    (SUBR)peakk,    NULL    },
   { "peak.a",   S(PEAK),0,  2,   "k",  "a",    NULL,     (SUBR)peaka   },
   { "printk", S(PRINTK),WR,  3,"",     "ikoooo",

--- a/H/ugrw1.h
+++ b/H/ugrw1.h
@@ -238,6 +238,14 @@ typedef struct {
 int instimek(CSOUND*,RDTIME *p);
 int instimes(CSOUND*,RDTIME *p);
 int instimset(CSOUND*,RDTIME *p);
+
+int eventcycles(CSOUND*,RDTIME *p);
+int eventtime(CSOUND*,RDTIME *p);
+
+int elapsedcycles(CSOUND*,RDTIME *p);
+int elapsedtime(CSOUND*,RDTIME *p);
+
+
 //int itablecopy(CSOUND*,TABLECOPY *p);
 //int itablegpw(CSOUND*,TABLEGPW *p);
 //int itablemix(CSOUND*,TABLEMIX *p);

--- a/OOps/ugrw1.c
+++ b/OOps/ugrw1.c
@@ -83,6 +83,24 @@ int32_t timesr(CSOUND *csound, RDTIME *p)
     return OK;
 }
 
+int32_t elapsedcycles(CSOUND *csound, RDTIME *p)
+{
+    IGN(csound);
+    /* Read the global variable kcounter and turn it into a float.   */
+    *p->rslt = (MYFLT) CS_KCNT - 1;
+    return OK;
+}
+
+/* timesr() */
+int32_t elapsedtime(CSOUND *csound, RDTIME *p)
+{
+    /* Read the global variable kcounter divide it by the k rate.    */
+    IGN(csound);
+    *p->rslt = (MYFLT) (CS_KCNT - 1) * CS_ONEDKR;
+    return OK;
+}
+
+
 /*-----------------------------------*/
 
 /* Subroutines to read time for this instance of the instrument. */
@@ -107,6 +125,19 @@ int32_t instimset(CSOUND *csound, RDTIME *p)
 int32_t instimek(CSOUND *csound, RDTIME *p)
 {
     IGN(csound);
+    *p->rslt = (MYFLT) (CS_KCNT - p->instartk);
+    return OK;
+}
+
+
+/* eventcycles()
+ *
+ * Read difference between the global variable kcounter and the starting
+ * time of this instance. Return it as a float.
+ */
+int32_t eventcycles(CSOUND *csound, RDTIME *p)
+{
+    IGN(csound);
     *p->rslt = (MYFLT) (CS_KCNT - p->instartk - 1);
     return OK;
 }
@@ -117,6 +148,18 @@ int32_t instimek(CSOUND *csound, RDTIME *p)
  * time of this instance.  Return it as a float in seconds.
  */
 int32_t instimes(CSOUND *csound, RDTIME *p)
+{
+    IGN(csound);
+    *p->rslt = (MYFLT) (CS_KCNT - p->instartk) * CS_ONEDKR;
+    return OK;
+}
+
+/* eventtime()
+ *
+ * Read difference between the global variable kcounter and the starting
+ * time of this instance.  Return it as a float in seconds.
+ */
+int32_t eventtime(CSOUND *csound, RDTIME *p)
 {
     IGN(csound);
     *p->rslt = (MYFLT) (CS_KCNT - p->instartk - 1) * CS_ONEDKR;


### PR DESCRIPTION
reverted changes in timeinstk and timeinsts; fixed order of .k and .i in times and timek; provided two sets of opcodes elapsedcycles, elapsedtime and eventcycles and eventtime which act like timek, times, timeinstk and timeinsts but return the correct values instead of being one cycle late