### PR TITLE
Add samplerate module

### DIFF
--- a/cmake/Modules/FindSampleRate.cmake
+++ b/cmake/Modules/FindSampleRate.cmake
@@ -1,0 +1,20 @@
+# SampleRate_FOUND: if found
+# SampleRate::samplerate: imported module
+
+include(FindPackageHandleStandardArgs)
+
+find_library(SampleRate_LIBRARY NAMES samplerate libsamplerate-0)
+find_path(SampleRate_INCLUDE_DIR NAMES samplerate.h)
+
+find_package_handle_standard_args(SampleRate
+	FOUND_VAR SampleRate_FOUND
+	REQUIRED_VARS SampleRate_LIBRARY SampleRate_INCLUDE_DIR
+)
+
+if(SampleRate_FOUND AND NOT TARGET SampleRate::samplerate)
+	add_library(SampleRate::samplerate UNKNOWN IMPORTED)
+	set_target_properties(SampleRate::samplerate PROPERTIES
+		IMPORTED_LOCATION "${SampleRate_LIBRARY}"
+		INTERFACE_INCLUDE_DIRECTORIES SampleRate_INCLUDE_DIR
+	)
+endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,4 +1,5 @@
 # UTILITY PLUGIN AND PROGRAMS
+option(BUILD_SRC_CONV "Build src_conv utility" ON)
 
 set(stdutil_SRCS
     atsa.c          cvanal.c        dnoise.c    envext.c
@@ -34,19 +35,18 @@ if(BUILD_UTILITIES)
     make_utility(scale       scale_main.c)
     make_utility(sndinfo     sndinfo_main.c)
     make_utility(srconv      srconv_main.c)
-
-    if (USE_VCPKG)
-        find_package(SampleRate REQUIRED)
-        set(LIBSAMPLERATE_LIBRARY SampleRate::samplerate)
-    else ()
-        find_library(LIBSAMPLERATE_LIBRARY NAMES samplerate libsamplerate-0)
-    endif()
-
-    if(USE_LIBSNDFILE AND LIBSAMPLERATE_LIBRARY)
-        make_executable(src_conv new_srconv.c "${LIBSNDFILE_LIBRARY};${LIBSAMPLERATE_LIBRARY}")
-    else()
-        message(STATUS "Not building src_conv (libsndfile or libsamplerate not found).")
-    endif()
-
 endif()
+
+if (USE_VCPKG)
+    find_package(SampleRate CONFIG)
+    assign_bool(SampleRate_FOUND TARGET SampleRate::samplerate)
+else()
+    find_package(SampleRate MODULE)
+endif()
+
+check_deps(BUILD_SRC_CONV BUILD_UTILITIES USE_LIBSNDFILE SampleRate_FOUND)
+if (BUILD_SRC_CONV)
+    make_executable(src_conv new_srconv.c "${LIBSNDFILE_LIBRARY};SampleRate::samplerate")
+endif()
+
 add_subdirectory(SDIF)


### PR DESCRIPTION
Using imported targets has several benefits:

- Packaging include-dirs and libraries together for cleaner code
- Automatic handling of usage requirements (see https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#target-usage-requirements)
- Tracking of runtime dependencies (https://cmake.org/cmake/help/latest/command/install.html#runtime-dependency-set)
- Unifies vcpkg and non-vcpkg builds
