### PR TITLE
Added x86 and x86_64 architectures to Android make files

### DIFF
--- a/Android/CsoundAndroid/jni/Application.mk
+++ b/Android/CsoundAndroid/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/doppler/jni/Application.mk
+++ b/Android/pluginlibs/doppler/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libOSC/jni/Application.mk
+++ b/Android/pluginlibs/libOSC/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libscansyn/jni/Application.mk
+++ b/Android/pluginlibs/libscansyn/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libstdutil/jni/Application.mk
+++ b/Android/pluginlibs/libstdutil/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_CFLAGS += -Wno-error=format-security
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/signalflowgraph/jni/Application.mk
+++ b/Android/pluginlibs/signalflowgraph/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21


### PR DESCRIPTION
This change is made to add support for a small subset of Android devices that use a different architecture, for example _Asus Zenfone 2_, _Genymotion / Android emulator_, and most of all _Chromebooks_.

Unfortunately, building Csound for Android then fails because of the _mp3in_ opcode.
Removing that specific opcode from compilation makes the build successful. 

To be able to build I had to:
- Remove line 263 from _Android/CsoundAndroid/jni/Android.mk_
- Remove line 1194 and 1256 from _Top/csmodule.c_

Of course it would be better to fix the issue in the opcode.