### PR TITLE
Added x86 and x86_64 architectures to Android make files

### DIFF
--- a/Android/CsoundAndroid/jni/Application.mk
+++ b/Android/CsoundAndroid/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/doppler/jni/Application.mk
+++ b/Android/pluginlibs/doppler/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libOSC/jni/Application.mk
+++ b/Android/pluginlibs/libOSC/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libscansyn/jni/Application.mk
+++ b/Android/pluginlibs/libscansyn/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libstdutil/jni/Application.mk
+++ b/Android/pluginlibs/libstdutil/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_CFLAGS += -Wno-error=format-security
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/signalflowgraph/jni/Application.mk
+++ b/Android/pluginlibs/signalflowgraph/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21


### PR DESCRIPTION
This change is made to add support for a small subset of Android devices that use a different architecture, for example Asus Zenfone 2, Genymotion / Android emulator, and most of all Chromebooks.

Unfortunately, building Csound for Android then fails in the csound6 branch because of the mp3in opcode.
Removing that specific opcode from compilation makes the build successful.

To be able to build I had to:

Remove line 263 from Android/CsoundAndroid/jni/Android.mk
Remove line 1194 and 1256 from Top/csmodule.c