### PR TITLE
target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ project(Csound)
 
 enable_testing()
 
+set(libcsound_private_include_dirs "")
+set(libcsound_public_include_dirs "")
+
 SET(BUILD_SHARED_LIBS ON)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
@@ -194,7 +197,7 @@ endif()
 
 if(WIN32 AND NOT MSVC)
     if(EXISTS "C:/MinGW/include")
-        include_directories(C:/MinGW/include)
+        list(APPEND libcsound_private_include_dirs "C:/MinGW/include")
     else()
         MESSAGE(STATUS "MinGW include dir not found.")
     endif()
@@ -409,12 +412,12 @@ if(USE_LIBSNDFILE)
     add_compile_definitions("USE_LIBSNDFILE")
 
     if(EMSCRIPTEN)
-        include_directories(emscripten/deps/libsndfile-1.0.25/src/)
+        list(APPEND libcsound_private_include_dirs ${Csound_SOURCE_DIR}/emscripten/deps/libsndfile-1.0.25/src/)
     endif()
 
     find_path(SNDFILE_H_PATH sndfile.h)
     if(SNDFILE_H_PATH)
-        include_directories(${SNDFILE_H_PATH})
+        list(APPEND libcsound_private_include_dirs ${SNDFILE_H_PATH})
     else()
         message(FATAL_ERROR "Could not find sndfile.h")
     endif()
@@ -568,14 +571,17 @@ endif()
 
 set(libcsound_CFLAGS -D__BUILDING_LIBCSOUND)
 
