### PR TITLE
use os flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1145,7 +1145,7 @@ endif()
 
 if(LINUX)
     message(STATUS "Building on Linux.")
-    add_definitions(-DLINUX -DPIPES -DNO_FLTK_THREADS -D_GNU_SOURCE -DHAVE_SOCKETS)
+    add_definitions(-DPIPES -DNO_FLTK_THREADS -D_GNU_SOURCE -DHAVE_SOCKETS)
     list(APPEND libcsound_LIBS ${MATH_LIBRARY} dl)
 
     find_library(LIBRT_LIBRARY rt)
@@ -1165,15 +1165,11 @@ endif()
 
 if(APPLE AND NOT IOS)
     message(STATUS "Building on OSX")
-    add_definitions(-DMACOSX -DPIPES -DNO_FLTK_THREADS -DHAVE_SOCKETS)
+    add_definitions(-DPIPES -DNO_FLTK_THREADS -DHAVE_SOCKETS)
     find_library(ACCELERATE_LIBRARY Accelerate)
     find_path(VECLIB_PATH "Accelerate/Accelerate.h")
     list(APPEND libcsound_private_include_dirs ${VECLIB_PATH})
     list(APPEND libcsound_LIBS ${MATH_LIBRARY} dl ${ACCELERATE_LIBRARY})
-endif()
-
-if(WIN32)
-    add_definitions(-DWIN32)
 endif()
 
 check_function_exists(strlcat HAVE_STRLCAT)

--- a/Engine/cs_par_base.c
+++ b/Engine/cs_par_base.c
@@ -42,7 +42,7 @@ int csp_thread_index_get(CSOUND *csound)
 
     while (current != NULL) {
     // PTHREAD: this should be a class in threads.c to abstract this away
-#if defined(HAVE_PTHREAD) && !defined(WIN32)
+#if defined(HAVE_PTHREAD) && !defined(_WIN32)
       if (pthread_equal(*(pthread_t *)threadId, *(pthread_t *)current->threadId)) {
 #else
       // FIXME not entirely sure what this should be...

--- a/Engine/csound_pre.lex
+++ b/Engine/csound_pre.lex
@@ -741,7 +741,7 @@ void do_comment(yyscan_t yyscanner)              /* Skip until * and / chars */
       goto TOP;
     }
 }
