### PR TITLE
Added x86 and x86_64 architectures to Android make files

### DIFF
--- a/Android/CsoundAndroid/jni/Application.mk
+++ b/Android/CsoundAndroid/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/doppler/jni/Application.mk
+++ b/Android/pluginlibs/doppler/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libOSC/jni/Application.mk
+++ b/Android/pluginlibs/libOSC/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libscansyn/jni/Application.mk
+++ b/Android/pluginlibs/libscansyn/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/libstdutil/jni/Application.mk
+++ b/Android/pluginlibs/libstdutil/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_CFLAGS += -Wno-error=format-security
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21

--- a/Android/pluginlibs/signalflowgraph/jni/Application.mk
+++ b/Android/pluginlibs/signalflowgraph/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a arm64-v8a
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_CPPFLAGS += -fexceptions -frtti
 APP_OPTIM := release
 APP_PLATFORM := android-21


### PR DESCRIPTION
This change is made to add support for a small subset of Android devices that use a different architecture, for example Asus Zenfone 2, Genymotion / Android emulator, and most of all Chromebooks.

Building Android on the develop branch fails despite the changes. I assume it is due to the changes made towards Csound7.

Some relevant logs below:

```
[armeabi-v7a] Compile thumb  : csoundandroid <= libsnd_u.c
rm -f /Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/obj/local/armeabi-v7a/objs/csoundandroid/__/__/__/InOut/libsnd_u.o
/Users/xxx/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang -MMD -MP -MF /Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/obj/local/armeabi-v7a/objs/csoundandroid/__/__/__/InOut/libsnd_u.o.d -target armv7-none-linux-androideabi21 -fdata-sections -ffunction-sections -fstack-protector-strong -funwind-tables -no-canonical-prefixes  --sysroot /Users/xxx/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -g -Wno-invalid-command-line-argument -Wno-unused-command-line-argument  -D_FORTIFY_SOURCE=2 -fpic -mthumb -Oz -DNDEBUG  -I/Users/xxx/Documents/CsoundUnity/Csound/csound/Android/pluginlibs/libsndfile-android/jni/ -I/Users/xxx/include -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../H -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../include -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../ -I/Users/xxx/Documents/CsoundUnity/Csound/csound/Android/pluginlibs/libsndfile-android/jni/ -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../Engine -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../interfaces -I/Users/xxx/Library/Android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/include -I/Users/xxx/Library/Android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/../llvm-libc++abi/include -I/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni   -DANDROID -std=c99 -O3 -DENABLE_OPCODEDIR_WARNINGS -D__BUILDING_LIBCSOUND -DENABLE_NEW_PARSER -DLINUX -DHAVE_DIRENT_H -DHAVE_FCNTL_H -DHAVE_UNISTD_H -DHAVE_STDINT_H -DHAVE_SYS_TIME_H -DHAVE_SYS_TYPES_H -DHAVE_TERMIOS_H -DHAVE_STRTOK_R -DHAVE_PTHREAD -DHAVE_ATOMIC_BUILTIN -mllvm -unroll-allow-partial -mllvm -unroll-runtime -funsafe-math-optimizations -ffast-math -DHAVE_NEON -nostdinc++ -Wformat -Werror=format-security  -c  /Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../InOut/libsnd_u.c -o /Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/obj/local/armeabi-v7a/objs/csoundandroid/__/__/__/InOut/libsnd_u.o
/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../InOut/libsnd_u.c:351:12: error: use of undeclared identifier 'TYP_MPEG'
      case TYP_MPEG:  return "MPEG";
           ^
/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../InOut/libsnd_u.c:381:13: error: use of undeclared identifier 'AE_MPEG'
      case  AE_MPEG:    return Str("mpeg encoding");
            ^
/Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/jni/../../../InOut/libsnd_u.c:422:12: error: use of undeclared identifier 'TYP_MPEG'
      case TYP_MPEG:   return CSFTYPE_MPEG;
           ^
3 errors generated.
make: *** [/Users/xxx/Library/Android/sdk/ndk/25.2.9519653/build/core/build-binary.mk:422: /Users/xxx/Documents/Csound/csound/Android/CsoundAndroid/obj/local/armeabi-v7a/objs/csoundandroid/__/__/__/InOut/libsnd_u.o] Error 1
```