### PR TITLE
vcpkg fixes

### DIFF
--- a/Engine/memalloc.c
+++ b/Engine/memalloc.c
@@ -207,13 +207,13 @@ void *mrealloc(CSOUND *csound, void *oldp, size_t size)
     /* allocate memory */
     p = realloc((void*) pp, ALLOC_BYTES(size));
     if (UNLIKELY(p == NULL)) {
-#ifdef MEMDEBUG
-      CSOUND_MEM_SPINLOCK
-      /* alloc failed, restore original header */
-      pp->magic = MEMALLOC_MAGIC;
-      pp->ptr = oldp;
-      CSOUND_MEM_SPINUNLOCK
-#endif
+// #ifdef MEMDEBUG
+//       CSOUND_MEM_SPINLOCK
+//       /* alloc failed, restore original header */
+//       pp->magic = MEMALLOC_MAGIC;
+//       pp->ptr = oldp;
+//       CSOUND_MEM_SPINUNLOCK
+// #endif
       memdie(csound, size);
       return NULL;
     }

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -63,9 +63,9 @@ void print_csound_version(CSOUND*);
 
 #ifdef HAVE_PTHREAD_SPIN_LOCK
 #define RT_SPIN_UNLOCK \
-if(csound->oparms->realtime) \
+if(csound->oparms->realtime) { \
   csoundSpinUnLock(&csound->alloc_spinlock); \
-  trylock = CSOUND_SUCCESS; } }
+  trylock = CSOUND_SUCCESS; } } }
 #else
 #define RT_SPIN_UNLOCK csoundSpinUnLock(&csound->alloc_spinlock);
 #endif

--- a/Top/threadsafe.c
+++ b/Top/threadsafe.c
@@ -70,7 +70,8 @@ typedef struct _message_queue {
 
 /* atomicGetAndIncrementWithModulus */
 static long atomicGet_Incr_Mod(volatile long* val, long mod) {
-  volatile long oldVal, newVal;
+  volatile long oldVal;
+  long newVal;
   do {
     oldVal = *val;
     newVal = (oldVal + 1) % mod;


### PR DESCRIPTION
Here are there errors I'm getting without these patches:

```
/home/brandon/vcpkg/buildtrees/csound/src/6.18.1-c8636a11f8.clean/Engine/memalloc.c:214:15: error: pointer ‘pp’ may be used after ‘realloc’ [-Werror=use-after-free]
  214 |       pp->ptr = oldp;
      |       ~~~~~~~~^~~~~~
/home/brandon/vcpkg/buildtrees/csound/src/6.18.1-c8636a11f8.clean/Engine/memalloc.c:208:9: note: call to ‘realloc’ here
  208 |     p = realloc((void*) pp, ALLOC_BYTES(size));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/home/brandon/vcpkg/buildtrees/csound/src/6.18.1-c8636a11f8.clean/Engine/musmon.c:66:1: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
   66 | if(csound->oparms->realtime) \
      | ^~

/home/brandon/vcpkg/buildtrees/csound/src/6.18.1-2b900c6227.clean/./include/sysdep.h:527:5: error: argument 3 of ‘__atomic_compare_exchange’ discards ‘volatile’ qualifier [-Werror=incompatible-pointer-types]
  527 |   !(__atomic_compare_exchange(val, (long *) &oldVal, &newVal, 0,        \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```