### PR TITLE
[csound6] Updated VCPKG

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "csound",
     "version-string": "6.16.2",
-    "builtin-baseline": "97f26935db51139372ef252e67e308fe76933500",
+    "builtin-baseline": "fbf25ddd1119211278c257f2e19c96a9d5a6ede7",
     "dependencies": [
         "zlib",
         "libsamplerate",
@@ -15,7 +15,9 @@
         },
         {
             "name": "libsndfile",
-            "features": ["external-libs"]
+            "features": [
+                "external-libs"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Update vcpkg to latest version as older version was using a new broken URL internally