### PR TITLE
Prefer config packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0077 NEW)
 
 # silence RPATH cmake warning
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 11)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 
 option(USE_VCPKG "Use VCPKG to download and manage dependencies" OFF)

--- a/Opcodes/CMakeLists.txt
+++ b/Opcodes/CMakeLists.txt
@@ -117,7 +117,7 @@ if(BUILD_DSSI_OPCODES)
 endif()
 
 ## OPCODES WITH EXTERNAL DEPENDENCIES ##
-find_package(LIBLO)
+find_package(LIBLO MODULE)
 if(BUILD_OSC_OPCODES AND LIBLO_FOUND)
     make_plugin(osc OSC.c)
     if(WIN32)


### PR DESCRIPTION
cmake prefers "find" modules to "config" modules by default. This is a problem because the vcpkg "config" modules are generally better, with one exception, see https://github.com/csound/csound/pull/1760#issuecomment-1785121404. So set cmake to prefer "config" modules, and force liblo to use a "find" module for now.