### PR TITLE
Add apple modules

### DIFF
--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -9,9 +9,8 @@ option(USE_PORTMIDI "Build the PortMIDI I/O module" ON)
 option(USE_IPMIDI "Build the IPMIDI I/O module" ON)
 option(USE_JACK "Build the jack I/O module and opcodes" ON)
 option(USE_ALSA "Build the ALSA I/O module" ON)
-# option(USE_COREAUDIO "Build the CoreAudio I/O module" ON)
-# option(USE_COREMIDI "Build the CoreMIDI I/O Module" ON)
-# option(USE_AUDIOUNIT "Build the CoreAudio AudioUnit I/O module (requires CoreAudio)" ON)
+option(USE_COREMIDI "Build the CoreMIDI I/O Module" ON)
+option(USE_AUDIOUNIT "Build the CoreAudio AudioUnit I/O module (requires CoreAudio)" ON)
 
 list(APPEND CMAKE_REQUIRED_INCLUDES "/usr/local/include")
 
@@ -47,37 +46,39 @@ if(USE_JACK)
     find_path(JACK_INCLUDE_PATH jack/jack.h)
 endif()
 
-# if(USE_COREAUDIO)
-#    find_path(COREAUDIO_INCLUDE_PATH CoreAudio.h)
-#    find_library(COREAUDIO_LIBRARY CoreAudio)
-# endif()
-if(APPLE)
-    find_path(COREMIDI_INCLUDE_PATH CoreMIDI.h)
-    find_library(COREMIDI_LIBRARY CoreMIDI)
-    find_library(AUDIOUNIT_LIBRARY AudioUnit)
-    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-    find_path(COREAUDIO_INCLUDE_PATH CoreAudio.h)
-    find_library(COREAUDIO_LIBRARY CoreAudio)
-endif()
+find_package(AudioUnit)
+find_package(CoreAudio)
+find_package(CoreFoundation)
+find_package(CoreMIDI)
 
 # BUILD TARGETS
 
-# check_deps(USE_COREAUDIO APPLE COREAUDIO_INCLUDE_PATH COREAUDIO_LIBRARY)
-# if(USE_COREAUDIO)
-#    make_plugin(rtcoreaudio rtcoreaudio.c)
-#    target_include_directories(rtcoreaudio PRIVATE ${COREAUDIO_INCLUDE_PATH})
-#    target_link_libraries(rtcoreaudio ${COREAUDIO_LIBRARY})
-# endif()
+check_deps(USE_COREMIDI
+    CoreAudio_FOUND
+    CoreMIDI_FOUND
+    CoreFoundation_FOUND
+)
+if(USE_COREMIDI)
+    make_plugin(cmidi cmidi.c)
+    target_link_libraries(cmidi PUBLIC
+        CoreAudio::coreaudio
+        CoreFoundation::corefoundation
+        CoreMIDI::coremidi
+    )
+endif()
 
-if(APPLE)
-#    check_deps(USE_COREMIDI APPLE COREMIDI_INCLUDE_PATH COREMIDI_LIBRARY COREFOUNDATION_LIBRARY)
-#   check_deps(USE_AUDIOUNIT APPLE COREAUDIO_INCLUDE_PATH COREAUDIO_LIBRARY AUDIOUNIT_INCLUDE_PATH AUDIOUNIT_LIBRARY COREFOUNDATION_LIBRARY)
-        make_plugin(cmidi cmidi.c)
-        target_include_directories(cmidi PRIVATE ${COREMIDI_INCLUDE_PATH})
-        target_link_libraries(cmidi PRIVATE ${COREMIDI_LIBRARY} ${COREFOUNDATION_LIBRARY})
-        make_plugin(rtauhal rtauhal.c)
-        target_include_directories(rtauhal PRIVATE ${AUDIOUNIT_INCLUDE_PATH})
-        target_link_libraries(rtauhal PRIVATE ${AUDIOUNIT_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COREAUDIO_LIBRARY})
+check_deps(USE_AUDIOUNIT
+    AudioUnit_FOUND
+    CoreAudio_FOUND
+    CoreFoundation_FOUND
+)
+if (USE_AUDIOUNIT)
+    make_plugin(rtauhal rtauhal.c)
+    target_link_libraries(rtauhal PUBLIC
+        AudioUnit::audiounit
+        CoreAudio::coreaudio
+        CoreFoundation::corefoundation
+    )
 endif()
 
 if(USE_ALSA AND LINUX)

