### PR TITLE
fix: don't use opmtimization flag sse for m1 apple silicon compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
+include(cmake/Modules/DetectAppleSilicon.cmake)
 
 option(USE_VCPKG "Use VCPKG to download and manage dependencies" OFF)
 
@@ -1440,7 +1441,7 @@ set (CPACK_PACKAGE_VERSION_PATCH "0")
 include (CPack)
 
 # Documentation
-if(BUILD_DOCS) 
+if(BUILD_DOCS)
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.doxygen
@@ -1469,4 +1470,3 @@ else()
  install(DIRECTORY ${CMAKE_SOURCE_DIR}/samples
           DESTINATION ${CMAKE_INSTALL_PREFIX}/share)
 endif()
-

--- a/cmake/CompilerOptimizations.cmake
+++ b/cmake/CompilerOptimizations.cmake
@@ -18,15 +18,13 @@ if (HAS_CXX_FAST_MATH AND NOT MINGW)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffast-math")
 endif()
 
-
-
 if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 check_c_compiler_flag(-mfpmath=sse HAS_FPMATH_SSE)
 check_cxx_compiler_flag(-mfpmath=sse HAS_CXX_FPMATH_SSE)
-  if (HAS_FPMATH_SSE)
+  if (HAS_FPMATH_SSE AND NOT APPLE_SILICON)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpmath=sse")
 endif()
-if (HAS_CXX_FPMATH_SSE)
+if (HAS_CXX_FPMATH_SSE AND NOT APPLE_SILICON)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse")
 endif()
 

--- a/cmake/Modules/DetectAppleSilicon.cmake
+++ b/cmake/Modules/DetectAppleSilicon.cmake
@@ -1,0 +1,18 @@
+# on m1 processors with rosetta installed
+# the variable CMAKE_SYSTEM_PROCESSOR will
+# show x86_64 when the host system is really arm64
+
+if(APPLE)
+  execute_process(COMMAND sysctl -q hw.optional.arm64
+    OUTPUT_VARIABLE _sysctl_stdout
+    ERROR_VARIABLE _sysctl_stderr
+    RESULT_VARIABLE _sysctl_result
+  )
+  if(_sysctl_result EQUAL 0 AND _sysctl_stdout MATCHES "hw.optional.arm64: 1")
+    message(STATUS "APPLE SILICON PROCESSOR DETECTED")
+    set(APPLE_SILICON "1")
+  endif()
+  unset(_sysctl_result)
+  unset(_sysctl_stderr)
+  unset(_sysctl_stdout)
+endif()


### PR DESCRIPTION
The background to this change is that I'm trying to use now only arm64 binaries, including libsndfile. I tell cmake to use arm64 over the rosetta2 x86_64 translator with `set(CMAKE_OSX_ARCHITECTURES "arm64")` in custom.cmake. But this causes an error `error: unknown FP unit 'sse'`. If I just make sure that `-mfpmath=sse` isn't set when apple silicon processor is detected, everything will be alright for me.

The reason I don't use the recently added `CMAKE_APPLE_SILICON_PROCESSOR` is because it doesn't seem to be set correctly. And I think m1 users also using rosetta2 will experience the same issue as of today. This check using sysw, I took from https://gitlab.kitware.com/cmake/cmake/-/blob/v3.22.2/Modules/CMakeDetermineSystem.cmake#L50-84

I believe we should also add this to the master branch.
Note that if we want to release fat binaries, supporting both x86_64 and arm64 `set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")`, we'd need this change I believe.