### PR TITLE
Make hash table functions available to plugins in cs6

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -544,9 +544,10 @@ static const CSOUND cenviron_ = {
     cs_hash_table_get_key,
     cs_hash_table_keys,
     cs_hash_table_values,
+    csoundPeekCircularBuffer,
     {
       NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-      NULL, NULL, NULL, NULL
+      NULL, NULL, NULL
     },
     /* ------- private data (not to be used by hosts or externals) ------- */
     /* callback function pointers */

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -536,10 +536,17 @@ static const CSOUND cenviron_ = {
     csoundCepsLP,
     csoundLPrms,
     csoundCreateThread2,
+    cs_hash_table_create,
+    cs_hash_table_get,
+    cs_hash_table_put,
+    cs_hash_table_remove,
+    cs_hash_table_free,
+    cs_hash_table_get_key,
+    cs_hash_table_keys,
+    cs_hash_table_values,
     {
       NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-      NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-      NULL, NULL
+      NULL, NULL, NULL, NULL
     },
     /* ------- private data (not to be used by hosts or externals) ------- */
     /* callback function pointers */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1410,11 +1410,19 @@ typedef struct _message_queue_t_ {
     MYFLT* (*CepsLP)(CSOUND *, MYFLT *, MYFLT *, int, int);
     MYFLT (*LPrms)(CSOUND *, void *);
     void *(*CreateThread2)(uintptr_t (*threadRoutine)(void *), unsigned int, void *userdata);
+    CS_HASH_TABLE *(*CreateHashTable)(CSOUND *);
+    void *(*GetHashTableValue)(CSOUND *, CS_HASH_TABLE *, char *);
+    void (*SetHashTableValue)(CSOUND *, CS_HASH_TABLE *, char *, void *);
+    void (*RemoveHashTableKey)(CSOUND *, CS_HASH_TABLE *, char *);
+    void (*DestroyHashTable)(CSOUND *, CS_HASH_TABLE *);
+    char *(*GetHashTableKey)(CSOUND *, CS_HASH_TABLE *, char *);
+    CONS_CELL *(*GetHashTableKeys)(CSOUND *, CS_HASH_TABLE *);
+    CONS_CELL *(*GetHashTableValues)(CSOUND *, CS_HASH_TABLE *);
     /**@}*/
     /** @name Placeholders
         To allow the API to grow while maintining backward binary compatibility. */
     /**@{ */
-    SUBR dummyfn_2[22];
+    SUBR dummyfn_2[14];
     /**@}*/
 #ifdef __BUILDING_LIBCSOUND
     /* ------- private data (not to be used by hosts or externals) ------- */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1418,11 +1418,12 @@ typedef struct _message_queue_t_ {
     char *(*GetHashTableKey)(CSOUND *, CS_HASH_TABLE *, char *);
     CONS_CELL *(*GetHashTableKeys)(CSOUND *, CS_HASH_TABLE *);
     CONS_CELL *(*GetHashTableValues)(CSOUND *, CS_HASH_TABLE *);
+    int (*PeekCircularBuffer)(CSOUND *csound, void *p, void *out, int items);
     /**@}*/
     /** @name Placeholders
         To allow the API to grow while maintining backward binary compatibility. */
     /**@{ */
-    SUBR dummyfn_2[14];
+    SUBR dummyfn_2[13];
     /**@}*/
 #ifdef __BUILDING_LIBCSOUND
     /* ------- private data (not to be used by hosts or externals) ------- */


### PR DESCRIPTION
Exposes the internal hash table functions so I can use them in a new set of websocket opcodes I'm working on. Also exposes `csoundPeekCircularBuffer`.