-#ifndef WIN32
+#ifndef _WIN32
 int isDir(char *path) {
    struct stat statbuf;
    if (stat(path, &statbuf) != 0)

--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -32,7 +32,7 @@
 #include <fcntl.h>
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #  include <direct.h>
 #  define getcwd(x,y) _getcwd(x,y)
 #endif
@@ -84,7 +84,7 @@ typedef struct CSFILE_ {
 #if defined(MSVC)
 #define RD_OPTS  _O_RDONLY | _O_BINARY
 #define WR_OPTS  _O_TRUNC | _O_CREAT | _O_WRONLY | _O_BINARY,_S_IWRITE
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #define RD_OPTS  O_RDONLY | O_BINARY
 #define WR_OPTS  O_TRUNC | O_CREAT | O_WRONLY | O_BINARY, 0644
 #elif defined DOSGCC
@@ -545,7 +545,7 @@ char *csoundConvertPathname(CSOUND *csound, const char *filename)
         name[i] = DIRSEP;
     } while (filename[i++] != '\0');
     if (name[i - 2] == DIRSEP
-#ifdef WIN32
+#ifdef _WIN32
         || (isalpha(name[0]) && name[1] == ':' && name[2] == '\0')
 #endif
         ) {
@@ -558,7 +558,7 @@ char *csoundConvertPathname(CSOUND *csound, const char *filename)
 /**  Check if name is a full pathname for the platform we are running on. */
 int csoundIsNameFullpath(const char *name)
 {
-#ifdef WIN32
+#ifdef _WIN32
     if (isalpha(name[0]) && name[1] == ':') return 1;
 #endif
     if (name[0] == DIRSEP) /* ||
@@ -582,7 +582,7 @@ int csoundIsNameRelativePath(const char *name)
 int csoundIsNameJustFilename(const char *name)
 {
     if (strchr(name, DIRSEP) != NULL) return 0;
-#ifdef WIN32
+#ifdef _WIN32
     if (name[2] == ':') return 0;
 #endif
     return 1;
@@ -645,7 +645,7 @@ char *csoundSplitDirectoryFromPath(CSOUND* csound, const char * path)
     lastIndex = strrchr(convPath, DIRSEP);
 
     if (lastIndex == NULL) {  /* no DIRSEP before filename */
-#ifdef WIN32  /* e.g. C:filename */
+#ifdef _WIN32  /* e.g. C:filename */
         if (isalpha(convPath[0]) && convPath[1] == ':') {
             partialPath = (char*) csound->Malloc(csound, (size_t) 3);
             partialPath[0] = convPath[0];
@@ -718,7 +718,7 @@ char *csoundGetDirectoryForPath(CSOUND* csound, const char * path) {
         return partialPath;
       }
 
-#  ifdef WIN32
+#  ifdef _WIN32
       /* check if root directory of Windows drive */
       if ((lastIndex - tempPath) == 2 && tempPath[1] == ':') {
         partialPath = (char *)csound->Malloc(csound, 4);
@@ -1033,7 +1033,7 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int type,
     }
     /* get full name and open file */
     if (env == NULL) {
-#if defined(WIN32)
+#if defined(_WIN32)
       /* To handle Widows errors in file name characters. */
       size_t sz = 2 * MultiByteToWideChar(CP_UTF8, 0, name, -1, NULL, 0);
       wchar_t *wfname = malloc(sz);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -48,7 +48,7 @@ static int insert_midi(CSOUND *csound, int insno, MCHNBLK *chn,
 static int insert_event(CSOUND *csound, int insno, EVTBLK *newevtp);
 
 static void print_messages(CSOUND *csound, int attr, const char *str){
-#if defined(WIN32)
+#if defined(_WIN32)
     switch (attr & CSOUNDMSG_TYPE_MASK) {
     case CSOUNDMSG_ERROR:
     case CSOUNDMSG_WARNING:

--- a/Engine/linevent.c
+++ b/Engine/linevent.c
@@ -31,7 +31,7 @@
 #include "linevent.h"
 
 #ifdef PIPES
-# if defined(SGI) || defined(LINUX) || defined(NeXT) || defined(__MACH__)
+# if defined(SGI) || defined(__gnu_linux__) || defined(NeXT) || defined(__MACH__)
 #  define _popen popen
 #  define _pclose pclose
 # elif defined(__BEOS__) ||  defined(__HAIKU__) || defined(__MACH__)
@@ -78,7 +78,7 @@ void RTLineset(CSOUND *csound)      /* set up Linebuf & ready the input files */
     STA(Linebufend) = STA(Linebuf) + STA(linebufsiz);
     STA(Linep) = STA(Linebuf);
     if (strcmp(O->Linename, "stdin") == 0) {
-#if defined(DOSGCC) || defined(WIN32)
+#if defined(DOSGCC) || defined(_WIN32)
       setvbuf(stdin, NULL, _IONBF, 0);
       /* WARNING("-L stdin:  system has no fcntl function to get stdin"); */
 #else
@@ -127,7 +127,7 @@ void RTclose(CSOUND *csound)
       {
         if (strcmp(csound->oparms->Linename, "stdin") != 0)
           close(csound->Linefd);
-#if !defined(DOSGCC) && !defined(WIN32)
+#if !defined(DOSGCC) && !defined(_WIN32)
         else
           if (UNLIKELY(fcntl(csound->Linefd, F_SETFL, STA(stdmode))))
             csoundDie(csound, Str("Failed to set file status\n"));

--- a/Engine/new_orc_parser.c
+++ b/Engine/new_orc_parser.c
@@ -38,7 +38,7 @@ int             closedir(DIR*);
 #  endif
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #  include <io.h>
 #  include <direct.h>
 #endif

--- a/Frontends/beats/beats.l
+++ b/Frontends/beats/beats.l
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include "beats.tab.h"
 
-#if defined(_WIN32) || defined(WIN32) 
+#if defined(_WIN32) 
 #include <io.h>
 #define isatty(x) _isatty(x)
 #endif

--- a/Frontends/beats/main.c
+++ b/Frontends/beats/main.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
     }
     time(&timep);
 
-#ifndef LINUX
+#ifndef __gnu_linux__
     {
       struct tm *date_ptr = localtime(&timep);
       memcpy(&tm, date_ptr, sizeof(struct tm));

--- a/Frontends/csound/csound_main.c
+++ b/Frontends/csound/csound_main.c
@@ -28,14 +28,14 @@
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
-#if defined(HAVE_UNISTD_H) || defined(MACOSX)
+#if defined(HAVE_UNISTD_H) || defined(__APPLE__)
 #include <unistd.h>
 #endif
 #ifdef GNU_GETTEXT
 #include <locale.h>
 #endif
 #define IGN(x) (void) x
-#ifdef LINUX
+#ifdef __gnu_linux__
 extern int set_rt_priority(int argc, const char **argv);
 #endif
 
@@ -52,7 +52,7 @@ static void msg_callback(CSOUND *csound,
       fflush(logFile);
       return;
      }
-    #if defined(WIN32) || defined(MAC)
+    #if defined(_WIN32) || defined(__APPLE__)
     switch (attr & CSOUNDMSG_TYPE_MASK) {
         case CSOUNDMSG_ERROR:
         case CSOUNDMSG_WARNING:
@@ -73,7 +73,7 @@ static void nomsg_callback(CSOUND *csound,
 }
 
 
-#if defined(ANDROID) || (!defined(LINUX) && !defined(SGI) && \
+#if defined(ANDROID) || (!defined(__gnu_linux__) && !defined(SGI) && \
                          !defined(__HAIKU__) && !defined(__BEOS__) && \
                          !defined(__MACH__) && !defined(__EMSCRIPTEN__))
 static char *signal_to_string(int sig)
@@ -237,10 +237,10 @@ static void signal_handler(int sig)
 }
 
 static const int sigs[] = {
-#if defined(LINUX) || defined(SGI) || defined(sol) || defined(__MACH__)
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || defined(__MACH__)
   SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGIOT, SIGBUS,
   SIGFPE, SIGSEGV, SIGPIPE, SIGTERM, SIGXCPU, SIGXFSZ,
-#elif defined(WIN32)
+#elif defined(_WIN32)
   SIGINT, SIGILL, SIGABRT, SIGFPE, SIGSEGV, SIGTERM,
 #elif defined(__EMX__)
   SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE,
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
     csoundInitialize(CSOUNDINIT_NO_SIGNAL_HANDLER);
 
     /* set stdout to non buffering if not outputing to console window */
-#if !defined(WIN32)
+#if !defined(_WIN32)
     if (!isatty(fileno(stdout))) {
       setvbuf(stdout, (char*) NULL, _IONBF, 0);
     }
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
 #endif
 
     /* Real-time scheduling on Linux by Istvan Varga (Jan 6 2002) */
-#ifdef LINUX
+#ifdef __gnu_linux__
     if (set_rt_priority(argc, (const char **)argv) != 0)
       return -1;
 

--- a/H/csGblMtx.h
+++ b/H/csGblMtx.h
@@ -46,7 +46,7 @@ void csoundUnLock() {
 }
 #endif
 
-#elif defined(_WIN32) || defined (__WIN32__)
+#elif defined(_WIN32)
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
 
@@ -94,7 +94,7 @@ void csoundUnLock() {
 }
 #endif
 
-#else /* END WIN32 */
+#else /* END _WIN32 */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/H/cs_jack.h
+++ b/H/cs_jack.h
@@ -26,7 +26,7 @@
 #define MAX_NAME_LEN    32      /* for client and port name */
 
 typedef struct RtJackBuffer_ {
-#ifdef LINUX
+#ifdef __gnu_linux__
     pthread_mutex_t csndLock;               /* signaled by process callback */
     pthread_mutex_t jackLock;               /* signaled by audio thread     */
 #else

--- a/H/cs_par_base.h
+++ b/H/cs_par_base.h
@@ -26,7 +26,7 @@
 
 #ifdef PARCS
 // Semaphone.h only exists when using pthreads, doesn't apply to Windows
-#ifndef WIN32
+#ifndef _WIN32
   #include <semaphore.h>
 #endif
 
@@ -42,7 +42,7 @@
 
 #if !defined(HAVE_PTHREAD_SPIN_LOCK)
 // Windows environment should use native threads
-# if WIN32
+# if _WIN32
  #define TAKE_LOCK(x) csoundLockMutex(x)
  #define RELS_LOCK(x) csoundUnlockMutex(x)
  #define LOCK_TYPE  LPCRITICAL_SECTION
@@ -177,7 +177,7 @@ struct set_t *csp_set_intersection(CSOUND *csound, struct set_t *first,
 // Kludge to allow us to pass in HANDLE objects to be used as semaphore whilst
 // supporting the traditional pthread way for non Windows platforms
 // FIXME, does this even work? API's take ** versions of sem_t
-#ifdef WIN32
+#ifdef _WIN32
 typedef HANDLE sem_t;
 #endif
 

--- a/H/remote.h
+++ b/H/remote.h
@@ -25,7 +25,7 @@
 #define CSOUND_REMOTE_H
 
 #ifdef HAVE_SOCKETS
-  #if defined(WIN32) && !defined(__CYGWIN__)
+  #if defined(_WIN32) && !defined(__CYGWIN__)
     #include <winsock2.h>
     #ifndef SHUT_RDWR
       #define SHUT_RD   0x00
@@ -39,10 +39,10 @@
     #endif
     #include <sys/socket.h>
     #include <netinet/in.h>
-    #ifdef MACOSX
+    #ifdef __APPLE__
       #include <net/if.h>
     #endif
-    #ifdef LINUX
+    #ifdef __gnu_linux__
       #include <linux/if.h>
     #endif
     #include <arpa/inet.h>

--- a/InOut/ipmidi.c
+++ b/InOut/ipmidi.c
@@ -27,7 +27,7 @@
 #define __HAIKU_CONFLICT
 
 #include <sys/types.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
@@ -50,7 +50,7 @@ static int OpenMidiInDevice_(CSOUND *csound, void **userData, const char *dev)
     struct sockaddr_in saddr;
     struct ip_mreq mreq;
 
-#ifdef WIN32
+#ifdef _WIN32
     WSADATA wsaData;
     if (WSAStartup (MAKEWORD(2, 2), &wsaData) != 0) {
       fprintf(stderr, "%s", Str("WSAStartup failed!\n"));
@@ -74,7 +74,7 @@ static int OpenMidiInDevice_(CSOUND *csound, void **userData, const char *dev)
 
     status = bind(sock, (struct sockaddr *) &saddr, sizeof(struct sockaddr_in));
     if ( status < 0 ) {
-#ifdef WIN32
+#ifdef _WIN32
       char *buff = strerror(errno);
       printf("WSAGetLastError() = %d\n", WSAGetLastError());
 #else
@@ -94,7 +94,7 @@ static int OpenMidiInDevice_(CSOUND *csound, void **userData, const char *dev)
                         (const char *)&mreq, sizeof(mreq));
 
     if ( status < 0 ) {
-#ifdef WIN32
+#ifdef _WIN32
         char *buff = strerror(errno);
         csound->ErrorMsg(csound, "WSAGetLastError() = %d\n", WSAGetLastError());
         return -1;
@@ -132,7 +132,7 @@ static int ReadMidiData_(CSOUND *csound, void *userData,
 
     rc = select(sock + 1, &rset, NULL, NULL, &timeout);
     if (rc > 0) {
-#ifdef WIN32
+#ifdef _WIN32
       n = recv(sock, mbuf, nbytes, 0);
 #else
       n = read(sock, mbuf, nbytes);
@@ -150,7 +150,7 @@ static int CloseMidiInDevice_(CSOUND *csound, void *userData)
     int             sock = *((int *) userData);
     //printf("CloseMidiInDevice_\n");
     close(sock);
-#ifdef WIN32
+#ifdef _WIN32
     WSACleanup();
 #endif
     return 0;

--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -27,7 +27,7 @@
 //#define ARCH_AMD64
 //#define ARCH_IA64
 
-#ifdef WIN32
+#ifdef _WIN32
 #define HAVE_IO_H
 #define HAVE_CONIO_H
 #undef OSS
@@ -93,7 +93,7 @@ typedef uint32_t uintptr_t;
 #define O_BINARY 0
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #define strcasecmp stricmp
 #endif
 

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -32,7 +32,7 @@
 #endif
 
 #ifdef PIPES
-# if defined(SGI) || defined(LINUX) || defined(__BEOS__) || defined(NeXT) ||  \
+# if defined(SGI) || defined(__gnu_linux__) || defined(__BEOS__) || defined(NeXT) ||  \
      defined(__MACH__)
 #  define _popen popen
 #  define _pclose pclose

--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -35,7 +35,7 @@
    with portmidi.lib built with MSVC AND with Windows
    libraries from MinGW (missing __wassert).
 */
-#if defined(WIN32) && !defined(MSVC)
+#if defined(_WIN32) && !defined(MSVC)
 
 void _wassert(wchar_t *condition)
 {
@@ -130,7 +130,7 @@ static int stop_portmidi(CSOUND *csound, void *userData)
 {
     (void) csound;
     (void) userData;
-#if !defined(WIN32)
+#if !defined(_WIN32)
     csoundLock();
 #endif
     if (portmidi_init_cnt) {
@@ -139,7 +139,7 @@ static int stop_portmidi(CSOUND *csound, void *userData)
         Pt_Stop();
       }
     }
-#if !defined(WIN32)
+#if !defined(_WIN32)
     csoundUnLock();
 #endif
     return 0;
@@ -149,7 +149,7 @@ static int start_portmidi(CSOUND *csound)
 {
     const char  *errMsg = NULL;
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
     csoundLock();
 #endif
     if (!portmidi_init_cnt) {
@@ -161,14 +161,14 @@ static int start_portmidi(CSOUND *csound)
 
     if (errMsg == NULL)
       portmidi_init_cnt++;
-#if !defined(WIN32)
+#if !defined(_WIN32)
     csoundUnLock();
 #endif
     if (UNLIKELY(errMsg != NULL)) {
       csound->ErrorMsg(csound, "%s", Str(errMsg));
       return -1;
     }
-    //#if !defined(WIN32)
+    //#if !defined(_WIN32)
     //csound_global_mutex_unlock();
     //#endif
     return csound->RegisterResetCallback(csound, NULL, stop_portmidi);

--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -31,12 +31,12 @@
 /* no #ifdef, should always have these on systems where JACK is available */
 #include <unistd.h>
 #include <stdint.h>
-#ifdef LINUX
+#ifdef __gnu_linux__
 #include <pthread.h>
 #endif
 #include "csdl.h"
 #include "soundio.h"
-#ifdef LINUX
+#ifdef __gnu_linux__
 #include <sched.h>
 #endif
 
@@ -81,7 +81,7 @@ static int listDevices(CSOUND *csound,
                        CS_AUDIODEVICE *list,
                        int isOutput);
 
-#ifdef LINUX
+#ifdef __gnu_linux__
 
 static inline int rtJack_CreateLock(CSOUND *csound, pthread_mutex_t *p)
 {
@@ -136,7 +136,7 @@ static inline void rtJack_DestroyLock(CSOUND *csound, pthread_mutex_t *p)
     pthread_mutex_destroy(p);
 }
 
-#else   /* LINUX */
+#else   /* __gnu_linux__ */
 
 static inline int rtJack_CreateLock(CSOUND *csound, void **p)
 {
@@ -172,7 +172,7 @@ static inline void rtJack_DestroyLock(CSOUND *csound, void **p)
     *p = NULL;
 }
 
-#endif  /* !LINUX */
+#endif  /* !__gnu_linux__ */
 
 /* print error message, close connection, and terminate performance */
 
@@ -202,7 +202,7 @@ static int bufferSizeCallback(jack_nframes_t nframes, void *arg)
     return 0;
 }
 
-#ifdef LINUX
+#ifdef __gnu_linux__
 static void freeWheelCallback(int starting, void *arg)
 {
     RtJackGlobals *p;
@@ -471,7 +471,7 @@ static void openJackStreams(RtJackGlobals *p)
                                                bufferSizeCallback, (void*) p)
                  != 0))
       rtJack_Error(csound, -1, Str("error setting buffer size callback"));
-#ifdef LINUX
+#ifdef __gnu_linux__
     if (UNLIKELY(jack_set_freewheel_callback(p->client,
                                              freeWheelCallback, (void*) p)
                  != 0))

--- a/InOut/rtpa.c
+++ b/InOut/rtpa.c
@@ -25,7 +25,7 @@
 /*                                              RTPA.C for PortAudio    */
 
 #include "csdl.h"
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include "soundio.h"
 #endif
 #include <portaudio.h>
@@ -62,7 +62,7 @@ typedef struct PA_BLOCKING_STREAM_ {
   csRtAudioParams outParm;
   PaStreamParameters inputPaParameters;
   PaStreamParameters outputPaParameters;
-#ifdef WIN32
+#ifdef _WIN32
   int         paused;                 /* VL: to allow for smooth pausing  */
 #endif
   int         paLockTimeout;
@@ -439,7 +439,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   }
   //#endif
 
-#ifdef WIN32
+#ifdef _WIN32
   if (pabs->paStream == NULL
       || pabs->paused
       ) {
@@ -454,7 +454,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   if (!pabs->noPaLock)
 #endif
     /*#ifndef __MACH__*/
-    /*#  ifdef WIN32 */
+    /*#  ifdef _WIN32 */
     err = csound->WaitThreadLock(pabs->paLock, (size_t) pabs->paLockTimeout);
   /*#  else
     err = csound->WaitThreadLock(pabs->paLock, (size_t) 500);
@@ -480,7 +480,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
 } while (++i < n);
 }
   else {
-#ifdef WIN32
+#ifdef _WIN32
   pabs->paused = err;
 #endif
   paClearOutputBuffer(pabs, paOutput);
@@ -542,7 +542,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   pabs = (PA_BLOCKING_STREAM*) *(csound->GetRtPlayUserData(csound));
   if (pabs == NULL)
     return;
-#ifdef WIN32
+#ifdef _WIN32
   pabs->paused = 0;
 #endif
 
@@ -680,7 +680,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   memset(&streamParams, 0, sizeof(PaStreamParameters));
   streamParams.hostApiSpecificStreamInfo = NULL;
   if (UNLIKELY(parm->devName != NULL && parm->devName[0] != '\0')) {
-#if !defined(LINUX)
+#if !defined(__gnu_linux__)
     listPortAudioDevices_blocking(p, 1, play);
     pa_PrintErrMsg(p, "%s", Str("Must specify a device number, not a name"));
     return -1;
@@ -856,7 +856,7 @@ static void rtclose_blocking(CSOUND *csound)
   }
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef __cplusplus
 extern "C"
 {
@@ -876,7 +876,7 @@ static void PaNoOpDebugPrint(const char* msg) {
 PUBLIC int csoundModuleCreate(CSOUND *csound)
 {
   IGN(csound);
-#ifdef WIN32
+#ifdef _WIN32
   PaUtil_SetDebugPrintFunction(PaNoOpDebugPrint);
 #endif
   /* nothing to do, report success */
@@ -904,7 +904,7 @@ PUBLIC int csoundModuleInit(CSOUND *csound)
   }
   csound->ErrorMsg(csound, "%s", Str("rtaudio: PortAudio module enabled ...\n"));
   /* set function pointers */
-#ifdef LINUX
+#ifdef __gnu_linux__
   if (strcmp(drv, "PA_CB") != 0)
 #else
     if (strcmp(drv, "PA_BL") == 0)

--- a/InOut/winEPS.c
+++ b/InOut/winEPS.c
@@ -144,7 +144,7 @@ void PS_MakeGraph(CSOUND *csound, WINDAT *wdptr, const char *name)
      *  Get the current time and date
      */
     lt = time(NULL);
-#ifndef LINUX
+#ifndef __gnu_linux__
     {
       struct tm *date_ptr;
       char      *date;

--- a/Java/cs_glue.cpp
+++ b/Java/cs_glue.cpp
@@ -642,7 +642,7 @@ extern "C" {
   {
     CsoundCallbackWrapper *p;
     p = (CsoundCallbackWrapper*) csoundGetHostData(csound);
-#if defined(HAVE_C99) && !defined(WIN32)
+#if defined(HAVE_C99) && !defined(_WIN32)
     {
       char  buf[2048];
       int   n;

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -47,7 +47,7 @@
 #  ifdef HAVE_TERMIOS_H
 #    include <termios.h>
 #  endif
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #  include <conio.h>
 #endif
 
@@ -1778,7 +1778,7 @@ int32_t sensekey_perf(CSOUND *csound, KSENSE *p)
         if (!p->evtbuf) {
 #if defined(__unix) || defined(__unix__) || defined(__MACH__)
             if (csound->inChar_ < 0) {
-#  if defined(WIN32)
+#  if defined(_WIN32)
                 setvbuf(stdin, NULL, _IONBF, 0);  /* Does not seem to work */
 #  elif defined(HAVE_TERMIOS_H)
                 struct termios  tty;
@@ -1819,7 +1819,7 @@ int32_t sensekey_perf(CSOUND *csound, KSENSE *p)
             else if (retval<0) perror(Str("sensekey error:"));
 #else
             unsigned char ch = (unsigned char) '\0';
-#  ifdef WIN32
+#  ifdef _WIN32
         if (_kbhit())
           ch = (unsigned char) _getch();
 #  else

--- a/OOps/remote.c
+++ b/OOps/remote.c
@@ -30,9 +30,9 @@
 */
 
 /* #ifdef HAVE_SOCKETS */
-/*   #ifndef WIN32 */
+/*   #ifndef _WIN32 */
 /*     #include <sys/ioctl.h> */
-/*     #ifdef LINUX */
+/*     #ifdef __gnu_linux__ */
 /*       #include <linux/if.h> */
 /*     #endif */
 /*     #ifdef __HAIKU__ */
@@ -45,7 +45,7 @@
 /*     #include <net/if.h> */
 /*   #else */
 /*     #include <winsock2.h> */
-/*   #endif /\* not WIN32 *\/ */
+/*   #endif /\* not _WIN32 *\/ */
 /* #endif /\* HAVE_SOCKETS *\/ */
 
 
@@ -63,7 +63,7 @@ void remoteRESET(CSOUND *csound)
 }
 
 #if defined(HAVE_SOCKETS)
-#if !defined(WIN32) || defined(__CYGWIN__)
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <netdb.h>
 #endif
 #if 0
@@ -89,7 +89,7 @@ static int32_t foo(char *ipaddr)
  /* get the IPaddress of this machine */
 static int32_t getIpAddress(char *ipaddr)
 {
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     /* VL 12/10/06: something needs to go here */
     /* gethostbyname is the real answer; code below is unsafe */
     char hostname[1024];
@@ -113,7 +113,7 @@ static int32_t getIpAddress(char *ipaddr)
       if (dev)
         strNcpy(ifr.ifr_name, dev, IFNAMSIZ-1);
       else {
-#ifdef MACOSX
+#ifdef __APPLE__
         strNcpy(ifr.ifr_name, "en0", IFNAMSIZ-1);
 #else
         strNcpy(ifr.ifr_name, "eth0", IFNAMSIZ-1);
@@ -282,7 +282,7 @@ static int32_t CLopen(CSOUND *csound, char *ipadrs)     /* Client -- open to sen
     memset(&(ST(to_addr)), 0, sizeof(ST(to_addr)));    /* clear sock mem */
     ST(to_addr).sin_family = AF_INET;                  /* set as INET address */
     /* server IP adr, netwk byt order */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     ST(to_addr).sin_addr.S_un.S_addr = inet_addr((const char *)ipadrs);
 #else
     inet_aton((const char *)ipadrs, &(ST(to_addr).sin_addr));
@@ -328,7 +328,7 @@ static int32_t SVopen(CSOUND *csound)
     int32_t conn, socklisten,opt;
     char ipadrs[15];
     int32_t *sop = ST(socksin), *sop_end = sop + MAXREMOTES;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     int32_t clilen;
 #else
     socklen_t clilen;
@@ -340,7 +340,7 @@ static int32_t SVopen(CSOUND *csound)
     }
     else csound->Message(csound, Str("created socket\n"));
     /* set the addresse to be reusable */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (UNLIKELY( setsockopt(socklisten, SOL_SOCKET, SO_REUSEADDR,
                              (const char*)&opt, sizeof(opt)) < 0 ))
 #else
@@ -354,7 +354,7 @@ static int32_t SVopen(CSOUND *csound)
     memset(&(ST(to_addr)), 0, sizeof(ST(to_addr)));    /* clear sock mem */
     ST(local_addr).sin_family = AF_INET;               /* set as INET address */
     /* our adrs, netwrk byt order */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     ST(to_addr).sin_addr.S_un.S_addr = inet_addr((const char *)ipadrs);
 #else
     inet_aton((const char *)ipadrs, &(ST(local_addr).sin_addr));
@@ -396,7 +396,7 @@ int32_t SVrecv(CSOUND *csound, int32_t conn, void *data, int32_t length)
 {
     struct sockaddr from;
     /* VL, 12/10/06: I'm guessing here. If someone knows better, fix it */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #define MSG_DONTWAIT  0
     int32_t clilen = sizeof(from);
 #else

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -1022,11 +1022,11 @@ int32_t getcfg_opcode(CSOUND *csound, GETCFG_OP *p)
     buf[1] = '\0';
     break;
   case 6:             /* host OS name */
-#ifdef LINUX
+#ifdef __gnu_linux__
     s = "Linux";
-#elif defined(WIN32)
+#elif defined(_WIN32)
     s = "Win32";
-#elif defined(MACOSX)
+#elif defined(__APPLE__)
     s = "MacOSX";
 #else
     s = "unknown";

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -33,7 +33,7 @@
 #endif
 #include <lo/lo.h>
 #include <ctype.h>
-#ifndef WIN32
+#ifndef _WIN32
   #include <sys/types.h>
   #include <sys/socket.h>
 #endif
@@ -239,7 +239,7 @@ static int32_t osc_send(CSOUND *csound, OSCSEND *p)
         // if (p->multicast) lo_address_set_ttl(p->addr, 2);
         if (UNLIKELY(p->multicast)) {
           u_char ttl = 2;
-#if defined(LINUX)
+#if defined(__gnu_linux__)
           if (UNLIKELY(setsockopt((uintptr_t)p->addr, IPPROTO_IP,
                                   IP_MULTICAST_TTL, &ttl, sizeof(ttl))==-1)) {
             csound->Message(csound, "%s", Str("Failed to set multicast"));

--- a/Opcodes/cpumeter.c
+++ b/Opcodes/cpumeter.c
@@ -16,7 +16,7 @@
  *
  */
 
-#ifndef WIN32
+#ifndef _WIN32
 
 #include "csoundCore.h"
 #include <time.h>
@@ -36,7 +36,7 @@
 #include <float.h>
 
 // only available on Linux (no /proc/stat on OSX)
-#if defined(LINUX)
+#if defined(__gnu_linux__)
 /*######  Miscellaneous global stuff  ####################################*/
 #define SMLBUFSIZ (512)
 #define TEST (0)

--- a/Opcodes/date.c
+++ b/Opcodes/date.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include "direct.h"
 #endif
 
@@ -57,7 +57,7 @@ static int32_t datemyfltset(CSOUND *csound, DATEMYFLT *p)
     /*    time_t base = 946684800; */  /* 1 Jan 2000 */
     const time_t base = 1262304000;    /* 1 Jan 2010 */
 #endif
-#ifdef LINUX
+#ifdef __gnu_linux__
     struct timespec tp;
     clock_gettime(CLOCK_REALTIME, &tp);
     *p->time_ = (MYFLT) (tp.tv_sec-base);
@@ -121,7 +121,7 @@ static int32_t getcurdir(CSOUND *csound, GETCWD *p)
       p->Scd->data = csound->Calloc(csound, p->Scd->size);
     }
 #ifndef BARE_METAL   
-#if defined(__MACH__) || defined(LINUX) || defined(__HAIKU__) || defined(__CYGWIN__) || defined(__GNUC__)
+#if defined(__MACH__) || defined(__gnu_linux__) || defined(__HAIKU__) || defined(__CYGWIN__) || defined(__GNUC__)
     if (UNLIKELY(getcwd(p->Scd->data, p->Scd->size-1)==NULL))
 #else
     if (UNLIKELY( _getcwd(p->Scd->data, p->Scd->size-1)==NULL))

--- a/Opcodes/ftsamplebank.cpp
+++ b/Opcodes/ftsamplebank.cpp
@@ -154,7 +154,7 @@ int loadSamplesToTables(CSOUND *csound, int index, char *directory,
           if(extension == fileExtensions[i])
             {
               if (strlen(directory) > 0) {
-#if defined(WIN32)
+#if defined(_WIN32)
               fullFileName << directory << "\\" << ent->d_name;
 #else
               fullFileName << directory << "/" << ent->d_name;
@@ -298,7 +298,7 @@ std::vector<std::string> searchDir(CSOUND *csound, char *directory,
             (lastPos != std::string::npos &&
             fname.substr(lastPos) == fileExtension))) {
           if (strlen(directory) > 0) {
-#if defined(WIN32)
+#if defined(_WIN32)
             fullFileName << directory << "\\" << ent->d_name;
 #else
             fullFileName << directory << "/" << ent->d_name;

--- a/Opcodes/serial.c
+++ b/Opcodes/serial.c
@@ -38,7 +38,7 @@
 #include <stdint.h>   /* Standard types */
 #include <string.h>   /* String function definitions */
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>   /* UNIX standard function definitions */
 #include <fcntl.h>    /* File control definitions */
 #include <termios.h>  /* POSIX terminal control definitions */
@@ -99,7 +99,7 @@ TODO: (might need some kind of threaded buffer-read?)
 
 *****************************************************/
 
-#ifdef WIN32
+#ifdef _WIN32
 typedef struct SERIAL_GLOBALS_ {
     CSOUND  *csound;
     int32_t     maxind;
@@ -174,7 +174,7 @@ typedef struct {
 int32_t serialPeekByte(CSOUND *csound, SERIALPEEK *p);
 //------------------
 
-#ifndef WIN32
+#ifndef _WIN32
 // takes the string name of the serial port (e.g. "/dev/tty.usbserial","COM1")
 // and a baud rate (bps) and connects to that port at that speed and 8N1.
 // opens the port in fully raw mode so you can send binary data.
@@ -350,7 +350,7 @@ int32_t serialBegin(CSOUND *csound, SERIALBEGIN *p)
 int32_t serialEnd(CSOUND *csound, SERIALEND *p)
 {
     IGN(csound);
-#ifdef WIN32
+#ifdef _WIN32
     SERIAL_GLOBALS *q;
     q = (SERIAL_GLOBALS*) csound->QueryGlobalVariable(csound,
                                                       "serialGlobals_");
@@ -367,13 +367,13 @@ int32_t serialEnd(CSOUND *csound, SERIALEND *p)
 int32_t serialWrite(CSOUND *csound, SERIALWRITE *p)
 {
     IGN(csound);
-#ifdef WIN32
+#ifdef _WIN32
     HANDLE port = get_port(csound, (int32_t)*p->port);
     if (UNLIKELY(port==NULL)) return NOTOK;
 #endif
     {
       unsigned char b = *p->toWrite;
-#ifndef WIN32
+#ifndef _WIN32
       if (UNLIKELY(write((int32_t)*p->port, &b, 1)<0))
         return NOTOK;
 #else
@@ -387,11 +387,11 @@ int32_t serialWrite(CSOUND *csound, SERIALWRITE *p)
 int32_t serialWrite_S(CSOUND *csound, SERIALWRITE *p)
 {
      IGN(csound);
-#ifdef WIN32
+#ifdef _WIN32
     HANDLE port = get_port(csound, (int32_t)*p->port);
     if (UNLIKELY(port==NULL)) return NOTOK;
 #endif
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(write((int32_t)*p->port,
                        ((STRINGDAT*)p->toWrite)->data,
                        ((STRINGDAT*)p->toWrite)->size))!=
@@ -410,7 +410,7 @@ int32_t serialRead(CSOUND *csound, SERIALREAD *p)
 {
     IGN(csound);
     unsigned char b = 0;
-#ifdef WIN32
+#ifdef _WIN32
     size_t bytes;
     HANDLE port = get_port(csound, (int32_t)*p->port);
     if (UNLIKELY(port==NULL)) return NOTOK;
@@ -430,7 +430,7 @@ int32_t serialRead(CSOUND *csound, SERIALREAD *p)
 int32_t serialPrint(CSOUND *csound, SERIALPRINT *p)
 {
     char str[32769];
-#ifdef WIN32
+#ifdef _WIN32
     size_t bytes;
     HANDLE port = get_port(csound, (int32_t)*p->port);
     if (UNLIKELY(port==NULL)) return NOTOK;
@@ -449,7 +449,7 @@ int32_t serialPrint(CSOUND *csound, SERIALPRINT *p)
 int32_t serialFlush(CSOUND *csound, SERIALFLUSH *p)
 {
      IGN(csound);
-#ifndef WIN32
+#ifndef _WIN32
     tcflush(*p->port, TCIFLUSH); // who knows if this works...
 #endif
     return OK;
@@ -490,7 +490,7 @@ int32_t serialPeekByte(CSOUND *csound, SERIALPEEK *p)
 typedef struct {
     CSOUND  *csound;
     void *thread;
-#ifdef WIN32
+#ifdef _WIN32
     HANDLE port;
 #else
     int32_t port;
@@ -529,7 +529,7 @@ typedef struct {
     ARDUINO_GLOBALS *q;
 } ARD_READF;
 
-#ifndef WIN32
+#ifndef _WIN32
 /* NOTE we need to remove timeout status VMIN/VTIME maybe */
 unsigned char arduino_get_byte(int32_t port)
 {
@@ -579,7 +579,7 @@ uintptr_t arduino_listen(void *p)
       csound->UnlockMutex(q->lock);
       // end critical region
       if (q->stop)
-        //#ifndef WIN32
+        //#ifndef _WIN32
         //pthread_exit(NULL);
         //#elsex
         return 0;
@@ -633,7 +633,7 @@ int32_t arduinoStart(CSOUND* csound, ARD_START* p)
     p->q = q;
     q->csound = csound;
     q->lock = csound->Create_Mutex(0);
-#ifdef WIN32
+#ifdef _WIN32
     q->port = get_port(csound, xx);
 #else
     q->port = xx;

--- a/Opcodes/sftype.h
+++ b/Opcodes/sftype.h
@@ -44,7 +44,7 @@
 #  undef WORDS_BIGENDIAN
 #endif
 
-#if !defined(WIN32) || defined(__CYGWIN__)
+#if !defined(_WIN32) || defined(__CYGWIN__)
 typedef uint32_t    DWORD;
 #endif
 /*  typedef int32_t     BOOL; */

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -28,7 +28,7 @@
 #include "csoundCore.h"
 #include <stdlib.h>
 #include <sys/types.h>
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
@@ -44,7 +44,7 @@
 #define MAXBUFS 32
 #define MTU (1456)
 
-#ifndef WIN32
+#ifndef _WIN32
 extern  int32_t     inet_aton(const char *cp, struct in_addr *inp);
 #endif
 
@@ -141,7 +141,7 @@ static int32_t deinit_udpRecv_S(CSOUND *csound, void *pdata)
     p->threadon = 0;
     csound->JoinThread(p->thrid);
 
-#ifndef WIN32
+#ifndef _WIN32
     close(p->sock);
     csound->Message(csound, Str("OSCraw: Closing socket\n"));
 #else
@@ -175,7 +175,7 @@ static uintptr_t udpRecv_S(void *pdata)
 static int32_t init_recv(CSOUND *csound, SOCKRECV *p)
 {
     MYFLT   *buf;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -183,7 +183,7 @@ static int32_t init_recv(CSOUND *csound, SOCKRECV *p)
 #endif
     p->cs = csound;
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0))
       return csound->InitError(csound, Str("Cannot set nonblock"));
 #else
@@ -237,7 +237,7 @@ static int32_t init_recv(CSOUND *csound, SOCKRECV *p)
 static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 {
     MYFLT   *buf;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -246,7 +246,7 @@ static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 
     p->cs = csound;
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0))
       return csound->InitError(csound, Str("Cannot set nonblock"));
 #endif
@@ -352,7 +352,7 @@ static int32_t send_recv(CSOUND *csound, SOCKRECV *p)
 static int32_t init_recvS(CSOUND *csound, SOCKRECV *p)
 {
     MYFLT   *buf;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if ((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0)
@@ -361,7 +361,7 @@ static int32_t init_recvS(CSOUND *csound, SOCKRECV *p)
 
     p->cs = csound;
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0))
       return csound->InitError(csound, Str("Cannot set nonblock"));
 #endif
@@ -437,7 +437,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
 {
     socklen_t clilen;
     int32_t err;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     if ((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0)
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
@@ -445,7 +445,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
     /* create a STREAM (TCP) socket in the INET (IP) protocol */
     p->sock = socket(PF_INET, SOCK_STREAM, 0);
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (p->sock == SOCKET_ERROR) {
       err = WSAGetLastError();
       csound->InitError(csound, Str("socket failed with error: %ld\n"), err);
@@ -465,7 +465,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
     p->server_addr.sin_family = AF_INET;
 
     /* the server IP address, in network byte order */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else
@@ -477,7 +477,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
     /* associate the socket with the address and port */
     err = bind(p->sock, (struct sockaddr *) &p->server_addr,
                sizeof(p->server_addr));
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (UNLIKELY(err == SOCKET_ERROR)) {
       err = WSAGetLastError();
 #else
@@ -489,7 +489,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
 
     /* start the socket listening for new connections -- may wait */
     err = listen(p->sock, 5);
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (UNLIKELY(err == SOCKET_ERROR)) {
       err = WSAGetLastError();
 #else
@@ -500,7 +500,7 @@ static int32_t init_srecv(CSOUND *csound, SOCKRECVT *p)
     }
     clilen = sizeof(p->server_addr);
     p->conn = accept(p->sock, (struct sockaddr *) &p->server_addr, &clilen);
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (UNLIKELY(err == SOCKET_ERROR)) {
       err = WSAGetLastError();
 #else
@@ -565,7 +565,7 @@ typedef struct _rawosc {
 
 static int32_t destroy_raw_osc(CSOUND *csound, void *pp) {
     RAWOSC *p = (RAWOSC *) pp;
-#ifndef WIN32
+#ifndef _WIN32
     close(p->sock);
     csound->Message(csound, Str("OSCraw: Closing socket\n"));
 #else
@@ -580,14 +580,14 @@ static int32_t destroy_raw_osc(CSOUND *csound, void *pp) {
 static int32_t init_raw_osc(CSOUND *csound, RAWOSC *p)
 {
     MYFLT   *buf;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if ((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0)
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
 #endif
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0))
       return csound->InitError(csound, Str("Cannot set nonblock"));
 #else

--- a/Opcodes/socksend.c
+++ b/Opcodes/socksend.c
@@ -28,7 +28,7 @@
 
 #include "csoundCore.h"
 #include <sys/types.h>
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
@@ -89,7 +89,7 @@ static int32_t init_send(CSOUND *csound, SOCKSEND *p)
 {
     int32_t     bsize;
     int32_t     bwidth = sizeof(MYFLT);
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -106,7 +106,7 @@ static int32_t init_send(CSOUND *csound, SOCKSEND *p)
     p->wp = 0;
 
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (p->sock == SOCKET_ERROR) {
       err = WSAGetLastError();
       csound->InitError(csound, Str("socket failed with error: %ld\n"), err);
@@ -119,7 +119,7 @@ static int32_t init_send(CSOUND *csound, SOCKSEND *p)
     /* create server address: where we want to send to and clear it out */
     memset(&p->server_addr, 0, sizeof(p->server_addr));
     p->server_addr.sin_family = AF_INET;    /* it is an INET address */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else
@@ -245,7 +245,7 @@ static int32_t init_sendS(CSOUND *csound, SOCKSENDS *p)
 {
     int32_t     bsize;
     int32_t     bwidth = sizeof(MYFLT);
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -269,7 +269,7 @@ static int32_t init_sendS(CSOUND *csound, SOCKSENDS *p)
     /* create server address: where we want to send to and clear it out */
     memset(&p->server_addr, 0, sizeof(p->server_addr));
     p->server_addr.sin_family = AF_INET;    /* it is an INET address */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else
@@ -355,7 +355,7 @@ static int32_t stsend_deinit(CSOUND *csound, SOCKSEND *p)
 static int32_t init_ssend(CSOUND *csound, SOCKSEND *p)
 {
     int32_t err;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
@@ -364,7 +364,7 @@ static int32_t init_ssend(CSOUND *csound, SOCKSEND *p)
     /* create a STREAM (TCP) socket in the INET (IP) protocol */
     p->sock = socket(PF_INET, SOCK_STREAM, 0);
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (p->sock == SOCKET_ERROR) {
       err = WSAGetLastError();
       csound->InitError(csound, Str("socket failed with error: %ld\n"), err);
@@ -383,7 +383,7 @@ static int32_t init_ssend(CSOUND *csound, SOCKSEND *p)
     p->server_addr.sin_family = AF_INET;
 
     /* the server IP address, in network byte order */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else
@@ -396,7 +396,7 @@ static int32_t init_ssend(CSOUND *csound, SOCKSEND *p)
  again:
     err = connect(p->sock, (struct sockaddr *) &p->server_addr,
                   sizeof(p->server_addr));
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (UNLIKELY(err==SOCKET_ERROR)) {
         err = WSAGetLastError();
         if (err == WSAECONNREFUSED) goto again;
@@ -453,7 +453,7 @@ typedef struct {
 static int32_t oscsend_deinit(CSOUND *csound, OSCSEND2 *p)
 {
     p->init_done = 0;
-#if defined(WIN32)
+#if defined(_WIN32)
     closesocket((SOCKET)p->sock);
     WSACleanup();
 #else
@@ -484,7 +484,7 @@ static int32_t osc_send2_init(CSOUND *csound, OSCSEND2 *p)
                              Str("insufficient number of arguments for "
                                  "OSC message types\n"));
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -497,7 +497,7 @@ static int32_t osc_send2_init(CSOUND *csound, OSCSEND2 *p)
     /* create server address: where we want to send to and clear it out */
     memset(&p->server_addr, 0, sizeof(p->server_addr));
     p->server_addr.sin_family = AF_INET;    /* it is an INET address */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else
@@ -905,7 +905,7 @@ static int oscbundle_init(CSOUND *csound, OSCBUNDLE *p) {
 
     if(*p->imtu) p->mtu = (int) *p->imtu;
     else p->mtu = MAX_PACKET_SIZE;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -918,7 +918,7 @@ static int oscbundle_init(CSOUND *csound, OSCBUNDLE *p) {
     /* create server address: where we want to send to and clear it out */
     memset(&p->server_addr, 0, sizeof(p->server_addr));
     p->server_addr.sin_family = AF_INET;    /* it is an INET address */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     p->server_addr.sin_addr.S_un.S_addr =
       inet_addr((const char *) p->ipaddress->data);
 #else

--- a/Opcodes/system_call.c
+++ b/Opcodes/system_call.c
@@ -35,7 +35,7 @@ typedef struct {
   CSOUND *csound;
 } SYSTEM;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <process.h>
 
 static void threadroutine(void *p)

--- a/Opcodes/urandom.c
+++ b/Opcodes/urandom.c
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #endif
 
-#ifdef MACOSX
+#ifdef __APPLE__
 #include <unistd.h>
 #endif
 

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -58,7 +58,7 @@ void msg_callback(CSOUND *csound,
       fflush(logFile);
       return;
      }
-    #if defined(WIN32) || defined(MAC)
+    #if defined(_WIN32) || defined(__APPLE__)
     switch (attr & CSOUNDMSG_TYPE_MASK) {
         case CSOUNDMSG_ERROR:
         case CSOUNDMSG_WARNING:
@@ -177,7 +177,7 @@ static const char *shortUsageList[] = {
   Str_noop("-Q dnam     select MIDI output device"),
   Str_noop("-z          list opcodes in this version"),
   Str_noop("-Z          dither output"),
-#if defined(LINUX)
+#if defined(__gnu_linux__)
   Str_noop("--sched     set real-time priority and lock memory"),
   Str_noop("              (requires -d and real time audio (-iadc/-odac))"),
   Str_noop("--sched=N   set specified scheduling priority, and lock memory"),
@@ -606,7 +606,7 @@ static int decode_long(CSOUND *csound, char *s, int argc, char **argv)
       if (UNLIKELY(*s == '\0')) dieu(csound, Str("no midifile name"));
       O->FMidiname = s;                 /* Midifile name */
       if (!strcmp(O->FMidiname, "stdin")) {
-#if defined(WIN32)
+#if defined(_WIN32)
         csoundDie(csound, Str("-F: stdin not supported on this platform"));
 #else
         set_stdin_assign(csound, STDINASSIGN_MIDIFILE, 1);
@@ -663,7 +663,7 @@ static int decode_long(CSOUND *csound, char *s, int argc, char **argv)
         csoundDie(csound, Str("input cannot be stdout"));
       if (strcmp(O->infilename, "stdin") == 0) {
         set_stdin_assign(csound, STDINASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
         csoundDie(csound, Str("stdin audio not supported"));
 #endif
       }
@@ -826,7 +826,7 @@ static int decode_long(CSOUND *csound, char *s, int argc, char **argv)
       O->Midiname = s;
       if (!strcmp(O->Midiname, "stdin")) {
         set_stdin_assign(csound, STDINASSIGN_MIDIDEV, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
         csoundDie(csound, Str("-M: stdin not supported on this platform"));
 #endif
       }
@@ -854,7 +854,7 @@ static int decode_long(CSOUND *csound, char *s, int argc, char **argv)
         dieu(csound, Str("-o cannot be stdin"));
       if (strcmp(O->outfilename, "stdout") == 0) {
         set_stdout_assign(csound, STDOUTASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
         csoundDie(csound, Str("stdout audio not supported"));
 #endif
       }
@@ -1325,7 +1325,7 @@ PUBLIC int argdecode(CSOUND *csound, int argc, const char **argv_)
               csoundDie(csound, Str("input cannot be stdout"));
             if (strcmp(O->infilename, "stdin") == 0) {
               set_stdin_assign(csound, STDINASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
               csoundDie(csound, Str("stdin audio not supported"));
 #endif
             }
@@ -1341,7 +1341,7 @@ PUBLIC int argdecode(CSOUND *csound, int argc, const char **argv_)
               dieu(csound, Str("-o cannot be stdin"));
             if (strcmp(O->outfilename, "stdout") == 0) {
               set_stdout_assign(csound, STDOUTASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
               csoundDie(csound, Str("stdout audio not supported"));
 #endif
             }
@@ -1447,7 +1447,7 @@ PUBLIC int argdecode(CSOUND *csound, int argc, const char **argv_)
             O->Midiname = s;              /* Midi device name */
             s += (int) strlen(s);
             if (strcmp(O->Midiname, "stdin")==0) {
-#if defined(WIN32)
+#if defined(_WIN32)
               csoundDie(csound, Str("-M: stdin not supported on this platform"));
 #else
               set_stdin_assign(csound, STDINASSIGN_MIDIDEV, 1);
@@ -1462,7 +1462,7 @@ PUBLIC int argdecode(CSOUND *csound, int argc, const char **argv_)
             O->FMidiname = s;             /* Midifile name */
             s += (int) strlen(s);
             if (strcmp(O->FMidiname, "stdin")==0) {
-#if defined(WIN32)
+#if defined(_WIN32)
               csoundDie(csound, Str("-F: stdin not supported on this platform"));
 #else
               set_stdin_assign(csound, STDINASSIGN_MIDIFILE, 1);
@@ -1547,7 +1547,7 @@ PUBLIC int argdecode(CSOUND *csound, int argc, const char **argv_)
             s--; /* semicolon on separate line to silence warning */
             break;
           case '-':
-#if defined(LINUX)
+#if defined(__gnu_linux__)
             if (!(strcmp (s, "sched"))) {             /* ignore --sched */
               while (*(++s));
               break;
@@ -1737,7 +1737,7 @@ PUBLIC void csoundSetOutput(CSOUND *csound, const char *name,
     strcpy(oparms->outfilename, name); /* unsafe -- REVIEW */
     if (strcmp(oparms->outfilename, "stdout") == 0) {
       set_stdout_assign(csound, STDOUTASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
       csound->Warning(csound, Str("stdout not supported on this platform"));
 #endif
     }
@@ -1798,7 +1798,7 @@ PUBLIC void csoundSetInput(CSOUND *csound, const char *name) {
     strcpy(oparms->infilename, name);
     if (strcmp(oparms->infilename, "stdin") == 0) {
       set_stdin_assign(csound, STDINASSIGN_SNDFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
       csound->Warning(csound, Str("stdin not supported on this platform"));
 #endif
     }
@@ -1818,7 +1818,7 @@ PUBLIC void csoundSetMIDIInput(CSOUND *csound, const char *name) {
     strcpy(oparms->Midiname, name);
     if (!strcmp(oparms->Midiname, "stdin")) {
       set_stdin_assign(csound, STDINASSIGN_MIDIDEV, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
       csound->Warning(csound, Str("stdin not supported on this platform"));
 #endif
     }
@@ -1838,7 +1838,7 @@ PUBLIC void csoundSetMIDIFileInput(CSOUND *csound, const char *name) {
     strcpy(oparms->FMidiname, name);
     if (!strcmp(oparms->FMidiname, "stdin")) {
       set_stdin_assign(csound, STDINASSIGN_MIDIFILE, 1);
-#if defined(WIN32)
+#if defined(_WIN32)
       csound->Warning(csound, Str("stdin not supported on this platform"));
 #endif
     }

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -764,7 +764,7 @@ void CsoundPerformanceThread::FlushMessageQueue()
 extern "C" {
 
 #ifndef PUBLIK
-#if (defined(WIN32) || defined(_WIN32))
+#if defined(_WIN32)
 #  define PUBLIK        __declspec(dllexport)
 #elif defined(__GNUC__) //&& !defined(__MACH__)
 #  define PUBLIK        __attribute__ ( (visibility("default")) )

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -92,9 +92,9 @@
 #endif
 
 #if !(defined (NACL)) && !(defined (__wasi__))
-#if defined(LINUX) || defined(NEW_MACH_CODE) || defined(__HAIKU__)
+#if defined(__gnu_linux__) || defined(NEW_MACH_CODE) || defined(__HAIKU__)
 #include <dlfcn.h>
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #include <windows.h>
 #endif
 #endif
@@ -110,7 +110,7 @@ int             closedir(DIR*);
 #  endif
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #  include <io.h>
 #  include <direct.h>
 #endif
@@ -152,7 +152,7 @@ static  const   char    *plugindir64_envvar = "OPCODE7DIR64";
         "/boot/home/config/non-packaged/lib/csound7/plugins64";
 # endif
 # define CS_DEFAULT_PLUGINDIR  haikudirs
-#elif !(defined(_CSOUND_RELEASE_) && (defined(LINUX) || defined(__MACH__)))
+#elif !(defined(_CSOUND_RELEASE_) && (defined(__gnu_linux__) || defined(__MACH__)))
 #  define ENABLE_OPCODEDIR_WARNINGS 1
 #  ifdef CS_DEFAULT_PLUGINDIR
 #    undef CS_DEFAULT_PLUGINDIR
@@ -400,13 +400,13 @@ static CS_NOINLINE int csoundLoadExternal(CSOUND *csound,
     if (UNLIKELY(fname[0] == '\0'))
       return CSOUND_ERROR;
     /* load library */
-/*  #if defined(LINUX) */
+/*  #if defined(__gnu_linux__) */
     //printf("About to open library '%s'\n", libraryPath);
 /* #endif */
     err = csoundOpenLibrary(&h, libraryPath);
     if (UNLIKELY(err)) {
       char ERRSTR[256];
- #if !(defined(NACL)) && (defined(LINUX) || defined(__HAIKU__))
+ #if !(defined(NACL)) && (defined(__gnu_linux__) || defined(__HAIKU__))
       snprintf(ERRSTR, 256, Str("could not open library '%s' (%s)"),
                libraryPath, dlerror());
  #else
@@ -572,7 +572,7 @@ int csoundLoadModules(CSOUND *csound)
     int read_directory = 1;
     char searchpath_buf[searchpath_buflen];
     char sep =
-#ifdef WIN32
+#ifdef _WIN32
     ';';
 #else
     ':';
@@ -624,9 +624,9 @@ int csoundLoadModules(CSOUND *csound)
       // to be expanded
       userplugindir = CS_DEFAULT_USER_PLUGINDIR;
 
-#if defined(LINUX) || defined(__MACH__)
+#if defined(__gnu_linux__) || defined(__MACH__)
       char *prefix = getenv("HOME");
-#elif defined(WIN32)
+#elif defined(_WIN32)
       char *prefix = getenv("LOCALAPPDATA");
 #endif
       // VL: need to check so we don't get a segfault with NULL strings
@@ -697,7 +697,7 @@ int csoundLoadModules(CSOUND *csound)
       if (UNLIKELY(fname[0]=='_')) continue;
       n = len = (int) strlen(fname);
       if (UNLIKELY(fname[0]=='_')) continue;
-#if defined(WIN32)
+#if defined(_WIN32)
       strcpy(buf, "dll");
       n -= 4;
 #elif defined(__MACH__)
@@ -864,7 +864,7 @@ int csoundLoadAndInitModules(CSOUND *csound, const char *opdir)
     char            *dname1, *end;
     int             read_directory = 1;
     char sep =
-#ifdef WIN32
+#ifdef _WIN32
     ';';
 #else
     ':';
@@ -949,7 +949,7 @@ int csoundLoadAndInitModules(CSOUND *csound, const char *opdir)
       if (UNLIKELY(fname[0]=='_')) continue;
       n = len = (int) strlen(fname);
       if (UNLIKELY(fname[0]=='_')) continue;
-#if defined(WIN32)
+#if defined(_WIN32)
       strcpy(buf, "dll");
       n -= 4;
 #elif defined(__MACH__)
@@ -1039,7 +1039,7 @@ int csoundDestroyModules(CSOUND *csound)
 
  /* ------------------------------------------------------------------------ */
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 PUBLIC int csoundOpenLibrary(void **library, const char *libraryPath)
 {
@@ -1057,7 +1057,7 @@ PUBLIC void *csoundGetLibrarySymbol(void *library, const char *procedureName)
     return (void*) GetProcAddress((HMODULE) library, procedureName);
 }
 
-#elif !(defined(NACL)) && !(defined(__wasi__)) && (defined(LINUX) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
+#elif !(defined(NACL)) && !(defined(__wasi__)) && (defined(__gnu_linux__) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
 
 PUBLIC int csoundOpenLibrary(void **library, const char *libraryPath)
 {
@@ -1251,7 +1251,7 @@ const INITFN staticmodules[] = { hrtfopcodes_localops_init, babo_localops_init,
                                  hrtfreverb_localops_init, minmax_localops_init,
                                  vaops_localops_init, paulstretch_localops_init,
                                  squinewave_localops_init, tabaudio_localops_init,
-#ifdef LINUX
+#ifdef __gnu_linux__
                                  cpumeter_localops_init,
 #endif
 

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -47,7 +47,7 @@
 #ifdef HAVE_SYS_TYPES_H
 # include <sys/types.h>
 #endif
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 # include <winsock2.h>
 # include <windows.h>
 #endif
@@ -704,9 +704,9 @@ static const CSOUND cenviron_ = {
     440.0,               /* A4 base frequency */
     NULL,           /*  rtRecord_userdata   */
     NULL,           /*  rtPlay_userdata     */
-#if defined(MSVC) ||defined(__POWERPC__) || defined(MACOSX)
+#if defined(MSVC) ||defined(__POWERPC__) || defined(__APPLE__)
     {0},
-#elif defined(LINUX)
+#elif defined(__gnu_linux__)
    {{{0}}},        /*  exitjmp of type jmp_buf */
 #else 
    {0},  
@@ -1059,7 +1059,7 @@ static  volatile  csInstance_t  *instance_list = NULL;
 static  volatile  int exitNow_ = 0;
 
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
 static void destroy_all_instances(void)
 {
     volatile csInstance_t *p;
@@ -1084,7 +1084,7 @@ static void destroy_all_instances(void)
 }
 #endif
 
-#if defined(ANDROID) || (!defined(LINUX) && !defined(SGI) && \
+#if defined(ANDROID) || (!defined(__gnu_linux__) && !defined(SGI) && \
                          !defined(__HAIKU__) && !defined(__BEOS__) && \
                          !defined(__MACH__) && !defined(__EMSCRIPTEN__))
 
@@ -1285,10 +1285,10 @@ static void signal_handler(int sig)
 }
 
 static const int sigs[] = {
-#if defined(LINUX) || defined(SGI) || defined(sol) || defined(__MACH__)
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || defined(__MACH__)
   SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGIOT, SIGBUS,
   SIGFPE, SIGSEGV, SIGPIPE, SIGTERM, SIGXCPU, SIGXFSZ,
-#elif defined(WIN32)
+#elif defined(_WIN32)
   SIGINT, SIGILL, SIGABRT, SIGFPE, SIGSEGV, SIGTERM,
 #elif defined(__EMX__)
   SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE,
@@ -1336,7 +1336,7 @@ PUBLIC int csoundInitialize(int flags)
     if (!(flags & CSOUNDINIT_NO_SIGNAL_HANDLER)) {
       install_signal_handler();
     }
-#if !defined(WIN32)
+#if !defined(_WIN32)
     if (!(flags & CSOUNDINIT_NO_ATEXIT))
       atexit(destroy_all_instances);
 #endif
@@ -1506,7 +1506,7 @@ static int getThreadIndex(CSOUND *csound, void *threadId)
     while (current != NULL) {
 #ifdef HAVE_PTHREAD
       if (pthread_equal(*(pthread_t *)threadId, *(pthread_t *)current->threadId))
-#elif defined(WIN32)
+#elif defined(_WIN32)
       DWORD* d = (DWORD*)threadId;
       if (*d == GetThreadId((HANDLE)current->threadId))
 #else
@@ -2271,7 +2271,7 @@ static int csoundPerformKsmpsInternal(CSOUND *csound)
     }
     /* setup jmp for return after an exit() */
         if (UNLIKELY((returnValue = setjmp(csound->exitjmp)))) {
-#ifndef MACOSX
+#ifndef __APPLE__
       csoundMessage(csound, Str("Early return from csoundPerformKsmps().\n"));
 #endif
       return ((returnValue - CSOUND_EXITJMP_SUCCESS) | CSOUND_EXITJMP_SUCCESS);
@@ -2300,7 +2300,7 @@ PUBLIC int csoundPerformBuffer(CSOUND *csound)
     }
     /* Setup jmp for return after an exit(). */
     if (UNLIKELY((returnValue = setjmp(csound->exitjmp)))) {
-#ifndef MACOSX
+#ifndef __APPLE__
       csoundMessage(csound, Str("Early return from csoundPerformBuffer().\n"));
 #endif
       return ((returnValue - CSOUND_EXITJMP_SUCCESS) | CSOUND_EXITJMP_SUCCESS);
@@ -2343,7 +2343,7 @@ PUBLIC int csoundPerform(CSOUND *csound)
     csound->performState = 0;
     /* setup jmp for return after an exit() */
     if (UNLIKELY((returnValue = setjmp(csound->exitjmp)))) {
-#ifndef MACOSX
+#ifndef __APPLE__
       csoundMessage(csound, Str("Early return from csoundPerform().\n"));
 #endif
       return ((returnValue - CSOUND_EXITJMP_SUCCESS) | CSOUND_EXITJMP_SUCCESS);
@@ -2574,7 +2574,7 @@ PUBLIC void csoundSetCscoreCallback(CSOUND *p,
 static void csoundDefaultMessageCallback(CSOUND *csound, int attr,
                                          const char *format, va_list args)
 {
-#if defined(WIN32)
+#if defined(_WIN32)
     switch (attr & CSOUNDMSG_TYPE_MASK) {
     case CSOUNDMSG_ERROR:
     case CSOUNDMSG_WARNING:
@@ -3601,7 +3601,7 @@ PUBLIC void csoundReset(CSOUND *csound)
     max_len = 21;
     csoundCreateGlobalVariable(csound, "_RTAUDIO", (size_t) max_len);
     s = csoundQueryGlobalVariable(csound, "_RTAUDIO");
-#ifndef LINUX
+#ifndef __gnu_linux__
  #ifdef __HAIKU__
       strcpy(s, "haiku");
  #else
@@ -3629,7 +3629,7 @@ PUBLIC void csoundReset(CSOUND *csound)
     s = csoundQueryGlobalVariable(csound, "_RTMIDI");
     strcpy(s, "null");
     if (csound->enableHostImplementedMIDIIO == 0)
-#ifndef LINUX
+#ifndef __gnu_linux__
  #ifdef __HAIKU__
       strcpy(s, "haiku");
  #else
@@ -3911,7 +3911,7 @@ void csoundNotifyFileOpened(CSOUND* csound, const char* pathname,
 #ifdef HAVE_GETTIMEOFDAY
 #undef HAVE_GETTIMEOFDAY
 #endif
-#if defined(LINUX) || defined(__unix) || defined(__unix__) || defined(__MACH__)
+#if defined(__gnu_linux__) || defined(__unix) || defined(__unix__) || defined(__MACH__)
 #define HAVE_GETTIMEOFDAY 1
 #include <sys/time.h>
 #endif
@@ -3925,7 +3925,7 @@ void csoundNotifyFileOpened(CSOUND* csound, const char* pathname,
 /* ------------------------------------ */
 
 #if defined(HAVE_RDTSC)
-#if !(defined(LINUX) && defined(__GNUC__) && defined(__i386__))
+#if !(defined(__gnu_linux__) && defined(__GNUC__) && defined(__i386__))
 #undef HAVE_RDTSC
 #endif
 #endif
@@ -3980,7 +3980,7 @@ static int getTimeResolution(void)
     }
     /* MHz -> seconds */
     timeResolutionSeconds = 0.000001 / timeResolutionSeconds;
-#elif defined(WIN32)
+#elif defined(_WIN32)
     LARGE_INTEGER tmp1;
     int_least64_t tmp2;
     QueryPerformanceFrequency(&tmp1);
@@ -4011,7 +4011,7 @@ static inline int_least64_t get_real_time(void)
     __asm__ volatile ("rdtsc" : "=a" (l), "=d" (h));
 #endif
     return ((int_least64_t) l + ((int_least64_t) h << 32));
-#elif defined(WIN32)
+#elif defined(_WIN32)
     /* Win32: use QueryPerformanceCounter - resolution depends on system, */
     /* but is expected to be better than 1 us. GetSystemTimeAsFileTime    */
     /* seems to have much worse resolution under Win95.                   */
@@ -4615,7 +4615,7 @@ PUBLIC int csoundPerformKsmpsAbsolute(CSOUND *csound)
     }
     /* setup jmp for return after an exit() */
     if (UNLIKELY((returnValue = setjmp(csound->exitjmp)))) {
-#ifndef MACOSX
+#ifndef __APPLE__
       csoundMessage(csound, Str("Early return from csoundPerformKsmps().\n"));
 #endif
       return ((returnValue - CSOUND_EXITJMP_SUCCESS) | CSOUND_EXITJMP_SUCCESS);

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -31,7 +31,7 @@ int mkstemp(char *);
 #include <stdlib.h>
 #include "corfile.h"
 
-#if defined(LINUX) || defined(__MACH__) || defined(WIN32)
+#if defined(__gnu_linux__) || defined(__MACH__) || defined(_WIN32)
 #  include <sys/types.h>
 #  include <sys/stat.h>
 #endif
@@ -66,13 +66,13 @@ CS_NOINLINE char *csoundTmpFileName(CSOUND *csound, const char *ext)
 {
 #define   nBytes (256)
     char lbuf[256];
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     struct _stat tmp;
 #else
     struct stat tmp;
 #endif
     do {
-#ifndef WIN32
+#ifndef _WIN32
       int fd;
       char *tmpdir = getenv("TMPDIR");
       if (tmpdir != NULL && tmpdir[0] != '\0')
@@ -100,7 +100,7 @@ CS_NOINLINE char *csoundTmpFileName(CSOUND *csound, const char *ext)
       }
 #endif
       if (ext != NULL && ext[0] != (char) 0) {
-#if !defined(LINUX) && !defined(__MACH__) && !defined(WIN32)
+#if !defined(__gnu_linux__) && !defined(__MACH__) && !defined(_WIN32)
         char  *p;
         /* remove original extension (does not work on OS X */
         /* and may be a bad idea) */
@@ -120,7 +120,7 @@ CS_NOINLINE char *csoundTmpFileName(CSOUND *csound, const char *ext)
           } while (lbuf[i] != '\0');
       }
 #endif
-#if defined(WIN32)
+#if defined(_WIN32)
     } while (_stat(lbuf, &tmp) == 0);
 #else
       /* if the file already exists, try again */

--- a/Top/server.c
+++ b/Top/server.c
@@ -28,7 +28,7 @@
 #define __HAIKU_CONFLICT
 
 #include "csoundCore.h"
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
@@ -53,7 +53,7 @@ static void udp_socksend(CSOUND *csound, int *sock, const char *addr,
                          int port, const char *msg) {
   struct sockaddr_in server_addr;
   if(*sock <= 0) {
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
@@ -65,7 +65,7 @@ static void udp_socksend(CSOUND *csound, int *sock, const char *addr,
       csound->Warning(csound, Str("UDP: error creating socket"));
       return;
     }
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(*sock, F_SETFL, O_NONBLOCK)<0)) {
       csound->Warning(csound, Str("UDP Server: Cannot set nonblock"));
       if (*sock>=0) close(*sock);
@@ -85,7 +85,7 @@ static void udp_socksend(CSOUND *csound, int *sock, const char *addr,
 
   }
   server_addr.sin_family = AF_INET;    /* it is an INET address */
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
   server_addr.sin_addr.S_un.S_addr = inet_addr(addr);
 #else
   inet_aton(addr, &server_addr.sin_addr);    /* the server IP address */
@@ -218,7 +218,7 @@ static uintptr_t udp_recv(void *pdata){
   csound->Free(csound, start);
   // csound->Message(csound, "orchestra dealloc\n");
   if(sock > 0)
-#ifndef WIN32
+#ifndef _WIN32
     close(sock);
 #else
   closesocket(sock);
@@ -229,7 +229,7 @@ static uintptr_t udp_recv(void *pdata){
 
 static int udp_start(CSOUND *csound, UDPCOM *p)
 {
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
   WSADATA wsaData = {0};
   int err;
   if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0)){
@@ -239,7 +239,7 @@ static int udp_start(CSOUND *csound, UDPCOM *p)
 #endif
   p->cs = csound;
   p->sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifndef WIN32
+#ifndef _WIN32
   if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0)) {
     csound->Warning(csound, Str("UDP Server: Cannot set nonblock"));
     if (p->sock>=0) close(p->sock);
@@ -270,7 +270,7 @@ static int udp_start(CSOUND *csound, UDPCOM *p)
                     sizeof(p->server_addr)) < 0)) {
     csound->Warning(csound, Str("bind failed"));
     p->thrid = NULL;
-#ifndef WIN32
+#ifndef _WIN32
     close(p->sock);
 #else
     closesocket(p->sock);
@@ -293,7 +293,7 @@ int csoundUDPServerClose(CSOUND *csound)
     /* wait for server thread to close */
     csoundJoinThread(p->thrid);
     /* close socket */
-#ifndef WIN32
+#ifndef _WIN32
     close(p->sock);
 #else
     closesocket(p->sock);
@@ -368,7 +368,7 @@ static int udp_console_stop(CSOUND *csound, void *pp) {
   UDPCONS *p = (UDPCONS *) pp;
   if(p) {
     csoundSetMessageCallback(csound, p->cb);
-#ifndef WIN32
+#ifndef _WIN32
     close(p->sock);
 #else
     closesocket(p->sock);

--- a/Top/threads.c
+++ b/Top/threads.c
@@ -27,7 +27,7 @@
 #endif
 
 #ifndef HAVE_GETTIMEOFDAY
-#if defined(LINUX)    || defined(__unix)   || defined(__unix__) || \
+#if defined(__gnu_linux__)    || defined(__unix)   || defined(__unix__) || \
     defined(__MACH__) || defined(__HAIKU__)
 #define HAVE_GETTIMEOFDAY 1
 #endif
@@ -46,7 +46,7 @@ static CS_NOINLINE void notImplementedWarning_(const char *name)
 
 #if defined(HAVE_PTHREAD)
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <windows.h>
 #include <process.h>
 
@@ -234,7 +234,7 @@ PUBLIC uintptr_t csoundJoinThread(void *thread)
     }
 }
 
-#if !defined(ANDROID) && (/*defined(LINUX) ||*/ defined(__HAIKU__) || defined(WIN32))
+#if !defined(ANDROID) && (/*defined(__gnu_linux__) ||*/ defined(__HAIKU__) || defined(_WIN32))
 
 PUBLIC void *csoundCreateThreadLock(void)
 {
@@ -300,7 +300,7 @@ PUBLIC void csoundDestroyThreadLock(void *lock)
 }
 
 
-#else   /* LINUX */
+#else   /* __gnu_linux__ */
 
 typedef struct CsoundThreadLock_s {
   pthread_mutex_t m;
@@ -403,7 +403,7 @@ PUBLIC void csoundDestroyThreadLock(void *threadLock)
 
 }
 
-#endif  /* !LINUX */
+#endif  /* !__gnu_linux__ */
 
 
 PUBLIC void *csoundCreateBarrier(unsigned int max)
@@ -585,7 +585,7 @@ PUBLIC void csoundDestroyCondVar(void* condVar) {
 
 /* ------------------------------------------------------------------------ */
 
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #include <windows.h>
 #if !defined(_USING_V110_SDK71_)
 #include <synchapi.h>
@@ -1056,7 +1056,7 @@ int csoundSpinLockInit(spin_lock_t *spinlock) {
     return 0;
 }
 
-#elif defined(MACOSX) // MacOS native locks
+#elif defined(__APPLE__) // MacOS native locks
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
 // New spinlock interface

--- a/include/csound.h
+++ b/include/csound.h
@@ -257,7 +257,7 @@
  * Platform-dependent definitions and declarations.
  */
 
-#if (defined(WIN32) || defined(_WIN32)) && !defined(SWIG)
+#if defined(_WIN32) && !defined(SWIG)
 #  if defined(__BUILDING_LIBCSOUND)
 #    define PUBLIC          __declspec(dllexport)
 #    define PUBLIC_DATA     __declspec(dllexport)

--- a/include/pvfileio.h
+++ b/include/pvfileio.h
@@ -29,7 +29,7 @@
 
 #include "sysdep.h"
 
-#if defined(WIN32) || defined(_WIN32) || defined(_MSC_VER)
+#if defined(_WIN32) || defined(_MSC_VER)
 
 #include <windows.h>
 

--- a/include/soundio.h
+++ b/include/soundio.h
@@ -27,7 +27,7 @@
 #include "soundfile.h"
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #define IOBUFSAMPS   4096   /* default sampframes in audio iobuf, -b settable */
 #define IODACSAMPS   16384  /* default samps in hardware buffer,  -B settable */
 #elif defined(NeXT) || defined(__MACH__)

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -25,7 +25,7 @@
 #define CSOUND_SYSDEP_H
 
 /* check for the presence of a modern compiler (for use of certain features) */
-#if defined(WIN32)
+#if defined(_WIN32)
 #if !defined(locale_t)
 typedef void *locale_t;
 #endif
@@ -33,13 +33,13 @@ typedef void *locale_t;
 
 #include <limits.h>
 /* this checks for 64BIT builds */
-#if defined(__MACH__) || defined(LINUX)
+#if defined(__MACH__) || defined(__gnu_linux__)
 #if ( __WORDSIZE == 64 ) || defined(__x86_64__) || defined(__amd64__)
 #define B64BIT
 #endif
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #if _WIN64
 #define B64BIT
 #endif
@@ -211,15 +211,15 @@ typedef uint_least16_t uint16;
 
 /* find out operating system if not specified on the command line */
 
-#if defined(_WIN32) || defined(__WIN32__)
-#  ifndef WIN32
-#    define WIN32 1
+#if defined(__WIN32__)
+#  ifndef _WIN32
+#    define _WIN32 1
 #  endif
-#elif (defined(linux) || defined(__linux)) && !defined(LINUX)
-#  define LINUX 1
+#elif defined(__linux) && !defined(__gnu_linux__)
+#  define __gnu_linux__ 1
 #endif
 
-#if defined(WIN32) && defined(_MSC_VER) && !defined(__GNUC__)
+#if defined(_WIN32) && defined(_MSC_VER) && !defined(__GNUC__)
 #  ifndef MSVC
 #    define MSVC 1
 #  endif
@@ -243,7 +243,7 @@ typedef uint_least16_t uint16;
 #endif
 
 #define DIRSEP '/'
-#ifdef WIN32
+#ifdef _WIN32
 #  undef  DIRSEP
 #  define DIRSEP '\\'
 #  if !defined(O_NDELAY)
@@ -259,7 +259,7 @@ typedef uint_least16_t uint16;
 #  ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #  endif
-/*  RWD for WIN32 on VC++ */
+/*  RWD for _WIN32 on VC++ */
 #endif
 #ifndef MSVC
 #  include <sys/file.h>
@@ -268,7 +268,7 @@ typedef uint_least16_t uint16;
 
 #endif  /* __BUILDING_LIBCSOUND || CSOUND_CSDL_H */
 
-#ifdef WIN32
+#ifdef _WIN32
 #  define ENVSEP ';'
 #else
 #  define ENVSEP ':'
@@ -296,7 +296,7 @@ typedef short               int16_t;
 typedef unsigned short      uint16_t;
 typedef int                 int32_t;
 typedef unsigned int        uint32_t;
-#  if defined(__GNUC__) || !defined(WIN32)
+#  if defined(__GNUC__) || !defined(_WIN32)
 typedef long long           int64_t;
 typedef unsigned long long  uint64_t;
 typedef long long           int_least64_t;
@@ -542,11 +542,11 @@ char *strNcpy(char *dst, const char *src, size_t siz);
 #define ATOMIC_CMP_XCH(val, newVal, oldVal) (*val = newVal) != oldVal
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 typedef int32_t spin_lock_t;
 #define SPINLOCK_INIT 0
 
-#elif defined(MACOSX)
+#elif defined(__APPLE__)
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
 #include <os/lock.h>
 typedef struct os_unfair_lock_s spin_lock_t;

--- a/tests/c/perfthread_test.cpp
+++ b/tests/c/perfthread_test.cpp
@@ -1,4 +1,4 @@
-#if defined(WIN32)
+#if defined(_WIN32)
 # include <Windows.h>
 #else
 # include "unistd.h"
@@ -62,7 +62,7 @@ TEST(PerfThreadsTests, Record) {
     performanceThread1.Play();
     //performanceThread1.Record("testrec.wav");
 
-#if !defined(WIN32)
+#if !defined(_WIN32)
     sleep(1);
 #else
     Sleep(1000);

--- a/tests/c/server_test.cpp
+++ b/tests/c/server_test.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "gtest/gtest.h"
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 # include <winsock2.h>
 # include <ws2tcpip.h>
 #else
@@ -9,7 +9,7 @@
 # include <netinet/in.h>
 # include <arpa/inet.h>
 #endif
-#if defined (WIN32)
+#if defined (_WIN32)
 # include <Windows.h>
 #else
 # include "unistd.h"
@@ -21,7 +21,7 @@
 void udp_send(const char* msg) {
     struct sockaddr_in server_addr;
     int sock;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = { 0 };
     int err;
     if (UNLIKELY((err = WSAStartup(MAKEWORD(2, 2), &wsaData)) != 0))
@@ -31,7 +31,7 @@ void udp_send(const char* msg) {
     if (UNLIKELY(sock < 0)) {
         return;
     }
-#ifndef WIN32
+#ifndef _WIN32
     if (UNLIKELY(fcntl(sock, F_SETFL, O_NONBLOCK) < 0)) {
         close(sock);
         return;
@@ -47,7 +47,7 @@ void udp_send(const char* msg) {
     }
 #endif
     server_addr.sin_family = AF_INET;
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     server_addr.sin_addr.S_un.S_addr = inet_addr("127.0.0.1");
 #else
     inet_aton("127.0.0.1", &server_addr.sin_addr);

--- a/util/atsa.c
+++ b/util/atsa.c
@@ -93,7 +93,7 @@ typedef float mus_sample_t;
  */
 #define ATSA_TYPE 4
 /* default residual file */
-#if defined(LINUX) || defined(MACOSX)
+#if defined(__gnu_linux__) || defined(__APPLE__)
 #  define ATSA_RES_FILE "/tmp/atsa_res.wav"
 #else
 #  define ATSA_RES_FILE "/atsa_res.wav"
@@ -719,7 +719,7 @@ static int atsa_main(CSOUND *csound, int argc, char **argv)
         soundfile == NULL || soundfile[0] == '\0' ||
         ats_outfile == NULL || ats_outfile[0] == '\0')
       usage(csound);
-#ifdef WIN32
+#ifdef _WIN32
     {
       char buffer[160];
       char * tmp = getenv("TEMP");
@@ -2385,7 +2385,7 @@ static ATS_SOUND *tracker(CSOUND *csound, ANARGS *anargs, char *soundfile,
     csound->Free(csound, bufs);
     /* analyse residual */
     if (UNLIKELY(anargs->type == 3 || anargs->type == 4)) {
-#ifdef WIN32
+#ifdef _WIN32
       char buffer[160];
       char * tmp = getenv("TEMP");
       strNcpy(buffer, tmp, 160);

--- a/util/hetro.c
+++ b/util/hetro.c
@@ -28,7 +28,7 @@
 
 //#define DEBUG 1
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #define INCSDIF 1

--- a/util/lpanal.c
+++ b/util/lpanal.c
@@ -27,7 +27,7 @@
 #include "soundio.h"
 #include "lpc.h"
 #include "cwindow.h"
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include <math.h>

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -209,7 +209,7 @@ static int mixer_main(CSOUND *csound, int argc, char **argv)
             for ( ; *s != '\0'; s++) ;
             if (UNLIKELY(strcmp(O.outfilename, "stdin") == 0))
               csound->Die(csound, "%s", Str("mixer: -o cannot be stdin"));
-#if defined(WIN32)
+#if defined(_WIN32)
             if (UNLIKELY(strcmp(O.outfilename,"stdout") == 0)) {
               csound->Die(csound, "%s", Str("mixer: stdout audio not supported"));
             }

--- a/util/mkdb.c
+++ b/util/mkdb.c
@@ -44,7 +44,7 @@ void handler(int sig)
     siglongjmp(env, 1);
 }
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #define DIRSEP '\\'
 
@@ -64,7 +64,7 @@ void *csGetLibrarySymbol(void *library, const char *procedureName)
     return (void*) GetProcAddress((HMODULE) library, procedureName);
 }
 
-#elif !(defined(NACL)) && (defined(LINUX) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
+#elif !(defined(NACL)) && (defined(__gnu_linux__) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
 
 #define DIRSEP '/'
 
@@ -177,7 +177,7 @@ static int csLoadExternal(const char *libraryPath)
     printf("Library '%s'\n", libraryPath);
     err = csOpenLibrary(&h, libraryPath);
     if (err) {
- #if !(defined(NACL)) && (defined(LINUX) || defined(__HAIKU__))
+ #if !(defined(NACL)) && (defined(__gnu_linux__) || defined(__HAIKU__))
       fprintf(stderr, "could not open library '%s' (%s)\n",
                libraryPath, dlerror());
  #else

--- a/util/scale.c
+++ b/util/scale.c
@@ -176,7 +176,7 @@ static int32_t scale(CSOUND *csound, int32_t argc, char **argv)
             for ( ; *s != '\0'; s++) ;
             if (UNLIKELY(strcmp(O.outfilename, "stdin") == 0))
               csound->Die(csound, "%s", Str("-o cannot be stdin"));
-#if defined(WIN32)
+#if defined(_WIN32)
             if (UNLIKELY(strcmp(O.outfilename, "stdout") == 0)) {
               csound->Die(csound, "%s", Str("stdout audio not supported"));
             }

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -257,7 +257,7 @@ static int srconv(CSOUND *csound, int argc, char **argv)
               csound->ErrorMsg(csound, "%s", Str("-o cannot be stdin"));
               return -1;
             }
-#if defined(WIN32)
+#if defined(_WIN32)
             if (strcmp(O.outfilename, "stdout") == 0) {
               csound->ErrorMsg(csound, "%s", Str("stdout audio not supported"));
               return -1;
@@ -757,7 +757,7 @@ static int srconv(CSOUND *csound, int argc, char **argv)
 }
 #else
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 

--- a/util1/csd_util/cs.c
+++ b/util1/csd_util/cs.c
@@ -11,12 +11,12 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <process.h>
 #endif
 
 /* default Csound executable */
-#ifdef WIN32
+#ifdef _WIN32
 char    default_csnd[] = "csound32 -W";
 char    default_csnd_r[] = "csound32 -h";
 #else
@@ -106,7 +106,7 @@ void split_filename(char *fullname, char *dir, char *bas)
            fullname[m] != '/' && fullname[m] != '\\' && fullname[m] != ':');
     /* directory name */
     if (m < 0)
-#ifdef WIN32
+#ifdef _WIN32
       strcpy(dir, ".\\");
 #else
       strcpy(dir, "./");

--- a/util1/sortex/smain.c
+++ b/util1/sortex/smain.c
@@ -23,7 +23,7 @@
 
 #include "csound.h"                                    /*   SMAIN.C  */
 
-#if defined(LINUX) || defined(SGI) || defined(sol) || \
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || \
     defined(__MACH__) || defined(__EMX__)
 #include <signal.h>
 #endif
@@ -43,7 +43,7 @@ int main(void)                          /* stdio stub for standalone scsort */
     int    err;
 
     csound = csoundCreate(NULL);
-#if defined(LINUX) || defined(SGI) || defined(sol) || \
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || \
     defined(__MACH__) || defined(__EMX__)
     signal(SIGPIPE, SIG_DFL);
 #endif

--- a/util1/sortex/xmain.c
+++ b/util1/sortex/xmain.c
@@ -23,7 +23,7 @@
 
 #include "csound.h"                                /*   XMAIN.C  */
 
-#if defined(LINUX) || defined(SGI) || defined(sol) || \
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || \
     defined(__MACH__) || defined(__EMX__)
 #include <signal.h>
 #endif
@@ -35,7 +35,7 @@ int main(int ac, char **av)         /* stdio stub for standalone extract */
     int     err = 1;
 
     csound = csoundCreate(NULL);
-#if defined(LINUX) || defined(SGI) || defined(sol) || \
+#if defined(__gnu_linux__) || defined(SGI) || defined(sol) || \
     defined(__MACH__) || defined(__EMX__)
     signal(SIGPIPE, SIG_DFL);
 #endif


### PR DESCRIPTION
Use the compiler flags for OS instead of adding our own:

`_WIN32` for windows
`__APPLE__` for macosx
`__gnu_linux__` for linux

See https://github.com/cpredef/predef/blob/master/OperatingSystems.md