### PR TITLE
PulseAudio module

### DIFF
--- a/InOut/CMakeLists.txt
+++ b/InOut/CMakeLists.txt
@@ -46,11 +46,7 @@ if(USE_JACK)
     # prevents "cannot open include file" errors
     find_path(JACK_INCLUDE_PATH jack/jack.h)
 endif()
-if(USE_PULSEAUDIO)
-    find_library(PULSEAUDIO_LIBRARY pulse)
-    find_library(PULSESIMPLE_LIBRARY pulse-simple)
-    check_include_file(pulse/simple.h PULSEAUDIO_HEADER)
-endif()
+
 # if(USE_COREAUDIO)
 #    find_path(COREAUDIO_INCLUDE_PATH CoreAudio.h)
 #    find_library(COREAUDIO_LIBRARY CoreAudio)
@@ -108,10 +104,10 @@ if(WIN32)
     endif()
 endif()
 
-
-check_deps(USE_PULSEAUDIO PULSEAUDIO_HEADER PULSEAUDIO_LIBRARY PULSESIMPLE_LIBRARY)
+find_package(PulseAudio)
+check_deps(USE_PULSEAUDIO PulseAudio_FOUND)
 if(USE_PULSEAUDIO)
-    make_plugin(rtpulse rtpulse.c ${PULSEAUDIO_LIBRARY} ${PULSESIMPLE_LIBRARY})
+    make_plugin(rtpulse rtpulse.c PulseAudio::PulseAudio)
 endif()
 
 if(PORTAUDIO_FOUND OR USE_VCPKG)

--- a/cmake/Modules/FindPulseAudio.cmake
+++ b/cmake/Modules/FindPulseAudio.cmake
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2008 Matthias Kretz <kretz@kde.org>
+# SPDX-FileCopyrightText: 2009 Marcus Hufgard <Marcus.Hufgard@hufgard.de>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FindPulseAudio
+--------------
+
+Try to locate the PulseAudio library.
+If found, this will define the following variables:
+
+``PulseAudio_FOUND``
+     True if the system has the PulseAudio library of at least
+     the minimum version specified by either the version parameter
+     to find_package() or the variable PulseAudio_MINIMUM_VERSION
+``PulseAudio_INCLUDE_DIRS``
+     The PulseAudio include directory
+``PulseAudio_LIBRARIES``
+     The PulseAudio libraries for linking
+``PulseAudio_MAINLOOP_LIBRARY``
+     The libraries needed to use PulseAudio Mainloop
+``PulseAudio_VERSION``
+     The version of PulseAudio that was found
+``PulseAudio_INCLUDE_DIR``
+    Deprecated, use ``PulseAudio_INCLUDE_DIRS``
+``PulseAudio_LIBRARY``
+    Deprecated, use ``PulseAudio_LIBRARIES``
+
+If ``PulseAudio_FOUND`` is TRUE, it will also define the following
+imported target:
+
+``PulseAudio::PulseAudio``
+    The PulseAudio library
+
+Since 5.41.0.
+#]=======================================================================]
+
+# Support PulseAudio_MINIMUM_VERSION for compatibility:
+if(NOT PulseAudio_FIND_VERSION)
+  set(PulseAudio_FIND_VERSION "${PulseAudio_MINIMUM_VERSION}")
+endif()
+
+# the minimum version of PulseAudio we require
+if(NOT PulseAudio_FIND_VERSION)
+  set(PulseAudio_FIND_VERSION "0.9.9")
+endif()
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_PulseAudio QUIET libpulse>=${PulseAudio_FIND_VERSION})
+pkg_check_modules(PC_PulseAudio_MAINLOOP QUIET libpulse-mainloop-glib)
+
+find_path(PulseAudio_INCLUDE_DIRS pulse/pulseaudio.h
+   HINTS
+   ${PC_PulseAudio_INCLUDEDIR}
+   ${PC_PulseAudio_INCLUDE_DIRS}
+   )
+
+find_library(PulseAudio_LIBRARIES NAMES pulse libpulse
+   HINTS
+   ${PC_PulseAudio_LIBDIR}
+   ${PC_PulseAudio_LIBRARY_DIRS}
+   )
+
+find_library(PulseAudio_MAINLOOP_LIBRARY NAMES pulse-mainloop pulse-mainloop-glib libpulse-mainloop-glib
+   HINTS
+   ${PC_PulseAudio_LIBDIR}
+   ${PC_PulseAudio_LIBRARY_DIRS}
+   )
+
+# Store the version number in the cache, so we don't have to search every time again:
+if (PulseAudio_INCLUDE_DIRS AND NOT PulseAudio_VERSION)
+
+   # get PulseAudio's version from its version.h
+   file(STRINGS "${PulseAudio_INCLUDE_DIRS}/pulse/version.h" pulse_version_h
+        REGEX ".*pa_get_headers_version\\(\\).*")
+   string(REGEX REPLACE ".*pa_get_headers_version\\(\\)\ \\(\"([0-9]+\\.[0-9]+\\.[0-9]+)[^\"]*\"\\).*" "\\1"
+                         _PulseAudio_VERSION "${pulse_version_h}")
+
+   set(PulseAudio_VERSION "${_PulseAudio_VERSION}" CACHE STRING "Version number of PulseAudio" FORCE)
+endif()
+
+# Use the new extended syntax of find_package_handle_standard_args(), which also handles version checking:
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PulseAudio REQUIRED_VARS PulseAudio_LIBRARIES PulseAudio_INCLUDE_DIRS
+                                             VERSION_VAR PulseAudio_VERSION)
+
+# Deprecated synonyms
+set(PULSEAUDIO_INCLUDE_DIR "${PulseAudio_INCLUDE_DIRS}")
+set(PULSEAUDIO_LIBRARY "${PulseAudio_LIBRARIES}")
+set(PULSEAUDIO_MAINLOOP_LIBRARY "${PulseAudio_MAINLOOP_LIBRARY}")
+set(PULSEAUDIO_FOUND "${PulseAudio_FOUND}")
+
+if(PulseAudio_FOUND AND NOT TARGET PulseAudio::PulseAudio)
+  add_library(PulseAudio::PulseAudio UNKNOWN IMPORTED)
+  set_target_properties(PulseAudio::PulseAudio PROPERTIES
+                        IMPORTED_LOCATION "${PulseAudio_LIBRARIES}"
+			INTERFACE_INCLUDE_DIRECTORIES "${PulseAudio_INCLUDE_DIRS}")
+endif()
+
+mark_as_advanced(PulseAudio_INCLUDE_DIRS PULSEAUDIO_INCLUDE_DIR
+                 PulseAudio_LIBRARIES PULSEAUDIO_LIBRARY
+		 PulseAudio_MAINLOOP_LIBRARY PULSEAUDIO_MAINLOOP_LIBRARY)
+
+include(FeatureSummary)
+set_package_properties(PulseAudio PROPERTIES
+  URL "https://www.freedesktop.org/wiki/Software/PulseAudio"
+  DESCRIPTION "Sound server, for sound stream routing and mixing")


### PR DESCRIPTION
Using imported targets has several benefits:

- Packaging include-dirs and libraries together for cleaner code
- Automatic handling of usage requirements (see https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#target-usage-requirements)
- Tracking of runtime dependencies (https://cmake.org/cmake/help/latest/command/install.html#runtime-dependency-set)
- Unifies vcpkg and non-vcpkg builds

I got the pulseaudio find module from here: https://github.com/KDE/extra-cmake-modules

