### PR TITLE
Add Jack module

### DIFF
--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -33,20 +33,6 @@ if(USE_PORTMIDI)
     endif()
 endif()
 
-
-if(USE_JACK)
-    find_library(JACK_LIBRARY jack)
-    check_include_file(jack/jack.h JACK_HEADER)
-    if(APPLE)
-    # VL: could not find a way to make check_include_file() work so
-    # I am hardcoding it for MacOS
-    set(JACK_HEADER  "jack/jack.h")
-    endif()
-    # HLO: including the jack2 common source dir
-    # prevents "cannot open include file" errors
-    find_path(JACK_INCLUDE_PATH jack/jack.h)
-endif()
-
 # if(USE_COREAUDIO)
 #    find_path(COREAUDIO_INCLUDE_PATH CoreAudio.h)
 #    find_library(COREAUDIO_LIBRARY CoreAudio)
@@ -151,14 +137,12 @@ if(USE_IPMIDI)
     make_plugin(ipmidi ipmidi.c "${ipmidi_LIBS}")
 endif()
 
-check_deps(USE_JACK JACK_HEADER JACK_LIBRARY JACK_INCLUDE_PATH Threads_FOUND)
+find_package(Jack MODULE)
+check_deps(USE_JACK Jack_FOUND)
 if(USE_JACK)
-    set(rtjack_LIBS ${JACK_LIBRARY} Threads::Threads)
-    # set(rtjack_SRCS rtjack.c natsort.c)
     set(rtjack_SRCS rtjack.c alphanumcmp.c)
-    make_plugin(rtjack "${rtjack_SRCS}" "${rtjack_LIBS}")
-    # make_plugin(rtjack rtjack.c "${rtjack_LIBS}")
-    target_include_directories(rtjack PRIVATE "${JACK_INCLUDE_PATH}")
+    make_plugin(rtjack "${rtjack_SRCS}")
+    target_link_libraries(rtjack PRIVATE Jack::jack)
 endif()
 
 if(HAIKU)

--- a/cmake/Modules/FindJack.cmake
+++ b/cmake/Modules/FindJack.cmake
@@ -1,0 +1,22 @@
+# Jack_FOUND: if found
+# Jack_STATIC: if static
+# Jack::jack: imported module
+
+include(FindPackageHandleStandardArgs)
+include(CMakeFindDependencyMacro)
+
+find_library(Jack_LIBRARY NAMES "jack")
+find_path(Jack_INCLUDE_DIR "jack/jack.h")
+
+find_package_handle_standard_args(Jack
+	FOUND_VAR Jack_FOUND
+	REQUIRED_VARS Jack_LIBRARY Jack_INCLUDE_DIR
+)
+
+if(Jack_FOUND)
+	add_library(Jack::jack UNKNOWN IMPORTED)
+	set_target_properties(Jack::jack PROPERTIES
+		IMPORTED_LOCATION ${Jack_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${Jack_INCLUDE_DIR}
+	)
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
         "portmidi",
         "liblo",
         "gtest",
+        "jack2",
         {
             "name": "portaudio"
         },


### PR DESCRIPTION
Using imported targets has several benefits:

- Packaging include-dirs and libraries together for cleaner code
- Automatic handling of usage requirements (see https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#target-usage-requirements)
- Tracking of runtime dependencies (https://cmake.org/cmake/help/latest/command/install.html#runtime-dependency-set)
- Unifies vcpkg and non-vcpkg builds
