### PR TITLE
Add open file callback

### DIFF
--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -764,7 +764,7 @@ static SNDFILE *csoundOpenFile_Snd(CSOUND *csound, const char *path, int mode, S
     SNDFILE *sf = NULL;
 
     if(csound->OpenSoundFileCallback_ != NULL) {
-        sf = csound->OpenSoundFileCallback_(csound, path, mode, &sfinfo);
+        sf = csound->OpenSoundFileCallback_(csound, path, mode, sfinfo);
     }
 
     return sf;

--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -760,6 +760,61 @@ char *csoundGetDirectoryForPath(CSOUND* csound, const char * path) {
 #endif  
 }
 
+static SNDFILE *csoundOpenFile_Snd(CSOUND *csound, const char *path, int mode, SFLIB_INFO *sfinfo){
+    SNDFILE *sf = NULL;
+
+    if(csound->OpenSoundFileCallback_ != NULL) {
+        sf = csound->OpenSoundFileCallback_(csound, path, mode, &sfinfo);
+    }
+
+    return sf;
+}
+
+static FILE *csoundOpenFile_Std(CSOUND *csound, char **fullName,
+                            const char *filename, const char *mode)
+{
+    FILE *f = NULL;
+
+    /* try to open file if callback is specified */
+    if(csound->OpenFileCallback_ != NULL) {
+        f = csound->OpenFileCallback_(csound, filename, (char*) mode);
+        if (f != NULL) {
+            *fullName = (char*) filename;
+        }
+    }
+
+    /* fallback to fopen */
+    if (f == NULL) {
+#if defined(WIN32)
+      /* To handle Widows errors in file name characters. */
+      size_t sz = 2 * MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+      wchar_t *wfname = malloc(sz);
+      wchar_t *wmode = 0;
+
+      MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfname, sz);
+      sz = 2 * MultiByteToWideChar(CP_UTF8, 0, mode, -1, NULL, 0);
+      wmode = malloc(sz);
+      MultiByteToWideChar(CP_UTF8, 0, mode, -1, wmode, sz);
+      f = _wfopen(wfname, wmode);
+      if (UNLIKELY(f == NULL)) {
+        /* csoundErrorMsg(csound, Str("csound->FileOpen2(\"%s\") failed: %s."), */
+        /*                filename, strerror(errno)); */
+        free(wfname);
+        free(wmode);
+      } else {
+        *fullName = (char*) filename;
+        free(wfname);
+        free(wmode);
+      }
+#else
+      *fullName = (char*) filename;
+      f = fopen(filename, (char*) mode);
+#endif
+    }
+
+    return f;
+}
+
 static FILE *csoundFindFile_Std(CSOUND *csound, char **fullName,
                                 const char *filename, const char *mode,
                                 const char *envList)
