### PR TITLE
cmake: better detection for if the compiler is Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ project(Csound)
 
 ENABLE_TESTING()
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
 endif()
 


### PR DESCRIPTION
On my macbook, the value of ${CMAKE_CXX_COMPILER_ID} is AppleClang, so this match doesn't catch it with string-equals operation, and as I wanted to test out some of the utilities, there are few in util1 that wont configure because of this issue `if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG OR MSVC)`