--- a/cmake/Modules/FindAudioUnit.cmake
+++ b/cmake/Modules/FindAudioUnit.cmake
@@ -1,0 +1,21 @@
+# AudioUnit_FOUND: if found
+# AudioUnit::audiounit: imported module
+include(FindPackageHandleStandardArgs)
+
+find_library(AudioUnit_LIBRARY NAMES AudioUnit)
+find_path(AudioUnit_INCLUDE_DIR AudioUnit.h)
+
+find_package_handle_standard_args(AudioUnit
+	FOUND_VAR AudioUnit_FOUND
+	REQUIRED_VARS AudioUnit_LIBRARY AudioUnit_INCLUDE_DIR
+)
+
+if(AudioUnit_FOUND AND NOT TARGET AudioUnit::audiounit)
+	add_library(AudioUnit::audiounit UNKNOWN IMPORTED)
+	set_target_properties(AudioUnit::audiounit PROPERTIES
+		IMPORTED_LOCATION ${AudioUnit_LIBRARY}
+		INTERFACE_INCLUDE_DIRECTORIES ${AudioUnit_INCLUDE_DIR}
+	)
+endif()
+
+mark_as_advanced(AudioUnit_LIBRARY AudioUnit_INCLUDE_DIR)

--- a/cmake/Modules/FindCoreAudio.cmake
+++ b/cmake/Modules/FindCoreAudio.cmake
@@ -1,0 +1,21 @@
+# CoreAudio_FOUND: if found
+# CoreAudio::coreaudio: imported module
+include(FindPackageHandleStandardArgs)
+
+find_library(CoreAudio_LIBRARY NAMES CoreAudio)
+find_path(CoreAudio_INCLUDE_DIR AudioHardware.h)
+
+find_package_handle_standard_args(CoreAudio
+	FOUND_VAR CoreAudio_FOUND
+	REQUIRED_VARS CoreAudio_LIBRARY CoreAudio_INCLUDE_DIR
+)
+
+if(CoreAudio_FOUND AND NOT TARGET CoreAudio::coreaudio)
+	add_library(CoreAudio::coreaudio UNKNOWN IMPORTED)
+	set_target_properties(CoreAudio::coreaudio PROPERTIES
+		IMPORTED_LOCATION ${CoreAudio_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${CoreAudio_INCLUDE_DIR}
+	)
+endif()
+
+mark_as_advanced(CoreAudio_LIBRARY CoreAudio_INCLUDE_DIR)

--- a/cmake/Modules/FindCoreFoundation.cmake
+++ b/cmake/Modules/FindCoreFoundation.cmake
@@ -1,0 +1,21 @@
+# CoreFoundation_FOUND: if found
+# CoreFoundation::corefoundation: imported module
+include(FindPackageHandleStandardArgs)
+
+find_library(CoreFoundation_LIBRARY NAMES CoreFoundation)
+find_path(CoreFoundation_INCLUDE_DIR CoreFoundation.h)
+
+find_package_handle_standard_args(CoreFoundation
+	FOUND_VAR CoreFoundation_FOUND
+	REQUIRED_VARS CoreFoundation_LIBRARY CoreFoundation_INCLUDE_DIR
+)
+
+if(CoreFoundation_FOUND AND NOT TARGET CoreFoundation::corefoundation)
+	add_library(CoreFoundation::corefoundation UNKNOWN IMPORTED)
+	set_target_properties(CoreFoundation::corefoundation PROPERTIES
+		IMPORTED_LOCATION ${CoreFoundation_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES ${CoreFoundation_INCLUDE_DIR}
+	)
+endif()
+
+mark_as_advanced(CoreFoundation_LIBRARY CoreFoundation_INCLUDE_DIR)

--- a/cmake/Modules/FindCoreMIDI.cmake
+++ b/cmake/Modules/FindCoreMIDI.cmake
@@ -1,0 +1,22 @@
+# CoreMIDI_FOUND: if found
+# CoreMIDI::coremidi: imported module
+
+include(FindPackageHandleStandardArgs)
+
+find_library(CoreMIDI_LIBRARY NAMES CoreMIDI)
+find_path(CoreMIDI_INCLUDE_DIR CoreMIDI.h)
+
+find_package_handle_standard_args(CoreMIDI
+	FOUND_VAR CoreMIDI_FOUND
+	REQUIRED_VARS CoreFoundation_FOUND CoreMIDI_LIBRARY CoreMIDI_INCLUDE_DIR
+)
+
+if(CoreMIDI_FOUND AND NOT TARGET CoreMIDI::coremidi)
+	add_library(CoreMIDI::coremidi UNKNOWN IMPORTED)
+	set_target_properties(CoreMIDI::coremidi PROPERTIES
+		IMPORTED_LOCATION ${CoreMIDI_LIBRARY}
+		INTERFACE_INCLUDE_DIRECTORIES ${CoreMIDI_INCLUDE_DIR}
+	)
+endif()
+
+mark_as_advanced(CoreMIDI_LIBRARY CoreMIDI_INCLUDE_DIR)


### PR DESCRIPTION
Using imported targets has several benefits:

- Packaging include-dirs and libraries together for cleaner code
- Automatic handling of usage requirements (see https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#target-usage-requirements)
- Tracking of runtime dependencies (https://cmake.org/cmake/help/latest/command/install.html#runtime-dependency-set)
- Unifies vcpkg and non-vcpkg builds
