### PR TITLE
Add renderer to worklet+singlethread setup

### DIFF
--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -120,6 +120,10 @@ class SingleThreadAudioWorkletMainThread {
         break;
       }
       case "renderStarted": {
+        if (this.eventPromises.isWaitingToStart()) {
+          log("Start promise resolved")();
+          this.eventPromises.releaseStartPromise();
+        }
         this.publicEvents.triggerRenderStarted(this);
         break;
       }

--- a/wasm/browser/src/workers/common.utils.js
+++ b/wasm/browser/src/workers/common.utils.js
@@ -53,3 +53,26 @@ export const instantiateAudioPacket = (numberChannels, numberFrames) => {
   }
   return channels;
 };
+
+export const renderFunction =
+  ({ libraryCsound, workerMessagePort, wasi }) =>
+  async ({ csound }) => {
+    const ksmps = libraryCsound.csoundGetKsmps(csound);
+    let lastResult = 0;
+    let cnt = 0;
+
+    while (
+      (workerMessagePort.vanillaWorkerState === "renderStarted" ||
+        workerMessagePort.workerState === "renderStarted") &&
+      lastResult === 0
+    ) {
+      lastResult = libraryCsound.csoundPerformKsmps(csound);
+      cnt += 1;
+
+      if (typeof setTimeout === "function" && lastResult === 0 && cnt % ksmps === 0) {
+        // this is immediately executed, but allows events to be picked up
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    }
+    workerMessagePort.broadcastPlayState("renderEnded");
+  };


### PR DESCRIPTION
Currently, rendering goes in sync with the realtime rendering. Maybe we'll need this as well for scriptProcessor setup. And maybe it was me that removed it, forgetting to re-add this mechanism.