-include_directories(./H)
-include_directories(./include)
-include_directories(./Engine)
+list(APPEND libcsound_private_include_dirs ${Csound_SOURCE_DIR}/H)
+list(APPEND libcsound_public_include_dirs 
+    $<BUILD_INTERFACE:${Csound_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+list(APPEND libcsound_private_include_dirs ${Csound_SOURCE_DIR}/Engine)
 
 #adding this for files that #include SDIF/sdif*
-include_directories(./util)
+list(APPEND libcsound_private_include_dirs ${Csound_SOURCE_DIR}/util)
 #adding this for files that #include files in local dirs
-include_directories(./)
+list(APPEND libcsound_private_include_dirs ${Csound_SOURCE_DIR})
 
 #checking pthread functions
 if(REQUIRE_PTHREADS AND (PTHREAD_LIBRARY OR HAIKU))
@@ -593,7 +599,7 @@ if(REQUIRE_PTHREADS AND (PTHREAD_LIBRARY OR HAIKU))
   endif()
 endif()
 
-include_directories(${LIBSNDFILE_INCLUDE_DIRECTORY})
+list(APPEND libcsound_private_include_dirs ${LIBSNDFILE_INCLUDE_DIRECTORY})
 
 # get the git hash and pass it to csound
 set(git_hash_values "none")
@@ -1008,8 +1014,8 @@ if(MSVC)
         COMPILE_FLAGS -DYY_NO_UNISTD_H)
 endif()
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+list(APPEND libcsound_private_include_dirs ${CMAKE_CURRENT_BINARY_DIR})
+list(APPEND libcsound_public_include_dirs $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 if(NEW_PARSER_DEBUG)
     message(STATUS "Building with new parser debugging.")
@@ -1044,6 +1050,8 @@ if(APPLE)
 endif()
 
 add_library(${CSOUNDLIB} SHARED ${libcsound_SRCS})
+target_include_directories(${CSOUNDLIB} PRIVATE ${libcsound_private_include_dirs})
+target_include_directories(${CSOUNDLIB} PUBLIC ${libcsound_public_include_dirs})
 set_target_properties(${CSOUNDLIB} PROPERTIES SOVERSION ${APIVERSION})
 
 if(INIT_STATIC_MODULES)
@@ -1142,7 +1150,7 @@ if(APPLE AND NOT IOS)
     add_definitions(-DMACOSX -DPIPES -DNO_FLTK_THREADS -DHAVE_SOCKETS)
     find_library(ACCELERATE_LIBRARY Accelerate)
     find_path(VECLIB_PATH "Accelerate/Accelerate.h")
-    include_directories(${VECLIB_PATH})
+    list(APPEND libcsound_private_include_dirs ${VECLIB_PATH})
     list(APPEND libcsound_LIBS ${MATH_LIBRARY} dl ${ACCELERATE_LIBRARY})
 endif()
 
@@ -1241,6 +1249,8 @@ set_target_properties(${CSOUNDLIB} PROPERTIES
 
 if(BUILD_STATIC_LIBRARY)
     add_library(${CSOUNDLIB_STATIC} STATIC ${libcsound_SRCS})
+    target_include_directories(${CSOUNDLIB_STATIC} PRIVATE ${libcsound_private_include_dirs})
+    target_include_directories(${CSOUNDLIB_STATIC} PUBLIC ${libcsound_public_include_dirs})
     SET_TARGET_PROPERTIES(${CSOUNDLIB_STATIC} PROPERTIES OUTPUT_NAME ${CSOUNDLIB})
     SET_TARGET_PROPERTIES(${CSOUNDLIB_STATIC} PROPERTIES PREFIX "lib")
     target_compile_options(${CSOUNDLIB_STATIC} PRIVATE ${libcsound_CFLAGS})

--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -42,11 +42,9 @@ if(USE_JACK)
     # I am hardcoding it for MacOS
     set(JACK_HEADER  "jack/jack.h")
     endif()
-    if(WIN32)
     # HLO: including the jack2 common source dir
     # prevents "cannot open include file" errors
     find_path(JACK_INCLUDE_PATH jack/jack.h)
-    endif()
 endif()
 if(USE_PULSEAUDIO)
     find_library(PULSEAUDIO_LIBRARY pulse)
@@ -157,25 +155,14 @@ if(USE_IPMIDI)
     make_plugin(ipmidi ipmidi.c "${ipmidi_LIBS}")
 endif()
 
-check_deps(USE_JACK JACK_HEADER JACK_LIBRARY)
+check_deps(USE_JACK JACK_HEADER JACK_LIBRARY JACK_INCLUDE_PATH)
 if(USE_JACK)
-    set(rtjack_LIBS "")
-    if(LINUX)
-        list(APPEND rtjack_LIBS
-            ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
-    elseif(WIN32)
-        check_deps(JACK_INCLUDE_PATH)
-        include_directories("${JACK_INCLUDE_PATH}")
-        list(APPEND rtjack_LIBS
-            ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
-    else()
-        list(APPEND rtjack_LIBS
-            ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
-    endif()
+    set(rtjack_LIBS ${JACK_LIBRARY} ${PTHREAD_LIBRARY})
     # set(rtjack_SRCS rtjack.c natsort.c)
     set(rtjack_SRCS rtjack.c alphanumcmp.c)
     make_plugin(rtjack "${rtjack_SRCS}" "${rtjack_LIBS}")
     # make_plugin(rtjack rtjack.c "${rtjack_LIBS}")
+    target_include_directories(rtjack PRIVATE "${JACK_INCLUDE_PATH}")
 endif()
 
 if(HAIKU)

--- a/cmake/cmake-utilities.cmake
+++ b/cmake/cmake-utilities.cmake
@@ -9,6 +9,8 @@
 #
 function(make_executable name srcs libs)
     add_executable(${name} ${srcs})
+    target_include_directories(${name} PRIVATE ${libcsound_private_include_dirs})
+    target_include_directories(${name} PUBLIC ${libcsound_public_include_dirs})
     target_link_libraries (${name} PRIVATE ${libs})
     set_target_properties(${name} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${BUILD_BIN_DIR})
@@ -95,6 +97,8 @@ function(make_plugin libname srcs)
     else()
         add_library(${libname} MODULE ${srcs})
     endif()
+    target_include_directories(${libname} PRIVATE ${libcsound_private_include_dirs})
+    target_include_directories(${libname} PUBLIC ${libcsound_public_include_dirs})
 
     set(i 2)
     while( ${i} LESS ${ARGC} )

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -19,9 +19,8 @@ if(BUILD_TESTS)
         server_test.cpp
     )
 
-    target_include_directories(unittests PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}/../../H
-        ${CMAKE_SOURCE_DIR}/interfaces)
+    target_include_directories(unittests PRIVATE ${libcsound_private_include_dirs})
+    target_include_directories(unittests PUBLIC ${libcsound_public_include_dirs})
 
     # Required because we're compiling the tests written in C as C++
     set(CMAKE_CXX_FLAGS "-fpermissive -Wwrite-strings -std=c++0x")


### PR DESCRIPTION
Uses `target_include_directories` instead of `include_directories` for more fine-grain control.

Eventually, it would be good for the plugins and utilities not to use the private include directories, but currently they do.