### PR TITLE
Run include what you use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,22 @@ option(REQUIRE_PTHREADS "For non-Windows systems, set whether Csound will use th
 option(BUILD_DOCS "Build documentation (requires doxygen)" OFF)
 option(DEBUG_ERROR_ON_WARNING "For a debug build, error on a compiler# warning" OFF)
 option(BARE_METAL "To configure for bare metal build" OFF)
+option(INCLUDE_WHAT_YOU_USE "Run include-what-you-use" ON)
+
+find_program(include_what_you_use_executable NAMES include-what-you-use)
+
+if (INCLUDE_WHAT_YOU_USE AND include_what_you_use_executable)
+    set(CMAKE_C_INCLUDE_WHAT_YOU_USE 
+        ${include_what_you_use_executable}
+        -Xiwyu
+        --mapping_file=${Csound_SOURCE_DIR}/map.imp
+    )
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE 
+        ${include_what_you_use_executable}
+        -Xiwyu
+        --mapping_file=${Csound_SOURCE_DIR}/map.imp
+    )
+endif()
 
 if(NO_CS_SERVER)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -DNO_CSOUND_SERVER")

--- a/Engine/auxfd.c
+++ b/Engine/auxfd.c
@@ -21,7 +21,14 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"                         /*      AUXFD.C         */
+#include "csound.h"
+#include "envvar.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static CS_NOINLINE void auxchprint(CSOUND *, INSDS *);
 static CS_NOINLINE void fdchprint(CSOUND *, INSDS *);

--- a/Engine/cfgvar.c
+++ b/Engine/cfgvar.c
@@ -25,11 +25,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <math.h>
 
 #include "csoundCore.h"
-#include "cfgvar.h"
-#include "namedins.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /* the global database */
 

--- a/Engine/corfiles.c
+++ b/Engine/corfiles.c
@@ -27,6 +27,10 @@
 #include <ctype.h>
 #include <stdlib.h>
 
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 
 extern int csoundFileClose(CSOUND*, void*);
 CORFIL *copy_url_corefile(CSOUND *, const char *, int);

--- a/Engine/cs_new_dispatch.c
+++ b/Engine/cs_new_dispatch.c
@@ -33,12 +33,15 @@
 */
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <limits.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "cs_par_base.h"
 #include "cs_par_orc_semantics.h"
 #include <stdbool.h>
+#include "cs_par_structs.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #if defined(_MSC_VER)
 /* For InterlockedCompareExchange */

--- a/Engine/cs_par_base.c
+++ b/Engine/cs_par_base.c
@@ -23,10 +23,16 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
 
 #include "csoundCore.h"
 
 #include "cs_par_base.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 static int csp_set_exists(struct set_t *set, void *data);
 
 int csp_thread_index_get(CSOUND *csound)

--- a/Engine/cs_par_orc_semantic_analysis.c
+++ b/Engine/cs_par_orc_semantic_analysis.c
@@ -22,16 +22,16 @@
 */
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
 
 #include "csoundCore.h"
 #include "csound_orc.h"
-#include "tok.h"
-
 #include "cs_par_base.h"
 #include "cs_par_orc_semantics.h"
-
 #include "interlocks.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 OENTRY* find_opcode(CSOUND *, char *);
 /***********************************************************************

--- a/Engine/csound_data_structures.c
+++ b/Engine/csound_data_structures.c
@@ -20,8 +20,13 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  02110-1301 USA
  */
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_data_structures.h"
+#include "csound.h"
+#include "prototyp.h"
 
 #define HASH_LOAD_FACTOR 0.75
 

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -26,17 +26,24 @@
 #include "csoundCore.h"
 #include "csound_orc.h"
 #include "parse_param.h"
-#include <ctype.h>
 #include <inttypes.h>
 #include <math.h>
 #include <string.h>
+#include <setjmp.h>
+#include <stdio.h>
 
-#include "insert.h"
-#include "oload.h"
-#include "pstream.h"
 //#include "typetabl.h"
-#include "csound_orc_semantics.h"
+
+
+
 #include "csound_standard_types.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "csound_type_system.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "score_param.h"
+#include "sysdep.h"
 
 MYFLT csoundInitialiseIO(CSOUND *csound);
 void    iotranset(CSOUND *), sfclosein(CSOUND*), sfcloseout(CSOUND*);
@@ -2410,6 +2417,7 @@ void debugPrintCsound(CSOUND *csound) {
 }
 
 #include "interlocks.h"
