### PR TITLE
Link sdif2ad to csound

### DIFF
--- a/util/SDIF/CMakeLists.txt
+++ b/util/SDIF/CMakeLists.txt
@@ -3,4 +3,5 @@
 if(BUILD_UTILITIES)
 set(sdif2ad_SRCS sdif2adsyn.c sdif.c sdif-mem.c)
 make_executable(sdif2ad "${sdif2ad_SRCS}" "")
+target_link_libraries(sdif2ad PUBLIC ${CSOUNDLIB})
 endif()


### PR DESCRIPTION
Needs to be public because csound is used in the headers