### PR TITLE
add include guards

### DIFF
--- a/Frontends/beats/beats.h
+++ b/Frontends/beats/beats.h
@@ -21,6 +21,7 @@
     02110-1301 USA
 */
 
+#pragma once
 
     typedef struct instr {
       struct instr *next;

--- a/H/aops.h
+++ b/H/aops.h
@@ -23,6 +23,8 @@
 
 /*                                                      AOPS.H          */
 
+#pragma once
+
 #define CSOUND_SPIN_SPINLOCK csoundSpinLock(&csound->spinlock);
 #define CSOUND_SPIN_SPINUNLOCK csoundSpinUnLock(&csound->spinlock);
 #define CSOUND_SPOUT_SPINLOCK csoundSpinLock(&csound->spoutlock);

--- a/H/bus.h
+++ b/H/bus.h
@@ -25,6 +25,8 @@
 
 /*                                                      BUS.H           */
 
+#pragma once
+
 #ifndef CSOUND_BUS_H
 #define CSOUND_BUS_H
 

--- a/H/cmath.h
+++ b/H/cmath.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 double besseli(double);
 
 /* returns 0 on success, -1 if there are insufficient arguments, */

--- a/H/compile_ops.h
+++ b/H/compile_ops.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include <csoundCore.h>
 
 typedef struct _compile {

--- a/H/csGblMtx.h
+++ b/H/csGblMtx.h
@@ -21,6 +21,7 @@
     02110-1301 USA
 */
 #ifndef CSOUND_CSGBLMTX_H
+#define CSOUND_CSGBLMTX_H
 
 
 #ifdef HAVE_PTHREAD

--- a/H/cs_jack.h
+++ b/H/cs_jack.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define MAX_NAME_LEN    32      /* for client and port name */
 
 typedef struct RtJackBuffer_ {

--- a/H/cs_par_ops.h
+++ b/H/cs_par_ops.h
@@ -23,6 +23,7 @@
 
 /*                                                      CS_PAR_OPS.H          */
 
+#pragma once
 
 typedef struct {
     OPDS    h;

--- a/H/disprep.h
+++ b/H/disprep.h
@@ -22,6 +22,8 @@
 */
 
                         /*                                      DISPREP.H       */
+#pragma once
+
 #include "pstream.h"
 
 typedef struct {

--- a/H/dumpf.h
+++ b/H/dumpf.h
@@ -22,6 +22,8 @@
 */
 
                                                         /*  DUMPF.H  */
+#pragma once
+
 typedef struct {
         OPDS   h;
         MYFLT  *ksig, *ifilcod, *iformat, *iprd;

--- a/H/entry1.h
+++ b/H/entry1.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "csoundCore.h"         /*                      ENTRY1.H        */
 #include "insert.h"
 #include "aops.h"

--- a/H/insert.h
+++ b/H/insert.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {                        /*       INSERT.H                */
     OPDS    h;
     LBLBLK  *lblblk;

--- a/H/lpc.h
+++ b/H/lpc.h
@@ -23,6 +23,8 @@
 
 /*                                                                      LPC.H   */
 
+#pragma once
+
 #define LP_MAGIC    999
 #define LP_MAGIC2   2399           /* pole file type */
 #define LPBUFSIZ    4096           /* in lpanal */

--- a/H/midioops.h
+++ b/H/midioops.h
@@ -28,6 +28,8 @@
  * Defines etc for the basic MIDI output codes
  * **********************************************************************/
 
+#pragma once
+
 #define MD_NOTEOFF      (0x80)
 #define MD_NOTEON       (0x90)
 #define MD_POLYAFTER    (0xa0)

--- a/H/midiout.h
+++ b/H/midiout.h
@@ -25,6 +25,8 @@
 /** midiout UGs by Gabriel Maldonado   **/
 /****************************************/
 
+#pragma once
+
 typedef int BOOL;
 #ifndef TRUE
 #   define TRUE (1)

--- a/H/resize.h
+++ b/H/resize.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
     OPDS h;
     MYFLT *size;                /* Ansser */

--- a/H/schedule.h
+++ b/H/schedule.h
@@ -22,6 +22,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
         OPDS   h;
         MYFLT  *which, *when, *dur;

--- a/H/sndinfUG.h
+++ b/H/sndinfUG.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
     OPDS    h;
     MYFLT   *r1, *ifilno, *irawfiles;

--- a/H/sort.h
+++ b/H/sort.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include <stdio.h>                                 /*      SORT.H */
 #ifndef MYFLT
 #include "sysdep.h"

--- a/H/ugens1.h
+++ b/H/ugens1.h
@@ -23,6 +23,8 @@
 
 /*                                                         UGENS1.H        */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *xr, *ia, *idur, *ib;

--- a/H/ugens2.h
+++ b/H/ugens2.h
@@ -23,6 +23,8 @@
 
 /*                                                              UGENS2.H        */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *sr, *xcps, *iphs;

--- a/H/ugens3.h
+++ b/H/ugens3.h
@@ -23,6 +23,8 @@
 
 /*                                                              UGENS3.H        */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *rslt, *xamp, *kcps, *xcar, *xmod, *kndx, *ifn, *iphs;

--- a/H/ugens4.h
+++ b/H/ugens4.h
@@ -23,6 +23,8 @@
 
 /*                                                      UGENS4.H        */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *xamp, *xcps, *knh, *ifn, *iphs;

--- a/H/ugens5.h
+++ b/H/ugens5.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "lpc.h"        /*                               UGENS5.H        */
 
 typedef struct {

--- a/H/ugens6.h
+++ b/H/ugens6.h
@@ -24,6 +24,8 @@
 
 /*                                                      UGENS6.H        */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *kr, *asig, *ilen;

--- a/H/ugens7.h
+++ b/H/ugens7.h
@@ -24,6 +24,8 @@
 
 /*                                                      UGENS7.H        */
 
+#pragma once
+
 #define PFRAC1(x)   ((MYFLT)((x) & ftp1->lomask) * ftp1->lodiv)
 
 typedef struct ovrlap {

--- a/H/ugrw1.h
+++ b/H/ugrw1.h
@@ -43,6 +43,8 @@
  * clearly indicated as such.
  */
 
+#pragma once
+
 #include "csoundCore.h"
 
 /*

--- a/H/ugtabs.h
+++ b/H/ugtabs.h
@@ -21,6 +21,7 @@
     02110-1301 USA
 */
 
+#pragma once
 
 typedef struct _tabl {
   OPDS h;

--- a/H/vdelay.h
+++ b/H/vdelay.h
@@ -25,6 +25,8 @@
 /*      Berklee College of Music Csound development team                */
 /*      Copyright (c) December 1994.  All rights reserved               */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *sr, *ain, *adel, *imaxd, *istod;

--- a/H/winEPS.h
+++ b/H/winEPS.h
@@ -26,6 +26,8 @@
    /*                             */
 
   /* Open PS file & write header */
+#pragma once
+
 void PS_MakeGraph(CSOUND *csound, WINDAT *wdptr, const char *name);
   /* Make one plot per page      */
 void PS_DrawGraph(CSOUND *csound, WINDAT *wdptr);

--- a/H/windin.h
+++ b/H/windin.h
@@ -23,6 +23,8 @@
 
 /*                                                      WINDIN.H        */
 
+#pragma once
+
 typedef struct
     {
     OPDS h;

--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -17,6 +17,8 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#pragma once
+
 /* Hardware architecture */
 //#define ARCH_ALPHA
 //#define ARCH_PPC

--- a/Opcodes/biquad.h
+++ b/Opcodes/biquad.h
@@ -24,6 +24,9 @@
 */
 
                                                         /* biquad.h */
+
+#pragma once
+
 #include "stdopcod.h"
 
                                 /* Structure for biquadratic filter */

--- a/Opcodes/clfilt.h
+++ b/Opcodes/clfilt.h
@@ -23,6 +23,8 @@
 
                                                         /* clfilt.h */
 
+#pragma once
+
 #define CL_LIM 40  /* The limit on the number of biquadratic sections */
 
                                 /* Structure for biquadratic filter */

--- a/Opcodes/control.h
+++ b/Opcodes/control.h
@@ -25,6 +25,8 @@
 /* Controls                                 */
 /********************************************/
 
+#pragma once
+
 #include "csdl.h"
 
 typedef struct CONTROL_GLOBALS_ {

--- a/Opcodes/crossfm.h
+++ b/Opcodes/crossfm.h
@@ -47,6 +47,8 @@
 /*                                                                   */
 /*********************************************************************/
 
+#pragma once
+
 typedef struct {
   OPDS h;                                     /* common to all opcodes */
 

--- a/Opcodes/dam.h
+++ b/Opcodes/dam.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "csdl.h"
 
 #define POWER_BUFSIZE 1000

--- a/Opcodes/dcblockr.h
+++ b/Opcodes/dcblockr.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct DCBlocker {
     OPDS        h;
     MYFLT       *ar, *in, *gg;

--- a/Opcodes/dsputil.h
+++ b/Opcodes/dsputil.h
@@ -28,6 +28,8 @@
 /* 20apr90 dpwe                                                 */
 /****************************************************************/
 
+#pragma once
+
 #define     SPTS    (16)    /* SINC TABLE: How many points in each lobe   */
 #define     SPDS    (6)     /*   (was 8)   How many sinc lobes to go out  */
 #define     SBW     0.9     /* To compensate for short sinc, reduce bandw */

--- a/Opcodes/fhtfun.h
+++ b/Opcodes/fhtfun.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct{
     OPDS          h;
     MYFLT         *out, *as, *af, *len, *ovlp, *iwin, *bias;

--- a/Opcodes/filter.h
+++ b/Opcodes/filter.h
@@ -29,6 +29,8 @@
  *
  */
 
+#pragma once
+
 #ifndef __filter_h
 #define __filter_h
 

--- a/Opcodes/flanger.h
+++ b/Opcodes/flanger.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *xdel, *kfeedback, *maxd, *iskip;

--- a/Opcodes/follow.h
+++ b/Opcodes/follow.h
@@ -25,6 +25,8 @@
 /*              Berklee College of Music Csound development team        */
 /*              Copyright (c) August 1994.  All rights reserved         */
 
+#pragma once
+
 typedef struct  {
         OPDS            h;
         MYFLT           *out, *in, *len;

--- a/Opcodes/grain.h
+++ b/Opcodes/grain.h
@@ -25,6 +25,8 @@
 /*      Berklee College of Music Csound development team                */
 /*      Copyright (c) May 1994.  All rights reserved                    */
 
+#pragma once
+
 typedef struct {
     OPDS        h;
     MYFLT       *sr, *xamp, *xlfr, *xdns, *kabnd, *kbnd, *kglen;

--- a/Opcodes/grain4.h
+++ b/Opcodes/grain4.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define MAXVOICE 128
 
 typedef struct {

--- a/Opcodes/hrtferx.h
+++ b/Opcodes/hrtferx.h
@@ -23,6 +23,8 @@
 
 /****************** hrtferxk.h *******************/
 
+#pragma once
+
 #include "3Dug.h"
 
 typedef struct {

--- a/Opcodes/linuxjoystick.h
+++ b/Opcodes/linuxjoystick.h
@@ -18,6 +18,8 @@
   02110-1301 USA
 
 */
+#pragma once
+
 #include <unistd.h>
 #include "csdl.h"
 #include "linux/joystick.h"

--- a/Opcodes/lowpassr.h
+++ b/Opcodes/lowpassr.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
         OPDS    h;
         MYFLT   *ar, *asig, *kfco, *kres, *istor;

--- a/Opcodes/midiops3.h
+++ b/Opcodes/midiops3.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
     MYFLT *ictlno, *imin, *imax, *initvalue, *ifn;
 } SLD;

--- a/Opcodes/modmatrix.h
+++ b/Opcodes/modmatrix.h
@@ -17,6 +17,8 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 //#include "csdl.h"
 #include "interlocks.h"
 #include "csoundCore.h"

--- a/Opcodes/nlfilt.h
+++ b/Opcodes/nlfilt.h
@@ -22,6 +22,8 @@
 */
 
                         /* Structure for Dobson/Fitch nonlinear filter */
+#pragma once
+
 typedef struct  {
         OPDS    h;
         MYFLT   *ar, *in, *a, *b, *d, *C, *L;   /* The parameter */

--- a/Opcodes/partikkel.h
+++ b/Opcodes/partikkel.h
@@ -1,6 +1,6 @@
 /*
 Partikkel - a granular synthesis module for Csound 5
-Copyright (C) 2006-2009 Øyvind Brandtsegg, Torgeir Strand Henriksen,
+Copyright (C) 2006-2009 ï¿½yvind Brandtsegg, Torgeir Strand Henriksen,
 Thom Johansen
 
 This library is free software; you can redistribute it and/or
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+
+#pragma once
 
 #include "csoundCore.h"
 #include "interlocks.h"

--- a/Opcodes/partikkel.h
+++ b/Opcodes/partikkel.h
@@ -1,6 +1,6 @@
 /*
 Partikkel - a granular synthesis module for Csound 5
-Copyright (C) 2006-2009 �yvind Brandtsegg, Torgeir Strand Henriksen,
+Copyright (C) 2006-2009 Øyvind Brandtsegg, Torgeir Strand Henriksen,
 Thom Johansen
 
 This library is free software; you can redistribute it and/or

--- a/Opcodes/ptrigtbl.h
+++ b/Opcodes/ptrigtbl.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define GOOD_TRIG
 
 #if defined(GOOD_TRIG)

--- a/Opcodes/pvadd.h
+++ b/Opcodes/pvadd.h
@@ -23,6 +23,8 @@
 
 /*                                                      PVADD.H    */
 
+#pragma once
+
 #define     MAXBINS         4096
 #ifndef PVFRAMSIZE
 #define     PVFRAMSIZE      8192                /* i.e. max FFT point size */

--- a/Opcodes/pvinterp.h
+++ b/Opcodes/pvinterp.h
@@ -23,6 +23,8 @@
 
 /*                                                              PVINTERP.H  */
 
+#pragma once
+
 typedef struct {
     OPDS    h;
     MYFLT   *ktimpnt, *ifilno;

--- a/Opcodes/pvocext.h
+++ b/Opcodes/pvocext.h
@@ -27,6 +27,7 @@
 
 /* Predeclare Functions */
 
+#pragma once
 
 
 void    SpectralExtract(float *, float *, int32_t, int32, int32_t, MYFLT);

--- a/Opcodes/pvread.h
+++ b/Opcodes/pvread.h
@@ -23,6 +23,8 @@
 
 /*                                                              PVREAD.H    */
 
+#pragma once
+
 typedef struct {
     OPDS    h;
     MYFLT   *kfreq, *kamp, *ktimpnt,  *ifilno, *ibin;

--- a/Opcodes/repluck.h
+++ b/Opcodes/repluck.h
@@ -22,6 +22,8 @@
 */
 
                                                         /* repluck.h */
+#pragma once
+
 typedef struct _DelayLine {
     MYFLT   *data;
     int32_t length;

--- a/Opcodes/scansyn.h
+++ b/Opcodes/scansyn.h
@@ -20,6 +20,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "csdl.h"
 
 typedef struct SCANSYN_GLOBALS_ SCANSYN_GLOBALS;

--- a/Opcodes/sfont.h
+++ b/Opcodes/sfont.h
@@ -22,6 +22,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "sftype.h"
 #include "sf.h"
 

--- a/Opcodes/sndwarp.h
+++ b/Opcodes/sndwarp.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
   int32_t    cnt, wsize, flag; /* , section; */
         MYFLT  ampincr, ampphs, offset;

--- a/Opcodes/ugens9.h
+++ b/Opcodes/ugens9.h
@@ -23,6 +23,8 @@
 
 /*                                                              UGENS9.H    */
 
+#pragma once
+
 typedef struct {
     OPDS    h;
     MYFLT   *ar1,*ar2,*ar3,*ar4,*ain,*ifilno,*channel;

--- a/Opcodes/ugensa.h
+++ b/Opcodes/ugensa.h
@@ -23,6 +23,8 @@
 
 /*                                                      UGENSM.H  */
 
+#pragma once
+
 #define PFRAC1(x)   ((MYFLT)((x) & ftp1->lomask) * ftp1->lodiv)
 
 typedef struct overlap {

--- a/Opcodes/ugmoss.h
+++ b/Opcodes/ugmoss.h
@@ -23,6 +23,8 @@
 
                                                          /* ugmoss.h */
 
+#pragma once
+
 typedef struct {
   OPDS                  h;
   MYFLT                 *ar, *ain, *isize, *ifn;

--- a/Opcodes/ugnorman.h
+++ b/Opcodes/ugnorman.h
@@ -26,6 +26,8 @@
  * header file for all of the ATScsound functions by Alex Norman
  */
 
+#pragma once
+
 #include "stdopcod.h"
 #include <stdlib.h>
 #include <stdio.h>

--- a/Opcodes/ugsc.h
+++ b/Opcodes/ugsc.h
@@ -33,6 +33,8 @@
  *
  */
 
+#pragma once
+
 typedef struct {
         OPDS h;
   MYFLT *low, *high, *band, *in, *kfco, *kq, *iscl, *iskip;

--- a/Opcodes/vbap.h
+++ b/Opcodes/vbap.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #define LOWEST_ACCEPTABLE_WT FL(0.0)
 #define CHANNELS 128
 #define MIN_VOL_P_SIDE_LGTH FL(0.01)

--- a/Opcodes/vpvoc.h
+++ b/Opcodes/vpvoc.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 typedef struct {
     FUNC    *function, *nxtfunction;
     MYFLT   d;

--- a/Opcodes/wave-terrain.h
+++ b/Opcodes/wave-terrain.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 #include "csdl.h"
 typedef struct {
 

--- a/Opcodes/wpfilters.h
+++ b/Opcodes/wpfilters.h
@@ -38,6 +38,8 @@ downloads/pdf/VAFilterDesign_1.1.1.pdf)
 Csound C versions by Steven Yi
 */
 
+#pragma once
+
 #include "csoundCore.h"
 
 typedef struct {

--- a/Opcodes/zak.h
+++ b/Opcodes/zak.h
@@ -22,6 +22,8 @@
 */
 
                                                         /*      ZAK.H */
+#pragma once
+
 typedef struct {
     MYFLT         *zkstart;
     int64_t       zklast;

--- a/include/interlocks.h
+++ b/include/interlocks.h
@@ -21,6 +21,8 @@
     02110-1301 USA
 */
 
+#pragma once
+
 // ZAK
 #define ZR (0x0001)
 #define ZW (0x0002)

--- a/include/ugen.h
+++ b/include/ugen.h
@@ -16,6 +16,8 @@
  * - context: required for things like hold, releasing, etc.
  * */
 
+#pragma once
+
 #include "csoundCore.h"
 #include <stdbool.h>
 

--- a/util1/scot/scot.h
+++ b/util1/scot/scot.h
@@ -24,6 +24,8 @@
 /*                                                      SCOT.H       */
 /* aldel Jul 91 */
 
+#pragma once
+
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
Add include guards to header files without include guards. This prevents accidentally including the same file twice