+
 void query_deprecated_opcode(CSOUND *csound, ORCTOKEN *o) {
   char *name = o->lexeme;
   OENTRY *ep = find_opcode(csound, name);

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -22,12 +22,20 @@
   02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_orc.h"
 #include "csound_orc_expressions.h"
 #include "csound_type_system.h"
 #include "csound_orc_semantics.h"
 #include <inttypes.h>
+#include "csound.h"
+#include "csound_standard_types.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 extern char argtyp2(char *);
 extern void print_tree(CSOUND *, char *, TREE *);

--- a/Engine/csound_orc_optimize.c
+++ b/Engine/csound_orc_optimize.c
@@ -22,8 +22,16 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_orc.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 extern void print_tree(CSOUND *csound, char*, TREE *l);
 extern void delete_tree(CSOUND *csound, TREE *l);
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -25,16 +25,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+
 //#include <stdbool.h>
 #include "csoundCore.h"
 #include "csound_orc.h"
 #include "interlocks.h"
-#include "namedins.h"
 #include "parse_param.h"
 #include "csound_type_system.h"
 #include "csound_standard_types.h"
 #include "csound_orc_expressions.h"
 #include "csound_orc_semantics.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "find_opcode.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 extern char *csound_orcget_text ( void *scanner );
 static int is_label(char* ident, CONS_CELL* labelList);

--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -21,10 +21,16 @@
  02110-1301 USA
  */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_standard_types.h"
 #include "pstream.h"
 #include <stdlib.h>
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
 
 /* MEMORY COPYING FUNCTIONS */

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include "csoundCore.h"
 #include "aops.h"
+#include "prototyp.h"
 
 int csTypeExistsWithSameName(TYPE_POOL* pool, CS_TYPE* typeInstance) {
     CS_TYPE_ITEM* current = pool->head;

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -22,7 +22,40 @@
 */
 
 #include "entry1.h"             /*                      ENTRY1.C        */
+
+#include <stddef.h>
+
 #include "interlocks.h"
+#include "aops.h"
+#include "bus.h"
+#include "cmath.h"
+#include "compile_ops.h"
+#include "csoundCore.h"
+#include "disprep.h"
+#include "dumpf.h"
+#include "insert.h"
+#include "linevent.h"
+#include "lpred.h"
+#include "midifile.h"
+#include "midiinterop.h"
+#include "midiops.h"
+#include "midiout.h"
+#include "oload.h"
+#include "oscils.h"
+#include "remote.h"
+#include "resize.h"
+#include "schedule.h"
+#include "sndinfUG.h"
+#include "str_ops.h"
+#include "ugens1.h"
+#include "ugens2.h"
+#include "ugens3.h"
+#include "ugens4.h"
+#include "ugens5.h"
+#include "ugens6.h"
+#include "ugrw1.h"
+#include "vdelay.h"
+#include "windin.h"
 
 /* thread vals, where isub=1, ksub=2:
    0 =     1  OR   2  (B out only)

--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -21,12 +21,23 @@
     02110-1301 USA
 */
 
+#include <emmintrin.h>
+#include <fcntl.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csoundCore.h"
-#include "soundio.h"
 #include "envvar.h"
 #include <stdio.h>
 #include <ctype.h>
-#include <math.h>
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 #if defined(MSVC) || defined(__wasi__)
 #include <fcntl.h>

--- a/Engine/extract.c
+++ b/Engine/extract.c
@@ -21,9 +21,15 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "sysdep.h"                                 /*    EXTRACT.C   */
 #include "extract.h"
+#include "csound.h"
+#include "float-version.h"
+#include "sort.h"
 
 extern  int     realtset(CSOUND *, SRTBLK *);
 extern  MYFLT   realt(CSOUND *, MYFLT);

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -24,15 +24,26 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      FGENS.C         */
 #include <ctype.h>
 #include "soundio.h"
 #include "cwindow.h"
 #include "cmath.h"
 #include "fgens.h"
-#include "pstream.h"
-#include "pvfileio.h"
 #include <stdlib.h>
+#include "csound.h"
+#include "float-version.h"
+#include "mpadec.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 /* #undef ISSTRCOD */
 
 static inline int32_t byte_order(void)

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -23,18 +23,25 @@
   02110-1301 USA
 */
 
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h" /*  INSERT.C */
-#include "oload.h"
 #include "insert.h"     /* for goto's */
 #include "aops.h"       /* for cond's */
-#include "midiops.h"
 #include "namedins.h"   /* IV - Oct 31 2002 */
-#include "pstream.h"
-#include "interlocks.h"
 #include "csound_type_system.h"
 #include "csound_standard_types.h"
 #include "csound_orc_semantics.h"
 #include <inttypes.h>
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static  void    showallocs(CSOUND *);
 static  void    deact(CSOUND *, INSDS *);
@@ -1699,7 +1706,6 @@ int xoutset(CSOUND *csound, XOUT *p)
   of a mechanism to perform at local ksmps (in kperf etc)
 */
 //#include "typetabl.h"
-#include "csound_standard_types.h"
 int setksmpsset(CSOUND *csound, SETKSMPS *p)
 {
 

--- a/Engine/linevent.c
+++ b/Engine/linevent.c
@@ -21,8 +21,17 @@
     02110-1301 USA
 */
 
+#include <fcntl.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csoundCore.h"     /*                              LINEVENT.C      */
 #include <ctype.h>
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #ifdef MSVC
 #include <fcntl.h>
@@ -36,6 +45,7 @@
 #  define _pclose pclose
 # elif defined(__BEOS__) ||  defined(__HAIKU__) || defined(__MACH__)
 #  include <stdio.h>
+
 #  define _popen popen
 #  define _pclose pclose
 # else

--- a/Engine/memalloc.c
+++ b/Engine/memalloc.c
@@ -22,7 +22,13 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "csoundCore.h"                 /*              MEMALLOC.C      */
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /* This code wraps malloc etc with maintaining a list of allocated memory
    so it can be freed on a reset.  It would not be necessary with a zoned

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -22,15 +22,26 @@
     02110-1301 USA
 */
 
+#include <string.h>
+#include <math.h>
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"     /*                              MEMFILES.C      */
-#include "soundio.h"
 #include "pvfileio.h"
 #include "convolve.h"
 #include "lpc.h"
 #include "pstream.h"
-#include "namedins.h"
-#include <string.h>
 #include <inttypes.h>
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "envvar.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 static int Load_Het_File_(CSOUND *csound, const char *filnam,
                           char **allocp, int32 *len)

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -22,6 +22,12 @@
   02110-1301 USA
 */
 
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                         MUSMON.C     */
 #include "midiops.h"
 #include "soundio.h"
@@ -32,6 +38,13 @@
 #include "corfile.h"
 
 #include "csdebug.h"
+#include "cscore.h"
+#include "csound.h"
+#include "cwindow.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 #define SEGAMPS CS_AMPLMSG
 #define SORMSG  CS_RNGEMSG

--- a/Engine/namedins.c
+++ b/Engine/namedins.c
@@ -21,10 +21,17 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "namedins.h"
-#include "csound_orc_semantics.h"
 #include <ctype.h>
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /* check if the string s is a valid instrument or opcode name */
 /* return value is zero if the string is not a valid name */

--- a/Engine/new_orc_parser.c
+++ b/Engine/new_orc_parser.c
@@ -23,10 +23,20 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_orc.h"
 #include "corfile.h"
 #include "score_param.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "parse_param.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #if defined(HAVE_DIRENT_H)
 #  include <dirent.h>

--- a/Engine/pools.c
+++ b/Engine/pools.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "csoundCore.h"
 #include "pools.h"
 #include "csound_standard_types.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
 /* MYFLT POOL */
 

--- a/Engine/rdscor.c
+++ b/Engine/rdscor.c
@@ -21,9 +21,18 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                  RDSCORSTR.C */
 #include "corfile.h"
 #include "insert.h"
+#include "csound.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static inline int32_t byte_order(void)
 {

--- a/Engine/scsort.c
+++ b/Engine/scsort.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "csoundCore.h"                                  /*   SCSORT.C  */
 #include "corfile.h"
 #include <ctype.h>
+#include "csound.h"
+#include "prototyp.h"
+#include "sort.h"
 
 extern void sort(CSOUND*);
 extern void twarp(CSOUND*);

--- a/Engine/scxtract.c
+++ b/Engine/scxtract.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"                            /*  SCXTRACT.C  */
 #include "corfile.h"
 #include "extract.h"
+#include "csound.h"
+#include "prototyp.h"
 
 extern void sfree(CSOUND *csound);
 extern int  sread(CSOUND *csound);

--- a/Engine/sort.c
+++ b/Engine/sort.c
@@ -27,7 +27,12 @@ recovered march 2010
 Adapted from Delphi implementation of Dijkstra's algorithm.
 */
 
+#include <stddef.h>
+
 #include "csoundCore.h"                         /*   SORT.C  */
+#include "csound.h"
+#include "sort.h"
+#include "sysdep.h"
 
 /* inline int ordering(SRTBLK *a, SRTBLK *b) */
 /* { */

--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -22,12 +22,20 @@
 */
 
 #include "csoundCore.h"                             /*   SREAD.C     */
-#include <math.h>      /* for fabs() */
 #include <ctype.h>
 #include <inttypes.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+
 #include "namedins.h"           /* IV - Oct 31 2002 */
 #include "corfile.h"
 #include "Engine/score_param.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sort.h"
+#include "sysdep.h"
 
 #define MEMSIZ  16384           /* size of memory requests from system  */
 #define MARGIN  4096            /* minimum remaining before new request */

--- a/Engine/swritestr.c
+++ b/Engine/swritestr.c
@@ -23,9 +23,14 @@
 
 #include "csoundCore.h"                                  /*    SWRITESTR.C  */
 #include <math.h>
-#include <stdlib.h>
 #include <ctype.h>
+#include <stdio.h>
+
+                                /*    SWRITESTR.C  */
 #include "corfile.h"
+#include "csound.h"
+#include "sort.h"
+#include "sysdep.h"
 
 static SRTBLK *nxtins(SRTBLK *), *prvins(SRTBLK *);
 static char   *pfout(CSOUND *,SRTBLK *, char *, int, int, CORFIL *sco);

--- a/Engine/symbtab.c
+++ b/Engine/symbtab.c
@@ -24,16 +24,22 @@
 */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
+
 #include "csoundCore.h"
 #include "tok.h"
 #include "csound_orc.h"
 #include "insert.h"
 #include "namedins.h"
 #include "interlocks.h"
-#include "csound_orc_semantics.h"
 #include "csound_standard_types.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "csound_type_system.h"
+#include "find_opcode.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #ifndef PARSER_DEBUG
 #define PARSER_DEBUG (0)

--- a/Engine/twarp.c
+++ b/Engine/twarp.c
@@ -21,7 +21,12 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "csoundCore.h"                               /*    TWARP.C  */
+#include "csound.h"
+#include "sort.h"
+#include "sysdep.h"
 
 typedef struct {
     MYFLT   betbas;

--- a/Engine/ugen.c
+++ b/Engine/ugen.c
@@ -41,8 +41,12 @@
  * */
 
 #include "ugen.h"
+
+#include <string.h>
+
 #include "csound_standard_types.h"
 #include "csound_orc.h"
+#include "csound_data_structures.h"
 
 extern OENTRIES* find_opcode2(CSOUND* csound, char* opname);
 extern char** splitArgs(CSOUND* csound, char* argString);

--- a/Frontends/beats/beats.h
+++ b/Frontends/beats/beats.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-
+#pragma once
 
     typedef struct instr {
       struct instr *next;

--- a/Frontends/beats/main.c
+++ b/Frontends/beats/main.c
@@ -22,8 +22,8 @@
 */
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
+
 #include "beats.h"
 
 FILE *myout;

--- a/Frontends/csound/csound_main.c
+++ b/Frontends/csound/csound_main.c
@@ -25,9 +25,12 @@
 #include "csound.h"
 #include <stdio.h>
 #include <signal.h>
-#include <stdarg.h>
 #include <string.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "msg_attr.h"
 #if defined(HAVE_UNISTD_H) || defined(MACOSX)
 #include <unistd.h>
 #endif

--- a/Frontends/csound/sched.c
+++ b/Frontends/csound/sched.c
@@ -22,19 +22,21 @@
 */
 
 #include "csound.h"
-
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
 #include <errno.h>
 #include <time.h>
-#include <sys/types.h>
 #include <signal.h>
 #include <pthread.h>
 #include <sched.h>
 #include <sys/mman.h>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sysdep.h"
 
 static  int     cpuMax = 0;
 static  int     secs = 0;

--- a/Frontends/debugger/csdebugger.cpp
+++ b/Frontends/debugger/csdebugger.cpp
@@ -34,10 +34,14 @@ ksmps offset] = number of k-cycle before breakpoint is hit
 */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csound.hpp"
 #include "csdebug.h"
 #include <iostream>
-#include <iomanip>
+#include "csound.h"
+#include "sysdep.h"
 
 using namespace std;
 

--- a/H/aops.h
+++ b/H/aops.h
@@ -23,6 +23,8 @@
 
 /*                                                      AOPS.H          */
 
+#pragma once
+
 #define CSOUND_SPIN_SPINLOCK csoundSpinLock(&csound->spinlock);
 #define CSOUND_SPIN_SPINUNLOCK csoundSpinUnLock(&csound->spinlock);
 #define CSOUND_SPOUT_SPINLOCK csoundSpinLock(&csound->spoutlock);

--- a/H/cmath.h
+++ b/H/cmath.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 double besseli(double);
 
 /* returns 0 on success, -1 if there are insufficient arguments, */

--- a/H/compile_ops.h
+++ b/H/compile_ops.h
@@ -24,6 +24,10 @@
 #pragma once
 
 #include <csoundCore.h>
+#include <stdint.h>
+
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct _compile {
   OPDS h;

--- a/H/compile_ops.h
+++ b/H/compile_ops.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include <csoundCore.h>
 
 typedef struct _compile {

--- a/H/csGblMtx.h
+++ b/H/csGblMtx.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 #ifndef CSOUND_CSGBLMTX_H
 
 

--- a/H/cs_jack.h
+++ b/H/cs_jack.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define MAX_NAME_LEN    32      /* for client and port name */
 
 typedef struct RtJackBuffer_ {

--- a/H/cs_par_ops.h
+++ b/H/cs_par_ops.h
@@ -22,7 +22,7 @@
 */
 
 /*                                                      CS_PAR_OPS.H          */
-
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/H/cs_par_orc_semantics.h
+++ b/H/cs_par_orc_semantics.h
@@ -24,6 +24,8 @@
 #ifndef __CSOUND_ORC_SEMANTIC_ANALYSIS_H__
 #define __CSOUND_ORC_SEMANTIC_ANALYSIS_H__
 
+#include "cs_par_base.h"
+
 #ifdef PARCS
 /*
  * This module maintains a list of instruments that have been parsed

--- a/H/diskin2.h
+++ b/H/diskin2.h
@@ -24,6 +24,7 @@
 #ifndef CSOUND_DISKIN2_H
 #define CSOUND_DISKIN2_H
 
+#include "csoundCore.h"
 #include "soundio.h"
 
 #define DISKIN2_MAXCHN  40              /* for consistency with soundin   */

--- a/H/disprep.h
+++ b/H/disprep.h
@@ -22,6 +22,7 @@
 */
 
                         /*                                      DISPREP.H       */
+#pragma once
 #include "pstream.h"
 
 typedef struct {

--- a/H/dumpf.h
+++ b/H/dumpf.h
@@ -22,6 +22,7 @@
 */
 
                                                         /*  DUMPF.H  */
+#pragma once
 typedef struct {
         OPDS   h;
         MYFLT  *ksig, *ifilcod, *iformat, *iprd;

--- a/H/entry1.h
+++ b/H/entry1.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-
+#pragma once
 #include "csoundCore.h"         /*                      ENTRY1.H        */
 #include "insert.h"
 #include "aops.h"

--- a/H/entry1.h
+++ b/H/entry1.h
@@ -21,43 +21,12 @@
     02110-1301 USA
 */
 #pragma once
-#include "csoundCore.h"         /*                      ENTRY1.H        */
-#include "insert.h"
-#include "aops.h"
-#include "midiops.h"
-#include "ugens1.h"
-#include "ugens2.h"
-#include "ugens3.h"
-#include "ugens4.h"
-#include "ugens5.h"
-#include "ugens6.h"
-#include "cwindow.h"
-#include "windin.h"
-#include "disprep.h"
-#include "soundio.h"
-#include "dumpf.h"
-#include "cmath.h"
+#include <stdint.h>
+
 #include "diskin2.h"
-#include "oload.h"
-#include "midiout.h"
-#include "sndinfUG.h"
-#include "ugrw1.h"
-#include "schedule.h"
-#include "vdelay.h"
+#include "csound.h"
 #include "pstream.h"
-#include "oscils.h"
-#include "midifile.h"
-#include "midiinterop.h"
-#include "linevent.h"
-#include "str_ops.h"
-#include "bus.h"
-#include "pstream.h"
-#include "remote.h"
-#include "resize.h"
-#include "cs_par_ops.h"
 #include "ugtabs.h"
-#include "compile_ops.h"
-#include "lpred.h"
 
 #define S(x)    sizeof(x)
 

--- a/H/insert.h
+++ b/H/insert.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-
+#pragma once
 typedef struct {                        /*       INSERT.H                */
     OPDS    h;
     LBLBLK  *lblblk;

--- a/H/lpc.h
+++ b/H/lpc.h
@@ -22,7 +22,7 @@
 */
 
 /*                                                                      LPC.H   */
-
+#pragma once
 #define LP_MAGIC    999
 #define LP_MAGIC2   2399           /* pole file type */
 #define LPBUFSIZ    4096           /* in lpanal */

--- a/H/midioops.h
+++ b/H/midioops.h
@@ -27,7 +27,7 @@
 /* **********************************************************************
  * Defines etc for the basic MIDI output codes
  * **********************************************************************/
-
+#pragma once
 #define MD_NOTEOFF      (0x80)
 #define MD_NOTEON       (0x90)
 #define MD_POLYAFTER    (0xa0)

--- a/H/midiout.h
+++ b/H/midiout.h
@@ -24,6 +24,7 @@
 /****************************************/
 /** midiout UGs by Gabriel Maldonado   **/
 /****************************************/
+#pragma once
 
 typedef int BOOL;
 #ifndef TRUE

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 /*  PROTOTYP.H  */
+#pragma once
+
 #if defined(__BUILDING_LIBCSOUND) && !defined(_CSOUND_PROTO_H)
 #define _CSOUND_PROTO_H
 #include <sysdep.h>

--- a/H/resize.h
+++ b/H/resize.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
     OPDS h;

--- a/H/schedule.h
+++ b/H/schedule.h
@@ -21,6 +21,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
         OPDS   h;

--- a/H/sndinfUG.h
+++ b/H/sndinfUG.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/H/sort.h
+++ b/H/sort.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include <stdio.h>                                 /*      SORT.H */
 #ifndef MYFLT

--- a/H/ugens1.h
+++ b/H/ugens1.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                         UGENS1.H        */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/ugens2.h
+++ b/H/ugens2.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                              UGENS2.H        */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/ugens3.h
+++ b/H/ugens3.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                              UGENS3.H        */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/ugens4.h
+++ b/H/ugens4.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                      UGENS4.H        */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/ugens5.h
+++ b/H/ugens5.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include "lpc.h"        /*                               UGENS5.H        */
 

--- a/H/ugens6.h
+++ b/H/ugens6.h
@@ -23,6 +23,7 @@
 */
 
 /*                                                      UGENS6.H        */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/ugens7.h
+++ b/H/ugens7.h
@@ -23,6 +23,7 @@
 */
 
 /*                                                      UGENS7.H        */
+#pragma once
 
 #define PFRAC1(x)   ((MYFLT)((x) & ftp1->lomask) * ftp1->lodiv)
 

--- a/H/ugrw1.h
+++ b/H/ugrw1.h
@@ -42,6 +42,7 @@
  * any alterations to the source code, including comments, are
  * clearly indicated as such.
  */
+#pragma once
 
 #include "csoundCore.h"
 

--- a/H/ugtabs.h
+++ b/H/ugtabs.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-
+#pragma once
 
 typedef struct _tabl {
   OPDS h;

--- a/H/vdelay.h
+++ b/H/vdelay.h
@@ -24,6 +24,7 @@
 /*      vdelay, multitap, reverb2 coded by Paris Smaragdis              */
 /*      Berklee College of Music Csound development team                */
 /*      Copyright (c) December 1994.  All rights reserved               */
+#pragma once
 
 typedef struct {
         OPDS    h;

--- a/H/winEPS.h
+++ b/H/winEPS.h
@@ -26,6 +26,8 @@
    /*                             */
 
   /* Open PS file & write header */
+#pragma once
+
 void PS_MakeGraph(CSOUND *csound, WINDAT *wdptr, const char *name);
   /* Make one plot per page      */
 void PS_DrawGraph(CSOUND *csound, WINDAT *wdptr);

--- a/H/windin.h
+++ b/H/windin.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                      WINDIN.H        */
+#pragma once
 
 typedef struct
     {

--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -22,6 +22,9 @@
 */
 
 #include <csoundCore.h>
+#include <string.h>
+
+#include "csound.h"
 
 typedef struct _circular_buffer {
   char *buffer;

--- a/InOut/ipmidi.c
+++ b/InOut/ipmidi.c
@@ -26,7 +26,6 @@
 /* Haiku 'int32' etc definitions in net headers conflict with sysdep.h */
 #define __HAIKU_CONFLICT
 
-#include <sys/types.h>
 #ifdef WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -38,10 +37,13 @@
 #include <arpa/inet.h>
 #endif
 #include <errno.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "csdl.h"                               /*      IPMIDI.C         */
-#include "midiops.h"
-#include "oload.h"
+#include "csound.h"
+#include "sysdep.h"
+#include "version.h"
 
 static int OpenMidiInDevice_(CSOUND *csound, void **userData, const char *dev)
 {

--- a/InOut/libmpadec/layer1.c
+++ b/InOut/libmpadec/layer1.c
@@ -19,7 +19,11 @@
 
 /* $Id: layer1.c,v 1.1.1.1 2004/07/27 02:57:18 metal_man Exp $ */
 
+#include <stdint.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 extern const uint32_t bitmask[17];
 extern alloc_table_t *alloc_tables[5];

--- a/InOut/libmpadec/layer2.c
+++ b/InOut/libmpadec/layer2.c
@@ -19,7 +19,11 @@
 
 /* $Id: layer2.c,v 1.2 2009/03/01 15:27:05 jpff Exp $ */
 
+#include <stdint.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 extern const uint32_t bitmask[17];
 extern alloc_table_t *alloc_tables[5];

--- a/InOut/libmpadec/layer3.c
+++ b/InOut/libmpadec/layer3.c
@@ -20,7 +20,12 @@
 
 /* $Id: layer3.c,v 1.3 2009/03/01 15:27:05 jpff Exp $ */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 extern const uint32_t bitmask[17];
 extern bandinfo_t band_info[];

--- a/InOut/libmpadec/mp3dec.c
+++ b/InOut/libmpadec/mp3dec.c
@@ -19,8 +19,17 @@
 
 /* $Id: mp3dec.c,v 1.6 2009/03/01 15:27:05 jpff Exp $ */
 
-#include "csoundCore.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
 #include "mp3dec_internal.h"
+#include "mp3dec.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 mp3dec_t mp3dec_init(void)
 {

--- a/InOut/libmpadec/mpadec.c
+++ b/InOut/libmpadec/mpadec.c
@@ -20,8 +20,13 @@
 /* $Id: mpadec.c,v 1.3 2009/03/01 15:27:05 jpff Exp $ */
 
 #include <stdlib.h>
-#include "csoundCore.h"
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 extern const uint16_t crc_table[256];
 extern void *synth_table[2][2][4][4];

--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -17,6 +17,8 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#pragma once
+
 /* Hardware architecture */
 //#define ARCH_ALPHA
 //#define ARCH_PPC

--- a/InOut/libmpadec/synth.c
+++ b/InOut/libmpadec/synth.c
@@ -19,7 +19,12 @@
 
 /* $Id: synth.c,v 1.3 2004/08/03 05:22:22 metal_man Exp $ */
 
+#include <math.h>
+#include <stdint.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 #define ROUND(x) (floor((x) + 0.5))
 #define LROUND(x) ((int32_t)(ROUND(x)))

--- a/InOut/libmpadec/tables.c
+++ b/InOut/libmpadec/tables.c
@@ -20,8 +20,12 @@
 /* $Id: tables.c,v 1.1.1.1 2004/07/27 02:58:48 metal_man Exp $ */
 
 #include <math.h>
-#include "csoundCore.h"
+#include <stddef.h>
+#include <stdint.h>
+
 #include "mpadec_internal.h"
+#include "mpadec.h"
+#include "sysdep.h"
 
 const uint16_t crc_table[256] = {
   0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011,

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -22,15 +22,17 @@
 */
 
 #include "csoundCore.h"                 /*             SNDLIB.C         */
-#include "soundio.h"
-#include <stdlib.h>
 #include <time.h>
 #include <inttypes.h>
-
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+#include "csound.h"
+#include "envvar.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 #ifdef PIPES
 # if defined(SGI) || defined(LINUX) || defined(__BEOS__) || defined(NeXT) ||  \
      defined(__MACH__)

--- a/InOut/libsnd_u.c
+++ b/InOut/libsnd_u.c
@@ -21,8 +21,18 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"
 #include "soundio.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 void rewriteheader(void *ofd)
 {

--- a/InOut/midifile.c
+++ b/InOut/midifile.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "midifile.h"
 #include <errno.h>
+#include "csound.h"
+#include "sysdep.h"
 
 static const char *midiFile_ID = "MThd";
 static const char *midiTrack_ID = "MTrk";

--- a/InOut/midirecv.c
+++ b/InOut/midirecv.c
@@ -100,9 +100,15 @@
                     const char *(*func)(int));
 */
 
+#include <stdio.h>
+
 #include "csoundCore.h"
 #include "midiops.h"
 #include "midifile.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "remote.h"
+#include "sysdep.h"
 
 #define MGLOB(x) (csound->midiGlobals->x)
 

--- a/InOut/midisend.c
+++ b/InOut/midisend.c
@@ -22,8 +22,15 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdio.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"                                 /*    MIDISEND.C    */
 #include "midioops.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 typedef struct midiOutFile_s {
     FILE            *f;

--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -25,11 +25,18 @@
 
 /* Realtime MIDI using Portmidi library */
 
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csdl.h"                               /*      PMIDI.C         */
 #include "csGblMtx.h"
-#include "midiops.h"
 #include <portmidi.h>
 #include <porttime.h>
+#include "csound.h"
+#include "sysdep.h"
+#include "version.h"
 
 /* Stub for compiling this file with MinGW and linking
    with portmidi.lib built with MSVC AND with Windows

--- a/InOut/rtalsa.c
+++ b/InOut/rtalsa.c
@@ -37,11 +37,6 @@
 #define _BSD_SOURCE 1
 #endif
 
-#include "csdl.h"
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/time.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/select.h>
@@ -50,13 +45,19 @@
 #include <stdio.h>
 #include <alsa/asoundlib.h>
 #include <sched.h>
-#include <unistd.h>
-#include <signal.h>
-#include <sys/mman.h>
 #include <sys/resource.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
-
-#include "soundio.h"
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
+#include "version.h"
 
 /* Modified from BSD sources for strlcpy */
 /*

--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -27,15 +27,20 @@
 #include <ctype.h>
 #include <sys/time.h>
 #include "alphanumcmp.h"
-
 /* no #ifdef, should always have these on systems where JACK is available */
-#include <unistd.h>
-#include <stdint.h>
+#include <jack/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "csound.h"
+#include "sysdep.h"
+#include "version.h"
+
 #ifdef LINUX
 #include <pthread.h>
 #endif
 #include "csdl.h"
-#include "soundio.h"
 #ifdef LINUX
 #include <sched.h>
 #endif

--- a/InOut/rtpa.c
+++ b/InOut/rtpa.c
@@ -25,10 +25,15 @@
 /*                                              RTPA.C for PortAudio    */
 
 #include "csdl.h"
-#if !defined(WIN32)
-#include "soundio.h"
-#endif
 #include <portaudio.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+
+#include "csound.h"
+#include "sysdep.h"
+#include "version.h"
 
 #define NO_FULLDUPLEX_PA_LOCK   0
 

--- a/InOut/rtpulse.c
+++ b/InOut/rtpulse.c
@@ -25,6 +25,12 @@
 #include <pulse/simple.h>
 #include <pulse/error.h>
 #include <string.h>
+#include <pulse/def.h>
+#include <pulse/sample.h>
+
+#include "csound.h"
+#include "sysdep.h"
+#include "version.h"
 
 typedef struct _pulse_params {
   pa_simple *ps;

--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -22,6 +22,7 @@
 */
 
 #include <soundfile.h>
+#include <sndfile.h>
 
 #if USE_LIBSNDFILE
 

--- a/InOut/winEPS.c
+++ b/InOut/winEPS.c
@@ -20,9 +20,13 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+
 #include "csoundCore.h"         /*                      WINEPS.C        */
 #include "cwindow.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /*--------------------------------------  winEPS.c ---------------------------
  *

--- a/InOut/winascii.c
+++ b/InOut/winascii.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"                         /*      winascii.c           */
 #include "cwindow.h"                            /*  teletype csound graphs   */
+#include "csound.h"
+#include "sysdep.h"
 
 #define HOR     80
 #define VER     20

--- a/InOut/windin.c
+++ b/InOut/windin.c
@@ -22,8 +22,8 @@
 */
 
 #include "csoundCore.h"         /*                           WINDIN.C   */
-#include "cwindow.h"
 #include "windin.h"             /* real-time input control units        */
+#include "csound.h"
                                 /* 26aug90 dpwe                         */
 
 int xyinset(CSOUND *csound, XYIN *p)

--- a/InOut/window.c
+++ b/InOut/window.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "csoundCore.h"                         /*      WINDOW.C        */
 #include "cwindow.h"                            /*  graph window mgr    */
 #include "winEPS.h"                             /* PostSCript routines  */
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
                                                 /*  dpwe 16may90        */
 
 extern OENTRY* find_opcode_new(CSOUND*, char*, char*, char*);

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -20,10 +20,16 @@
   02110-1301 USA
 */
 
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h" /*                                      AOPS.C  */
 #include "aops.h"
 #include <math.h>
-#include <time.h>
+#include "csound.h"
+#include "float-version.h"
+#include "sysdep.h"
 
 #define POW2TABSIZI 4096
 #if ULONG_MAX == 18446744073709551615UL
@@ -446,6 +452,7 @@ int32_t modak(CSOUND *csound, AOP *p)
 */
 #ifdef USE_SSE
 #include "emmintrin.h"
+
 #define AA_VEC(OPNAME,OP)                   \
 int32_t OPNAME(CSOUND *csound, AOP *p){     \
   MYFLT   *r, *a, *b;                       \

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -22,28 +22,34 @@
          02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/select.h>
+#include <unistd.h>
+
 /*                      BUS.C           */
 #include "csoundCore.h"
-#include <setjmp.h>
-#include <ctype.h>
 #include <string.h>
 #include <stdio.h>
+#include "arrays.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "pstream.h"
+#include "sysdep.h"
 
 #if defined(NACL) || defined(__wasi__)
 #include <sys/select.h>
 #endif
 
 #include "bus.h"
-#include "namedins.h"
 
 /* For sensing opcodes */
 #if defined(__unix) || defined(__unix__) || defined(__MACH__)
-#  ifdef HAVE_SYS_TIME_H
-#    include <sys/time.h>
-#  endif
-#  ifdef HAVE_SYS_TYPES_H
-#    include <sys/types.h>
-#  endif
 #  ifdef HAVE_TERMIOS_H
 #    include <termios.h>
 #  endif

--- a/OOps/cmath.c
+++ b/OOps/cmath.c
@@ -24,9 +24,14 @@
 /*      Math functions for Csound coded by Paris Smaragdis 1994         */
 /*      Berklee College of Music Csound development team                */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "cmath.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 int32_t ipow(CSOUND *csound, POW *p)        /*      Power for i-rate */
 {

--- a/OOps/compile_ops.c
+++ b/OOps/compile_ops.c
@@ -21,7 +21,11 @@
 */
 
 #include "compile_ops.h"
+
 #include <stdio.h>
+
+#include "csoundCore.h"
+
 int32_t csoundCompileOrcInternal(CSOUND *csound, const char *str, int32_t async);
 int32_t csoundReadScoreInternal(CSOUND *csound, const char *str);
 

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -21,11 +21,22 @@
   02110-1301 USA
 */
 
+#include <emmintrin.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"
-#include "soundio.h"
 #include "diskin2.h"
 #include <math.h>
 #include <inttypes.h>
+#include "csound.h"
+#include "csound_type_system.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 typedef struct DISKIN_INST_ {
   CSOUND *csound;

--- a/OOps/disprep.c
+++ b/OOps/disprep.c
@@ -21,10 +21,21 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      DISPREP.C       */
 #include <math.h>
 #include "cwindow.h"
 #include "disprep.h"
+#include "csound.h"
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "pstream.h"
+#include "sysdep.h"
 
 
 #ifdef MSVC                   /* Thanks to Richard Dobson */

--- a/OOps/dumpf.c
+++ b/OOps/dumpf.c
@@ -21,10 +21,17 @@
   02110-1301 USA
 */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"                              /*  DUMPF.C  */
 #include "dumpf.h"
 #include <ctype.h>
 #include <inttypes.h>
+#include "csound.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static const int32_t dumpf_format_table[9] = {
   0,

--- a/OOps/fftlib.c
+++ b/OOps/fftlib.c
@@ -29,11 +29,13 @@
 */
 
 #include <stdlib.h>
-#include <math.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
 #include "csound.h"
 #include "fftlib.h"
 #include "pffft.h"
+#include "sysdep.h"
 
 
 

--- a/OOps/goto_ops.c
+++ b/OOps/goto_ops.c
@@ -23,9 +23,18 @@
   02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h" /*                            GOTO_OPS.C        */
 #include "insert.h"     /* for goto's */
 #include "aops.h"       /* for cond's */
+#include "csound.h"
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 extern int32_t strarg2insno(CSOUND *, void *p, int32_t is_string);
 
 int32_t igoto(CSOUND *csound, GOTO *p)

--- a/OOps/lpred.c
+++ b/OOps/lpred.c
@@ -19,10 +19,15 @@
 
 #include <stdlib.h>
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound.h"
 #include "fftlib.h"
 #include "lpred.h"
+#include "pstream.h"
+#include "sysdep.h"
 
 static inline MYFLT magc(MYCMPLX c) {
   return HYPOT(c.re, c.im);

--- a/OOps/midiinterop.c
+++ b/OOps/midiinterop.c
@@ -21,9 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+
 #include "csoundCore.h"
 #include "midiinterop.h"
-#include "math.h"
+#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define dv127   (FL(1.0)/FL(127.0))
 

--- a/OOps/midiops.c
+++ b/OOps/midiops.c
@@ -22,12 +22,18 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "csoundCore.h"                                 /*      MIDIOPS.C   */
 #include "midiops.h"
 #include <math.h>
 #include <time.h>
 #include "namedins.h"           /* IV - Oct 31 2002 */
 #include "arrays.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define dv127   (FL(1.0)/FL(127.0))
 

--- a/OOps/midiout.c
+++ b/OOps/midiout.c
@@ -27,9 +27,14 @@
 
 /* Some modifications by JPff for general use */
 
-#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "midiout.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define MGLOB(x) (((CSOUND*)csound)->midiGlobals->x)
 

--- a/OOps/mxfft.c
+++ b/OOps/mxfft.c
@@ -21,6 +21,9 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdlib.h>
+
 /* This program converted from the FORTRAN routines by Singleton in
  * Section 1.4 of  "Programs for Digital Signal Processing", IEEE Press, 1979.
  *  Conversion by Trevor Wishart and Keith Henderson, York Univ.
@@ -86,6 +89,8 @@ static char *rcsid = "$Id$";
 #include "csoundCore.h"
 #include <math.h>
 #include <assert.h>
+#include "csound.h"
+#include "sysdep.h"
 
 static void fft_(CSOUND *,MYFLT *, MYFLT *, int32_t, int32_t, int32_t, int32_t);
 static void fftmx(MYFLT *, MYFLT *, int32_t, int32_t, int32_t, int32_t, int32_t,

--- a/OOps/oscils.c
+++ b/OOps/oscils.c
@@ -23,8 +23,14 @@
 
 /* ------ oscils, lphasor, and tablexkt by Istvan Varga (Jan 5 2002) ------ */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
+
 #define CSOUND_OSCILS_C 1
 #include "oscils.h"
 

--- a/OOps/pstream.c
+++ b/OOps/pstream.c
@@ -26,9 +26,14 @@
    pvsops.c for everythng else, under ????
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "pstream.h"
-#include "pvfileio.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #ifdef _DEBUG
 #include <assert.h>

--- a/OOps/pvfileio.c
+++ b/OOps/pvfileio.c
@@ -55,8 +55,15 @@
    as only 32bit floats supported at present.
  */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"
 #include "pvfileio.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #if !defined(WAVE_FORMAT_EXTENSIBLE)
 #define WAVE_FORMAT_EXTENSIBLE  (0xFFFE)

--- a/OOps/pvsanal.c
+++ b/OOps/pvsanal.c
@@ -27,8 +27,13 @@
 */
 
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "pstream.h"
+#include "csound.h"
+#include "sysdep.h"
 
         double  besseli(double x);
 static  void    hamming(MYFLT *win, int32_t winLen, int32_t even);

--- a/OOps/random.c
+++ b/OOps/random.c
@@ -40,7 +40,12 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* simple linear congruential generator */
 

--- a/OOps/remote.c
+++ b/OOps/remote.c
@@ -22,8 +22,21 @@
     02110-1301 USA
 */
 
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include "csoundCore.h"
 #include "remote.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* Somewhat revised from the original.  Pete G. Nov 2012
    More correct, I think, but I could be wrong... (:-/)
@@ -63,9 +76,6 @@ void remoteRESET(CSOUND *csound)
 }
 
 #if defined(HAVE_SOCKETS)
-#if !defined(WIN32) || defined(__CYGWIN__)
-#include <netdb.h>
-#endif
 #if 0
 static int32_t foo(char *ipaddr)
 {

--- a/OOps/schedule.c
+++ b/OOps/schedule.c
@@ -22,10 +22,18 @@
     02110-1301 USA
 */
 
-#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "namedins.h"
 #include "linevent.h"
+#include "csound.h"
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "prototyp.h"
+#include "sysdep.h"
 /* Keep Microsoft's schedule.h from being used instead of our schedule.h. */
 #ifdef _MSC_VER
 #include "H/schedule.h"

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -25,11 +25,20 @@
 /* sndinfUG.c         -matt 7/25/99
              ugens to retrieve info about a sound file */
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "soundio.h"
 #include "sndinfUG.h"
 #include "pvfileio.h"
 #include "convolve.h"
+#include "csound.h"
+#include "envvar.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 static int32_t getsndinfo(CSOUND *csound, SNDINFO *p, SFLIB_INFO *hdr, int32_t strin)
 {

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -24,7 +24,16 @@
 */
 
 #include "csoundCore.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 #define CSOUND_STR_OPS_C    1
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include "str_ops.h"
 #include <ctype.h>
 #ifdef HAVE_CURL

--- a/OOps/ugens1.c
+++ b/OOps/ugens1.c
@@ -21,9 +21,17 @@
     02110-1301 USA
 */
 
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      UGENS1.C        */
 #include "ugens1.h"
 #include <math.h>
+#include "csound.h"
+#include "csound_type_system.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #define FHUND (FL(100.0))
 

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h" /*                              UGENS2.C        */
 #include "ugens2.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /* Macro form of Istvan's speedup ; constant should be 3fefffffffffffff */
 /* #define FLOOR(x) (x >= FL(0.0) ? (int64_t)x                          */

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -21,9 +21,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                              UGENS3.C    */
 #include "ugens3.h"
 #include <math.h>
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 int32_t foscset(CSOUND *csound, FOSC *p)
 {

--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -21,10 +21,14 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 #include "csoundCore.h"         /*                      UGENS4.C        */
 #include "ugens4.h"
-#include <math.h>
 #include <inttypes.h>
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /* The branch prediction slows it down!! */
 

--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -21,10 +21,17 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      UGENS5.C        */
 #include "ugens5.h"
 #include <math.h>
 #include <inttypes.h>
+#include "csound.h"
+#include "lpc.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /*
  * LPC storage slots

--- a/OOps/ugens6.c
+++ b/OOps/ugens6.c
@@ -22,9 +22,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h" /*                              UGENS6.C        */
 #include "ugens6.h"
 #include <math.h>
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #define log001 (-FL(6.9078))    /* log(.001) */
 

--- a/OOps/ugrw1.c
+++ b/OOps/ugrw1.c
@@ -44,10 +44,19 @@
  * clearly indicated as such.
  */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "ugrw1.h"
-#include <math.h>
 #include <ctype.h>
+#include "csound.h"
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 /*****************************************************************************/
 /*****************************************************************************/

--- a/OOps/ugtabs.c
+++ b/OOps/ugtabs.c
@@ -21,10 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "ugtabs.h"
-#include "ugens2.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 //(x >= FL(0.0) ? (int32_t)x : (int32_t)((double)x - 0.99999999))
 #define MYFLOOR(x) FLOOR(x)

--- a/OOps/vdelay.c
+++ b/OOps/vdelay.c
@@ -26,10 +26,15 @@
 /*      Berklee College of Music Csound development team        */
 /*      Copyright (c) May 1994.  All rights reserved            */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 
 #include <math.h>
 #include "vdelay.h"
+#include "csound.h"
+#include "sysdep.h"
 
 //#define ESR     (csound->esr/FL(1000.0))
 #define ESR     (csound->esr*FL(0.001))

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -28,6 +28,13 @@
 #include "csdl.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
+#include "version.h"
 #ifdef HAVE_UNISTD_H
     #include <unistd.h>
 #endif

--- a/Opcodes/Vosim.c
+++ b/Opcodes/Vosim.c
@@ -37,11 +37,15 @@
  * a new pulse should start, and that pulseinc can be negative.
  */
 
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
-#include <math.h>
 #include <limits.h>
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS h;

--- a/Opcodes/afilters.c
+++ b/Opcodes/afilters.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      AFILTERS.C        */
 #include "ugens5.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 extern int32_t rsnset(CSOUND *csound, RESON *p);
 

--- a/Opcodes/ambicode.c
+++ b/Opcodes/ambicode.c
@@ -21,9 +21,14 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;                                      /* required header */

--- a/Opcodes/ambicode1.c
+++ b/Opcodes/ambicode1.c
@@ -29,9 +29,14 @@
 */
 
 #include "csoundCore.h"
-#include "interlocks.h"
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+
+#include "csound.h"
+#include "sysdep.h"
 
 /* ------------------------------------------------------------------------- */
 

--- a/Opcodes/ampmidid.cpp
+++ b/Opcodes/ampmidid.cpp
@@ -22,6 +22,9 @@
  */
 #include <cmath>
 #include "OpcodeBase.hpp"
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 using namespace csound;
 

--- a/Opcodes/arrayops.cpp
+++ b/Opcodes/arrayops.cpp
@@ -25,6 +25,10 @@
 #include <numeric>
 #include <plugin.h>
 
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
+
 
 inline MYFLT logb(MYFLT a, MYFLT b) {
   return log(a)/log(b);
@@ -209,6 +213,7 @@ template <typename T, int I> struct Accum : csnd::Plugin<1, 1> {
 
 
 #include <modload.h>
+
 void csnd::on_load(Csound *csound) {
   csnd::plugin<ArrayOp<lim1>>(csound, "limit1", "i[]", "i[]", csnd::thread::i);
   csnd::plugin<ArrayOp<lim1>>(csound, "limit1", "k[]", "k[]", csnd::thread::ik);

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -25,6 +25,10 @@
 #include "interlocks.h"
 #include "aops.h"
 #include "find_opcode.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 extern MYFLT MOD(MYFLT a, MYFLT bb);
 
@@ -154,6 +158,11 @@ static int32_t tabfill(CSOUND *csound, TABFILL *p)
 }
 
 #include <ctype.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static MYFLT nextval(FILE *f)
 {

--- a/Opcodes/babo.c
+++ b/Opcodes/babo.c
@@ -123,11 +123,15 @@ input  |    |------>|
                     Move static fn declarations out of function
  */
 
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include "babo.h"
 #include <math.h>
 #include "interlocks.h"
+#include "csound.h"
 
 #if !defined(FLT_MAX)
 #define FLT_MAX         (1.0e38)

--- a/Opcodes/babo.h
+++ b/Opcodes/babo.h
@@ -38,6 +38,11 @@
 #if !defined(__babo_h__)
 #   define  __babo_h__
 
+#include <stddef.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define BABO_NODES     (15) /* Number of nodes of feedback delay network    */
 #define BABO_TAPS       (6) /* Number of taps in the early reflections line */
 

--- a/Opcodes/bbcut.c
+++ b/Opcodes/bbcut.c
@@ -20,10 +20,11 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
 #include "bbcut.h"
-#include <math.h>
+#include "csound.h"
 
 /* my auxilliary functions */
 

--- a/Opcodes/bbcut.h
+++ b/Opcodes/bbcut.h
@@ -38,6 +38,11 @@
 #if !defined(__bbcut_h__)
 #   define  __bbcut_h__
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 /* Csound ugen struct- can't use same struct for Mono and Stereo version */
 typedef struct {
       OPDS  h;                              /* defined in cs.h */

--- a/Opcodes/bformdec2.cpp
+++ b/Opcodes/bformdec2.cpp
@@ -22,12 +22,15 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
+#include <new>
+#include <cmath>
+
 //#include <unistd.h>
 #include "csdl.h"
-#include <math.h>
-#include "csoundCore.h"
 #include <string.h>
-#include <new>
+#include "csound.h"
+#include "sysdep.h"
 
 
 /* Band-splitting constants */

--- a/Opcodes/bilbar.c
+++ b/Opcodes/bilbar.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /* %% bar sound synthesis translated from Mathlab and much changed */
 

--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -32,8 +32,13 @@
 /***************************************************************/
 //#include "csdl.h"
 #include <math.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "biquad.h"
-#include "csound_standard_types.h"
+#include "Opcodes/stdopcod.h"
+#include "csound.h"
+#include "interlocks.h"
 
 /***************************************************************************/
 /* The biquadratic filter computes the digital filter two x components and */

--- a/Opcodes/biquad.h
+++ b/Opcodes/biquad.h
@@ -26,7 +26,10 @@
                                                         /* biquad.h */
 #pragma once
 
-#include "stdopcod.h"
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
 
                                 /* Structure for biquadratic filter */
 typedef struct {

--- a/Opcodes/biquad.h
+++ b/Opcodes/biquad.h
@@ -24,6 +24,8 @@
 */
 
                                                         /* biquad.h */
+#pragma once
+
 #include "stdopcod.h"
 
                                 /* Structure for biquadratic filter */

--- a/Opcodes/bowedbar.c
+++ b/Opcodes/bowedbar.c
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 /*********************************************/
 /*  Bowed Bar model                          */
 /*  by Georg Essl, 1999                      */
@@ -32,6 +34,9 @@
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "bowedbar.h"
+#include "Opcodes/bowed.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
 
 /* Number of banded waveguide modes */
 

--- a/Opcodes/bowedbar.h
+++ b/Opcodes/bowedbar.h
@@ -34,8 +34,12 @@
 #define __BowedBar_h
 #define NR_MODES (4)
 
+#include <stdint.h>
+
 #include "physutil.h"
 #include "bowed.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 /*******************************************/
 /*  Non-Interpolating Delay Line           */

--- a/Opcodes/buchla.c
+++ b/Opcodes/buchla.c
@@ -21,8 +21,14 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
                                                         /* buchla.c */
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 #ifdef MSVC
 #define _USE_MATH_DEFINES
 #include <math.h>

--- a/Opcodes/butter.c
+++ b/Opcodes/butter.c
@@ -26,6 +26,9 @@
 /*              Copyright (c) May 1994.  All rights reserved            */
 
 #include "stdopcod.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct  {
         OPDS    h;
@@ -42,6 +45,8 @@ typedef struct  {
 } BBFIL;
 
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
 //#define ROOT2 (1.4142135623730950488)
 
 static void butter_filter(uint32_t, uint32_t, MYFLT *, MYFLT *, double *);

--- a/Opcodes/cellular.c
+++ b/Opcodes/cellular.c
@@ -22,8 +22,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 // classical 1-D Cellular Automaton by Gleb Rogozinsky.
 // It is the modified version of vcella opcode by Gabriel Maldonado

--- a/Opcodes/clfilt.c
+++ b/Opcodes/clfilt.c
@@ -34,8 +34,11 @@
 /***************************************************************/
 
 #include <math.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "clfilt.h"
+#include "csound.h"
 
 static int32_t clfiltset(CSOUND *csound, CLFILT *p)
 {

--- a/Opcodes/clfilt.h
+++ b/Opcodes/clfilt.h
@@ -24,6 +24,11 @@
                                                         /* clfilt.h */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define CL_LIM 40  /* The limit on the number of biquadratic sections */
 
                                 /* Structure for biquadratic filter */

--- a/Opcodes/clfilt.h
+++ b/Opcodes/clfilt.h
@@ -22,6 +22,7 @@
 */
 
                                                         /* clfilt.h */
+#pragma once
 
 #define CL_LIM 40  /* The limit on the number of biquadratic sections */
 

--- a/Opcodes/compress.c
+++ b/Opcodes/compress.c
@@ -21,9 +21,15 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/control.c
+++ b/Opcodes/control.c
@@ -21,11 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdlib.h>
+#include <sys/select.h>
+#include <unistd.h>
+
 #include "csdl.h"
 #include "control.h"
 
-#include <sys/time.h>
-#include <sys/types.h>
 #include <signal.h>
 
 #if defined(__MACH__)

--- a/Opcodes/control.h
+++ b/Opcodes/control.h
@@ -25,6 +25,8 @@
 /* Controls                                 */
 /********************************************/
 
+#pragma once
+
 #include "csdl.h"
 
 typedef struct CONTROL_GLOBALS_ {

--- a/Opcodes/control.h
+++ b/Opcodes/control.h
@@ -27,7 +27,12 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <stdio.h>
+
 #include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct CONTROL_GLOBALS_ {
     CSOUND  *csound;

--- a/Opcodes/counter.c
+++ b/Opcodes/counter.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"       /*                              COUNTER.C         */
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* Structure of a counter */
 typedef struct {

--- a/Opcodes/cpumeter.c
+++ b/Opcodes/cpumeter.c
@@ -19,21 +19,13 @@
 #ifndef WIN32
 
 #include "csoundCore.h"
-#include <time.h>
-#include <sys/resource.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <ctype.h>
 #include <errno.h>
-#include <stdarg.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
-#include <unistd.h>
-#include <limits.h>
-#include <float.h>
+#include "csound.h"
+#include "sysdep.h"
 
 // only available on Linux (no /proc/stat on OSX)
 #if defined(LINUX)

--- a/Opcodes/cross2.c
+++ b/Opcodes/cross2.c
@@ -21,11 +21,16 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "ptrigtbl.h"
 #include "fhtfun.h"
 #include "interlocks.h"
-#include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define CH_THRESH       1.19209e-7
 #define CHOP(a) (a < CH_THRESH ? CH_THRESH : a)

--- a/Opcodes/crossfm.c
+++ b/Opcodes/crossfm.c
@@ -21,10 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
 #include "crossfm.h"
-#include <math.h>
+#include "csound.h"
 
 int32_t xfmset(CSOUND *csound, CROSSFM *p)
 {

--- a/Opcodes/crossfm.h
+++ b/Opcodes/crossfm.h
@@ -48,6 +48,9 @@
 /*********************************************************************/
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
   OPDS h;                                     /* common to all opcodes */
 

--- a/Opcodes/crossfm.h
+++ b/Opcodes/crossfm.h
@@ -46,6 +46,7 @@
 /* iphs2 - optional, initial phase of waveform in table #2           */
 /*                                                                   */
 /*********************************************************************/
+#pragma once
 
 typedef struct {
   OPDS h;                                     /* common to all opcodes */

--- a/Opcodes/dam.c
+++ b/Opcodes/dam.c
@@ -21,9 +21,12 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "dam.h"
-#include <math.h>
+#include "csound.h"
 
 
 /*

--- a/Opcodes/dam.h
+++ b/Opcodes/dam.h
@@ -22,7 +22,8 @@
 */
 #pragma once
 
-#include "csdl.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define POWER_BUFSIZE 1000
 

--- a/Opcodes/dam.h
+++ b/Opcodes/dam.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include "csdl.h"
 

--- a/Opcodes/date.c
+++ b/Opcodes/date.c
@@ -21,8 +21,16 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csoundCore.h"
 #include <time.h>
+#include "csound.h"
+#include "float-version.h"
+#include "sysdep.h"
 
 #ifndef __wasi__
 #include <errno.h>

--- a/Opcodes/dcblockr.c
+++ b/Opcodes/dcblockr.c
@@ -31,8 +31,12 @@
 /*  structures.                            */
 /*******************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "dcblockr.h"
+#include "csound.h"
 
 static int32_t dcblockrset(CSOUND *csound, DCBlocker* p)
 {

--- a/Opcodes/dcblockr.h
+++ b/Opcodes/dcblockr.h
@@ -22,6 +22,9 @@
 */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct DCBlocker {
     OPDS        h;
     MYFLT       *ar, *in, *gg;

--- a/Opcodes/dcblockr.h
+++ b/Opcodes/dcblockr.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct DCBlocker {
     OPDS        h;

--- a/Opcodes/deprecated.c
+++ b/Opcodes/deprecated.c
@@ -19,9 +19,17 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csdl.h"
 #include "interlocks.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
+
+struct CsoundArgStack_s;
 
 /**    
  stackops: copyright (C) 2006 Istvan Varga

--- a/Opcodes/doppler.cpp
+++ b/Opcodes/doppler.cpp
@@ -22,9 +22,16 @@
  */
 
 #include "OpcodeBase.hpp"
+#include "csdl.h"
+#include <stddef.h>
+#include <stdint.h>
 #include <cmath>
 #include <list>
 #include <vector>
+#include <algorithm>
+
+#include "csound.h"
+#include "sysdep.h"
 
 
 #ifndef M_PI

--- a/Opcodes/dsputil.c
+++ b/Opcodes/dsputil.c
@@ -28,8 +28,14 @@
 /* 20apr90 dpwe                                                   */
 /******************************************************************/
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "pvoc.h"
-#include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+#include "dsputil.h"
 
 /* Do we do the whole buffer, or just indep vals? */
 #define someof(s)       (s)

--- a/Opcodes/dsputil.h
+++ b/Opcodes/dsputil.h
@@ -30,6 +30,12 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include "Opcodes/pvoc.h"
+#include "csound.h"
+#include "sysdep.h"
+
 #define     SPTS    (16)    /* SINC TABLE: How many points in each lobe   */
 #define     SPDS    (6)     /*   (was 8)   How many sinc lobes to go out  */
 #define     SBW     0.9     /* To compensate for short sinc, reduce bandw */

--- a/Opcodes/dsputil.h
+++ b/Opcodes/dsputil.h
@@ -28,6 +28,8 @@
 /* 20apr90 dpwe                                                 */
 /****************************************************************/
 
+#pragma once
+
 #define     SPTS    (16)    /* SINC TABLE: How many points in each lobe   */
 #define     SPDS    (6)     /*   (was 8)   How many sinc lobes to go out  */
 #define     SBW     0.9     /* To compensate for short sinc, reduce bandw */

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -22,10 +22,20 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "emugens_common.h"
 #include "interlocks.h"
 #include "arrays.h"
 #include <ctype.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "csound_type_system.h"
+#include "msg_attr.h"
+#include "sysdep.h"
 
 #define SAMPLE_ACCURATE \
     uint32_t n, nsmps = CS_KSMPS;                                    \

--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -23,7 +23,13 @@
 */
 
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "emugens_common.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define LOG001 FL(-6.907755278982137)
 #define CALCSLOPE(next,prev,nsmps) ((next - prev)/nsmps)

--- a/Opcodes/eqfil.c
+++ b/Opcodes/eqfil.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct _equ {
   OPDS h;

--- a/Opcodes/exciter.c
+++ b/Opcodes/exciter.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"       /*                    EXCITER.C         */
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /**********************************************************************
  * EXCITER by Markus Schmidt

--- a/Opcodes/fareygen.c
+++ b/Opcodes/fareygen.c
@@ -21,8 +21,12 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define MAX_PFACTOR 16
 static const int32_t MAX_PRIMES = 168; /* 168 primes < 1000 */

--- a/Opcodes/fareyseq.c
+++ b/Opcodes/fareyseq.c
@@ -26,10 +26,16 @@
     by Robin Whittle, see source OOps/ugrw1.c
 */
 
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
 #include <math.h>
 #include <time.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define MAX_PFACTOR 16
 const int32_t MAX_PRIMES = 1229;

--- a/Opcodes/fhtfun.h
+++ b/Opcodes/fhtfun.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct{
     OPDS          h;
     MYFLT         *out, *as, *af, *len, *ovlp, *iwin, *bias;

--- a/Opcodes/fhtfun.h
+++ b/Opcodes/fhtfun.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "csoundCore.h"
+
 typedef struct{
     OPDS          h;
     MYFLT         *out, *as, *af, *len, *ovlp, *iwin, *bias;

--- a/Opcodes/filter.c
+++ b/Opcodes/filter.c
@@ -131,10 +131,12 @@
  * Main changes are to work in double precision internally */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "stdopcod.h"
 #include "filter.h"
 #include <math.h>
+#include "csound.h"
 
 typedef struct FCOMPLEX {double r,i;} fcomplex;
 

--- a/Opcodes/filter.h
+++ b/Opcodes/filter.h
@@ -32,6 +32,11 @@
 #ifndef __filter_h
 #define __filter_h
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define MAXZEROS 50 /* Allow up to 50th-order digital filters */
 #define MAXPOLES 50
 

--- a/Opcodes/flanger.c
+++ b/Opcodes/flanger.c
@@ -23,7 +23,11 @@
 
 #include "stdopcod.h"               /* Flanger by Maldonado, with coding
                                    enhancements by JPff -- July 1998 */
+#include "csound.h"
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "flanger.h"
 
 static int32_t flanger_set (CSOUND *csound, FLANGER *p)

--- a/Opcodes/flanger.h
+++ b/Opcodes/flanger.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *xdel, *kfeedback, *maxd, *iskip;

--- a/Opcodes/flanger.h
+++ b/Opcodes/flanger.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *xdel, *kfeedback, *maxd, *iskip;

--- a/Opcodes/fm4op.c
+++ b/Opcodes/fm4op.c
@@ -34,8 +34,13 @@
 /*                                                       */
 /*********************************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "fm4op.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
 
 /***********************************************************/
 /*  Two Zero Filter Class,                                 */

--- a/Opcodes/fm4op.h
+++ b/Opcodes/fm4op.h
@@ -40,6 +40,8 @@
 #define __FM4OP_h
 
 #include "physutil.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 /*******************************************/
 /*  Two Zero Filter Class,                 */

--- a/Opcodes/follow.c
+++ b/Opcodes/follow.c
@@ -26,9 +26,12 @@
         /*      Copyright (c) August 1994.  All rights reserve */
         /*      Improvements 1999 John ffitch */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
-#include <math.h>
 #include "follow.h"
+#include "csound.h"
 
 static int32_t flwset(CSOUND *csound, FOL *p)
 {

--- a/Opcodes/follow.h
+++ b/Opcodes/follow.h
@@ -25,6 +25,8 @@
 /*              Berklee College of Music Csound development team        */
 /*              Copyright (c) August 1994.  All rights reserved         */
 
+#pragma once
+
 typedef struct  {
         OPDS            h;
         MYFLT           *out, *in, *len;

--- a/Opcodes/follow.h
+++ b/Opcodes/follow.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct  {
         OPDS            h;
         MYFLT           *out, *in, *len;

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -26,10 +26,21 @@
 /* Code modified by JPff to remove fixed size arrays, allow
    AIFF and WAV, and close files neatly.  Also bugs fixed */
 
+#include <sndfile.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "stdopcod.h"
 #include "fout.h"
-#include "soundio.h"
 #include <ctype.h>
+#include "csound.h"
+#include "csound_type_system.h"
+#include "envvar.h"
+#include "float-version.h"
+#include "interlocks.h"
+#include "prototyp.h"
+#include "soundfile.h"
 
 /* remove a file reference, optionally closing the file */
 

--- a/Opcodes/fout.h
+++ b/Opcodes/fout.h
@@ -24,7 +24,11 @@
 #ifndef FOUT_H
 #define FOUT_H
 
-#include "stdopcod.h"
+#include <stdint.h>
+#include <stdio.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct FOUT_FILE_ {
     OPDS    h;

--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -24,8 +24,14 @@
  02110-1301 USA
  */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
     typedef struct OLABuffer {
 

--- a/Opcodes/freeverb.c
+++ b/Opcodes/freeverb.c
@@ -21,8 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define DEFAULT_SRATE   44100.0
 #define STEREO_SPREAD   23.0

--- a/Opcodes/ftconv.c
+++ b/Opcodes/ftconv.c
@@ -21,8 +21,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
-#include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 #define FTCONV_MAXCHN   8
 

--- a/Opcodes/ftest.c
+++ b/Opcodes/ftest.c
@@ -22,9 +22,13 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 static int32_t tanhtable(FGDATA *ff, FUNC *ftp)
 {

--- a/Opcodes/ftgen.c
+++ b/Opcodes/ftgen.c
@@ -17,11 +17,17 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "stdopcod.h"
-#include <ctype.h>
-#include <stdarg.h>
-#include "soundio.h"
-#include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/ftsamplebank.cpp
+++ b/Opcodes/ftsamplebank.cpp
@@ -19,15 +19,19 @@
     02110-1301 USA
  */
 
+#include <string.h>
 #include <algorithm>
-#include <cmath>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <memory>
+
 #include "OpcodeBase.hpp"
 #include <dirent.h>
-#include <sys/types.h>
+#include "csdl.h"
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
 using namespace std;
 using namespace csound;

--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -29,10 +29,13 @@
 /*Check other opcodes commented out in Oentry */
 
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "gab.h"
 #include <math.h>
 #include "interlocks.h"
+#include "csound.h"
 
 #define FLT_MAX ((MYFLT)0x7fffffff)
 

--- a/Opcodes/gab/gab.h
+++ b/Opcodes/gab/gab.h
@@ -21,9 +21,10 @@
 #ifndef GAB_H
 #define GAB_H
 
-#include "../stdopcod.h"
-#include "H/ugrw1.h"    /* for zread function */
-#include "ugens6.h"     /* for a_k_set function */
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/gab/hvs.c
+++ b/Opcodes/gab/hvs.c
@@ -16,9 +16,14 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 
 /* -------------------------------------------------------------------- */

--- a/Opcodes/gab/newgabopc.c
+++ b/Opcodes/gab/newgabopc.c
@@ -16,8 +16,13 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* (Shouldn't there be global decl's for these?) */
 #define INCR (0.001f)
@@ -299,8 +304,6 @@ static int32_t lposca_stereo_no_trasp(CSOUND *csound, LPOSC_ST *p)
 
 
 /* -------------------------------------------------------------------- */
-
-#include "vectorial.h"
 
 typedef struct  {       /* gab d5*/
         OPDS    h;

--- a/Opcodes/gab/sliderTable.c
+++ b/Opcodes/gab/sliderTable.c
@@ -16,10 +16,15 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define f7bit       (FL(127.0))
 #define oneTOf7bit  (MYFLT)(1.0/127.0)

--- a/Opcodes/gab/tabmorph.c
+++ b/Opcodes/gab/tabmorph.c
@@ -16,8 +16,13 @@
   02110-1301 USA
 */
 //#include "csdl.h"
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/gab/vectorial.c
+++ b/Opcodes/gab/vectorial.c
@@ -21,11 +21,14 @@
     and Istvan Varga.
 */
 //#include "stdopcod.h"
+#include <inttypes.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
 #include "vectorial.h"
 #include <math.h>
-#include <inttypes.h>
+#include "csound.h"
 
 static int32_t mtable_i(CSOUND *csound,MTABLEI *p)
 {

--- a/Opcodes/gab/vectorial.h
+++ b/Opcodes/gab/vectorial.h
@@ -21,6 +21,11 @@
 #ifndef GAB_VECTORIAL_H
 #define GAB_VECTORIAL_H
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 /* The follwoing from CsoundAV/newopcodes.h */
 typedef struct {
     OPDS    h;

--- a/Opcodes/gammatone.c
+++ b/Opcodes/gammatone.c
@@ -22,8 +22,12 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/gendy.c
+++ b/Opcodes/gendy.c
@@ -26,7 +26,12 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/grain.c
+++ b/Opcodes/grain.c
@@ -27,8 +27,13 @@
 
 /* Some speed hacks added by John Fitch */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "grain.h"
+#include "csound.h"
+#include "interlocks.h"
 
 static inline MYFLT Unirand(CSOUND *csound, MYFLT a)
 {

--- a/Opcodes/grain.h
+++ b/Opcodes/grain.h
@@ -25,6 +25,8 @@
 /*      Berklee College of Music Csound development team                */
 /*      Copyright (c) May 1994.  All rights reserved                    */
 
+#pragma once
+
 typedef struct {
     OPDS        h;
     MYFLT       *sr, *xamp, *xlfr, *xdns, *kabnd, *kbnd, *kglen;

--- a/Opcodes/grain.h
+++ b/Opcodes/grain.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS        h;
     MYFLT       *sr, *xamp, *xlfr, *xdns, *kabnd, *kbnd, *kglen;

--- a/Opcodes/grain4.c
+++ b/Opcodes/grain4.c
@@ -33,11 +33,14 @@
 /*        envelop rise and decade curve                 */
 /* Minor changes by John Fitch Dec 1995                 */
 
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
 #include "grain4.h"
 #include <math.h>
+#include "csound.h"
 
 #define        RNDMUL  15625L
 

--- a/Opcodes/grain4.h
+++ b/Opcodes/grain4.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define MAXVOICE 128
 
 typedef struct {

--- a/Opcodes/grain4.h
+++ b/Opcodes/grain4.h
@@ -23,6 +23,11 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define MAXVOICE 128
 
 typedef struct {

--- a/Opcodes/harmon.c
+++ b/Opcodes/harmon.c
@@ -21,10 +21,12 @@
     02110-1301 USA
 */
 
-#include "csoundCore.h"
-#include "interlocks.h"
+#include <stdint.h>
+#include <string.h>
 
-#include <math.h>
+#include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         MYFLT   *srcp;

--- a/Opcodes/hrtfearly.c
+++ b/Opcodes/hrtfearly.c
@@ -21,9 +21,15 @@
   02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 /* #include "csdl.h" */
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #ifdef __FAST_MATH__
 #undef __FAST_MATH__

--- a/Opcodes/hrtferX.c
+++ b/Opcodes/hrtferX.c
@@ -50,13 +50,18 @@
  * the old and new HRTFs (probably a project in itself).
  ***************************************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
 #include <stdio.h>
 #include <math.h>
-#include <stdlib.h>
 #include "hrtferx.h"
+#include "Opcodes/3Dug.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* This array transferred here so as to be declared once.  Belongs to
    the structure of the HRTF data really in 3Dug.h */

--- a/Opcodes/hrtferx.h
+++ b/Opcodes/hrtferx.h
@@ -23,6 +23,8 @@
 
 /****************** hrtferxk.h *******************/
 
+#pragma once
+
 #include "3Dug.h"
 
 typedef struct {

--- a/Opcodes/hrtfopcodes.c
+++ b/Opcodes/hrtfopcodes.c
@@ -21,10 +21,13 @@
     02110-1301 USA
 */
 
-#include "csoundCore.h"
-#include "interlocks.h"
+#include <stdint.h>
+#include <string.h>
 
-#include <math.h>
+#include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
+
 /* definitions */
 /* from mit */
 #define minelev (-40)

--- a/Opcodes/hrtfreverb.c
+++ b/Opcodes/hrtfreverb.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define SQUARE(X) ((X)*(X))
 

--- a/Opcodes/ifd.c
+++ b/Opcodes/ifd.c
@@ -38,8 +38,15 @@
 
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct _ifd {
   OPDS    h;

--- a/Opcodes/lfsr.cpp
+++ b/Opcodes/lfsr.cpp
@@ -84,6 +84,8 @@
 
 #include <time.h>
 #include <plugin.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 struct LFSR : csnd::Plugin<1, 3> {
     static constexpr char const *otypes = "k";
@@ -134,6 +136,9 @@ struct LFSR : csnd::Plugin<1, 3> {
 };
 
 #include <modload.h>
+
+#include "csdl.h"
+
 void csnd::on_load(Csound *csound) {
   csnd::plugin<LFSR>(csound, "lfsr", "k", "iij", csnd::thread::ik);
 }

--- a/Opcodes/linuxjoystick.c
+++ b/Opcodes/linuxjoystick.c
@@ -36,7 +36,16 @@
 */
 
 #include "linuxjoystick.h"
+
 #include <errno.h>
+#include <fcntl.h>
+#include <linux/joystick.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "csound.h"
 
 static int32_t linuxjoystick (CSOUND *csound, LINUXJOYSTICK *stick)
 {

--- a/Opcodes/linuxjoystick.h
+++ b/Opcodes/linuxjoystick.h
@@ -18,6 +18,9 @@
   02110-1301 USA
 
 */
+
+#pragma once
+
 #include <unistd.h>
 #include "csdl.h"
 #include "linux/joystick.h"

--- a/Opcodes/linuxjoystick.h
+++ b/Opcodes/linuxjoystick.h
@@ -22,8 +22,11 @@
 #pragma once
 
 #include <unistd.h>
+#include <stdint.h>
+
 #include "csdl.h"
 #include "linux/joystick.h"
+#include "sysdep.h"
 
 typedef struct
 {

--- a/Opcodes/liveconv.c
+++ b/Opcodes/liveconv.c
@@ -23,9 +23,13 @@
 
 /* The implementation is indebted to the ftconv opcode by Istvan Varga 2005 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /*
 ** Data structures holding the load/unload information

--- a/Opcodes/locsig.c
+++ b/Opcodes/locsig.c
@@ -29,9 +29,12 @@
 /* University of Washington, Seattle 1998 */
 /******************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "locsig.h"
-#include <math.h>
+#include "csound.h"
 
 static int32_t locsigset(CSOUND *csound, LOCSIG *p)
 {

--- a/Opcodes/locsig.h
+++ b/Opcodes/locsig.h
@@ -31,7 +31,8 @@
 
 #pragma once
 
-#include "stdopcod.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/locsig.h
+++ b/Opcodes/locsig.h
@@ -29,6 +29,8 @@
 /* University of Washington, Seattle 1998 */
 /******************************************/
 
+#pragma once
+
 #include "stdopcod.h"
 
 typedef struct {

--- a/Opcodes/loscilx.c
+++ b/Opcodes/loscilx.c
@@ -21,10 +21,18 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
-#include "soundio.h"
+#include "csound.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 typedef struct SNDLOAD_OPCODE_ {
     OPDS    h;

--- a/Opcodes/lowpassr.c
+++ b/Opcodes/lowpassr.c
@@ -23,9 +23,12 @@
 
 /* Resonant Lowpass filters by G.Maldonado */
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "lowpassr.h"
 #include <math.h>
+#include "csound.h"
 
 static int32_t lowpr_set(CSOUND *csound, LOWPR *p)
 {

--- a/Opcodes/lowpassr.h
+++ b/Opcodes/lowpassr.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *kfco, *kres, *istor;

--- a/Opcodes/lowpassr.h
+++ b/Opcodes/lowpassr.h
@@ -23,6 +23,11 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *kfco, *kres, *istor;

--- a/Opcodes/lufs.c
+++ b/Opcodes/lufs.c
@@ -22,8 +22,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct filter_ {
         MYFLT x1, x2;

--- a/Opcodes/mandolin.c
+++ b/Opcodes/mandolin.c
@@ -39,9 +39,14 @@
 /*  Technology Licensing, Stanford U.       */
 /********************************************/
 
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "mandolin.h"
+#include "Opcodes/brass.h"
+#include "Opcodes/clarinet.h"
+#include "csound.h"
 
 static inline int32_t infoTick(MANDOL *p)
 {

--- a/Opcodes/mandolin.h
+++ b/Opcodes/mandolin.h
@@ -35,8 +35,13 @@
 
 #if !defined(__Mandolin_h)
 #define __Mandolin_h
+#include <stdint.h>
+
 #include "clarinet.h"
 #include "brass.h"
+#include "Opcodes/physutil.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct Mandolin {
     OPDS        h;

--- a/Opcodes/metro.c
+++ b/Opcodes/metro.c
@@ -21,8 +21,15 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "stdopcod.h"
 #include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/midiops2.c
+++ b/Opcodes/midiops2.c
@@ -26,8 +26,12 @@
 /** midicXX   UGs by Gabriel Maldonado **/
 /****************************************/
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "stdopcod.h"
 #include "midiops2.h"
+#include "csound.h"
 #ifndef TRUE
 #define TRUE (1)
 #endif

--- a/Opcodes/midiops2.h
+++ b/Opcodes/midiops2.h
@@ -27,6 +27,9 @@
 #ifndef MIDIOPS2_H
 #define MIDIOPS2_H
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS   h;
     MYFLT  *r, *ictlno, *imin, *imax, *ifn;

--- a/Opcodes/midiops3.c
+++ b/Opcodes/midiops3.c
@@ -23,10 +23,13 @@
 
 /* sliders and other MIDI opcodes by Gabriel Maldonado */
 
+#include <stdint.h>
+#include <stdio.h>
+
 #include "stdopcod.h"
-#include "midiops.h"
 #include "midiops3.h"
 #include <math.h>
+#include "csound.h"
 
 #define f7bit           (FL(127.0))
 #define oneTOf7bit      (MYFLT)(1.0/127.0)

--- a/Opcodes/midiops3.h
+++ b/Opcodes/midiops3.h
@@ -22,6 +22,9 @@
 */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     MYFLT *ictlno, *imin, *imax, *initvalue, *ifn;
 } SLD;

--- a/Opcodes/midiops3.h
+++ b/Opcodes/midiops3.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
     MYFLT *ictlno, *imin, *imax, *initvalue, *ifn;

--- a/Opcodes/minmax.c
+++ b/Opcodes/minmax.c
@@ -30,10 +30,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/mixer.cpp
+++ b/Opcodes/mixer.cpp
@@ -20,9 +20,17 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#include <stddef.h>
 #include <map>
 #include <vector>
+#include <memory>
+#include <utility>
+
 #include "OpcodeBase.hpp"
+#include "csdl.h"
+#include "csound.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 using namespace csound;
 
@@ -295,6 +303,10 @@ struct MixerClear : public OpcodeBase<MixerClear> {
         return OK;
   }
 };
+
+#ifndef _CR
+#define _CR (0x0020)
+#endif
 
 extern "C" {
 

--- a/Opcodes/modal4.c
+++ b/Opcodes/modal4.c
@@ -21,6 +21,9 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <string.h>
+
 /*******************************************/
 /*  4 Resonance Modal Synthesis Instrument */
 /*  by Perry R. Cook, 1995-96              */
@@ -33,8 +36,9 @@
 #include "modal4.h"
 #include "marimba.h"
 #include "vibraphn.h"
-#include <math.h>
 #include "interlocks.h"
+#include "Opcodes/physutil.h"
+
 static int32_t make_Modal4(CSOUND *csound,
                        Modal4 *m, MYFLT *ifn, MYFLT vgain, MYFLT vrate)
 {

--- a/Opcodes/modal4.h
+++ b/Opcodes/modal4.h
@@ -32,7 +32,12 @@
 #if !defined(__Modal4_h)
 #define __Modal4_h
 
+#include <stdint.h>
+
 #include "physutil.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct Modal4 {
     Envelope envelope;

--- a/Opcodes/modmatrix.c
+++ b/Opcodes/modmatrix.c
@@ -19,6 +19,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "modmatrix.h"
 
+#include <string.h>
+
+#include "csound.h"
+#include "float-version.h"
+#include "interlocks.h"
+
 #define INITERROR(x) csound->InitError(csound, Str("modmatrix: " x))
 
 #if defined(__SSE2__)

--- a/Opcodes/modmatrix.h
+++ b/Opcodes/modmatrix.h
@@ -17,6 +17,8 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 //#include "csdl.h"
 #include "interlocks.h"
 #include "csoundCore.h"

--- a/Opcodes/modmatrix.h
+++ b/Opcodes/modmatrix.h
@@ -19,9 +19,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+#include <stdint.h>
+
 //#include "csdl.h"
-#include "interlocks.h"
 #include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS h;

--- a/Opcodes/moog1.c
+++ b/Opcodes/moog1.c
@@ -21,9 +21,12 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "moog1.h"
+#include "Opcodes/fm4op.h"
 
 extern void make_TwoZero(TwoZero *);
 extern void TwoZero_setZeroCoeffs(TwoZero *, MYFLT*);

--- a/Opcodes/moog1.h
+++ b/Opcodes/moog1.h
@@ -35,7 +35,13 @@
 #if !defined(__Moog1_h)
 #define __Moog1_h
 
+#include <stdint.h>
+
 #include "fm4op.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 /*******************************************/
 /*  Sweepable Formant (2-pole)             */

--- a/Opcodes/mp3in.c
+++ b/Opcodes/mp3in.c
@@ -21,10 +21,20 @@
   02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 /* mp3in.c */
 /* #include "csdl.h" */
 #include "csoundCore.h"
 #include "mp3dec.h"
+#include "csound.h"
+#include "mpadec.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 typedef struct {
   OPDS    h;
@@ -1316,6 +1326,7 @@ static int32_t player_init(CSOUND *csound, PLAYER *p){
 #include <stdbool.h>
 #ifdef HAVE_NEON
 #include <arm_neon.h>
+
 static
 inline
 void

--- a/Opcodes/newfils.c
+++ b/Opcodes/newfils.c
@@ -22,6 +22,8 @@
   02110-1301 USA
 */
 
+#include <string.h>
+
 #include "stdopcod.h"
 
 #include "newfils.h"

--- a/Opcodes/newfils.h
+++ b/Opcodes/newfils.h
@@ -108,6 +108,12 @@ on startup. 0 means no initialisation.
 
 #ifndef _NEWFILS_H
 #define _NEWFILS_H
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define DIM 4
 
 typedef struct _moogladder {

--- a/Opcodes/nlfilt.c
+++ b/Opcodes/nlfilt.c
@@ -30,8 +30,12 @@
 *       See paper by Dobson and ffitch, ICMC'96                 *
 \***************************************************************/
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "nlfilt.h"
+#include "csound.h"
+#include "prototyp.h"
 
 typedef struct {
         OPDS    h;
@@ -287,6 +291,7 @@ int32_t pinit(CSOUND *csound, PINIT *p)
 }
 
 #include "arrays.h"
+
 int32_t painit(CSOUND *csound, PAINIT *p)
 {
     int32_t n;

--- a/Opcodes/nlfilt.h
+++ b/Opcodes/nlfilt.h
@@ -22,6 +22,8 @@
 */
 
                         /* Structure for Dobson/Fitch nonlinear filter */
+#pragma once
+
 typedef struct  {
         OPDS    h;
         MYFLT   *ar, *in, *a, *b, *d, *C, *L;   /* The parameter */

--- a/Opcodes/nlfilt.h
+++ b/Opcodes/nlfilt.h
@@ -24,6 +24,11 @@
                         /* Structure for Dobson/Fitch nonlinear filter */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct  {
         OPDS    h;
         MYFLT   *ar, *in, *a, *b, *d, *C, *L;   /* The parameter */

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -21,9 +21,14 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "oscbnk.h"
 #include <math.h>
+#include "csound.h"
+#include "float-version.h"
+#include "interlocks.h"
 
 static inline STDOPCOD_GLOBALS *get_oscbnk_globals(CSOUND *csound)
 {

--- a/Opcodes/oscbnk.h
+++ b/Opcodes/oscbnk.h
@@ -24,7 +24,11 @@
 #ifndef CSOUND_OSCBNK_H
 #define CSOUND_OSCBNK_H
 
+#include <stdint.h>
+
 #include "stdopcod.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 /*
 #ifdef  B64BIT

--- a/Opcodes/padsynth_gen.cpp
+++ b/Opcodes/padsynth_gen.cpp
@@ -22,10 +22,16 @@
 */
 extern "C" {
 #include "csdl.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "sysdep.h"
 }
+#include <stdarg.h>
+#include <stdio.h>
 #include <cmath>
 #include <complex>
 #include <random>
+#include <vector>
 
 /**
 

--- a/Opcodes/pan2.c
+++ b/Opcodes/pan2.c
@@ -21,11 +21,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
-
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS h;

--- a/Opcodes/partials.c
+++ b/Opcodes/partials.c
@@ -37,8 +37,17 @@ imaxtracks - max number of tracks (<= number of analysis bins)
 
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 typedef struct _parts {
     OPDS    h;

--- a/Opcodes/partikkel.c
+++ b/Opcodes/partikkel.c
@@ -20,8 +20,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "partikkel.h"
+
 #include <limits.h>
 #include <math.h>
+#include <string.h>
+
+#include "interlocks.h"
 
 #define INITERROR(x) csound->InitError(csound, Str("partikkel: " x))
 #define PERFERROR(x) csound->PerfError(csound, &(p->h),Str("partikkel: " x))

--- a/Opcodes/partikkel.h
+++ b/Opcodes/partikkel.h
@@ -1,6 +1,6 @@
 /*
 Partikkel - a granular synthesis module for Csound 5
-Copyright (C) 2006-2009 Øyvind Brandtsegg, Torgeir Strand Henriksen,
+Copyright (C) 2006-2009 ï¿½yvind Brandtsegg, Torgeir Strand Henriksen,
 Thom Johansen
 
 This library is free software; you can redistribute it and/or
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+
+#pragma once
 
 #include "csoundCore.h"
 #include "interlocks.h"

--- a/Opcodes/partikkel.h
+++ b/Opcodes/partikkel.h
@@ -1,6 +1,6 @@
 /*
 Partikkel - a granular synthesis module for Csound 5
-Copyright (C) 2006-2009 �yvind Brandtsegg, Torgeir Strand Henriksen,
+Copyright (C) 2006-2009 Øyvind Brandtsegg, Torgeir Strand Henriksen,
 Thom Johansen
 
 This library is free software; you can redistribute it and/or
@@ -20,8 +20,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #pragma once
 
+#include <stdint.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     FUNC *table;
@@ -58,8 +61,6 @@ typedef struct {
     char *mempool;
     uint32_t free_nodes;
 } GRAINPOOL;
-
-struct PARTIKKEL;
 
 typedef struct PARTIKKEL_GLOBALS_ENTRY {
     MYFLT id;

--- a/Opcodes/paulstretch.c
+++ b/Opcodes/paulstretch.c
@@ -26,15 +26,18 @@
 */
 #include <stdlib.h>
 #include <complex.h>
+#include <stdint.h>
+#include <string.h>
 
 #ifdef _MSC_VER
 #define _USE_MATH_DEFINES
 #endif
 #include <math.h>
-#include <math.h>
 #include "csoundCore.h"
 #include "interlocks.h"
 #include "H/fftlib.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #ifdef ANDROID
 float crealf(_Complex float);

--- a/Opcodes/phisem.c
+++ b/Opcodes/phisem.c
@@ -45,11 +45,12 @@
 /*  Sandpapr (sandpaper)                                  */
 /**********************************************************/
 
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
 #include "phisem.h"
-#include <math.h>
+#include "csound.h"
 
 /* To do
    "10: Wrench", "12: CokeCan"};

--- a/Opcodes/phisem.h
+++ b/Opcodes/phisem.h
@@ -47,6 +47,11 @@
 #if !defined(__Phisem_h)
 #define __Phisem_h
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct Cabasa {
     OPDS        h;
     MYFLT       *ar;            /* Output */

--- a/Opcodes/physmod.c
+++ b/Opcodes/physmod.c
@@ -23,14 +23,21 @@
 
 /* Collection of physical modelled instruments */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
 #include "clarinet.h"
 #include "flute.h"
 #include "bowed.h"
 #include "brass.h"
-#include <math.h>
 #include "interlocks.h"
+#include "Opcodes/moog1.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
+#include "sysdep.h"
 /* ************************************** */
 /*  Waveguide Clarinet model ala Smith    */
 /*  after McIntyre, Schumacher, Woodhouse */

--- a/Opcodes/physutil.c
+++ b/Opcodes/physutil.c
@@ -27,7 +27,6 @@
 
 // #include "csdl.h"
 #include "csoundCore.h"
-#include <stdlib.h>
 #include "physutil.h"
 
 /*******************************************/

--- a/Opcodes/physutil.h
+++ b/Opcodes/physutil.h
@@ -25,7 +25,11 @@
 
 /* Various filters etc for Physical models */
 
-#include <math.h>
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define AMP_SCALE (csound->e0dbfs)
 #define AMP_RSCALE (csound->dbfs_to_float)

--- a/Opcodes/pinker.c
+++ b/Opcodes/pinker.c
@@ -29,7 +29,11 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+
 #include "csoundCore.h"       /*                              PINKER.C         */
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
   OPDS h;

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -23,15 +23,17 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"       /*                              PITCH.C         */
 #include <math.h>
 #include <limits.h>
-#include "cwindow.h"
 #include "spectra.h"
 #include "pitch.h"
 #include "uggab.h"
 #include <inttypes.h>
+#include "csound_type_system.h"
 
 #define STARTING  1
 #define PLAYING   2
@@ -2131,7 +2133,6 @@ int32_t varicol(CSOUND *csound, VARI *p)
 /* ***** Josep Comajuncosas' 18dB/oct resonant 3-pole LPF with tanh dist ** */
 /* ***** Coded in C by John ffitch, 2000 Dec 17 *************************** */
 /* ************************************************************************ */
-#include <math.h>
 
 /* This code is transcribed from a Csound macro, so no real comments */
 

--- a/Opcodes/pitch.h
+++ b/Opcodes/pitch.h
@@ -3,7 +3,7 @@
 /*
     pitch.h:
 
-    Copyright (C) 1999 John ffitch, Istvan Varga, Peter Neub�cker,
+    Copyright (C) 1999 John ffitch, Istvan Varga, Peter Neubäcker,
                        rasmus ekman, Phil Burk
 
     This file is part of Csound.
@@ -27,8 +27,14 @@
                         /*                                      PITCH.H */
 #pragma once
 
+#include <stdint.h>
+
 #include "spectra.h"
 #include "uggab.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "cwindow.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/pitch.h
+++ b/Opcodes/pitch.h
@@ -3,7 +3,7 @@
 /*
     pitch.h:
 
-    Copyright (C) 1999 John ffitch, Istvan Varga, Peter Neubäcker,
+    Copyright (C) 1999 John ffitch, Istvan Varga, Peter Neubï¿½cker,
                        rasmus ekman, Phil Burk
 
     This file is part of Csound.
@@ -25,6 +25,8 @@
 */
 
                         /*                                      PITCH.H */
+#pragma once
+
 #include "spectra.h"
 #include "uggab.h"
 

--- a/Opcodes/pitch0.c
+++ b/Opcodes/pitch0.c
@@ -21,13 +21,15 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"       /*                                  PITCH.C       */
-#include "cwindow.h"
-#include <limits.h>
-#include "spectra.h"
 #include "pitch.h"
-#include "uggab.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 int32_t mute_inst(CSOUND *csound, MUTE *p)
 {

--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -25,9 +25,13 @@
   02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define MINFREQINBINS 5
 #define MAXHIST 3

--- a/Opcodes/platerev.c
+++ b/Opcodes/platerev.c
@@ -22,8 +22,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /* #undef CS_KSMPS */
 /* #define CS_KSMPS     (csound->GetKsmps(csound)) */

--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -31,9 +31,13 @@
  * Some modifications John ffitch, 2000, simplifying code
  */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "wavegde.h"
 #include "pluck.h"
+#include "csound.h"
 
 /* external prototypes */
 static void pluckSetFilters(CSOUND*, WGPLUCK*, MYFLT, MYFLT);

--- a/Opcodes/pluck.h
+++ b/Opcodes/pluck.h
@@ -35,6 +35,8 @@
 #define _pluck_h
 
 #include "wavegde.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 /* pluck -- derived class to implement simple plucked string algorithm */
 typedef struct {

--- a/Opcodes/psynth.c
+++ b/Opcodes/psynth.c
@@ -63,8 +63,15 @@ PLUS a number of track processing opcodes.
 
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 typedef struct _psyn {
     OPDS    h;

--- a/Opcodes/ptrigtbl.h
+++ b/Opcodes/ptrigtbl.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #define GOOD_TRIG
 

--- a/Opcodes/pvadd.c
+++ b/Opcodes/pvadd.c
@@ -28,8 +28,17 @@
 /******************************************/
 /*    PVADD.C        */
 
-#include "pvoc.h"
-#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "Opcodes/pvadd.h"
+#include "Opcodes/pvocext.h"
+#include "Opcodes/ugens8.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static int32_t pvx_loadfile(CSOUND *csound, const char *fname, PVADD *p);
 

--- a/Opcodes/pvadd.h
+++ b/Opcodes/pvadd.h
@@ -24,6 +24,12 @@
 /*                                                      PVADD.H    */
 #pragma once
 
+#include <stdint.h>
+
+#include "Opcodes/ugens8.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define     MAXBINS         4096
 #ifndef PVFRAMSIZE
 #define     PVFRAMSIZE      8192                /* i.e. max FFT point size */

--- a/Opcodes/pvadd.h
+++ b/Opcodes/pvadd.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                      PVADD.H    */
+#pragma once
 
 #define     MAXBINS         4096
 #ifndef PVFRAMSIZE

--- a/Opcodes/pvinterp.c
+++ b/Opcodes/pvinterp.c
@@ -26,8 +26,18 @@
 /******** By Richard Karpen 1996 *********/
 /*****************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 #include "pvoc.h"
 #include <math.h>
+#include "Opcodes/dsputil.h"
+#include "Opcodes/ugens8.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "prototyp.h"
+#include "sysdep.h"
+#include "pvinterp.h"
 
 #define WLN   1         /* time window is WLN*2*ksmps long */
 #define OPWLEN (2*WLN*CS_KSMPS)    /* manifest used for final time wdw */

--- a/Opcodes/pvinterp.h
+++ b/Opcodes/pvinterp.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                              PVINTERP.H  */
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/pvinterp.h
+++ b/Opcodes/pvinterp.h
@@ -24,6 +24,9 @@
 /*                                                              PVINTERP.H  */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS    h;
     MYFLT   *ktimpnt, *ifilno;

--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -21,10 +21,17 @@
   02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
 #include "pstream.h"
-#include "soundio.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
+
 #define MAXOUTS 2
 
 typedef struct dats {

--- a/Opcodes/pvoc.c
+++ b/Opcodes/pvoc.c
@@ -23,6 +23,15 @@
 
 #include "pvoc.h"
 
+#include <stdint.h>
+
+#include "Opcodes/pvadd.h"
+#include "Opcodes/pvinterp.h"
+#include "Opcodes/pvread.h"
+#include "Opcodes/ugens8.h"
+#include "Opcodes/vpvoc.h"
+#include "interlocks.h"
+
 int32_t     pvset(CSOUND *, void *), pvset_S(CSOUND *, void *);
 int32_t     pvoc(CSOUND *, void *);
 int32_t     pvaddset(CSOUND *, void *), pvadd(CSOUND *, void *);

--- a/Opcodes/pvoc.h
+++ b/Opcodes/pvoc.h
@@ -24,19 +24,18 @@
 #ifndef CSOUND_PVOC_H
 #define CSOUND_PVOC_H
 
+#include <stddef.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct PVOC_GLOBALS_ PVOC_GLOBALS;
 
-#include "dsputil.h"
-#include "ugens8.h"
-#include "pvread.h"
 #include "pvinterp.h"
 #include "vpvoc.h"
-#include "pvadd.h"
-#include "pvocext.h"
+
 
 struct PVOC_GLOBALS_ {
     CSOUND    *csound;

--- a/Opcodes/pvocext.c
+++ b/Opcodes/pvocext.c
@@ -29,8 +29,13 @@
 
 /*    PVOCEXT.C        */
 
-#include "pvoc.h"
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "Opcodes/pvocext.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define minval(val1, val2) (val1 <= val2 ? val1 : val2)
 

--- a/Opcodes/pvocext.h
+++ b/Opcodes/pvocext.h
@@ -26,7 +26,7 @@
 /* Based on ideas from Tom Erbe's SoundHack  */
 
 /* Predeclare Functions */
-
+#pragma once
 
 
 void    SpectralExtract(float *, float *, int32_t, int32, int32_t, MYFLT);

--- a/Opcodes/pvocext.h
+++ b/Opcodes/pvocext.h
@@ -29,6 +29,11 @@
 #pragma once
 
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 void    SpectralExtract(float *, float *, int32_t, int32, int32_t, MYFLT);
 MYFLT   PvocMaxAmp(float *, int32, int32);
 void    PvAmpGate(MYFLT *, int32, FUNC *, MYFLT);

--- a/Opcodes/pvread.c
+++ b/Opcodes/pvread.c
@@ -26,11 +26,16 @@
 /*** By Richard Karpen - July-October 1992*********************/
 /**************************************************************/
 
-#include "pvoc.h"
-#include <math.h>
 
-/*RWD 10:9:2000 read pvocex file format */
-#include "pvfileio.h"
+#include <stdint.h>
+
+#include "Opcodes/pvadd.h"
+#include "Opcodes/pvread.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 static int32_t pvocex_loadfile(CSOUND *, const char *fname, PVREAD *p);
 
 #define WLN   1         /* time window is WLN*2*ksmps long */

--- a/Opcodes/pvread.h
+++ b/Opcodes/pvread.h
@@ -24,6 +24,9 @@
 /*                                                              PVREAD.H    */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS    h;
     MYFLT   *kfreq, *kamp, *ktimpnt,  *ifilno, *ibin;

--- a/Opcodes/pvread.h
+++ b/Opcodes/pvread.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                              PVREAD.H    */
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/pvs_ops.h
+++ b/Opcodes/pvs_ops.h
@@ -25,9 +25,10 @@
 #define CSOUND_PVS_OPS_H
 
 /* #include "csdl.h" */
-#include "csoundCore.h"
+#include <stdint.h>
 
-#include "interlocks.h"
+
+#include "csound.h"
 
 
 extern int32_t ifd_init_(CSOUND *);

--- a/Opcodes/pvsband.c
+++ b/Opcodes/pvsband.c
@@ -22,8 +22,15 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS h;

--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -25,10 +25,17 @@
 
 /* pvsmix */
 
+#include <emmintrin.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pvsbasic.h"
 #include "pvfileio.h"
 #include <math.h>
+#include "interlocks.h"
+#include "prototyp.h"
+
 #define MAXOUTS 16
 
 static int32_t fsigs_equal(const PVSDAT *f1, const PVSDAT *f2);

--- a/Opcodes/pvsbasic.h
+++ b/Opcodes/pvsbasic.h
@@ -123,7 +123,12 @@
 #ifndef _PVSBASIC_H
 #define _PVSBASIC_H
 
+#include <stdint.h>
+
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct _pvsini {
     OPDS    h;

--- a/Opcodes/pvsbuffer.c
+++ b/Opcodes/pvsbuffer.c
@@ -19,11 +19,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
-
 #include "pstream.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
   PVSDAT  header;

--- a/Opcodes/pvscent.c
+++ b/Opcodes/pvscent.c
@@ -23,8 +23,15 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "pvs_ops.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
   OPDS    h;

--- a/Opcodes/pvsdemix.c
+++ b/Opcodes/pvsdemix.c
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "pvs_ops.h"
 #include "pvsdemix.h"
 

--- a/Opcodes/pvsdemix.h
+++ b/Opcodes/pvsdemix.h
@@ -45,7 +45,12 @@ of points around kpos which will be used in the de-mixing process.
 #ifndef _PVSDEMIX_H
 #define _PVSDEMIX_H
 
+#include <stdint.h>
+
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct _pvsdemix {
         OPDS h;

--- a/Opcodes/pvsgendy.c
+++ b/Opcodes/pvsgendy.c
@@ -22,8 +22,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "pstream.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS h;

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -22,6 +22,14 @@
 */
 #include <algorithm>
 #include <plugin.h>
+#include <complex>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
+
+#include "csdl.h"
+#include "sysdep.h"
 
 struct PVTrace : csnd::FPlugin<1, 2> {
   csnd::AuxMem<float> amps;
@@ -466,6 +474,7 @@ struct TPrint : csnd::Plugin<0, 1> {
 */
 
 #include <modload.h>
+
 void csnd::on_load(Csound *csound) {
   csnd::plugin<PVTrace>(csound, "pvstrace",  csnd::thread::ik);
   csnd::plugin<PVTrace2>(csound, "pvstrace", csnd::thread::ik);

--- a/Opcodes/quadbezier.c
+++ b/Opcodes/quadbezier.c
@@ -21,8 +21,12 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 static MYFLT SolveQuadratic(MYFLT a, MYFLT b, MYFLT c);
 static MYFLT FindTforX(MYFLT x1, MYFLT x2, MYFLT x3, int32_t x);

--- a/Opcodes/repluck.c
+++ b/Opcodes/repluck.c
@@ -28,8 +28,11 @@
 *   3 March 1996 John ffitch                                   *
 \***************************************************************/
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "repluck.h"
+#include "csound.h"
 
 static int32_t wgpsetin(CSOUND *, WGPLUCK2 *);
 

--- a/Opcodes/repluck.h
+++ b/Opcodes/repluck.h
@@ -22,6 +22,8 @@
 */
 
                                                         /* repluck.h */
+#pragma once
+
 typedef struct _DelayLine {
     MYFLT   *data;
     int32_t length;

--- a/Opcodes/repluck.h
+++ b/Opcodes/repluck.h
@@ -24,6 +24,11 @@
                                                         /* repluck.h */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct _DelayLine {
     MYFLT   *data;
     int32_t length;

--- a/Opcodes/reverbsc.c
+++ b/Opcodes/reverbsc.c
@@ -34,8 +34,14 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include <math.h>
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define DEFAULT_SRATE   44100.0
 #define MIN_SRATE       5000.0

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -26,11 +26,12 @@
 
 #include "csdl.h"
 #include "scansyn.h"
-#include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
+#include <string.h>
 #include "cwindow.h"
 #include "arrays.h"
+#include "interlocks.h"
+#include "version.h"
 
 /* #undef CS_KSMPS */
 /* #define CS_KSMPS     (csound->GetKsmps(csound)) */
@@ -298,14 +299,6 @@ static int32_t scsnu_init(CSOUND *csound, PSCSNU *p)
     p->v = p->ext + len;
 #if PHASE_INTERP == 3
     p->x3 = p->v + len;
-#endif
-
-    /* Initialize them ... */
-    /* This relies on contiguous allocation of these vectors
-       but as they are allocated via AuxAlloc they are zeroed anyway!  */
-    //memset(p->x0, '\0', 4*len+sizeof(MYFlT));
-#if PHASE_INTERP == 3
-    //memset(p->x3, '\0', len+sizeof(MYFlT));
 #endif
     /* Setup display window */
     if (*p->i_disp) {

--- a/Opcodes/scansyn.h
+++ b/Opcodes/scansyn.h
@@ -19,6 +19,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include "csdl.h"
 

--- a/Opcodes/scansyn.h
+++ b/Opcodes/scansyn.h
@@ -21,7 +21,12 @@
 */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct SCANSYN_GLOBALS_ SCANSYN_GLOBALS;
 

--- a/Opcodes/scansynx.c
+++ b/Opcodes/scansynx.c
@@ -52,10 +52,16 @@
 /* Code fixes by John ffitch, March 2000 */
 /*               Made interpolation selectable April 2000 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csdl.h"
 #include "scansyn.h"
-#include <math.h>
 #include "cwindow.h"
+#include "csound.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 /* Order of interpolation of scanning */
 /* Either 1, 2 (linear), 3 (cubic) or 4 (quadratic) */

--- a/Opcodes/scoreline.c
+++ b/Opcodes/scoreline.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 //#include "csdl.h"
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 //extern void csoundInputMessageInternal(CSOUND *, const char *);
 
 typedef struct _inmess {

--- a/Opcodes/select.c
+++ b/Opcodes/select.c
@@ -21,7 +21,12 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct Select {
   OPDS        h;

--- a/Opcodes/seqtime.c
+++ b/Opcodes/seqtime.c
@@ -21,7 +21,14 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "stdopcod.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS   h;

--- a/Opcodes/sequencer.c
+++ b/Opcodes/sequencer.c
@@ -22,8 +22,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS        h;
     MYFLT       *res;           /*  state */

--- a/Opcodes/serial.c
+++ b/Opcodes/serial.c
@@ -34,21 +34,24 @@
 
 #ifndef NO_SERIAL_OPCODES
 
-#include <stdlib.h>
 #include <stdint.h>   /* Standard types */
 #include <string.h>   /* String function definitions */
+#include <math.h>
+#include <stdio.h>
 
 #ifndef WIN32
 #include <unistd.h>   /* UNIX standard function definitions */
 #include <fcntl.h>    /* File control definitions */
 #include <termios.h>  /* POSIX terminal control definitions */
-#include <sys/ioctl.h>
 #else
 #include "winsock2.h"
 #endif
 
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "sysdep.h"
 
 /* **************************************************
    As far as I can tell his should work on Windows

--- a/Opcodes/sf.h
+++ b/Opcodes/sf.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #if !defined(_SF_H)
 #include "sftype.h"
@@ -97,7 +98,7 @@ typedef struct _presetType presetType;
 struct _CHUNK {
   BYTE  ckID[4]; /* A chunk ID identifies the type of data within the chunk. */
   DWORD ckSize;  /* The size of the chunk data in bytes, excluding any pad byte. */
-  BYTE  *ckDATA; /* The actual data plus a pad byte if req’d to word align. */
+  BYTE  *ckDATA; /* The actual data plus a pad byte if reqï¿½d to word align. */
 } PACKED;
 typedef struct _CHUNK CHUNK;
 

--- a/Opcodes/sfont.c
+++ b/Opcodes/sfont.c
@@ -31,11 +31,20 @@
 
 // #include "csdl.h"
 #include "csoundCore.h"
-#include "interlocks.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 #include <ctype.h>
+#include <string.h>
+
+
+
+#include "Opcodes/sf.h"
+#include "Opcodes/sftype.h"
+#include "csound.h"
+#include "prototyp.h"
+
 #ifndef __wasi__
 #include <errno.h>
 #endif

--- a/Opcodes/sfont.h
+++ b/Opcodes/sfont.h
@@ -23,8 +23,11 @@
 */
 #pragma once
 
+#include <stdint.h>
+
 #include "sftype.h"
-#include "sf.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/sfont.h
+++ b/Opcodes/sfont.h
@@ -21,6 +21,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include "sftype.h"
 #include "sf.h"

--- a/Opcodes/shaker.c
+++ b/Opcodes/shaker.c
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
 /********************************************************/
 /*    Maracha SImulation by Perry R. Cook, 1996         */
 /********************************************************/
@@ -53,6 +55,8 @@ But we're smarter than that!!!  See below
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "shaker.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
 
 int32_t shakerset(CSOUND *csound, SHAKER *p)
 {

--- a/Opcodes/shaker.h
+++ b/Opcodes/shaker.h
@@ -33,7 +33,11 @@
 #if !defined(__Shaker_h)
 #define __Shaker_h
 
+#include <stdint.h>
+
 #include "physutil.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct Shaker {
     OPDS        h;

--- a/Opcodes/shape.c
+++ b/Opcodes/shape.c
@@ -30,10 +30,12 @@
     02110-1301 USA
  */
 
-#include "csoundCore.h"
-#include "interlocks.h"
+#include <stdint.h>
+#include <string.h>
 
-#include <math.h>
+#include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 
 typedef struct {

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -122,25 +122,30 @@
  * causes the creation of a new function table.
  */
 
+#define SIGNAL_FLOW_GRAPH_H
+
+#include <stdarg.h>
+#include <stdint.h>
 #include <algorithm>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <functional>
 #include <iostream>
 #include <map>
 #include <string>
 #include <vector>
+
 #include "OpcodeBase.hpp"
-#include "sysdep.h"
-#include "text.h"
 #include <pstream.h>
+#include "csdl.h"
+#include "csound.h"
+#include "interlocks.h"
+#include "msg_attr.h"
+#include "sysdep.h"
 
 #define SIGNALFLOWGRAPH_DEBUG 0
 
 namespace csound {
 
-struct SignalFlowGraph;
 struct Outleta;
 struct Outletk;
 struct Outletf;
@@ -151,9 +156,6 @@ struct Inletk;
 struct Inletf;
 struct Inletkid;
 struct Inletv;
-struct Connect;
-struct AlwaysOn;
-struct FtGenOnce;
 
 static const int MAX_STRING = 256;
 
@@ -323,6 +325,10 @@ struct Outleta : public OpcodeNoteoffBase<Outleta> {
     return OK;
   }
 };
+
+#ifndef FL
+#define FL(x) ((MYFLT) (x))
+#endif
 
 struct Inleta : public OpcodeBase<Inleta> {
   /**
@@ -1436,6 +1442,10 @@ static int ftgenonce_SS(CSOUND *csound, FTGEN *p) {
   return ftgenonce_(csound, p, true, true);
 }
 
+#ifndef _CR
+#define _CR (0x0020)
+#endif
+
 extern "C" {
 static OENTRY oentries[] = {
     {(char *)"outleta", sizeof(Outleta), _CW, 3, (char *)"", (char *)"Sa",
@@ -1548,3 +1558,5 @@ PUBLIC int csoundModuleDestroy(CSOUND *csound) {
 #endif
 }
 }
+
+#undef SIGNAL_FLOW_GRAPH_H

--- a/Opcodes/singwave.c
+++ b/Opcodes/singwave.c
@@ -33,10 +33,16 @@
 /*  excitation source for other instruments*/
 /*******************************************/
 
+#include <math.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "singwave.h"
 #include "moog1.h"
+#include "Opcodes/clarinet.h"
+#include "Opcodes/physutil.h"
+#include "csound.h"
 
 void OneZero_setCoeff(OneZero*, MYFLT);
 MYFLT Wave_tick(MYFLT *, int32_t len, MYFLT *, MYFLT, MYFLT);

--- a/Opcodes/singwave.h
+++ b/Opcodes/singwave.h
@@ -49,9 +49,13 @@ extern char phonemes[32][4];
 /*  natural human modulation function.     */
 /*******************************************/
 
+#include <stdint.h>
+
 #include "physutil.h"
 #include "clarinet.h"
 #include "moog1.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct SubNoise {
      Noise      lastOutput;

--- a/Opcodes/sndloop.c
+++ b/Opcodes/sndloop.c
@@ -118,8 +118,16 @@ kgain - signal gain
 
 */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "pstream.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 typedef struct _sndloop {
   OPDS h;

--- a/Opcodes/sndwarp.c
+++ b/Opcodes/sndwarp.c
@@ -29,8 +29,12 @@
 /*from soundfiles.                                            */
 /**************************************************************/
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "sndwarp.h"
+#include "csound.h"
+#include "interlocks.h"
 
 #define unirand(x) ((MYFLT) (x->Rand31(&(x->randSeed1)) - 1) / FL(2147483645.0))
 

--- a/Opcodes/sndwarp.h
+++ b/Opcodes/sndwarp.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
   int32_t    cnt, wsize, flag; /* , section; */

--- a/Opcodes/sndwarp.h
+++ b/Opcodes/sndwarp.h
@@ -22,6 +22,11 @@
 */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
   int32_t    cnt, wsize, flag; /* , section; */
         MYFLT  ampincr, ampphs, offset;

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -25,9 +25,14 @@
 /* Haiku 'int32' etc definitions in net headers conflict with sysdep.h */
 #define __HAIKU_CONFLICT
 
+#include <fcntl.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
 #include "csoundCore.h"
-#include <stdlib.h>
-#include <sys/types.h>
+#include "csound.h"
+#include "sysdep.h"
 #if defined(WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -35,7 +40,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
+
 #define SOCKET_ERROR (-1)
 #endif
 #include <string.h>

--- a/Opcodes/socksend.c
+++ b/Opcodes/socksend.c
@@ -27,19 +27,22 @@
 #define __HAIKU_CONFLICT
 
 #include "csoundCore.h"
-#include <sys/types.h>
+#include "csound.h"
+#include "sysdep.h"
 #if defined(WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 #include <unistd.h>
+
 #define SOCKET_ERROR (-1)
 #endif
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
 
 extern  int32_t     inet_aton(const char *cp, struct in_addr *inp);
 

--- a/Opcodes/space.c
+++ b/Opcodes/space.c
@@ -27,9 +27,14 @@
 /* University of Washington, Seattle 1998 */
 /******************************************/
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "space.h"
-#include <math.h>
+#include "csound.h"
+#include "interlocks.h"
 
 #define RESOLUTION 100
 

--- a/Opcodes/space.h
+++ b/Opcodes/space.h
@@ -29,7 +29,8 @@
 
 #pragma once
 
-#include "stdopcod.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/space.h
+++ b/Opcodes/space.h
@@ -27,6 +27,8 @@
 /* University of Washington, Seattle 1998 */
 /******************************************/
 
+#pragma once
+
 #include "stdopcod.h"
 
 typedef struct {

--- a/Opcodes/spat3d.c
+++ b/Opcodes/spat3d.c
@@ -24,10 +24,13 @@
 /* ----- spat3d, spat3di, and spat3dt -- written by Istvan Varga, 2001 ----- */
 
 #include "stdopcod.h"
-#include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include <time.h>
+
+
+#include "csoundCore.h"
+#include "csdl.h"
+#include "csound.h"
 
 #define CSOUND_SPAT3D_C 1
 

--- a/Opcodes/spat3d.h
+++ b/Opcodes/spat3d.h
@@ -26,7 +26,11 @@
 #ifndef CSOUND_SPAT3D_H
 #define CSOUND_SPAT3D_H
 
-#include "csdl.h"
+#include <math.h>
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #ifdef CSOUND_SPAT3D_C  /* define these only when included from spat3d.c */
 

--- a/Opcodes/spectra.c
+++ b/Opcodes/spectra.c
@@ -21,15 +21,21 @@
     02110-1301 USA
 */
 
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
 // #include "csdl.h"
 #include "csoundCore.h"
 #include "interlocks.h"
-#include <math.h>
 #include "cwindow.h"
 #include "spectra.h"
 #include "pitch.h"
 #include "uggab.h"
 #include <inttypes.h>
+#include "csound_standard_types.h"
+#include "csound_type_system.h"
+#include "prototyp.h"
 
 #define LOGTWO  (0.69314718056)
 

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -26,6 +26,13 @@
 #ifndef __SPECTRA_H
 #define __SPECTRA_H
 
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "cwindow.h"
+#include "sysdep.h"
+
 #define MAXFRQS 120
 
 typedef struct {

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
                         /*                              SPECTRA.H       */
+#pragma once
+
 #ifndef __SPECTRA_H
 #define __SPECTRA_H
 

--- a/Opcodes/squinewave.c
+++ b/Opcodes/squinewave.c
@@ -25,8 +25,12 @@
 */
 
 #include <math.h>
+#include <stdint.h>
+#include <string.h>
 
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 
 /* ================================================================== */

--- a/Opcodes/stdopcod.c
+++ b/Opcodes/stdopcod.c
@@ -23,6 +23,8 @@
 
 #include "stdopcod.h"
 
+#include "csoundCore.h"
+
 /* PUBLIC int32_t csoundModuleCreate(CSOUND *csound)
 {
     (void) csound;

--- a/Opcodes/stdopcod.h
+++ b/Opcodes/stdopcod.h
@@ -24,11 +24,12 @@
 #ifndef CSOUND_STDOPCOD_H
 #define CSOUND_STDOPCOD_H
 
+#include <stdint.h>
+#include <stdio.h>
+
 //#include "csdl.h"
-#include "csoundCore.h"
-
-
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 /* file structure for fout opcodes */
 

--- a/Opcodes/sterrain.c
+++ b/Opcodes/sterrain.c
@@ -19,9 +19,13 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 /*  Wave-terrain synthesis opcode
  *

--- a/Opcodes/syncgrain.c
+++ b/Opcodes/syncgrain.c
@@ -21,10 +21,15 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "stdopcod.h"
 #include "syncgrain.h"
-#include "soundio.h"
 #include "interlocks.h"
+#include "soundfile.h"
 
 /*
 #ifdef HAVE_VALUES_H

--- a/Opcodes/syncgrain.h
+++ b/Opcodes/syncgrain.h
@@ -103,6 +103,12 @@ istart - start position (in secs), defaults to 0.
 #ifndef _SYNCGRAIN_H
 #define _SYNCGRAIN_H
 
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct _syncgrain {
     OPDS h;
     MYFLT *output;

--- a/Opcodes/system_call.c
+++ b/Opcodes/system_call.c
@@ -22,7 +22,12 @@
 */
 
 
+#include <stdint.h>
+#include <stdlib.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
   OPDS  h;

--- a/Opcodes/tabaudio.c
+++ b/Opcodes/tabaudio.c
@@ -21,9 +21,17 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
-#include "soundio.h"
+#include "csound.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/tabsum.c
+++ b/Opcodes/tabsum.c
@@ -21,8 +21,12 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/tl/fractalnoise.cpp
+++ b/Opcodes/tl/fractalnoise.cpp
@@ -23,7 +23,12 @@
     02110-1301 USA
 */
 
-#include "../OpcodeBase.hpp"
+#include <stdint.h>
+#include <string.h>
+
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define max(x, y) (((x) > (y)) ? (x) : (y))
 #define min(x, y) (((x) < (y)) ? (x) : (y))

--- a/Opcodes/tl/sc_noise.c
+++ b/Opcodes/tl/sc_noise.c
@@ -34,7 +34,12 @@
 
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
         OPDS    h;

--- a/Opcodes/trigEnvSegs.cpp
+++ b/Opcodes/trigEnvSegs.cpp
@@ -21,9 +21,15 @@
 */
 
 #include <plugin.h>
+#include <math.h>
+#include <stdint.h>
 #include <vector>
 #include <numeric>
 #include <modload.h>
+#include <algorithm>
+
+#include "csdl.h"
+#include "sysdep.h"
 
 
 // linseg type opcode with trigger mechanism

--- a/Opcodes/ugakbari.c
+++ b/Opcodes/ugakbari.c
@@ -24,9 +24,12 @@
 /* scale modified and scale2 written as a replacement by JPff Dec 2020 */
 
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
-#include "interlocks.h"
-#include <math.h>
+#include "csound.h"
+#include "sysdep.h"
 
 #define LOGCURVE(x,y) ((LOG(x * (y-FL(1.0))+FL(1.0)))/(LOG(y)))
 #define EXPCURVE(x,y) ((EXP(x * LOG(y))-FL(1.0))/(y-FL(1.0)))

--- a/Opcodes/ugens7.c
+++ b/Opcodes/ugens7.c
@@ -22,9 +22,17 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "stdopcod.h"               /*                      UGENS7.C        */
+#include "csoundCore.h"
 #include "ugens7.h"
 #include <math.h>
+#include "csound.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 /* loosely based on code of Michael Clarke, University of Huddersfield */
 

--- a/Opcodes/ugens8.c
+++ b/Opcodes/ugens8.c
@@ -21,11 +21,20 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "pvoc.h"         /*      UGENS8.C        */
-#include <math.h>
+#include "Opcodes/dsputil.h"
+#include "Opcodes/pvocext.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
+#include "ugens8.h"
 
 /* RWD 10:9:2000 read pvocex file format */
-#include "pvfileio.h"
 static int32_t pvx_loadfile(CSOUND *, const char *, PVOC *);
 
 /********************************************/

--- a/Opcodes/ugens8.h
+++ b/Opcodes/ugens8.h
@@ -25,7 +25,11 @@
 #ifndef _UGENS8_H_
 #define _UGENS8_H_
 
+#include <stdint.h>
+
 #include "pvoc.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 
 #define     PVFRAMSIZE      8192                /* i.e. max FFT point size */
 #define     PVFFTSIZE       (2*PVFRAMSIZE)      /* 2x for real + imag */

--- a/Opcodes/ugens8.h
+++ b/Opcodes/ugens8.h
@@ -24,6 +24,9 @@
 /*                                                              UGENS8.H    */
 #ifndef _UGENS8_H_
 #define _UGENS8_H_
+
+#include "pvoc.h"
+
 #define     PVFRAMSIZE      8192                /* i.e. max FFT point size */
 #define     PVFFTSIZE       (2*PVFRAMSIZE)      /* 2x for real + imag */
 #define     PVDATASIZE      (1+PVFRAMSIZE/2)    /* Need 1/2 channels + mid */

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -21,12 +21,16 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <string.h>
+
 #include "stdopcod.h"   /*                                      UGENS9.C        */
-#include <math.h>
 #include "convolve.h"
 #include "ugens9.h"
 #include "soundio.h"
 #include <inttypes.h>
+#include "csound.h"
+#include "prototyp.h"
 
 static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
 {

--- a/Opcodes/ugens9.h
+++ b/Opcodes/ugens9.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                              UGENS9.H    */
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/Opcodes/ugens9.h
+++ b/Opcodes/ugens9.h
@@ -24,6 +24,11 @@
 /*                                                              UGENS9.H    */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     OPDS    h;
     MYFLT   *ar1,*ar2,*ar3,*ar4,*ain,*ifilno,*channel;

--- a/Opcodes/ugensa.c
+++ b/Opcodes/ugensa.c
@@ -21,10 +21,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"                 /*                              UGENSA.C  */
 #include "ugensa.h"
 #include "ugens7.h"
 #include <math.h>
+#include "csound.h"
+#include "interlocks.h"
 
 /* FOG generator */
 

--- a/Opcodes/ugensa.h
+++ b/Opcodes/ugensa.h
@@ -24,6 +24,9 @@
 /*                                                      UGENSM.H  */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define PFRAC1(x)   ((MYFLT)((x) & ftp1->lomask) * ftp1->lodiv)
 
 typedef struct overlap {

--- a/Opcodes/ugensa.h
+++ b/Opcodes/ugensa.h
@@ -22,6 +22,7 @@
 */
 
 /*                                                      UGENSM.H  */
+#pragma once
 
 #define PFRAC1(x)   ((MYFLT)((x) & ftp1->lomask) * ftp1->lodiv)
 

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -27,9 +27,12 @@
 /* Code adapted by JPff 1998 Sep 19         */
 /********************************************/
 
+#include <string.h>
+
 #include "stdopcod.h"
 #include "uggab.h"
 #include <math.h>
+#include "interlocks.h"
 
 static int32_t wrap(CSOUND *csound, WRAP *p)
 {

--- a/Opcodes/uggab.h
+++ b/Opcodes/uggab.h
@@ -1,5 +1,10 @@
 #ifndef UGGAB_H
 #define UGGAB_H
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
 /*
     uggab.h:
 

--- a/Opcodes/ugmoss.c
+++ b/Opcodes/ugmoss.c
@@ -21,11 +21,15 @@
     02110-1301 USA
 */
 
+#include <string.h>
+
                                                         /* ugmoss.c */
 #include "stdopcod.h"
 #include "ugmoss.h"
 #include "aops.h"
-#include <math.h>
+#include "csound.h"
+#include "float-version.h"
+#include "interlocks.h"
 
 /******************************************************************************
   all this code was written by william 'pete' moss. <petemoss@petemoss.org>

--- a/Opcodes/ugmoss.h
+++ b/Opcodes/ugmoss.h
@@ -22,6 +22,7 @@
 */
 
                                                          /* ugmoss.h */
+#pragma once
 
 typedef struct {
   OPDS                  h;

--- a/Opcodes/ugmoss.h
+++ b/Opcodes/ugmoss.h
@@ -24,6 +24,11 @@
                                                          /* ugmoss.h */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
   OPDS                  h;
   MYFLT                 *ar, *ain, *isize, *ifn;

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -65,8 +65,17 @@ kamp            ATSinterpread   kfreq
 #define OUT_OF_FRAMES (frIndx >= p->maxFr+1)
 
 #include "ugnorman.h"
+
 #include <ctype.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "interlocks.h"
+#include "Opcodes/stdopcod.h"
+#include "csound.h"
+#include "prototyp.h"
 
 #define ATSA_NOISE_VARIANCE 0.04
 

--- a/Opcodes/ugnorman.h
+++ b/Opcodes/ugnorman.h
@@ -25,6 +25,7 @@
  * Mon May 10 19:44:46 PDT 2004
  * header file for all of the ATScsound functions by Alex Norman
  */
+#pragma once
 
 #include "stdopcod.h"
 #include <stdlib.h>

--- a/Opcodes/ugnorman.h
+++ b/Opcodes/ugnorman.h
@@ -27,11 +27,10 @@
  */
 #pragma once
 
-#include "stdopcod.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
 
 typedef struct atsdataloc {
     double  amp;

--- a/Opcodes/ugsc.c
+++ b/Opcodes/ugsc.c
@@ -23,8 +23,12 @@
 
 /* ugsc.c -- Opcodes from Sean Costello <costello@seanet.com> */
 
+#include <math.h>
+#include <string.h>
+
 #include "stdopcod.h"
 #include "ugsc.h"
+#include "csound.h"
 
 /* svfilter.c
  *

--- a/Opcodes/ugsc.h
+++ b/Opcodes/ugsc.h
@@ -32,6 +32,7 @@
  * outputs.
  *
  */
+#pragma once
 
 typedef struct {
         OPDS h;

--- a/Opcodes/ugsc.h
+++ b/Opcodes/ugsc.h
@@ -34,6 +34,11 @@
  */
 #pragma once
 
+#include <stdint.h>
+
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
         OPDS h;
   MYFLT *low, *high, *band, *in, *kfco, *kq, *iscl, *iskip;

--- a/Opcodes/urandom.c
+++ b/Opcodes/urandom.c
@@ -21,7 +21,14 @@
     02110-1301 USA
 */
 
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 //#include <ieee754.h>
 
 #ifdef __HAIKU__

--- a/Opcodes/vaops.c
+++ b/Opcodes/vaops.c
@@ -21,8 +21,13 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "csoundCore.h"
 #include "interlocks.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define MYFLOOR(x) (x >= FL(0.0) ? (int32)x : (int32)((double)x - 0.99999999))
 

--- a/Opcodes/vbap.c
+++ b/Opcodes/vbap.c
@@ -34,7 +34,9 @@ Re-written to take flexible number of outputs by JPff 2012 */
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "interlocks.h"
+#include <string.h>
+
+
 
 #define MATSIZE (4)
 #define ATORAD  (TWOPI_F / FL(360.0))

--- a/Opcodes/vbap.h
+++ b/Opcodes/vbap.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #define LOWEST_ACCEPTABLE_WT FL(0.0)
 #define CHANNELS 128

--- a/Opcodes/vbap.h
+++ b/Opcodes/vbap.h
@@ -22,6 +22,12 @@
 */
 #pragma once
 
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 #define LOWEST_ACCEPTABLE_WT FL(0.0)
 #define CHANNELS 128
 #define MIN_VOL_P_SIDE_LGTH FL(0.01)

--- a/Opcodes/vbap1.c
+++ b/Opcodes/vbap1.c
@@ -35,6 +35,12 @@ Ville Pulkki heavily modified by John ffitch 2012
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+
+#include "csound.h"
+#include "sysdep.h"
 
 static int32_t vbap1_moving_control(CSOUND *, VBAP1_MOVE_DATA *, OPDS *, MYFLT,
                                 MYFLT, MYFLT, MYFLT**);

--- a/Opcodes/vbap_n.c
+++ b/Opcodes/vbap_n.c
@@ -34,7 +34,11 @@ Ville Pulkki heavily modified by John ffitch 2012
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
 #include "arrays.h"
+#include "csound.h"
+#include "sysdep.h"
 
 int32_t vbap_moving_control(CSOUND *, VBAP_MOVE_DATA *, OPDS*, MYFLT,
                         MYFLT *, MYFLT*,MYFLT**);

--- a/Opcodes/vbap_zak.c
+++ b/Opcodes/vbap_zak.c
@@ -34,7 +34,12 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "zak.h"
+#include <stdint.h>
+#include <string.h>
+
+
+#include "csound.h"
+#include "sysdep.h"
 
 int32_t vbap_zak_moving_control(CSOUND *, VBAP_ZAK_MOVING *);
 int32_t vbap_zak_control(CSOUND *,VBAP_ZAK *);

--- a/Opcodes/vpvoc.c
+++ b/Opcodes/vpvoc.c
@@ -26,8 +26,17 @@
 /*** By Richard Karpen - July-October 1992************/
 /************************************************************/
 
+#include <stdint.h>
+#include <string.h>
+
 #include "pvoc.h"
-#include <math.h>
+#include "Opcodes/dsputil.h"
+#include "Opcodes/ugens8.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "prototyp.h"
+#include "sysdep.h"
+#include "vpvoc.h"
 
 int32_t tblesegset(CSOUND *csound, TABLESEG *p)
 {

--- a/Opcodes/vpvoc.h
+++ b/Opcodes/vpvoc.h
@@ -22,6 +22,9 @@
 */
 #pragma once
 
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     FUNC    *function, *nxtfunction;
     MYFLT   d;

--- a/Opcodes/vpvoc.h
+++ b/Opcodes/vpvoc.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 typedef struct {
     FUNC    *function, *nxtfunction;

--- a/Opcodes/wave-terrain.c
+++ b/Opcodes/wave-terrain.c
@@ -21,9 +21,15 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "stdopcod.h"
+#include "csoundCore.h"
 #include "wave-terrain.h"
-#include <math.h>
+#include "csdl.h"
+#include "csound.h"
+#include "interlocks.h"
 
 /*  Wave-terrain synthesis opcode
  *

--- a/Opcodes/wave-terrain.h
+++ b/Opcodes/wave-terrain.h
@@ -22,7 +22,9 @@
 */
 #pragma once
 
-#include "csdl.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
 
   OPDS h;

--- a/Opcodes/wave-terrain.h
+++ b/Opcodes/wave-terrain.h
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#pragma once
 
 #include "csdl.h"
 typedef struct {

--- a/Opcodes/wpfilters.c
+++ b/Opcodes/wpfilters.c
@@ -43,6 +43,9 @@ Csound C versions by Steven Yi
 
 #include "wpfilters.h"
 
+#include <math.h>
+#include <string.h>
+
 static int32_t zdf_1pole_mode_init(CSOUND* csound, ZDF_1POLE_MODE* p) {
      IGN(csound);
     if (*p->skip == 0) {

--- a/Opcodes/wpfilters.h
+++ b/Opcodes/wpfilters.h
@@ -37,6 +37,7 @@ downloads/pdf/VAFilterDesign_1.1.1.pdf)
 
 Csound C versions by Steven Yi
 */
+#pragma once
 
 #include "csoundCore.h"
 

--- a/Opcodes/wpfilters.h
+++ b/Opcodes/wpfilters.h
@@ -39,7 +39,11 @@ Csound C versions by Steven Yi
 */
 #pragma once
 
+#include <stdint.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "sysdep.h"
 
 typedef struct {
   OPDS h;

--- a/Opcodes/wterrain2.c
+++ b/Opcodes/wterrain2.c
@@ -25,7 +25,12 @@
 */
 
 #include <csdl.h>
-#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "csound.h"
+#include "interlocks.h"
+#include "sysdep.h"
 
 /*  Wave-terrain synthesis opcode
  *

--- a/Opcodes/zak.c
+++ b/Opcodes/zak.c
@@ -46,12 +46,11 @@
  * clearly indicated as such.
  */
 
+#include <string.h>
+
 #include "csoundCore.h"
 //#include "csdl.h"
 #include "interlocks.h"
-#include <math.h>
-#include <ctype.h>
-
 #include "zak.h"
 
 /*****************************************************************************/

--- a/Opcodes/zak.h
+++ b/Opcodes/zak.h
@@ -22,6 +22,8 @@
 */
 
                                                         /*      ZAK.H */
+#pragma once
+
 typedef struct {
     MYFLT         *zkstart;
     int64_t       zklast;

--- a/Opcodes/zak.h
+++ b/Opcodes/zak.h
@@ -24,6 +24,12 @@
                                                         /*      ZAK.H */
 #pragma once
 
+#include <stdint.h>
+
+#include "csound.h"
+#include "csoundCore.h"
+#include "sysdep.h"
+
 typedef struct {
     MYFLT         *zkstart;
     int64_t       zklast;

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -20,12 +20,24 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      ARGDECODE.C     */
 #include "soundio.h"
 #include "new_opts.h"
 #include "csmodule.h"
 #include "corfile.h"
 #include <ctype.h>
+#include "csound.h"
+#include "envvar.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 static void list_audio_devices(CSOUND *csound, int output);
 static void list_midi_devices(CSOUND *csound, int output);

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -21,12 +21,20 @@
     02110-1301 USA
 */
 
-#include <iostream>
-#include <exception>
+#include <emmintrin.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <string.h>
+#include <new>
+#include <string>
 
 #include "csound.hpp"
 #include "csPerfThread.hpp"
-#include "soundio.h"
+#include "csound.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 // ----------------------------------------------------------------------------
 

--- a/Top/cscore_internal.c
+++ b/Top/cscore_internal.c
@@ -21,7 +21,10 @@
     02110-1301 USA
 */
 
+#include <stddef.h>
+
 #include "cscore.h"                              /*  CSCORE_DEFAULT.C   */
+#include "csound.h"
 
 void cscore_(CSOUND *cs)  /* callable from Csound or standalone cscore  */
                           /* csound -C will run Csound scores as normal */

--- a/Top/cscorfns.c
+++ b/Top/cscorfns.c
@@ -21,9 +21,18 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
 #include "csoundCore.h"     /*                      CSCORFNS.C      */
 #include "cscore.h"
 #include "corfile.h"
+#include "csound.h"
+#include "envvar.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #define TYP_FREE   0
 #define TYP_EVENT  1

--- a/Top/csdebug.c
+++ b/Top/csdebug.c
@@ -22,8 +22,13 @@
 */
 
 #include <assert.h>
+#include <string.h>
 
 #include "csdebug.h"
+#include "csound.h"
+#include "csoundCore.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
 debug_instr_t *csoundDebugGetCurrentInstrInstance(CSOUND *csound);
 debug_opcode_t *csoundDebugGetCurrentOpcodeList(CSOUND *csound);

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -72,6 +72,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
+#include <sys/stat.h>
 
 #if !(defined (__wasi__))
 #include <setjmp.h>
@@ -80,6 +82,11 @@
 
 #include "csoundCore.h"
 #include "csmodule.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "sysdep.h"
+#include "version.h"
 
 #if defined(__MACH__)
 #include <TargetConditionals.h>

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -29,10 +29,12 @@
 //#ifdef __cplusplus
 //extern "C" {
 //#endif
-
-#if defined(HAVE_UNISTD_H) || defined (__unix) || defined(__unix__)
-#include <unistd.h>
-#endif
+#include <emmintrin.h>
+#include <setjmp.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "csoundCore.h"
 #include "csmodule.h"
@@ -42,25 +44,28 @@
 #include <stdarg.h>
 #include <signal.h>
 #include <time.h>
-#include <ctype.h>
 #include <limits.h>
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "csound_type_system.h"
+#include "cwindow.h"
+#include "envvar.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
+#include "version.h"
+
 #if defined(WIN32) && !defined(__CYGWIN__)
 # include <winsock2.h>
 # include <windows.h>
 #endif
-#include <math.h>
-#include "oload.h"
 #include "fgens.h"
 #include "namedins.h"
 #include "pvfileio.h"
 #include "fftlib.h"
 #include "lpred.h"
-#include "cs_par_base.h"
-#include "cs_par_orc_semantics.h"
-#include "namedins.h"
 //#include "cs_par_dispatch.h"
 #include "find_opcode.h"
 
@@ -71,7 +76,6 @@
 #include "csound_standard_types.h"
 
 #include "csdebug.h"
-#include <time.h>
 
 extern void allocate_message_queue(CSOUND *csound);
 static void SetInternalYieldCallback(CSOUND *, int (*yieldCallback)(CSOUND *));
@@ -247,6 +251,9 @@ static int csoundGetDitherMode(CSOUND *csound){
 }
 
 #include "Opcodes/zak.h"
+
+struct CsoundCallbackEntry_s;
+
 static int csoundGetZakBounds(CSOUND *csound, MYFLT **zkstart){
     ZAK_GLOBALS *zz;
     zz = (ZAK_GLOBALS*) csound->QueryGlobalVariable(csound, "_zak_globals");

--- a/Top/getstring.c
+++ b/Top/getstring.c
@@ -24,6 +24,8 @@
 */
 
 #include "csoundCore.h"
+#include "csound.h"
+
 #ifdef HAVE_STRTOD_L
 static locale_t csound_c_locale = NULL;
 #else
@@ -31,8 +33,6 @@ static char *csound_c_locale = NULL;
 #endif
 
 #ifdef HAVE_DIRENT_H
-#  include <sys/types.h>
-#  include <dirent.h>
 #  if 0 && defined(__MACH__)
 typedef void* DIR;
 DIR opendir(const char *);
@@ -41,10 +41,12 @@ int closedir(DIR*);
 #  endif
 #endif
 
-#include "namedins.h"
-
 #define CSSTRNGS_VERSION 0x2000
 #include <locale.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #ifdef GNU_GETTEXT
 #include <libintl.h>
 #endif

--- a/Top/main.c
+++ b/Top/main.c
@@ -16,16 +16,20 @@
     02110-1301 USA
 */
 
-#include <ctype.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "csoundCore.h"         /*                      MAIN.C          */
-#include "soundio.h"
 #include "csmodule.h"
 #include "corfile.h"
-
-#include "csound_orc.h"
-
-#include "cs_par_base.h"
-#include "cs_par_orc_semantics.h"
+#include "csound.h"
+#include "envvar.h"
+#include "prototyp.h"
+#include "soundfile.h"
+#include "sysdep.h"
 //#include "cs_par_dispatch.h"
 
 extern void allocate_message_queue(CSOUND *csound);

--- a/Top/new_opts.c
+++ b/Top/new_opts.c
@@ -30,12 +30,12 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "csoundCore.h"
 #include "csound.h"
 #include "new_opts.h"
+#include "sysdep.h"
 
 /* list command line usage of all registered configuration variables */
 

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -21,18 +21,24 @@
     02110-1301 USA
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csoundCore.h"
 #include <stdlib.h>
+#include "csound.h"
+#include "envvar.h"
+#include "prototyp.h"
+#include "sysdep.h"
+
 int mkstemp(char *);
 #include <ctype.h>
-#ifndef __wasi__
-#include <errno.h>
-#endif
-#include <stdlib.h>
+
 #include "corfile.h"
 
 #if defined(LINUX) || defined(__MACH__) || defined(WIN32)
-#  include <sys/types.h>
 #  include <sys/stat.h>
 #endif
 
@@ -1113,9 +1119,6 @@ int read_unified_file4(CSOUND *csound, CORFIL *cf)
     int started = FALSE;
     int notrunning = csound->engineStatus & CS_STATE_COMP;
     char    buffer[CSD_MAX_LINE_LEN];
-#ifdef _DEBUG
-    //csoundMessage(csound, "Calling unified file system4\n");
-#endif
     if (notrunning==0) {
       alloc_globals(csound);
       STA(orcname) = STA(sconame) = STA(midname) = NULL;

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -25,6 +25,9 @@
                                 /* OPCODE.C */
                                 /* Print opcodes in system */
 
+#include <stdlib.h>
+#include <string.h>
+
                                 /* John ffitch -- 26 Jan 97 */
                                 /*  4 april 02 -- ma++ */
                                 /*  restructure to retrieve externally  */
@@ -32,6 +35,10 @@
 #include "csoundCore.h"
 #include <ctype.h>
 #include "interlocks.h"
+#include "csound.h"
+#include "csound_data_structures.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 static int opcode_cmp_func(const void *a, const void *b)
 {

--- a/Top/server.c
+++ b/Top/server.c
@@ -27,7 +27,19 @@
 /* Haiku 'int32' etc definitions in net headers conflict with sysdep.h */
 #define __HAIKU_CONFLICT
 
+#include <fcntl.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "csoundCore.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 #if defined(WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -410,7 +422,6 @@ void csoundStopUDPConsole(CSOUND *csound) {
 }
 
 #else // STUBS
-#include "csoundCore.h"
 void csoundStopUDPConsole(CSOUND *csound) { };
 int csoundUDPConsole(CSOUND *csound, const char *addr, int port, int
                      mirror) { return CSOUND_ERROR; }

--- a/Top/threads.c
+++ b/Top/threads.c
@@ -22,6 +22,14 @@
 */
 
 #include <errno.h>
+#include <features.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "csound.h"
+#include "sysdep.h"
 
 #if defined(__linux) || defined(__linux__)
 /* for pthread_mutex_timedlock() */
@@ -36,8 +44,6 @@
 #define HAVE_GETTIMEOFDAY 1
 #endif
 #endif
-
-#include "csoundCore.h"
 
 #if 0
 static CS_NOINLINE void notImplementedWarning_(const char *name)
@@ -159,11 +165,6 @@ PUBLIC void csoundSleep(size_t milliseconds)
 }
 
 #endif
-
-#ifndef __wasi__
-#include <errno.h>
-#endif
-
 #include <pthread.h>
 #include <time.h>
 #include <unistd.h>

--- a/Top/threads.c
+++ b/Top/threads.c
@@ -21,9 +21,13 @@
   02110-1301 USA
 */
 
+#include <errno.h>
+
 #if defined(__linux) || defined(__linux__)
 /* for pthread_mutex_timedlock() */
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
+#endif
 #endif
 
 #ifndef HAVE_GETTIMEOFDAY

--- a/Top/threadsafe.c
+++ b/Top/threadsafe.c
@@ -19,9 +19,17 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include "csound_orc.h"
 #include <stdlib.h>
+#include "csound.h"
+#include "float-version.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 #ifdef USE_DOUBLE
 #  define MYFLT_INT_TYPE int64_t

--- a/Top/utility.c
+++ b/Top/utility.c
@@ -21,9 +21,16 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "csoundCore.h"
 #include <setjmp.h>
 #include "corfile.h"
+#include "csound.h"
+#include "prototyp.h"
+#include "sysdep.h"
 
 typedef struct csUtility_s {
     char                *name;

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -23,7 +23,7 @@
 #ifndef CSOUNDCORE_H
 #define CSOUNDCORE_H
 
-#if !defined(__BUILDING_LIBCSOUND) && !defined(CSOUND_CSDL_H)
+#if !defined(__BUILDING_LIBCSOUND) && !defined(CSOUND_CSDL_H)  && !defined(SIGNAL_FLOW_GRAPH_H)
 #  error "Csound plugins and host applications should not include csoundCore.h"
 #endif
 

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -20,13 +20,12 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
+#ifndef CSOUNDCORE_H
+#define CSOUNDCORE_H
 
 #if !defined(__BUILDING_LIBCSOUND) && !defined(CSOUND_CSDL_H)
 #  error "Csound plugins and host applications should not include csoundCore.h"
 #endif
-
-#ifndef CSOUNDCORE_H
-#define CSOUNDCORE_H
 
 #if defined(__EMSCRIPTEN__) && !defined(EMSCRIPTEN)
 #define EMSCRIPTEN

--- a/include/csound_type_system.h
+++ b/include/csound_type_system.h
@@ -31,13 +31,11 @@ extern "C" {
 #include "csound.h"
 #include "csound_data_structures.h"
 #include <stdint.h>
+#include "sysdep.h"
 
 #define CS_ARG_TYPE_BOTH 0
 #define CS_ARG_TYPE_IN 1
 #define CS_ARG_TYPE_OUT 2
-
-    struct csvariable;
-    struct cstype;
     
     typedef struct cstype {
         char* varTypeName;

--- a/include/interlocks.h
+++ b/include/interlocks.h
@@ -22,6 +22,8 @@
 */
 
 // ZAK
+#pragma once
+
 #define ZR (0x0001)
 #define ZW (0x0002)
 #define ZB (0x0003)

--- a/include/pstream.h
+++ b/include/pstream.h
@@ -24,6 +24,8 @@
 #ifndef __PSTREAM_H_INCLUDED
 #define __PSTREAM_H_INCLUDED
 
+#include "csoundCore.h"
+
 /* pstream.h.  Implementation of PVOCEX streaming opcodes.
    (c) Richard Dobson August 2001
    NB pvoc routines based on CARL distribution (Mark Dolson).

--- a/include/soundio.h
+++ b/include/soundio.h
@@ -24,6 +24,7 @@
 #ifndef CSOUND_SOUNDIO_H
 #define CSOUND_SOUNDIO_H
 
+#include "csound.h"
 #include "soundfile.h"
 
 

--- a/include/ugen.h
+++ b/include/ugen.h
@@ -19,6 +19,9 @@
 
 #include "csoundCore.h"
 #include <stdbool.h>
+#include "csound.h"
+#include "csound_type_system.h"
+#include "sysdep.h"
 
 typedef struct {
   CSOUND* csound;

--- a/include/ugen.h
+++ b/include/ugen.h
@@ -15,6 +15,7 @@
  *
  * - context: required for things like hold, releasing, etc.
  * */
+#pragma once
 
 #include "csoundCore.h"
 #include <stdbool.h>

--- a/map.imp
+++ b/map.imp
@@ -1,0 +1,11 @@
+[
+  { include: ["<bits/termios-baud.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-c_cc.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-c_cflag.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-c_iflag.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-c_lflag.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-c_oflag.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-struct.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/termios-tcflow.h>", "private", "<termios.h>", "public"] },
+  { include: ["<bits/types/struct_sched_param.h>", "private", "<sched.h>", "public"] }
+]

--- a/map.imp
+++ b/map.imp
@@ -7,5 +7,8 @@
   { include: ["<bits/termios-c_oflag.h>", "private", "<termios.h>", "public"] },
   { include: ["<bits/termios-struct.h>", "private", "<termios.h>", "public"] },
   { include: ["<bits/termios-tcflow.h>", "private", "<termios.h>", "public"] },
-  { include: ["<bits/types/struct_sched_param.h>", "private", "<sched.h>", "public"] }
+  { include: ["<bits/types/locale_t.h>", "private", "<locale.h>", "public"] },
+  { include: ["<bits/types/struct_sched_param.h>", "private", "<sched.h>", "public"] },
+  { include: ["<bits/types/struct_tm.h>", "private", "<time.h>", "public"] },
+  { include: ["<ext/alloc_traits.h>", "private", "<memory>", "public"] }
 ]

--- a/util/SDIF/sdif-mem.c
+++ b/util/SDIF/sdif-mem.c
@@ -38,10 +38,10 @@ Technologies, University of California, Berkeley.
 
 */
 
-#include "sysdep.h"
 #include <assert.h>
-#include <errno.h>
+
 #include "sdif-mem.h"
+#include "SDIF/sdif.h"
 
 /* Global variables local to this file */
 static void *(*my_malloc)(int32_t numBytes);

--- a/util/SDIF/sdif-mem.h
+++ b/util/SDIF/sdif-mem.h
@@ -47,6 +47,9 @@ Version 1.0, 9/21/99
 /*RWD TODO: declare objects, no pounters */
 #ifndef CSOUND_SDIF_MEM_H
 #define CSOUND_SDIF_MEM_H
+#include <stdint.h>
+#include <stdio.h>
+
 #include "sdif.h"
 
 typedef struct SDIFmemMatrixStruct {

--- a/util/SDIF/sdif.c
+++ b/util/SDIF/sdif.c
@@ -75,8 +75,6 @@ Music and Audio Technologies, University of California, Berkeley.
 #define assert(x) /* Do nothing */
 #endif
 
-#include "sysdep.h"
-#include <errno.h>
 #include "sdif.h"
 
 /* prototypes for functions used only in this file. */

--- a/util/SDIF/sdif.h
+++ b/util/SDIF/sdif.h
@@ -51,6 +51,8 @@ Music and Audio Technologies, University of California, Berkeley.
 #ifndef CSOUND_SDIF_H
 #define CSOUND_SDIF_H
 
+#include <stdint.h>
+
 #include "sysdep.h"
 #include <stdio.h>
 /****************************************************/

--- a/util/SDIF/sdif2adsyn.c
+++ b/util/SDIF/sdif2adsyn.c
@@ -23,11 +23,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "sdif.h"
-#include "sdif-mem.h"
 
 #ifndef max
 #define max(x,y) ((x)>(y) ? (x) : (y))
@@ -269,9 +268,6 @@ int main(int argc, char **argv)
         fprintf(stderr,"\nWARNING: multiple stream IDs found - skipping");
         continue;
       }
-#ifdef _DEBUG
-      /*printf("\nReading SDIF Frame %d, time = %.4f",framecount,fh.time); */
-#endif
       thistime = (float) fh.time;
       /* Csound adsyn counts time in msecs, in shorts, so can only have
          32.767 seconds! */
@@ -294,9 +290,6 @@ int main(int argc, char **argv)
         }
 
         n_partials = mh.rowCount;
-#ifdef _DEBUG
-        /*printf("\nReading Matrix %d: %d rows",i+1,n_partials); */
-#endif
 
         for (j=0;j < n_partials; j++) {
 

--- a/util/atsa.c
+++ b/util/atsa.c
@@ -32,7 +32,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
+#include <sndfile.h>
+
+#include "csdl.h"
+#include "csound.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 #if defined(__GNUC__) && defined(__STRICT_ANSI__)
 #  ifndef inline

--- a/util/csanalyze.c
+++ b/util/csanalyze.c
@@ -21,6 +21,8 @@
  02110-1301 USA
  */
 
+#include <stdio.h>
+
 #include "csound.h"
 
 extern void     print_tree(CSOUND *, char *, TREE *);

--- a/util/cvanal.c
+++ b/util/cvanal.c
@@ -30,9 +30,18 @@
 /*  Greg Sullivan                                                       */
 /************************************************************************/
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "std_util.h"
 #include "soundio.h"
 #include "convolve.h"
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "sysdep.h"
 
 static int32_t takeFFT(CSOUND *csound, SOUNDIN *inputSound, CVSTRUCT *outputCVH,
                        int64_t Hlenpadded, SNDFILE *infd, FILE *ofd, int32_t nf);

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -78,6 +78,17 @@
 #include <math.h>
 #include <ctype.h>
 #include <inttypes.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 
 #define ERR(x)                          \

--- a/util/envext.c
+++ b/util/envext.c
@@ -28,10 +28,19 @@
 *   mainly lifted from scale and Csound itself          *
 \*******************************************************/
 
+#include <inttypes.h>
+#include <sndfile.h>
+#include <stdarg.h>
+#include <string.h>
+
 #include "std_util.h"
 #include "soundio.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "csdl.h"
+#include "csound.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 /* Constants */
 

--- a/util/het_export.c
+++ b/util/het_export.c
@@ -30,7 +30,11 @@
 
 #include "std_util.h"
 #include <stdio.h>
-#include <stdarg.h>
+#include <stdint.h>
+
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 #define END  32767
 

--- a/util/het_import.c
+++ b/util/het_import.c
@@ -30,13 +30,18 @@
 
 #include "std_util.h"
 #include <stdio.h>
-#include <stdarg.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 #ifndef MYFLT
 #include "sysdep.h"
 #endif
 /*#include "hetro.h"*/
-#include "text.h"
 
 #define END  32767
 

--- a/util/heti_main.c
+++ b/util/heti_main.c
@@ -29,7 +29,6 @@
 /* ***************************************************************** */
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <stdlib.h>
 #define END  32767
 

--- a/util/hetro.c
+++ b/util/hetro.c
@@ -21,10 +21,18 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "std_util.h"                                   /*  HETRO.C   */
 #include "soundio.h"
 #include <math.h>
 #include <inttypes.h>
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "sysdep.h"
 
 //#define DEBUG 1
 
@@ -38,7 +46,7 @@
 #define _WINDOWS_
 /* CNMAT sdif library, subject to change..... */
 #include "SDIF/sdif.h"
-#include "SDIF/sdif-mem.h"
+
 typedef struct {
     sdif_float32 index, freq, amp, phase;
 } SDIF_RowOf1TRC;

--- a/util/lpanal.c
+++ b/util/lpanal.c
@@ -27,10 +27,18 @@
 #include "soundio.h"
 #include "lpc.h"
 #include "cwindow.h"
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "sysdep.h"
 #ifndef WIN32
 #include <unistd.h>
 #endif
 #include <math.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* LPC analysis, modified by BV 8'92 for linkage to audio files via soundin.c.
  * Currently set for maximum of 50 poles, & max anal segment of 1000 samples,
@@ -95,7 +103,6 @@ static  MYFLT   getpch(CSOUND *, MYFLT *, LPANAL_GLOBALS*);
     if (UNLIKELY(!(--argc) || (((s = *++argv)!=0) && *s == '-')))       \
       lpdieu(csound, MSG);
 
-#include <math.h>
 #include <stdio.h>
 #ifndef TRUE
 #define TRUE (1)

--- a/util/lpc_export.c
+++ b/util/lpc_export.c
@@ -28,15 +28,17 @@
 /* John ffitch 1995 Jun 25                                           */
 /* ***************************************************************** */
 
+#include <math.h>
+#include <stdint.h>
 #include "std_util.h"
 #include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 #ifndef MYFLT
 #include "sysdep.h"
 #endif
 #include "lpc.h"
-#include "text.h"
 
 void lpc_export_usage(CSOUND *csound)
 {

--- a/util/lpc_import.c
+++ b/util/lpc_import.c
@@ -29,10 +29,13 @@
 /* ***************************************************************** */
 
 #include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
+#include <stdint.h>
+
 #include "std_util.h"
 #include "lpc.h"
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 void lpc_import_usage(CSOUND *csound)
 {

--- a/util/lpci_main.c
+++ b/util/lpci_main.c
@@ -30,7 +30,6 @@
 /* ***************************************************************** */
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <stdlib.h>
 #ifndef MYFLT
 #include "sysdep.h"

--- a/util/lpcx_main.c
+++ b/util/lpcx_main.c
@@ -30,8 +30,9 @@
 /* ***************************************************************** */
 
 #include <stdio.h>
-#include <stdarg.h>
 #include <stdlib.h>
+#include <math.h>
+#include <stdint.h>
 #ifndef MYFLT
 #include "sysdep.h"
 #endif

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -34,10 +34,22 @@
  *     Needs to take much more care
  */
 
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "std_util.h"
 #include "soundio.h"
 #include <ctype.h>
 #include <inttypes.h>
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 /* Constants */
 

--- a/util/new_srconv.c
+++ b/util/new_srconv.c
@@ -47,7 +47,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <limits.h>
 #include <ctype.h>
 #include <sndfile.h>
 #include <samplerate.h>

--- a/util/pv_export.c
+++ b/util/pv_export.c
@@ -29,11 +29,15 @@
 /* John ffitch 1995 Jun 17                                           */
 /* ***************************************************************** */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "std_util.h"
 #include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
 #include "pvfileio.h"
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 static void pv_export_usage(CSOUND *csound)
 {

--- a/util/pv_import.c
+++ b/util/pv_import.c
@@ -32,8 +32,13 @@
 #include "std_util.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
+#include <stdint.h>
+
+
 #include "pvfileio.h"
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
 
 static void pv_import_usage(CSOUND *csound)
 {

--- a/util/pvanal.c
+++ b/util/pvanal.c
@@ -34,12 +34,21 @@
 /************************************************************************/
 /************************************************************************/
 
+#include <inttypes.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "std_util.h"
 #include "cwindow.h"
 #include "soundio.h"
 #include "pvfileio.h"
 #include <math.h>
-#include <ctype.h>
+#include "csdl.h"
+#include "csound.h"
+#include "float-version.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 
 typedef struct pvocex_ch {

--- a/util/pvl_main.c
+++ b/util/pvl_main.c
@@ -21,8 +21,10 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+
 #include "csound.h"
-#include <stdarg.h>
+#include "msg_attr.h"
 
 static void messageCallback_(CSOUND *csound, int attr,
                              const char *fmt, va_list args)

--- a/util/pvlook.c
+++ b/util/pvlook.c
@@ -31,6 +31,15 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+#include "csdl.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "sysdep.h"
 
 typedef struct PVLOOK_ {
     CSOUND  *csound;

--- a/util/scale.c
+++ b/util/scale.c
@@ -29,9 +29,20 @@
 *   and a certain amount of lifting from Csound itself  *
 \*******************************************************/
 
+#include <inttypes.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "std_util.h"
 #include "soundio.h"
 #include <ctype.h>
+#include "csdl.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 /* Constants */
 

--- a/util/sndinfo.c
+++ b/util/sndinfo.c
@@ -22,8 +22,17 @@
     02110-1301 USA
 */
 
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "std_util.h"                               /*  SNDINFO.C  */
-#include "soundio.h"
+#include "csdl.h"
+#include "csound.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 /* Some of the information is borrowed from libsndfile's sndfile-info code */
 

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -44,10 +44,11 @@
  *    MODIFIED:  John ffitch December 2000; changes to Csound context
  */
 
+#include <stddef.h>
+
 #include "std_util.h"
-#include "soundio.h"
-#include <math.h>
-#include <ctype.h>
+#include "csdl.h"
+#include "csound.h"
 
 #define IBUF    (4096)
 #define IBUF2   (IBUF/2)

--- a/util/std_util.c
+++ b/util/std_util.c
@@ -21,6 +21,12 @@
 
 #include "std_util.h"
 
+#include <stddef.h>
+
+#include "csdl.h"
+#include "sysdep.h"
+#include "version.h"
+
 /* Modified from BSD sources for strlcpy */
 /*
  * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>

--- a/util/std_util.h
+++ b/util/std_util.h
@@ -25,6 +25,9 @@
 #include "csdl.h"
 #include <inttypes.h>
 
+
+#include "csound.h"
+
 extern int32_t atsa_init_(CSOUND *);
 extern int32_t cvanal_init_(CSOUND *);
 extern int32_t dnoise_init_(CSOUND *);

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -31,9 +31,21 @@
  *     Needs to take much more care
  */
 
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
 #include "std_util.h"
 #include "soundio.h"
-#include <ctype.h>
+#include "csdl.h"
+#include "csound.h"
+#include "msg_attr.h"
+#include "soundfile.h"
+#include "sysdep.h"
 
 
 /* Constants */

--- a/util1/csd_util/cs.c
+++ b/util1/csd_util/cs.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/types.h>
 #include <dirent.h>
 #include <ctype.h>
 #ifdef HAVE_UNISTD_H

--- a/util1/scot/scot.c
+++ b/util1/scot/scot.c
@@ -26,6 +26,10 @@
 
 #include "scot.h"
 
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
 #define Str(x)  (x)
 #if defined(HAVE_GCC3)
 #  define UNLIKELY(x)   __builtin_expect(!!(x),0)

--- a/util1/scot/scot.h
+++ b/util1/scot/scot.h
@@ -23,6 +23,7 @@
 
 /*                                                      SCOT.H       */
 /* aldel Jul 91 */
+#pragma once
 
 #include <stdio.h>
 #include <string.h>

--- a/util1/scot/scot_main.c
+++ b/util1/scot/scot_main.c
@@ -1,7 +1,5 @@
 
 #include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
 
 extern int scot(FILE *inf, FILE *outf, char *fil);
 

--- a/util1/sortex/smain.c
+++ b/util1/sortex/smain.c
@@ -21,7 +21,10 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+
 #include "csound.h"                                    /*   SMAIN.C  */
+#include "msg_attr.h"
 
 #if defined(LINUX) || defined(SGI) || defined(sol) || \
     defined(__MACH__) || defined(__EMX__)

--- a/util1/sortex/xmain.c
+++ b/util1/sortex/xmain.c
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#include <stdio.h>
+
 #include "csound.h"                                /*   XMAIN.C  */
 
 #if defined(LINUX) || defined(SGI) || defined(sol) || \


### PR DESCRIPTION
include-what-you-use automatically detects and adds headers you've used, so I ran it. I also added a `map.imp` file to map some system files to more general ones. Only issue I ran into was that I couldn't get `signalflowgraph` not to rely on `csoundCore`, which violates a rule in the code. So I added an exception for it for now?