@@ -772,7 +827,7 @@ static FILE *csoundFindFile_Std(CSOUND *csound, char **fullName,
       return (FILE*) NULL;
     if (mode[0] != 'w') {
       /* read: try the specified name first */
-      f = fopen(name, mode);
+      f = csoundOpenFile_Std(csound, fullName, name, mode);
       if (f != NULL) {
         *fullName = name;
         return f;
@@ -785,7 +840,7 @@ static FILE *csoundFindFile_Std(CSOUND *csound, char **fullName,
     }
     else if (csoundIsNameFullpath(name)) {
       /* if write and full path: */
-      f = fopen(name, mode);
+      f = csoundOpenFile_Std(csound, fullName, name, mode);
       if (f != NULL)
         *fullName = name;
       else
@@ -799,7 +854,7 @@ static FILE *csoundFindFile_Std(CSOUND *csound, char **fullName,
       //len = (int) strlen(name) + 1;
       while (*searchPath != NULL) {
         name2 = csoundConcatenatePaths(csound, *searchPath, name);
-        f = fopen(name2, mode);
+        f = csoundOpenFile_Std(csound, fullName, name2, mode);
         if (f != NULL) {
           csound->Free(csound, name);
           *fullName = name2;
@@ -811,7 +866,7 @@ static FILE *csoundFindFile_Std(CSOUND *csound, char **fullName,
     }
     /* if write mode, try current directory last */
     if (mode[0] == 'w') {
-      f = fopen(name, mode);
+      f = csoundOpenFile_Std(csound, fullName, name, mode);
       if (f != NULL) {
         *fullName = name;
         return f;
@@ -885,6 +940,71 @@ static int csoundFindFile_Fd(CSOUND *csound, char **fullName,
     /* not found */
     csound->Free(csound, name);
     return -1;
+}
+
+static SNDFILE *csoundFindFile_Snd(CSOUND *csound, char **fullName,
+                             const char *filename, int write_mode,
+                             SFLIB_INFO *sfinfo, const char *envList)
+{
+    char  *name, *name2, **searchPath;
+    SNDFILE *sf;
+
+    *fullName = NULL;
+    if ((name = csoundConvertPathname(csound, filename)) == NULL)
+      return NULL;
+    if (!write_mode) {
+      /* read: try the specified name first */
+      sf = csoundOpenFile_Snd(csound, name, SFM_READ, sfinfo);
+      if (sf != NULL) {
+        *fullName = name;
+        return sf;
+      }
+      /* if full path, and not found: */
+      if (csoundIsNameFullpath(name)) {
+        csound->Free(csound, name);
+        return NULL;
+      }
+    }
+    else if (csoundIsNameFullpath(name)) {
+      /* if write and full path: */
+      sf = csoundOpenFile_Snd(csound, name, SFM_WRITE, sfinfo);
+      if (sf != NULL)
+        *fullName = name;
+      else
+        csound->Free(csound, name);
+      return sf;
+    }
+    /* search paths defined by environment variable list */
+    if (envList != NULL && envList[0] != '\0' &&
+        (searchPath = csoundGetSearchPathFromEnv((CSOUND*) csound, envList))
+        != NULL) {
+      //len = (int) strlen(name) + 1;
+      while (*searchPath != NULL) {
+        name2 = csoundConcatenatePaths(csound, *searchPath, name);
+        if (!write_mode)
+          sf = csoundOpenFile_Snd(csound, name2, SFM_READ, sfinfo);
+        else
+          sf = csoundOpenFile_Snd(csound, name2, SFM_WRITE, sfinfo);
+        if (sf != NULL) {
+          csound->Free(csound, name);
+          *fullName = name2;
+          return sf;
+        }
+        csound->Free(csound, name2);
+        searchPath++;
+      }
+    }
+    /* if write mode, try current directory last */
+    if (write_mode) {
+      sf = csoundOpenFile_Snd(csound, name, SFM_WRITE, sfinfo);
+      if (sf != NULL) {
+        *fullName = name;
+        return sf;
+      }
+    }
+    /* not found */
+    csound->Free(csound, name);
+    return NULL;
 }
 
 /**
@@ -1006,6 +1126,7 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
     CSFILE  *p = NULL;
     char    *fullName = NULL;
     FILE    *tmp_f = NULL;
+    SNDFILE *tmp_sf = NULL;
     SFLIB_INFO sfinfo;
     int     tmp_fd = -1, nbytes = (int) sizeof(CSFILE);
 
@@ -1018,51 +1139,33 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
     }
     /* get full name and open file */
     if (env == NULL) {
-#if defined(WIN32)
-      /* To handle Widows errors in file name characters. */
-      size_t sz = 2 * MultiByteToWideChar(CP_UTF8, 0, name, -1, NULL, 0);
-      wchar_t *wfname = malloc(sz);
-      wchar_t *wmode = 0;
-
-      MultiByteToWideChar(CP_UTF8, 0, name, -1, wfname, sz);
-      sz = 2 * MultiByteToWideChar(CP_UTF8, 0, param, -1, NULL, 0);
-      wmode = malloc(sz);
-      MultiByteToWideChar(CP_UTF8, 0, param, -1, wmode, sz);
       if (type == CSFILE_STD) {
-        tmp_f = _wfopen(wfname, wmode);
-        if (UNLIKELY(tmp_f == NULL)) {
-          /* csoundErrorMsg(csound, Str("csound->FileOpen(\"%s\") failed: %s."), */
-          /*                name, strerror(errno)); */
-          free(wfname);
-          free(wmode);
-          goto err_return;
-        }
-        fullName = (char*) name;
-      }
-      free(wfname);
-      free(wmode);
-      // so we can resume with an else still
-      if (type == CSFILE_STD) {
-      }
-#else
-      if (type == CSFILE_STD) {
-        fullName = (char*) name;
-        tmp_f = fopen(fullName, (char*) param);
+        tmp_f = csoundOpenFile_Std(csound, &fullName, name, param);
         if (UNLIKELY(tmp_f == NULL)) {
           /* csoundErrorMsg(csound, Str("csound->FileOpen(\"%s\") failed: %s."), */
           /*                name, strerror(errno)); */
           goto err_return;
         }
       }
-#endif
       else {
-        fullName = (char*) name;
-        if (type == CSFILE_SND_R || type == CSFILE_FD_R)
-          tmp_fd = open(fullName, RD_OPTS);
-        else
-          tmp_fd = open(fullName, WR_OPTS);
-        if (tmp_fd < 0)
-          goto err_return;
+        /* try to open sound file if callback is specified */
+        if (csound->OpenSoundFileCallback_ != NULL) {
+          memcpy(&sfinfo, param, sizeof(SFLIB_INFO));
+          if (type == CSFILE_SND_R)
+            tmp_sf = csoundOpenFile_Snd(csound, name, SFM_READ, &sfinfo);
+          if (type == CSFILE_SND_W)
+            tmp_sf = csoundOpenFile_Snd(csound, name, SFM_WRITE, &sfinfo);
+        }
+        /* fallback to open with fd */
+        if (tmp_sf == (SNDFILE*) NULL) {
+          fullName = (char*) name;
+          if (type == CSFILE_SND_R || type == CSFILE_FD_R)
+            tmp_fd = open(fullName, RD_OPTS);
+          else
+            tmp_fd = open(fullName, WR_OPTS);
+          if (tmp_fd < 0)
+            goto err_return;
+        }
       }
     }
     else {
@@ -1072,12 +1175,23 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
           goto err_return;
       }
       else {
-        if (type == CSFILE_SND_R || type == CSFILE_FD_R)
-          tmp_fd = csoundFindFile_Fd(csound, &fullName, name, 0, env);
-        else
-          tmp_fd = csoundFindFile_Fd(csound, &fullName, name, 1, env);
-        if (UNLIKELY(tmp_fd < 0))
-          goto err_return;
+        /* try to open sound file if callback is specified */
+        if(csound->OpenSoundFileCallback_ != NULL) {
+          memcpy(&sfinfo, param, sizeof(SFLIB_INFO));
+          if (type == CSFILE_SND_R)
+            tmp_sf = csoundFindFile_Snd(csound, &fullName, name, 0, &sfinfo, env);
+          if (type == CSFILE_SND_W)
+            tmp_sf = csoundFindFile_Snd(csound, &fullName, name, 1, &sfinfo, env);
+        }
+        /* fallback to open with fd */
+        if (tmp_sf == (SNDFILE*) NULL) {
+          if (type == CSFILE_SND_R || type == CSFILE_FD_R)
+            tmp_fd = csoundFindFile_Fd(csound, &fullName, name, 0, env);
+          else
+            tmp_fd = csoundFindFile_Fd(csound, &fullName, name, 1, env);
+          if (UNLIKELY(tmp_fd < 0))
+            goto err_return;
+        }
       }
     }
     nbytes += (int) strlen(fullName);
@@ -1090,19 +1204,21 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
     p->type = type;
     p->fd = tmp_fd;
     p->f = tmp_f;
-    p->sf = (SNDFILE*) NULL;
+    p->sf = tmp_sf;
     strcpy(&(p->fullName[0]), fullName);
     if (env != NULL) {
       csound->Free(csound, fullName);
       env = NULL;
     }
 
-    /* if sound file, re-open file descriptor with libsndfile */
+    /* if sound file, re-open file descriptor with libsndfile if tmp_sf is null */
     switch (type) {
     case CSFILE_STD:                          /* stdio */
       *((FILE**) fd) = tmp_f;
       break;
     case CSFILE_SND_R:                        /* sound file read */
+      if (p->sf != (SNDFILE*) NULL)
+          goto doneSFOpen;
       memcpy(&sfinfo, param, sizeof(SFLIB_INFO));
       p->sf = sflib_open_fd(tmp_fd, SFM_READ, &sfinfo, 0);
       if (p->sf == (SNDFILE*) NULL) {
@@ -1154,11 +1270,13 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
       *((SNDFILE**) fd) = p->sf;
       break;
     case CSFILE_SND_W:                        /* sound file write */
-      p->sf = sflib_open_fd(tmp_fd, SFM_WRITE, (SFLIB_INFO*) param, 0);
-      if (UNLIKELY(p->sf == (SNDFILE*) NULL)) {
-          csound->Warning(csound, Str("Failed to open %s: %s\n"),
-                          fullName, sflib_strerror(NULL));
-        goto err_return;
+      if (p->sf == (SNDFILE*) NULL) {
+        p->sf = sflib_open_fd(tmp_fd, SFM_WRITE, (SFLIB_INFO*) param, 0);
+        if (UNLIKELY(p->sf == (SNDFILE*) NULL)) {
+            csound->Warning(csound, Str("Failed to open %s: %s\n"),
+                            fullName, sflib_strerror(NULL));
+          goto err_return;
+        }
       }
       sflib_command(p->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
       sflib_command(p->sf, SFC_SET_VBR_ENCODING_QUALITY,

--- a/H/mp3dec.h
+++ b/H/mp3dec.h
@@ -23,6 +23,7 @@
 #define __MP3DEC_H
 
 #include <stdint.h>
+#include <stdio.h>
 #include "mpadec.h"
 
 #define MP3DEC_RETCODE_OK                 0
@@ -44,7 +45,7 @@ extern "C" {
 #endif
 
 mp3dec_t mp3dec_init(void);
-int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap);
+int mp3dec_init_file(mp3dec_t mp3dec, FILE *f, int64_t length, int nogap);
 int mp3dec_uninit(mp3dec_t mp3dec);
 int mp3dec_reset(mp3dec_t mp3dec);
 int mp3dec_configure(mp3dec_t mp3dec, mpadec_config_t *cfg);

--- a/InOut/libmpadec/mp3dec.c
+++ b/InOut/libmpadec/mp3dec.c
@@ -30,7 +30,7 @@ mp3dec_t mp3dec_init(void)
     if (!mp3) return NULL;
     memset(mp3, 0, sizeof(struct mp3dec_t));
     mp3->size = sizeof(struct mp3dec_t);
-    mp3->fd = -1;
+    mp3->f = NULL;
     mp3->mpadec = mpadec_init();
     if (!mp3->mpadec) {
       free(mp3);
@@ -39,7 +39,7 @@ mp3dec_t mp3dec_init(void)
     return mp3;
 }
 
-int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap)
+int mp3dec_init_file(mp3dec_t mp3dec, FILE *f, int64_t length, int nogap)
 {
     register struct mp3dec_t *mp3 = (struct mp3dec_t *)mp3dec;
     int64_t tmp;
@@ -47,24 +47,24 @@ int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap)
 
     if (!mp3 || (mp3->size != sizeof(struct mp3dec_t)) || !mp3->mpadec)
       return MP3DEC_RETCODE_INVALID_HANDLE;
-    if (fd < 0) {
+    if (f == NULL) {
       mp3dec_reset(mp3);
       return MP3DEC_RETCODE_INVALID_PARAMETERS;
     }
-    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) close(mp3->fd);
-    mp3->fd = fd;
+    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) fclose(mp3->f);
+    mp3->f = f;
     mp3->flags = MP3DEC_FLAG_SEEKABLE;
     mp3->stream_offset = mp3->stream_size = mp3->stream_position = 0;
     mp3->in_buffer_offset = mp3->in_buffer_used = 0;
     mp3->out_buffer_offset = mp3->out_buffer_used = 0;
-    tmp = lseek(fd, (off_t)0, SEEK_CUR);
+    tmp = fseek(f, (off_t)0, SEEK_CUR);
     if (tmp >= 0) mp3->stream_offset = tmp;
     else mp3->flags &= ~MP3DEC_FLAG_SEEKABLE;
     if (mp3->flags & MP3DEC_FLAG_SEEKABLE) {
-      tmp = lseek(fd, (off_t)0, SEEK_END);
+      tmp = fseek(f, (off_t)0, SEEK_END);
       if (tmp >= 0) {
         mp3->stream_size = tmp;
-        tmp = lseek(fd, mp3->stream_offset, SEEK_SET);
+        tmp = fseek(f, mp3->stream_offset, SEEK_SET);
         if (tmp<0) fprintf(stderr, "seek failure im mp3\n");
       } else mp3->flags &= ~MP3DEC_FLAG_SEEKABLE;
     }
@@ -73,32 +73,32 @@ int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap)
       if (length && (length < mp3->stream_size)) mp3->stream_size = length;
     } else mp3->stream_size = length;
     // check for ID3 tag
-    if (lseek(fd, (off_t)0, SEEK_SET)==0) {
+    if (fseek(f, (off_t)0, SEEK_SET)==0) {
       char hdr[10];
-      if (read(fd, &hdr, 10)!= 10) return MP3DEC_RETCODE_NOT_MPEG_STREAM;
+      if (fread(&hdr, 1, 10, f)!= 10) return MP3DEC_RETCODE_NOT_MPEG_STREAM;
       if (hdr[0] == 'I' && hdr[1] == 'D' && hdr[2] == '3') {
         /* A*2^21+B*2^14+C*2^7+D=A*2097152+B*16384+C*128+D*/
         mp3->stream_offset = hdr[6]*2097152+hdr[7]*16384+hdr[8]*128+hdr[9] + 10;
         // fprintf(stderr, "==== found ID3 tag, skipping %lld bytes ==== \n",
         //     mp3->stream_offset);
       }
-      (void) lseek(fd, mp3->stream_offset, SEEK_SET);
+      (void) fseek(f, mp3->stream_offset, SEEK_SET);
     }
-    r = read(fd, mp3->in_buffer, 4);
+    r = fread(mp3->in_buffer, 1, 4, f);
     if (r < 4) {
       mp3dec_reset(mp3);
       return ((r < 0) ? MP3DEC_RETCODE_INVALID_PARAMETERS :
               MP3DEC_RETCODE_NOT_MPEG_STREAM);
     } else mp3->in_buffer_used = r;
     if (mp3->flags & MP3DEC_FLAG_SEEKABLE)
-      tmp = lseek(fd, mp3->stream_offset, SEEK_SET);
+      tmp = fseek(f, mp3->stream_offset, SEEK_SET);
     else tmp = -1;
     if (tmp < 0) {
       int32_t n = sizeof(mp3->in_buffer) - mp3->in_buffer_used;
       mp3->flags &= ~MP3DEC_FLAG_SEEKABLE;
       if (mp3->stream_size && (n > (mp3->stream_size - mp3->in_buffer_used)))
         n = (int32_t)(mp3->stream_size - mp3->in_buffer_used);
-      n = read(fd, mp3->in_buffer + mp3->in_buffer_used, n);
+      n = fread(mp3->in_buffer + mp3->in_buffer_used, 1, n, f);
       if (n < 0) n = 0;
       mp3->in_buffer_used += n;
       mp3->stream_position = mp3->in_buffer_used;
@@ -107,7 +107,7 @@ int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap)
       int32_t n = sizeof(mp3->in_buffer);
       if (mp3->stream_size && (n > mp3->stream_size))
         n = (int32_t)mp3->stream_size;
-      n = read(fd, mp3->in_buffer, n);
+      n = fread(mp3->in_buffer, 1, n, f);
       if (n < 0) n = 0;
       mp3->stream_position = mp3->in_buffer_used = n;
     }
@@ -136,7 +136,7 @@ int mp3dec_init_file(mp3dec_t mp3dec, int fd, int64_t length, int nogap)
           int32_t n = sizeof(mp3->in_buffer);
           if (mp3->stream_size && (n > mp3->stream_size))
             n = (int32_t)mp3->stream_size;
-          n = read(fd, mp3->in_buffer, n);
+          n = fread(mp3->in_buffer, 1, n, f);
           if (n <= 0){ /* n = 0; */ break; } /* EOF */
           mp3->stream_position = mp3->in_buffer_used = n;
           r = mpadec_decode(mp3->mpadec, mp3->in_buffer,
@@ -185,8 +185,8 @@ int mp3dec_uninit(mp3dec_t mp3dec)
 
     if (!mp3 || (mp3->size != sizeof(struct mp3dec_t)) || !mp3->mpadec)
       return MP3DEC_RETCODE_INVALID_HANDLE;
-    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) close(mp3->fd);
-    mp3->fd = -1;
+    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) fclose(mp3->f);
+    mp3->f = NULL;
     mp3->flags = 0;
     mpadec_uninit(mp3->mpadec);
     mp3->size = 0;
@@ -200,8 +200,8 @@ int mp3dec_reset(mp3dec_t mp3dec)
 
     if (!mp3 || (mp3->size != sizeof(struct mp3dec_t)) || !mp3->mpadec)
       return MP3DEC_RETCODE_INVALID_HANDLE;
-    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) close(mp3->fd);
-    mp3->fd = -1;
+    if (mp3->flags & MP3DEC_FLAG_INITIALIZED) fclose(mp3->f);
+    mp3->f = NULL;
     mp3->flags = 0;
     mpadec_reset(mp3->mpadec);
     mp3->stream_offset = mp3->stream_size = mp3->stream_position = 0;
@@ -293,7 +293,7 @@ int mp3dec_decode(mp3dec_t mp3dec, uint8_t *buf, uint32_t bufsize, uint32_t *use
       n = sizeof(mp3->in_buffer) - mp3->in_buffer_used;
       if (mp3->stream_size && (n > (mp3->stream_size - mp3->stream_position)))
         n = (int32_t)(mp3->stream_size - mp3->stream_position);
-      if (n) r = read(mp3->fd, mp3->in_buffer + mp3->in_buffer_used, n);
+      if (n) r = fread(mp3->in_buffer + mp3->in_buffer_used, 1, n, mp3->f);
       else r = 0;
       if (r < 0) r = 0;
       mp3->in_buffer_used += r;
@@ -316,7 +316,7 @@ int mp3dec_seek(mp3dec_t mp3dec, int64_t pos, int units)
     if (!(mp3->flags & MP3DEC_FLAG_SEEKABLE)) return MP3DEC_RETCODE_SEEK_FAILED;
     if (units == MP3DEC_SEEK_BYTES) {
       newpos = (pos < mp3->stream_size) ? pos : mp3->stream_size;
-      newpos = lseek(mp3->fd, mp3->stream_offset + newpos, SEEK_SET);
+      newpos = fseek(mp3->f, mp3->stream_offset + newpos, SEEK_SET);
       if (newpos < 0) return MP3DEC_RETCODE_SEEK_FAILED;
       mp3->stream_position = newpos - mp3->stream_offset;
       mp3->in_buffer_offset = mp3->in_buffer_used = 0;
@@ -332,7 +332,7 @@ int mp3dec_seek(mp3dec_t mp3dec, int64_t pos, int units)
       if (newpos > mp3->stream_size) newpos = mp3->stream_size;
       pos = (pos%mp3->mpainfo.decoded_frame_samples)*
         mp3->mpainfo.decoded_sample_size;
-      newpos = lseek(mp3->fd, mp3->stream_offset + newpos, SEEK_SET);
+      newpos = fseek(mp3->f, mp3->stream_offset + newpos, SEEK_SET);
       if (newpos < 0) return MP3DEC_RETCODE_SEEK_FAILED;
       mp3->stream_position = newpos - mp3->stream_offset;
       mp3->in_buffer_offset = mp3->in_buffer_used = 0;
@@ -353,7 +353,7 @@ int mp3dec_seek(mp3dec_t mp3dec, int64_t pos, int units)
              (pos*mp3->stream_size + (mp3->mpainfo.duration >> 1))/
              mp3->mpainfo.duration;
       if (newpos > mp3->stream_size) newpos = mp3->stream_size;
-      newpos = lseek(mp3->fd, mp3->stream_offset + newpos, SEEK_SET);
+      newpos = fseek(mp3->f, mp3->stream_offset + newpos, SEEK_SET);
       if (newpos < 0) return MP3DEC_RETCODE_SEEK_FAILED;
       mp3->stream_position = newpos - mp3->stream_offset;
       mp3->in_buffer_offset = mp3->in_buffer_used = 0;

--- a/InOut/libmpadec/mp3dec_internal.h
+++ b/InOut/libmpadec/mp3dec_internal.h
@@ -31,7 +31,7 @@
 struct mp3dec_t {
   uint32_t size;
   mpadec_t mpadec;
-  int32_t fd;
+  FILE *f;
   uint32_t flags;
   off_t stream_offset;
   int64_t stream_size;

--- a/Python/ctcsound.py
+++ b/Python/ctcsound.py
@@ -263,6 +263,13 @@ libcsound.csoundSetMIDIInput.argtypes = [ct.c_void_p, ct.c_char_p]
 libcsound.csoundSetMIDIFileInput.argtypes = [ct.c_void_p, ct.c_char_p]
 libcsound.csoundSetMIDIOutput.argtypes = [ct.c_void_p, ct.c_char_p]
 libcsound.csoundSetMIDIFileOutput.argtypes = [ct.c_void_p, ct.c_char_p]
+
+OPENSOUNDFILEFUNC = ct.CFUNCTYPE(ct.c_void_p, ct.c_void_p, ct.c_char_p, ct.c_int, ct.c_void_p)
+libcsound.csoundSetOpenSoundFileCallback.argtypes = [ct.c_void_p, OPENSOUNDFILEFUNC]
+
+OPENFILEFUNC = ct.CFUNCTYPE(ct.c_void_p, ct.c_void_p, ct.c_char_p, ct.c_char_p)
+libcsound.csoundSetOpenFileCallback.argtypes = [ct.c_void_p, OPENFILEFUNC]
+
 FILEOPENFUNC = ct.CFUNCTYPE(None, ct.c_void_p, ct.c_char_p, ct.c_int, ct.c_int, ct.c_int)
 libcsound.csoundSetFileOpenCallback.argtypes = [ct.c_void_p, FILEOPENFUNC]
 
@@ -1146,6 +1153,42 @@ class Csound:
     def setMIDIFileOutput(self, name):
         """Sets MIDI file output name."""
         libcsound.csoundSetMIDIFileOutput(self.cs, cstring(name))
+
+    def setOpenSoundFileCallback(self, function):
+        """Sets a callback for opening a sound file.
+
+        The callback is made when a sound file is going to be opened.
+        The following information is passed to the callback:
+
+        bytes
+            pathname of the file; either full or relative to current dir
+        int
+            access flags for the file.
+        ptr
+            sound file info of the file.
+
+        Pass NULL to disable the callback.
+        This callback is retained after a :py:meth:`reset()` call.
+        """
+        self.openSoundFileCbRef = OPENSOUNDFILEFUNC(function)
+        libcsound.csoundSetOpenSoundFileCallback(self.cs, self.openSoundFileCbRef)
+
+    def setOpenFileCallback(self, function):
+        """Sets a callback for opening a file.
+
+        The callback is made when a file is going to be opened.
+        The following information is passed to the callback:
+
+        bytes
+            pathname of the file; either full or relative to current dir
+        bytes
+            access mode of the file.
+
+        Pass NULL to disable the callback.
+        This callback is retained after a :py:meth:`reset()` call.
+        """
+        self.openFileCbRef = OPENFILEFUNC(function)
+        libcsound.csoundSetOpenFileCallback(self.cs, self.openFileCbRef)
 
     def setFileOpenCallback(self, function):
         """Sets a callback for receiving notices whenever Csound opens a file.

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -613,6 +613,8 @@ static const CSOUND cenviron_ = {
   (int (*)(CSOUND *)) NULL, /* was: defaultCsoundExitGraph, */
   defaultCsoundYield,
   cscore_,        /*  cscoreCallback_     */
+  (void*(*)(CSOUND*, const char*, int, void*)) NULL,/* OpenSoundFileCallback_ */
+  (FILE*(*)(CSOUND*, const char*, const char*)) NULL, /* OpenFileCallback_ */
   (void(*)(CSOUND*, const char*, int, int, int)) NULL, /* FileOpenCallback_ */
   (SUBR) NULL,    /*  last_callback_      */
   /* these are not saved on RESET */
@@ -3860,6 +3862,22 @@ PUBLIC void csoundRemoveKeyboardCallback(CSOUND *csound,
     prv = pp;
     pp = pp->nxt;
   }
+}
+
+PUBLIC void csoundSetOpenSoundFileCallback(CSOUND *p,
+                                           void *(*openSoundFileCallback)(CSOUND*,
+                                                                          const char*,
+                                                                          int, void*))
+{
+    p->OpenSoundFileCallback_= openSoundFileCallback;
+}
+
+PUBLIC void csoundSetOpenFileCallback(CSOUND *p,
+                                      FILE *(*openFileCallback)(CSOUND*,
+                                                                const char*,
+                                                                const char*))
+{
+    p->OpenFileCallback_ = openFileCallback;
 }
 
 

--- a/iOS/Csound iOS Obj-C Examples/csound-iOS/headers/csound.h
+++ b/iOS/Csound iOS Obj-C Examples/csound-iOS/headers/csound.h
@@ -1131,6 +1131,37 @@ extern "C" {
    */
   PUBLIC void csoundSetMIDIFileOutput(CSOUND *csound, const char *name);
 
+  /**
+   * Sets an external callback for opening a sound file.
+   * The callback is made when a sound file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     int    flags of the file descriptor.
+   *     SFLIB_INFO* sound file info of the sound file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+
+  PUBLIC void csoundSetOpenSoundFileCallback(CSOUND *p,
+                                             void *(*openSoundFileCallback)(CSOUND*,
+                                                                            const char*,
+                                                                            int, void*));
+
+  /**
+   * Sets an external callback for opening a file.
+   * The callback is made when a file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     char*  access mode of the file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+  PUBLIC void csoundSetOpenFileCallback(CSOUND *p,
+                                        FILE *(*func)(CSOUND*, const char*,
+                                                     const char*));
+
 #if !defined(SWIG)
   /**
    * Sets an external callback for receiving notices whenever Csound opens

--- a/iOS/Csound iOS Obj-C Examples/csound-iOS/headers/csoundCore.h
+++ b/iOS/Csound iOS Obj-C Examples/csound-iOS/headers/csoundCore.h
@@ -1419,6 +1419,8 @@ typedef struct _message_queue_t_ {
     int           (*csoundExitGraphCallback_)(CSOUND *);
     int           (*csoundYieldCallback_)(CSOUND *);
     void          (*cscoreCallback_)(CSOUND *);
+    void*         (*OpenSoundFileCallback_)(CSOUND*, const char*, int, void*);
+    FILE*         (*OpenFileCallback_)(CSOUND*, const char*, const char*);
     void          (*FileOpenCallback_)(CSOUND*, const char*, int, int, int);
     SUBR          last_callback_;
     /* these are not saved on RESET */

--- a/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/csound-iOS/headers/csound.h
+++ b/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/csound-iOS/headers/csound.h
@@ -1131,6 +1131,37 @@ extern "C" {
    */
   PUBLIC void csoundSetMIDIFileOutput(CSOUND *csound, const char *name);
 
+  /**
+   * Sets an external callback for opening a sound file.
+   * The callback is made when a sound file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     int    flags of the file descriptor.
+   *     SFLIB_INFO* sound file info of the sound file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+
+  PUBLIC void csoundSetOpenSoundFileCallback(CSOUND *p,
+                                             void *(*openSoundFileCallback)(CSOUND*,
+                                                                            const char*,
+                                                                            int, void*));
+
+  /**
+   * Sets an external callback for opening a file.
+   * The callback is made when a file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     char*  access mode of the file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+  PUBLIC void csoundSetOpenFileCallback(CSOUND *p,
+                                        FILE *(*func)(CSOUND*, const char*,
+                                                     const char*));
+
 #if !defined(SWIG)
   /**
    * Sets an external callback for receiving notices whenever Csound opens

--- a/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/csound-iOS/headers/csoundCore.h
+++ b/iOS/Csound iOS Swift Examples/Csound iOS SwiftExamples/csound-iOS/headers/csoundCore.h
@@ -1419,6 +1419,8 @@ typedef struct _message_queue_t_ {
     int           (*csoundExitGraphCallback_)(CSOUND *);
     int           (*csoundYieldCallback_)(CSOUND *);
     void          (*cscoreCallback_)(CSOUND *);
+    void*         (*OpenSoundFileCallback_)(CSOUND*, const char*, int, void*);
+    FILE*         (*OpenFileCallback_)(CSOUND*, const char*, const char*);
     void          (*FileOpenCallback_)(CSOUND*, const char*, int, int, int);
     SUBR          last_callback_;
     /* these are not saved on RESET */

--- a/include/csound.h
+++ b/include/csound.h
@@ -1160,6 +1160,38 @@ extern "C" {
    */
   PUBLIC void csoundSetMIDIFileOutput(CSOUND *csound, const char *name);
 
+  /**
+   * Sets an external callback for opening a sound file.
+   * The callback is made when a sound file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     int    flags of the file descriptor.
+   *     SFLIB_INFO* sound file info of the sound file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+
+  PUBLIC void csoundSetOpenSoundFileCallback(CSOUND *p,
+                                             void *(*openSoundFileCallback)(CSOUND*,
+                                                                            const char*,
+                                                                            int, void*));
+
+  /**
+   * Sets an external callback for opening a file.
+   * The callback is made when a file is going to be opened.
+   * The following information is passed to the callback:
+   *     char*  pathname of the file; either full or relative to current dir
+   *     char*  access mode of the file.
+   *
+   * Pass NULL to disable the callback.
+   * This callback is retained after a csoundReset() call.
+   */
+  PUBLIC void csoundSetOpenFileCallback(CSOUND *p,
+                                        FILE *(*openFileCallback)(CSOUND*,
+                                                                  const char*,
+                                                                  const char*));
+
 #if !defined(SWIG)
   /**
    * Sets an external callback for receiving notices whenever Csound opens

--- a/include/csound.hpp
+++ b/include/csound.hpp
@@ -172,9 +172,24 @@ public:
   virtual void SetMIDIOutput(const char *name){
      csoundSetMIDIOutput(csound,name);
   }
-   virtual void SetMIDIFileOutput(const char *name){
-    csoundSetMIDIFileOutput(csound,name);
+  virtual void SetMIDIFileOutput(const char *name){
+     csoundSetMIDIFileOutput(csound,name);
   }
+
+  virtual void SetOpenSoundFileCallback(
+     void *(*openSoundFileCallback_)(CSOUND*, const char *name,
+                                     int flags, void *sf_info))
+  {
+     csoundSetOpenSoundFileCallback(csound, openSoundFileCallback_);
+  }
+
+  virtual void SetOpenFileCallback(
+     FILE *(*openFileCallback_)(CSOUND*, const char*,
+                                const char*))
+  {
+     csoundSetOpenFileCallback(csound, openFileCallback_);
+  }
+
   virtual TREE *ParseOrc(const char *str)
   {
     return csoundParseOrc(csound, str);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1719,6 +1719,8 @@ static inline double intpow(MYFLT x, int32_t n)
     int           (*csoundExitGraphCallback_)(CSOUND *);
     int           (*csoundYieldCallback_)(CSOUND *);
     void          (*cscoreCallback_)(CSOUND *);
+    void*         (*OpenSoundFileCallback_)(CSOUND*, const char*, int, void*);
+    FILE*         (*OpenFileCallback_)(CSOUND*, const char*, const char*);
     void          (*FileOpenCallback_)(CSOUND*, const char*, int, int, int);
     SUBR          last_callback_;
     /* these are not saved on RESET */

--- a/wasm/src/exports.json
+++ b/wasm/src/exports.json
@@ -177,6 +177,8 @@
   "csoundSetExternalMidiOutOpenCallback",
   "csoundSetExternalMidiReadCallback",
   "csoundSetExternalMidiWriteCallback",
+  "csoundSetOpenSoundFileCallback",
+  "csoundSetOpenFileCallback",
   "csoundSetFileOpenCallback",
   "csoundSetGlobalEnv",
   "csoundSetHostData",


### PR DESCRIPTION
Add callback for open file and open file descriptor to allow extending csound api when opening files.

These changes could allow csound to open files that are not located in file system and instead add user defined code to open files from memory, zip files, etc.