### PR TITLE
Local SR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,20 @@ if(BARE_METAL)
     endif() 
 endif()
 
+# secret rabbit code
+if (USE_VCPKG)
+  find_package(SampleRate CONFIG REQUIRED)
+  assign_bool(SampleRate_FOUND TARGET SampleRate::samplerate)
+else()
+   find_package(SampleRate MODULE)
+endif()
+
+if(SampleRate_FOUND)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_SRC")
+    message(STATUS "Using Secret Rabbit Code")
+endif()
+
+
 # Include this after the install path definitions so we can override them here.
 # Also after function definitions so we can use them there
 # Also after user options so that the default values don't overwrite the custom files values
@@ -1279,6 +1293,10 @@ if(USE_LIBSNDFILE)
     endif()
 endif()
 
+if(SampleRate_FOUND)
+  target_link_libraries(${CSOUNDLIB} PUBLIC SampleRate::samplerate)
+endif()
+
 if(NOT IOS)
     set_target_properties(${CSOUNDLIB} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${BUILD_BIN_DIR}
@@ -1301,6 +1319,11 @@ if(BUILD_STATIC_LIBRARY)
     if (USE_LIBSNDFILE)
         target_link_libraries(${CSOUNDLIB_STATIC} PUBLIC SndFile::sndfile)
     endif()
+
+   if(SampleRate_FOUND)
+        target_link_libraries(${CSOUNDLIB_STATIC} PUBLIC SampleRate::samplerate)
+   endif()
+
     if(MSVC)
         target_link_libraries(${CSOUNDLIB_STATIC} PRIVATE ${CSOUND_WINDOWS_LIBRARIES})
     else()

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -962,6 +962,9 @@ INSTRTXT *create_instrument(CSOUND *csound, TREE *root,
   /* same for kr */
   var = csoundCreateVariable(csound, csound->typePool, rType, "kr", NULL);
   csoundAddVariable(csound, ip->varPool, var);
+  /* same for sr */
+  var = csoundCreateVariable(csound, csound->typePool, rType, "sr", NULL);
+  csoundAddVariable(csound, ip->varPool, var);
 
   /* Maybe should do this assignment at end when instr is setup?
    * Note: look into how "instr 4,5,6,8" is handled, i.e. if copies

--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -65,7 +65,7 @@ void string_copy_value(CSOUND* csound, CS_TYPE* cstype, void* dest, void* src) {
     if (UNLIKELY(src == NULL)) return;
     if (UNLIKELY(dest == NULL)) return;
 
-    int64_t kcnt = csound->GetKcounter(csound);
+    int64_t kcnt = csound->kcounter;
     if (sSrc->size > sDest->size) {
       cs->Free(cs, sDest->data);
       sDest->data = csound->Calloc(csound, sSrc->size); 

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -112,6 +112,7 @@ OENTRY opcodlst_1[] = {
   { "xout", S(XOUT_MAX),0,  1,  "",         "*", xoutset, NULL, NULL, NULL },
   { "setksmps", S(SETKSMPS),0,  1,  "",   "i", setksmpsset, NULL, NULL },
   { "oversample", S(OVSMPLE),0,  1,  "",   "io", oversampleset, NULL, NULL },
+  { "undersample", S(OVSMPLE),0,  1,  "",   "io", oversampleset, NULL, NULL },
   { "ctrlinit",S(CTLINIT),0,1,      "",  "im", ctrlinit, NULL, NULL, NULL},
   { "ctrlinit.S",S(CTLINITS),0,1,      "",  "Sm", ctrlnameinit, NULL, NULL, NULL},
   { "ctrlsave",S(SAVECTRL),0,3,       "k[]","im", savectrl_init, savectrl_perf, NULL, NULL},

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -111,7 +111,7 @@ OENTRY opcodlst_1[] = {
     xinset,  NULL, NULL },*/
   { "xout", S(XOUT_MAX),0,  1,  "",         "*", xoutset, NULL, NULL, NULL },
   { "setksmps", S(SETKSMPS),0,  1,  "",   "i", setksmpsset, NULL, NULL },
-  { "oversample", S(OVSMPLE),0,  1,  "",   "ip", oversampleset, NULL, NULL },
+  { "oversample", S(OVSMPLE),0,  1,  "",   "io", oversampleset, NULL, NULL },
   { "ctrlinit",S(CTLINIT),0,1,      "",  "im", ctrlinit, NULL, NULL, NULL},
   { "ctrlinit.S",S(CTLINITS),0,1,      "",  "Sm", ctrlnameinit, NULL, NULL, NULL},
   { "ctrlsave",S(SAVECTRL),0,3,       "k[]","im", savectrl_init, savectrl_perf, NULL, NULL},

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -111,6 +111,7 @@ OENTRY opcodlst_1[] = {
     xinset,  NULL, NULL },*/
   { "xout", S(XOUT_MAX),0,  1,  "",         "*", xoutset, NULL, NULL, NULL },
   { "setksmps", S(SETKSMPS),0,  1,  "",   "i", setksmpsset, NULL, NULL },
+  { "oversample", S(OVSMPLE),0,  1,  "",   "ip", oversampleset, NULL, NULL },
   { "ctrlinit",S(CTLINIT),0,1,      "",  "im", ctrlinit, NULL, NULL, NULL},
   { "ctrlinit.S",S(CTLINITS),0,1,      "",  "Sm", ctrlnameinit, NULL, NULL, NULL},
   { "ctrlsave",S(SAVECTRL),0,3,       "k[]","im", savectrl_init, savectrl_perf, NULL, NULL},

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -241,6 +241,7 @@ int hfgens(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp, int mode)
         csoundMessage(csound, Str("ftable %d:\n"), ff.fno);
       i = (*csound->gensub[genum])(&ff, NULL);
       ftp = csound->flist[ff.fno];
+      ftp->sr = csound->esr;
       if (i != 0) {
         csound->flist[ff.fno] = NULL;
         csound->Free(csound, ftp);
@@ -375,6 +376,7 @@ int csoundFTAlloc(CSOUND *csound, int tableNum, int len)
     ftp->flenfrms = (int32) len;
     ftp->nchanls = 1L;
     ftp->fno = (int32) tableNum;
+    ftp->sr = csound->esr;
     return 0;
 }
 

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -3166,15 +3166,15 @@ SR_CONVERTER *src_init(CSOUND *csound, int mode,
       }  else {
         p->cvt.input_frames = size/ratio;
         p->cvt.output_frames = size;
-      }
+        } 
       pp->bufferin = (float *)
-        csound->Calloc(csound, sizeof(float)*p->cvt.input_frames);
+       csound->Calloc(csound, sizeof(float)*p->cvt.input_frames);
       p->cvt.data_in = pp->bufferin;
       pp->bufferout = (float *)
         csound->Calloc(csound, sizeof(float)*p->cvt.output_frames);
       p->cvt.data_out = pp->bufferout; 
       p->cvt.end_of_input = 0;
-      pp->data = (void *) p;
+      pp->data = (void *)  p;
       pp->size = size;
       pp->ratio = ratio;
       pp->cnt = 0;
@@ -3182,7 +3182,7 @@ SR_CONVERTER *src_init(CSOUND *csound, int mode,
       return pp;
     }
     else return NULL;
-  } else
+    } else
     return src_linear_init(csound, mode, ratio, size); 
 }
 
@@ -3218,7 +3218,8 @@ int src_convert(CSOUND *csound, SR_CONVERTER *pp, MYFLT *in, MYFLT *out){
     pp->cnt = cnt;
     return 0;
   } else 
-    return src_linear_convert(csound, pp, in, out);
+  return src_linear_convert(csound, pp, in, out);
+  return 0;
 }
 
 void src_deinit(CSOUND *csound, SR_CONVERTER *pp) {
@@ -3230,7 +3231,7 @@ void src_deinit(CSOUND *csound, SR_CONVERTER *pp) {
   csound->Free(csound, pp->bufferout);
   csound->Free(csound, pp);
   }
-  src_linear_deinit(csound, pp);
+  else src_linear_deinit(csound, pp);
 }
 #endif  // ifndef USE_SRC
 

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1626,6 +1626,8 @@ int xinset(CSOUND *csound, XIN *p)
     else if (csoundGetTypeForArg(in) == &CS_VAR_TYPE_A) {
       // initialise the converter
       if(CS_ESR != csound->esr) {
+        // free converter if it has already been created (maybe we could reuse?)
+        if(udo->cvt_in[k] != NULL) src_deinit(csound, udo->cvt_in[k]);
         if((udo->cvt_in[k++] = src_init(csound, p->h.insdshead->overmode,
                                         CS_ESR/csound->esr, CS_KSMPS)) == NULL)
           return csound->InitError(csound, "could not initialise sample rate "
@@ -1673,6 +1675,8 @@ int xoutset(CSOUND *csound, XOUT *p)
     else if (csoundGetTypeForArg(in) == &CS_VAR_TYPE_A) {
       // initialise the converter
       if(CS_ESR != csound->esr) {
+        // free converter if it has already been created (maybe we could reuse?)
+        if(udo->cvt_out[k] != NULL) src_deinit(csound, udo->cvt_out[k]);
         if((udo->cvt_out[k++] = src_init(csound, p->h.insdshead->overmode,
                                          csound->esr/CS_ESR, CS_KSMPS)) == 0)
           return csound->InitError(csound, "could not initialise sample rate "

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -2960,7 +2960,7 @@ int csoundKillInstanceInternal(CSOUND *csound, MYFLT instr, char *instrName,
 
 
 // sample rate conversion
-#if 0
+#ifdef SRC
 #include <samplerate.h>
 
 typedef struct {

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -244,6 +244,8 @@ int init0(CSOUND *csound)
   csound->ids = (OPDS*) ip;
   tp->active++;
   ip->actflg++;
+  ip->esr = csound->esr;
+  ip->onedsr = csound->onedsr;
   ip->ksmps = csound->ksmps;
   ip->ekr = csound->ekr;
   ip->kcounter = csound->kcounter;
@@ -392,6 +394,8 @@ int insert_event(CSOUND *csound, int insno, EVTBLK *newevtp)
     ATOMIC_SET(ip->init_done, 0);
     tp->act_instance = ip->nxtact;
     ip->insno = (int16) insno;
+    ip->esr = csound->esr;
+    ip->onedsr = csound->onedsr;
     ip->ksmps = csound->ksmps;
     ip->ekr = csound->ekr;
     ip->kcounter = csound->kcounter;
@@ -689,6 +693,8 @@ int insert_midi(CSOUND *csound, int insno, MCHNBLK *chn, MEVENT *mep)
   ip->p1.value     = (MYFLT) insno;     /* set these required p-fields */
   ip->p2.value     = (MYFLT) (csound->icurTime/csound->esr - csound->timeOffs);
   ip->p3.value     = FL(-1.0);
+  ip->esr          = csound->esr;
+  ip->onedsr       = csound->onedsr;
   ip->ksmps        = csound->ksmps;
   ip->ekr          = csound->ekr;
   ip->kcounter     = csound->kcounter;
@@ -1274,6 +1280,8 @@ int subinstrset_(CSOUND *csound, SUBINST *p, int instno)
     p->parent_ip = p->buf.parent_ip = saved_curip;
   }
 
+  p->ip->esr = CS_ESR;
+  p->ip->onedsr = CS_ONEDSR;
   p->ip->ksmps = CS_KSMPS;
   p->ip->kcounter = CS_KCNT;
   p->ip->ekr = CS_EKR;
@@ -1290,7 +1298,6 @@ int subinstrset_(CSOUND *csound, SUBINST *p, int instno)
   p->ip->nxtolap  = NULL;
   p->ip->p2       = saved_curip->p2;
   p->ip->p3       = saved_curip->p3;
-  p->ip->ksmps = CS_KSMPS;
 
   /* IV - Oct 31 2002 */
   p->ip->m_chnbp  = saved_curip->m_chnbp;
@@ -1521,6 +1528,8 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
     /* set the local ksmps values */
     if (local_ksmps != CS_KSMPS) {
       /* this is the case when p->ip->ksmps != p->h.insdshead->ksmps */
+      lcurip->esr = CS_ESR;
+      lcurip->onedsr = CS_ESR;
       lcurip->ksmps = local_ksmps;
       ksmps_scale = CS_KSMPS / local_ksmps;
       lcurip->onedksmps =  FL(1.0) / (MYFLT) local_ksmps;
@@ -1529,6 +1538,8 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
       lcurip->kicvt = (MYFLT) FMAXLEN /lcurip->ekr;
       lcurip->kcounter = (CS_KCNT)*ksmps_scale;
     } else {
+      lcurip->esr = CS_ESR;
+      lcurip->onedsr = CS_ESR;
       lcurip->ksmps = CS_KSMPS;
       lcurip->kcounter = CS_KCNT;
       lcurip->ekr = CS_EKR;

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -3078,6 +3078,7 @@ void src_process(SR_CONVERTER *pp, MYFLT *in, MYFLT *out, int outsamps){
     fac += 1./ratio;
     incnt += fac;
     if(incnt >= 1) start = in[incnt - 1];
+    fac -= MYFLT2LRND(fac); 
   }
   *((MYFLT *) pp->data) = in[incnt - 1];
 }

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1655,7 +1655,8 @@ int xinset(CSOUND *csound, XIN *p)
       if((current->subType == &CS_VAR_TYPE_A ||
           current->subType == &CS_VAR_TYPE_K)
          && CS_ESR != csound->esr)
-          return csound->InitError(csound, "audio arrays not allowed with oversampling\n");
+           return csound->InitError(csound, "audio/control arrays not allowed\n"
+                                   "as UDO arguments when using oversampling\n");
     }
     current = current->next;
   }
@@ -1717,7 +1718,8 @@ int xoutset(CSOUND *csound, XOUT *p)
       if((current->subType == &CS_VAR_TYPE_A ||
           current->subType == &CS_VAR_TYPE_K)
            && CS_ESR != csound->esr)
-          return csound->InitError(csound, "audio arrays not allowed with oversampling\n");
+           return csound->InitError(csound, "audio/control arrays not allowed\n"
+                                   "as UDO arguments when using oversampling\n");
     }
     current = current->next;
   }

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -250,6 +250,7 @@ int init0(CSOUND *csound)
   tp->active++;
   ip->actflg++;
   ip->esr = csound->esr;
+  ip->pidsr = csound->pidsr;
   ip->sicvt = csound->sicvt;
   ip->onedsr = csound->onedsr;
   ip->ksmps = csound->ksmps;
@@ -401,6 +402,7 @@ int insert_event(CSOUND *csound, int insno, EVTBLK *newevtp)
     tp->act_instance = ip->nxtact;
     ip->insno = (int16) insno;
     ip->esr = csound->esr;
+    ip->pidsr = csound->pidsr;
     ip->sicvt = csound->sicvt;
     ip->onedsr = csound->onedsr;
     ip->ksmps = csound->ksmps;
@@ -701,6 +703,7 @@ int insert_midi(CSOUND *csound, int insno, MCHNBLK *chn, MEVENT *mep)
   ip->p2.value     = (MYFLT) (csound->icurTime/csound->esr - csound->timeOffs);
   ip->p3.value     = FL(-1.0);
   ip->esr          = csound->esr;
+  ip->pidsr        = csound->pidsr;
   ip->sicvt        = csound->sicvt;
   ip->onedsr       = csound->onedsr;
   ip->ksmps        = csound->ksmps;
@@ -1305,6 +1308,7 @@ int subinstrset_(CSOUND *csound, SUBINST *p, int instno)
   }
 
   p->ip->esr = CS_ESR;
+  p->ip->pidsr = CS_PIDSR;
   p->ip->sicvt = CS_SICVT;
   p->ip->onedsr = CS_ONEDSR;
   p->ip->ksmps = CS_KSMPS;
@@ -1478,7 +1482,7 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
   unsigned int instno;
   unsigned int i;
   OPCODINFO    *inm;
-  OPCOD_IOBUFS *buf = NULL;
+  OPCOD_IOBUFS *buf = p->buf;
   /* look up the 'fake' instr number, and opcode name */
   inm = (OPCODINFO*) p->h.optext->t.oentry->useropinfo;
   instno = inm->instno;
@@ -1523,11 +1527,12 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
     /* store parameters of input and output channels, and parent ip */
     buf->uopcode_struct = (void*) p;
     buf->parent_ip = p->parent_ip = parent_ip;
-  }
+  } else
 
   /* copy parameters from the caller instrument into our subinstrument */
   lcurip = p->ip;
   lcurip->esr = CS_ESR;
+  lcurip->pidsr = CS_PIDSR;
   lcurip->sicvt = CS_SICVT;
   lcurip->onedsr = CS_ONEDSR;
   lcurip->ksmps = CS_KSMPS;
@@ -1844,6 +1849,7 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
      
   l_sr = CS_ESR*os;
   CS_ESR = l_sr;
+  CS_PIDSR = M_PI/l_sr;
   CS_ONEDSR = 1./l_sr;
   CS_SICVT = (MYFLT) FMAXLEN / CS_ESR;
   CS_EKR = CS_ESR/CS_KSMPS;
@@ -1924,6 +1930,7 @@ int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
   CS_ONEDKSMPS = FL(1.0)/lksmps;
   l_sr = CS_ESR*onedos;
   CS_ESR = l_sr;
+  CS_PIDSR = M_PI/l_sr;
   CS_ONEDSR = 1./l_sr;
   CS_SICVT = (MYFLT) FMAXLEN / CS_ESR;
   CS_EKR = CS_ESR/CS_KSMPS;

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -933,10 +933,20 @@ static void deact(CSOUND *csound, INSDS *ip)
     int k;
     UOPCODE *p = (UOPCODE*) ip->opcod_deact;          /* IV - Oct 26 2002 */
     // free converter if it has already been created (maybe we could reuse?)
-    for(k=0; k<OPCODENUMOUTS_MAX; k++) {
-    if(p->cvt_in[k] != NULL) src_deinit(csound, p->cvt_in[k]);
-    if(p->cvt_out[k] != NULL) src_deinit(csound, p->cvt_out[k]);
-    }
+    for(k=0; k<OPCODENUMOUTS_MAX; k++) 
+      if(p->cvt_in[k] != NULL) {
+        src_deinit(csound, p->cvt_in[k]);
+        p->cvt_in[k] = NULL; // clear pointer
+      }
+      else break; // first null indicates end of cvt list
+
+    for(k=0; k<OPCODENUMOUTS_MAX; k++) 
+      if(p->cvt_out[k] != NULL) {
+        src_deinit(csound, p->cvt_out[k]);
+        p->cvt_out[k] = NULL; // clear pointer
+      }
+      else break; // first null indicates end of cvt list
+           
     deact(csound, p->ip);     /* deactivate */
     p->ip = NULL;
     /* IV - Oct 26 2002: set perf routine to "not initialised" */

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -2459,7 +2459,7 @@ int useropcd2(CSOUND *csound, UOPCODE *p)
   OPCODINFO   *inm;
   CS_VARIABLE* current;
   int i, done;
-  int os = (int) (p->ip->esr/csound->esr);
+  int os = (int) (p->ip->esr/p->parent_ip->esr);
     
   inm = (OPCODINFO*) p->h.optext->t.oentry->useropinfo; 
   done = ATOMIC_GET(p->ip->init_done);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -926,7 +926,13 @@ static void deact(CSOUND *csound, INSDS *ip)
   /* IV - Sep 8 2002: free subinstr instances */
   /* that would otherwise result in a memory leak */
   if (ip->opcod_deact) {
+    int k;
     UOPCODE *p = (UOPCODE*) ip->opcod_deact;          /* IV - Oct 26 2002 */
+    // free converter if it has already been created (maybe we could reuse?)
+    for(k=0; k<OPCODENUMOUTS_MAX; k++) {
+    if(p->cvt_in[k] != NULL) src_deinit(csound, p->cvt_in[k]);
+    if(p->cvt_out[k] != NULL) src_deinit(csound, p->cvt_out[k]);
+    }
     deact(csound, p->ip);     /* deactivate */
     p->ip = NULL;
     /* IV - Oct 26 2002: set perf routine to "not initialised" */
@@ -1639,8 +1645,6 @@ int xinset(CSOUND *csound, XIN *p)
     else if (csoundGetTypeForArg(out) == &CS_VAR_TYPE_A) {
       // initialise the converter
       if(CS_ESR != parent_sr) {
-        // free converter if it has already been created (maybe we could reuse?)
-        if(udo->cvt_in[k] != NULL) src_deinit(csound, udo->cvt_in[k]);
         if((udo->cvt_in[k++] = src_init(csound, p->h.insdshead->overmode,
                                         CS_ESR/parent_sr, CS_KSMPS)) == NULL)
           return csound->InitError(csound, "could not initialise sample rate "
@@ -1650,8 +1654,6 @@ int xinset(CSOUND *csound, XIN *p)
     else if(csoundGetTypeForArg(out) == &CS_VAR_TYPE_K) { 
       // initialise the converter
       if(CS_ESR != parent_sr) {
-        // free converter if it has already been created (maybe we could reuse?)
-        if(udo->cvt_in[k] != NULL) src_deinit(csound, udo->cvt_in[k]);
         if((udo->cvt_in[k++] = src_init(csound, p->h.insdshead->overmode,
                                         CS_ESR/parent_sr, 1)) == NULL)
           return csound->InitError(csound, "could not initialise sample rate "
@@ -1705,8 +1707,6 @@ int xoutset(CSOUND *csound, XOUT *p)
     else if (csoundGetTypeForArg(out) == &CS_VAR_TYPE_A) {
       // initialise the converter
       if(CS_ESR != parent_sr) {
-        // free converter if it has already been created (maybe we could reuse?)
-        if(udo->cvt_out[k] != NULL) src_deinit(csound, udo->cvt_out[k]);
         if((udo->cvt_out[k++] = src_init(csound, p->h.insdshead->overmode,
                                          parent_sr/CS_ESR, CS_KSMPS)) == 0)
           return csound->InitError(csound, "could not initialise sample rate "
@@ -1716,8 +1716,6 @@ int xoutset(CSOUND *csound, XOUT *p)
     else if (csoundGetTypeForArg(out) == &CS_VAR_TYPE_K) {
       // initialise the converter
       if(CS_ESR != parent_sr) {
-        // free converter if it has already been created (maybe we could reuse?)
-        if(udo->cvt_out[k] != NULL) src_deinit(csound, udo->cvt_out[k]);
         if((udo->cvt_out[k++] = src_init(csound, p->h.insdshead->overmode,
                                          parent_sr/CS_ESR, 1)) == 0)
           return csound->InitError(csound, "could not initialise sample rate "

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1849,7 +1849,7 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
      
   l_sr = CS_ESR*os;
   CS_ESR = l_sr;
-  CS_PIDSR = M_PI/l_sr;
+  CS_PIDSR = PI/l_sr;
   CS_ONEDSR = 1./l_sr;
   CS_SICVT = (MYFLT) FMAXLEN / CS_ESR;
   CS_EKR = CS_ESR/CS_KSMPS;
@@ -1930,7 +1930,7 @@ int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
   CS_ONEDKSMPS = FL(1.0)/lksmps;
   l_sr = CS_ESR*onedos;
   CS_ESR = l_sr;
-  CS_PIDSR = M_PI/l_sr;
+  CS_PIDSR = PI/l_sr;
   CS_ONEDSR = 1./l_sr;
   CS_SICVT = (MYFLT) FMAXLEN / CS_ESR;
   CS_EKR = CS_ESR/CS_KSMPS;

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -265,7 +265,6 @@ int musmon(CSOUND *csound)
     m_chn_init_all(csound);     /* allocate MIDI channels */
     dispinit(csound);           /* initialise graphics or character display */
 
-    reverbinit(csound);
     dbfs_init(csound, csound->e0dbfs);
     csound->nspout = csound->ksmps * csound->nchnls;  /* alloc spin & spout */
     csound->nspin = csound->ksmps * csound->inchnls; /* JPff: in preparation */

--- a/H/cs_jack.h
+++ b/H/cs_jack.h
@@ -1,5 +1,5 @@
 /*
-    .h:
+    cs_jack.h:
 
     Copyright (C) 2008 by  Cesare Marilungo
 
@@ -66,4 +66,5 @@ typedef struct RtJackGlobals_ {
     int     xrunFlag;                   /* non-zero if an xrun has occured  */
     jack_client_t   *listclient;
     int outDevNum, inDevNum;            /* select devs by number */
+    MYFLT sr;
 } RtJackGlobals;

--- a/H/entry1.h
+++ b/H/entry1.h
@@ -504,4 +504,5 @@ int32_t coef2parm(CSOUND *csound, void *p);
 int32_t resonbnk_init(CSOUND *csound, void *p);
 int32_t resonbnk(CSOUND *csound, void *p);
 int32_t schedule_array(CSOUND *csound, void *p);
-int oversampleset(CSOUND *csound, void *p);
+int32_t oversampleset(CSOUND *csound, void *p);
+int32_t undersampleset(CSOUND *csound, void *p);

--- a/H/entry1.h
+++ b/H/entry1.h
@@ -504,4 +504,4 @@ int32_t coef2parm(CSOUND *csound, void *p);
 int32_t resonbnk_init(CSOUND *csound, void *p);
 int32_t resonbnk(CSOUND *csound, void *p);
 int32_t schedule_array(CSOUND *csound, void *p);
-
+int oversampleset(CSOUND *csound, void *p);

--- a/H/insert.h
+++ b/H/insert.h
@@ -62,6 +62,7 @@ typedef struct {
   float   ratio;
   int     size;
   int     cnt;
+  int     mode;
   void   *data;
 } SR_CONVERTER;
 

--- a/H/insert.h
+++ b/H/insert.h
@@ -56,6 +56,19 @@ typedef struct {
     MYFLT  *inst;
 } KILLOP;
 
+/* sampling rate conversion functions */
+typedef struct {
+  float *buffer;
+  float   os;
+  int     size;
+  int     cnt;
+  void  *cvt;
+} SR_CONVERTER;
+
+SR_CONVERTER *src_init(CSOUND *, int, float, int);
+void src_deinit(CSOUND *, SR_CONVERTER *);
+int src_convert(CSOUND *, SR_CONVERTER *, MYFLT *, MYFLT *);
+
 /* the number of optional outputs defined in entry.c */
 #define SUBINSTNUMOUTS  8
 
@@ -78,10 +91,8 @@ typedef struct {                /* IV - Sep 8 2002: new structure: UOPCODE */
     OPDS          h;
     INSDS         *ip, *parent_ip;
     OPCOD_IOBUFS  *buf;
-    /*unsigned int  l_ksmps;
-    int           ksmps_scale;
-    MYFLT         l_ekr, l_onedkr, l_onedksmps, l_kicvt;
-    int           mode;*/
+    SR_CONVERTER  *cvt_in[OPCODENUMOUTS_MAX];
+    SR_CONVERTER  *cvt_out[OPCODENUMOUTS_MAX];
     /* special case: the argument list is stored at the end of the */
     /* opcode data structure */
     MYFLT         *ar[1];
@@ -161,3 +172,5 @@ typedef struct {
     MYFLT   *type;
 } OVSMPLE;
 
+
+                

--- a/H/insert.h
+++ b/H/insert.h
@@ -77,7 +77,8 @@ typedef struct {
     OPCODINFO *opcode_info;
     void    *uopcode_struct;
     INSDS   *parent_ip;
-    MYFLT   *iobufp_ptrs[12];  /* expandable IV - Oct 26 2002 */ /* was 8 */
+    int32   iflag;
+    MYFLT   *iobufp_ptrs[12];  
 } OPCOD_IOBUFS;
 
 typedef struct {                        /* IV - Oct 16 2002 */
@@ -88,7 +89,7 @@ typedef struct {                        /* IV - Oct 16 2002 */
     OPCOD_IOBUFS    buf;
 } SUBINST;
 
-typedef struct {                /* IV - Sep 8 2002: new structure: UOPCODE */
+typedef struct {                
     OPDS          h;
     INSDS         *ip, *parent_ip;
     OPCOD_IOBUFS  *buf;

--- a/H/insert.h
+++ b/H/insert.h
@@ -58,11 +58,11 @@ typedef struct {
 
 /* sampling rate conversion functions */
 typedef struct {
-  float *buffer;
-  float   os;
+  float *bufferin, *bufferout;
+  float   ratio;
   int     size;
   int     cnt;
-  void  *cvt;
+  void   *data;
 } SR_CONVERTER;
 
 SR_CONVERTER *src_init(CSOUND *, int, float, int);

--- a/H/insert.h
+++ b/H/insert.h
@@ -56,19 +56,8 @@ typedef struct {
     MYFLT  *inst;
 } KILLOP;
 
-/* sampling rate conversion functions */
-typedef struct {
-  float *bufferin, *bufferout;
-  float   ratio;
-  int     size;
-  int     cnt;
-  int     mode;
-  void   *data;
-} SR_CONVERTER;
-
-SR_CONVERTER *src_init(CSOUND *, int, float, int);
-void src_deinit(CSOUND *, SR_CONVERTER *);
-int src_convert(CSOUND *, SR_CONVERTER *, MYFLT *, MYFLT *);
+/* sampling rate conversion */
+typedef struct _SR_CONVERTER SR_CONVERTER;
 
 /* the number of optional outputs defined in entry.c */
 #define SUBINSTNUMOUTS  8

--- a/H/insert.h
+++ b/H/insert.h
@@ -155,3 +155,9 @@ typedef struct {
     MYFLT   *insno;
 } DELETEIN;
 
+typedef struct {
+    OPDS    h;
+    MYFLT   *os;
+    MYFLT   *type;
+} OVSMPLE;
+

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -55,7 +55,6 @@ void    csoundErrorMsgS(CSOUND *, int attr, const char *, ...);
 void    csoundErrMsgV(CSOUND *, const char *, const char *, va_list);
 CS_NORETURN void    csoundLongJmp(CSOUND *, int retval);
 TEXT    *getoptxt(CSOUND *, int *);
-void    reverbinit(CSOUND *);
 void    dispinit(CSOUND *);
 int     init0(CSOUND *);
 void    scsort(CSOUND *, FILE *, FILE *);

--- a/H/ugens6.h
+++ b/H/ugens6.h
@@ -115,6 +115,7 @@ typedef struct {
         MYFLT   *adr1, *adr2, *adr3, *adr4, *adr5, *adr6;
         AUXCH   auxch;
         int32   revlpsum;
+        int32   revlpsiza[6];
         AUXCH   revlpsiz;
 } REVERB;
 
@@ -159,7 +160,6 @@ int32_t cmbset(CSOUND *, COMB *p);
 int32_t comb(CSOUND *, COMB *p);
 int32_t invcomb(CSOUND *, COMB *p);
 int32_t alpass(CSOUND *, COMB *p);
-void reverbinit(CSOUND *);
 int32_t rvbset(CSOUND *, REVERB *p);
 int32_t reverb(CSOUND *, REVERB *p);
 int32_t panset(CSOUND *, PAN *p);

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -535,6 +535,7 @@ void sfopenin(CSOUND *csound)           /* init for continuous soundin */
         parm.nChannels    = csound->inchnls;
         parm.sampleFormat = O->informat;
         parm.sampleRate   = (float) csound->esr;
+        parm.ksmps = csound->ksmps;
         /* open devaudio for input */
         if (UNLIKELY(csound->recopen_callback(csound, &parm) != 0))
           csoundDie(csound, Str("Failed to initialise real time audio input"));
@@ -750,6 +751,7 @@ void sfopenout(CSOUND *csound)                  /* init for sound out       */
         parm.nChannels    = csound->nchnls;
         parm.sampleFormat = O->outformat;
         parm.sampleRate   = (float) csound->esr;
+        parm.ksmps = csound->ksmps;
         csound->spoutran  = spoutsf;
         /* open devaudio for output */
         if (UNLIKELY(csound->playopen_callback(csound, &parm) != 0))

--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -461,9 +461,6 @@ static int WriteMidiData_(CSOUND *csound, void *userData,
       return 0;
     n = 0;
     do {
-      //int time = csound->GetCurrentTimeSamples(csound)/csound->GetSr(csound);
-      //printf("jitter: %d \n",
-      //       Pt_Time(NULL) - (int)(1000*time/csound->GetSr(csound)));
       st = (int)*(mbuf++);
       if (UNLIKELY(st < 0x80)) {
         portMidiErrMsg(csound, Str("invalid MIDI out data"));

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -735,7 +735,6 @@ static int rtrecord_(CSOUND *csound, MYFLT *inbuff_, int nbytes)
     csdata  *cdata;
     int n = nbytes/sizeof(MYFLT);
     int m = 0, l;//, w = n;
-    //MYFLT sr = csound->GetSr(csound);
     cdata = (csdata *) *(csound->GetRtRecordUserData(csound));
     do{
       l = csound->ReadCircularBuffer(csound,cdata->incb,&inbuff_[m],n);
@@ -791,7 +790,6 @@ static void rtplay_(CSOUND *csound, const MYFLT *outbuff_, int nbytes)
     csdata  *cdata;
     int n = nbytes/sizeof(MYFLT);
     int m = 0, l;//, w = n;
-    //MYFLT sr = csound->GetSr(csound);
     cdata = (csdata *) *(csound->GetRtPlayUserData(csound));
     do {
       l = csound->WriteCircularBuffer(csound, cdata->outcb,&outbuff_[m],n);

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -108,6 +108,7 @@ typedef struct csdata_ {
   int devout;
   void *incb;
   void *outcb;
+  MYFLT sr;
 } csdata;
 
 
@@ -368,7 +369,7 @@ int AuHAL_open(CSOUND *csound, const csRtAudioParams * parm,
     }
     CFRelease(devName);
 
-    srate = csound->GetSr(csound);
+    cdata->sr = srate = parm->sampleRate;
     if(!isInput){
       nchnls =cdata->onchnls = parm->nChannels;
       bufframes = csound->GetOutputBufferSize(csound)/nchnls;
@@ -812,7 +813,7 @@ static void rtclose_(CSOUND *csound)
 
     if (cdata != NULL) {
       usleep(1000*csound->GetOutputBufferSize(csound)/
-             (csound->GetSr(csound)*csound->GetNchnls(csound)));
+             (cdata->sr*csound->GetNchnls(csound)));
 
       if(cdata->inunit != NULL){
         AudioOutputUnitStop(cdata->inunit);

--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -706,8 +706,8 @@ static void rtJack_CopyDevParams(RtJackGlobals *p,
                      (unsigned int)p->bufSize != parm->bufSamp_SW))
           rtJack_Error(csound, -1,
                        Str("input and output parameters are not consistent"));
-        if (UNLIKELY((unsigned int)((parm->bufSamp_SW / csound->GetKsmps(csound)) *
-                                    csound->GetKsmps(csound)) != parm->bufSamp_SW))
+        if (UNLIKELY((unsigned int)((parm->bufSamp_SW / parm->ksmps) *
+                                    parm->ksmps) != parm->bufSamp_SW))
           rtJack_Error(csound, -1,
                        Str("period size (-b) must be an integer "
                            "multiple of ksmps"));
@@ -721,6 +721,7 @@ static void rtJack_CopyDevParams(RtJackGlobals *p,
 
     p->bufSize = parm->bufSamp_SW;
     p->nBuffers = (parm->bufSamp_HW + parm->bufSamp_SW - 1) / parm->bufSamp_SW;
+    p->sr = parm->sampleRate;
 
 }
 
@@ -900,7 +901,7 @@ static int rtrecord_(CSOUND *csound, MYFLT *inbuf_, int bytes_)
         /* VL 28.03.15 -- timeout after wait for 10 buffer
            lengths */
         int ret = rtJack_LockTimeout(csound, &(p->bufs[bufcnt]->csndLock),
-                                     10000*(nframes/csound->GetSr(csound)));
+                                     10000*(nframes/p->sr));
         if (ret) {
           memset(inbuf_, 0, bytes_);
           OPARMS oparms;

--- a/InOut/rtpa.c
+++ b/InOut/rtpa.c
@@ -67,6 +67,7 @@ typedef struct PA_BLOCKING_STREAM_ {
 #endif
   int         paLockTimeout;
   int         complete;
+  int         ksmps;
 } PA_BLOCKING_STREAM;
 
 static int pa_PrintErrMsg(CSOUND *csound, const char *fmt, ...)
@@ -335,8 +336,8 @@ static int paBlockingReadWriteOpen(CSOUND *csound)
       pa_PrintErrMsg(csound, Str("Inconsistent full-duplex sample rates"));
       goto err_return;
     }
-    if (UNLIKELY(((pabs->inParm.bufSamp_SW / csound->GetKsmps(csound)) *
-                  csound->GetKsmps(csound)) != pabs->inParm.bufSamp_SW))
+    if (UNLIKELY(((pabs->inParm.bufSamp_SW / pabs->ksmps) *
+                  pabs->ksmps) != pabs->inParm.bufSamp_SW))
       csound->Warning(csound,
                        "%s", Str("WARNING: buffer size should be an integer "
                                  "multiple of ksmps in full-duplex mode\n"));
@@ -581,7 +582,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   pabs->mode |= 1;
   memcpy(&(pabs->inParm), parm, sizeof(csRtAudioParams));
   *(p->GetRtRecordUserData(p)) = (void*) pabs;
-
+  pabs->ksmps = parm->ksmps;
   pabs->complete = 0;
 
   return 0;
@@ -605,7 +606,7 @@ static int paBlockingReadWriteStreamCallback(const void *input,
   pabs->mode |= 2;
   memcpy(&(pabs->outParm), parm, sizeof(csRtAudioParams));
   *(p->GetRtPlayUserData(p)) = (void*) pabs;
-
+  pabs->ksmps = parm->ksmps;
   pabs->complete = 0;
 
   return (paBlockingReadWriteOpen(p));

--- a/InOut/rtpulse.c
+++ b/InOut/rtpulse.c
@@ -99,7 +99,7 @@ static int pulse_playopen(CSOUND *csound, const csRtAudioParams *parm)
 
     pulse = (pulse_params *) csound->Malloc(csound, sizeof(pulse_params));
     *(csound->GetRtPlayUserData(csound))  = (void *) pulse;
-    pulse->spec.rate = csound->GetSr(csound);
+    pulse->spec.rate = parm->sampleRate;
     pulse->spec.channels = csound->GetNchnls(csound);
     pulse->spec.format = PA_SAMPLE_FLOAT32;
     pulse->buf =
@@ -201,7 +201,7 @@ static int pulse_recopen(CSOUND *csound, const csRtAudioParams *parm)
     int pulserror;
     pulse = (pulse_params *) csound->Malloc(csound, sizeof(pulse_params));
     *(csound->GetRtRecordUserData(csound))  = (void *) pulse;
-    pulse->spec.rate = csound->GetSr(csound);
+    pulse->spec.rate = parm->sampleRate;
     pulse->spec.channels = csound->GetNchnls_i(csound);
     pulse->spec.format = PA_SAMPLE_FLOAT32;
     pulse->buf =

--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -20,12 +20,9 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-
 #include <soundfile.h>
 
 #if USE_LIBSNDFILE
-
-
 const char *sflib_strerror(void *p){
   return sf_strerror((SNDFILE *)p); 
 }
@@ -174,6 +171,5 @@ int  sflib_set_string(void *sndfile, int str_type, const char* str){
 const char *sflib_strerror(void *p){
   return NULL;
 }
-
-
 #endif
+

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -1014,7 +1014,7 @@ int32_t ftlptim(CSOUND *csound, EVAL *p)
     if (UNLIKELY((ftp = csound->FTnp2Finde(csound, p->a)) == NULL))
       return NOTOK;
     if (LIKELY(ftp->loopmode1))
-      *p->r = ftp->begin1 * csound->onedsr;
+      *p->r = ftp->begin1 * CS_ONEDSR;
     else {
       *p->r = FL(0.0);
       csound->Warning(csound, Str("non-looping sample"));

--- a/OOps/cmath.c
+++ b/OOps/cmath.c
@@ -395,7 +395,7 @@ int32_t aexprndi(CSOUND *csound, PRANDI *p)
     cpsp = p->xcps;
     ampp = p->xamp;
     ar = p->ar;
-    inc = (int32_t)(cpsp[0] * csound->sicvt);
+    inc = (int32_t)(cpsp[0] * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -409,7 +409,7 @@ int32_t aexprndi(CSOUND *csound, PRANDI *p)
         ar[n] = (p->num1 + (MYFLT)phs * p->dfdmax) * ampp[0];
       phs += inc;                                /* phs += inc       */
       if (p->cpscod)
-        inc = (int32_t)(cpsp[n] * csound->sicvt);  /*   (nxt inc)      */
+        inc = (int32_t)(cpsp[n] * CS_SICVT);  /*   (nxt inc)      */
       if (UNLIKELY(phs >= MAXLEN)) {             /* when phs o'flows */
         phs &= PHMASK;
         p->num1 = p->num2;
@@ -553,7 +553,7 @@ int32_t agaussi(CSOUND *csound, PRANDI *p)
     cpsp = p->xcps;
     ampp = p->xamp;
     ar = p->ar;
-    inc = (int32_t)(*cpsp * csound->sicvt);
+    inc = (int32_t)(*cpsp * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -567,7 +567,7 @@ int32_t agaussi(CSOUND *csound, PRANDI *p)
         ar[n] = (p->num1 + (MYFLT)phs * p->dfdmax) * ampp[0];
       phs += inc;                                /* phs += inc       */
       if (p->cpscod)
-        inc = (int32_t)(cpsp[n] * csound->sicvt);  /*   (nxt inc)      */
+        inc = (int32_t)(cpsp[n] * CS_SICVT);  /*   (nxt inc)      */
       if (UNLIKELY(phs >= MAXLEN)) {             /* when phs o'flows */
         phs &= PHMASK;
         p->num1 = p->num2;
@@ -651,7 +651,7 @@ int32_t acauchyi(CSOUND *csound, PRANDI *p)
     cpsp = p->xcps;
     ampp = p->xamp;
     ar = p->ar;
-    inc = (int32_t)(*cpsp * csound->sicvt);
+    inc = (int32_t)(*cpsp * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -665,7 +665,7 @@ int32_t acauchyi(CSOUND *csound, PRANDI *p)
         ar[n] = (p->num1 + (MYFLT)phs * p->dfdmax) * ampp[0];
       phs += inc;                                /* phs += inc       */
       if (p->cpscod)
-        inc = (int32_t)(cpsp[n] * csound->sicvt);  /*   (nxt inc)      */
+        inc = (int32_t)(cpsp[n] * CS_SICVT);  /*   (nxt inc)      */
       if (UNLIKELY(phs >= MAXLEN)) {             /* when phs o'flows */
         phs &= PHMASK;
         p->num1 = p->num2;

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -319,7 +319,7 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
     }
     /* set default format parameters */
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
-    sfinfo.samplerate = MYFLT2LONG(csound->esr);
+    sfinfo.samplerate = MYFLT2LONG(CS_ESR);
     sfinfo.channels = p->nChannels;
     /* check for user specified sample format */
     n = MYFLT2LONG(*p->iSampleFormat);
@@ -379,15 +379,15 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
     /* set file parameters from header info */
     p->fileLength = (int32_t) sfinfo.frames;
     p->warpScale = 1.0;
-    if (MYFLT2LONG(csound->esr) != sfinfo.samplerate) {
+    if (MYFLT2LONG(CS_ESR) != sfinfo.samplerate) {
       if (LIKELY(p->winSize != 1)) {
         /* will automatically convert sample rate if interpolation is enabled */
-        p->warpScale = (double)sfinfo.samplerate / (double)csound->esr;
+        p->warpScale = (double)sfinfo.samplerate / (double)CS_ESR;
       }
       else {
         csound->Warning(csound, Str("diskin2: warning: file sample rate (%d) "
                                     "!= orchestra sr (%d)\n"),
-                        sfinfo.samplerate, MYFLT2LONG(csound->esr));
+                        sfinfo.samplerate, MYFLT2LONG(CS_ESR));
       }
     }
     /* wrap mode */
@@ -395,7 +395,7 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
     if (UNLIKELY(p->fileLength < 1L))
       p->wrapMode = 0;
     /* initialise read position */
-    pos = (double)*(p->iSkipTime) * (double)csound->esr * p->warpScale;
+    pos = (double)*(p->iSkipTime) * (double)CS_ESR * p->warpScale;
     pos *= (double)POS_FRAC_SCALE;
     p->pos_frac = (int64_t)(pos >= 0.0 ? (pos + 0.5) : (pos - 0.5));
     if (p->wrapMode) {
@@ -979,7 +979,7 @@ int32_t diskin2_perf_asynchronous(CSOUND *csound, DISKIN2 *p)
 
 uintptr_t diskin_io_thread(void *p){
     DISKIN_INST *current = (DISKIN_INST *) p;
-    int32_t wakeup = 1000*current->csound->ksmps/current->csound->esr;
+    int32_t wakeup = 1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
     int32_t *start =
       current->csound->QueryGlobalVariable(current->csound,"DISKIN_THREAD_START");
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
@@ -1074,7 +1074,7 @@ static int32_t sndo1set_(CSOUND *csound, void *pp, int32_t stringname)
     sfname = name;
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
     //sfinfo.frames = 0;
-    sfinfo.samplerate = MYFLT2LONG(csound->esr);
+    sfinfo.samplerate = MYFLT2LONG(((SNDOUT*) pp)->h.insdshead->esr);
     sfinfo.channels = nchns;
     switch (MYFLT2LONG(*iformat)) {
     case 1: format = AE_CHAR; break;
@@ -1543,7 +1543,7 @@ int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
 
 uintptr_t diskin_io_thread_array(void *p){
     DISKIN_INST *current = (DISKIN_INST *) p;
-    int32_t wakeup = 1000*current->csound->ksmps/current->csound->esr;
+    int32_t wakeup = 1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
     int32_t *start =
       current->csound->QueryGlobalVariable(current->csound,
                                            "DISKIN_THREAD_START_ARRAY");
@@ -1581,7 +1581,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
     if (t->data) p->nChannels = t->sizes[0];
     /* set default format parameters */
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
-    sfinfo.samplerate = MYFLT2LONG(csound->esr);
+    sfinfo.samplerate = MYFLT2LONG(CS_ESR);
     sfinfo.channels = p->nChannels;
     /* check for user specified sample format */
     n = MYFLT2LONG(*p->iSampleFormat);
@@ -1660,15 +1660,15 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
     /* set file parameters from header info */
     p->fileLength = (int32_t) sfinfo.frames;
     p->warpScale = 1.0;
-    if (MYFLT2LONG(csound->esr) != sfinfo.samplerate) {
+    if (MYFLT2LONG(CS_ESR) != sfinfo.samplerate) {
       if (LIKELY(p->winSize != 1)) {
         /* will automatically convert sample rate if interpolation is enabled */
-        p->warpScale = (double)sfinfo.samplerate / (double)csound->esr;
+        p->warpScale = (double)sfinfo.samplerate / (double)CS_ESR;
       }
       else {
         csound->Warning(csound, Str("diskin2: warning: file sample rate (%d) "
                                     "!= orchestra sr (%d)\n"),
-                        sfinfo.samplerate, MYFLT2LONG(csound->esr));
+                        sfinfo.samplerate, MYFLT2LONG(CS_ESR));
       }
     }
     /* wrap mode */
@@ -1676,7 +1676,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
     if (UNLIKELY(p->fileLength < 1L))
       p->wrapMode = 0;
     /* initialise read position */
-    pos = (double)*(p->iSkipTime) * (double)csound->esr * p->warpScale;
+    pos = (double)*(p->iSkipTime) * (double)CS_ESR * p->warpScale;
     pos *= (double)POS_FRAC_SCALE;
     p->pos_frac = (int64_t)(pos >= 0.0 ? (pos + 0.5) : (pos - 0.5));
     if (p->wrapMode) {
@@ -2146,7 +2146,7 @@ static int32_t sndinset_(CSOUND *csound, SOUNDIN_ *p, int32_t stringname)
     }
     /* set default format parameters */
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
-    sfinfo.samplerate = MYFLT2LONG(csound->esr);
+    sfinfo.samplerate = MYFLT2LONG(CS_ESR);
     sfinfo.channels = p->nChannels;
     /* check for user specified sample format */
     n = MYFLT2LONG(*p->iSampleFormat);
@@ -2211,10 +2211,10 @@ static int32_t sndinset_(CSOUND *csound, SOUNDIN_ *p, int32_t stringname)
       return OK;
     /* set file parameters from header info */
     p->fileLength = (int_least64_t) sfinfo.frames;
-    if (MYFLT2LONG(csound->esr) != sfinfo.samplerate)
+    if (MYFLT2LONG(CS_ESR) != sfinfo.samplerate)
       csound->Warning(csound, Str("soundin: file sample rate (%d) "
                                   "!= orchestra sr (%d)\n"),
-                      sfinfo.samplerate, MYFLT2LONG(csound->esr));
+                      sfinfo.samplerate, MYFLT2LONG(CS_ESR));
     fmt = TYPE2ENC(sfinfo.format);
     typ = SF2TYPE(sfinfo.format);
     if ((fmt != AE_FLOAT && fmt != AE_DOUBLE) ||

--- a/OOps/disprep.c
+++ b/OOps/disprep.c
@@ -88,7 +88,7 @@ int32_t dspset(CSOUND *csound, DSPLAY *p)
 
     if (csoundGetTypeForArg(p->signal) == &CS_VAR_TYPE_K)
       npts = (int32)(*p->iprd * CS_EKR);
-    else npts = (int32)(*p->iprd * csound->esr);
+    else npts = (int32)(*p->iprd * CS_ESR);
     if (UNLIKELY(npts <= 0)) {
       return csound->InitError(csound, Str("illegal iprd in display"));
 
@@ -257,7 +257,7 @@ int32_t fftset(CSOUND *csound, DSPFFT *p) /* fftset, dspfft -- calc Fast Fourier
     }
     if (csoundGetTypeForArg(p->signal) == &CS_VAR_TYPE_K)
       step_size = (int32)(*p->iprd * CS_EKR);
-    else step_size = (int32)(*p->iprd * csound->esr);
+    else step_size = (int32)(*p->iprd * CS_ESR);
     if (UNLIKELY(step_size <= 0)) {
       return csound->InitError(csound, Str("illegal iprd in ffy display"));
     }

--- a/OOps/lpred.c
+++ b/OOps/lpred.c
@@ -298,7 +298,7 @@ static void pkinterp(LPCparam *p){
 MYFLT csoundLPcps(CSOUND *csound, void *parm){
   LPCparam *p = (LPCparam *) parm;
   int i;
-  MYFLT mx = FL(0.0), pmx, sr = csound->GetSr(csound);
+  MYFLT mx = FL(0.0), pmx, sr = csoundGetSr(csound);
   MYFLT *pk = p->pk, *am = p->am;
   pkpick(p);
   pkinterp(p);
@@ -966,7 +966,7 @@ int32_t lpcpvs(CSOUND *csound, LPCPVS *p){
     cbuf[bp] = in[n];
     bp = bp != N - 1 ? bp + 1 : 0;
     if(--cp == 0) {
-      MYFLT k, incr = p->wlen/N, g, sr = csound->GetSr(csound);
+      MYFLT k, incr = p->wlen/N, g, sr = csoundGetSr(csound);
       MYFLT *fftframe =  (MYFLT *) p->fftframe.auxp;
       float *pvframe = (float *)p->fout->frame.auxp;
       int32_t j,i;
@@ -1073,7 +1073,7 @@ static int cmpfunc (const void * a, const void * b) {
 int32_t coef2parm(CSOUND *csound, CF2P *p) {
   MYCMPLX *pl;
   MYFLT *c = p->in->data, pm, pf, sum = 0.0;
-  MYFLT *pp = p->out->data, Nyq = csound->esr/2;
+  MYFLT *pp = p->out->data, Nyq = CS_ESR/2;
   int i,j;
   // simple check for new data
   for(i=0; i< p->M; i++) sum += c[i];

--- a/OOps/lpred.c
+++ b/OOps/lpred.c
@@ -1083,7 +1083,7 @@ int32_t coef2parm(CSOUND *csound, CF2P *p) {
     memset(pp,0,sizeof(MYFLT)*p->M);
     for(i = j = 0; i < p->M; i++) {
       pm = magc(pl[i]);
-      pf = phsc(pl[i])/csound->tpidsr;
+      pf = phsc(pl[i])/CS_TPIDSR;
       if(isnan(pf)) {
         pp[j] = 0;
         pp[j+1] = 0;
@@ -1091,7 +1091,7 @@ int32_t coef2parm(CSOUND *csound, CF2P *p) {
       else {
         if(pf > 0 && pf < Nyq && j < p->M) {
           pp[j] = pf;
-          pp[j+1] = -LOG(pm)*2/csound->tpidsr;
+          pp[j+1] = -LOG(pm)*2/CS_TPIDSR;
           j += 2;
         }
       }
@@ -1187,7 +1187,7 @@ int32_t resonbnk(CSOUND *csound, RESONB *p)
         cf = p->kparm->data[k];
         bw = p->kparm->data[k+1];
         if(cf > fmin && cf < fmax) {
-          cosf = cos(cf * (double)(csound->tpidsr));
+          cosf = cos(cf * (double)(CS_TPIDSR));
           c3[j] = exp(bw * (double)(csound->mtpdsr));
           c3p1 = c3[j] + 1.0;
           c3t4 = c3[j] * 4.0;

--- a/OOps/oscils.c
+++ b/OOps/oscils.c
@@ -71,7 +71,7 @@ int32_t oscils_set(CSOUND *csound, OSCILS *p)
     iflg = (int32_t) (*(p->iflg) + FL(0.5)) & 0x07; /* check flags */
     if (UNLIKELY(iflg & 1)) return OK;          /* skip init, nothing to do */
     p->use_double = (iflg & 2 ? 1 : 0);         /* use doubles internally */
-    init_sine_gen((double)*(p->iamp), (double)(*(p->icps) * csound->tpidsr),
+    init_sine_gen((double)*(p->iamp), (double)(*(p->icps) * CS_TPIDSR),
                   (double)(*(p->iphs) * TWOPI_F),
                    &(p->xd), &(p->cd), &(p->vd));
     if (!(p->use_double)) {

--- a/OOps/pstream.c
+++ b/OOps/pstream.c
@@ -64,7 +64,7 @@ int32_t fassign_set(CSOUND *csound, FASSIGN *p)
     /* sliding needs to be checked */
     if (p->fsrc->sliding) {
       p->fout->NB = p->fsrc->NB;
-      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * csound->ksmps,
+      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * CS_KSMPS,
                        &p->fout->frame);
       return OK;
     }
@@ -96,7 +96,7 @@ int32_t fassign(CSOUND *csound, FASSIGN *p)
     //                         Str("fsig = : formats are different.\n"));
     if (p->fsrc->sliding) {
       memcpy(p->fout->frame.auxp, p->fsrc->frame.auxp,
-             sizeof(MYFLT)*(p->fsrc->N+2)*csound->ksmps);
+             sizeof(MYFLT)*(p->fsrc->N+2)*CS_KSMPS);
       return OK;
     }
 
@@ -161,7 +161,7 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
 
     p->outptr = 0;
     p->lastframe = 0;
-/*  p->one_over_sr = (float) csound->onedsr; */
+/*  p->one_over_sr = (float) CS_ONEDSR; */
 /*  p->pi_over_sr = (float) csound->pidsr; */
     p->one_over_overlap = (float)(FL(1.0) / p->overlap);
     /* alloc for all oscs;
@@ -201,7 +201,7 @@ static void adsyn_frame(CSOUND *csound, PVADS *p)
     MYFLT *a,*x,*y;
     MYFLT *amps,*freqs,*lastamps;
     MYFLT ffac    = *p->kfmod;
-    MYFLT nyquist = csound->esr * FL(0.5);
+    MYFLT nyquist = CS_ESR * FL(0.5);
     /* we add to outbuf, so clear it first*/
     memset(p->outbuf.auxp,0,p->overlap * sizeof(MYFLT));
 
@@ -395,7 +395,7 @@ static int32_t pvsfreadset_(CSOUND *csound, PVSFREAD *p, int32_t stringname)
     p->format  = pp.format;
     p->chans   = pp.chans;
     p->nframes = pp.nframes;
-    p->arate   = csound->esr / (MYFLT) pp.overlap;
+    p->arate   = CS_ESR / (MYFLT) pp.overlap;
     p->membase = (float*) pp.data;
 
     if (UNLIKELY(p->overlap < (int32_t)CS_KSMPS || p->overlap < 10))

--- a/OOps/pstream.c
+++ b/OOps/pstream.c
@@ -162,7 +162,7 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
     p->outptr = 0;
     p->lastframe = 0;
 /*  p->one_over_sr = (float) CS_ONEDSR; */
-/*  p->pi_over_sr = (float) csound->pidsr; */
+/*  p->pi_over_sr = (float) CS_PIDSR; */
     p->one_over_overlap = (float)(FL(1.0) / p->overlap);
     /* alloc for all oscs;
        in case we can do something with them dynamically, one day */
@@ -224,7 +224,7 @@ static void adsyn_frame(CSOUND *csound, PVADS *p)
       /* kill stuff over Nyquist. Need to worry about vlf values? */
       if (freqs[i] > nyquist)
         amps[i] = FL(0.0);
-      a[i] = FL(2.0) * SIN(freqs[i] * csound->pidsr);
+      a[i] = FL(2.0) * SIN(freqs[i] * CS_PIDSR);
     }
 
     /* we need to interp amplitude, but seems we can avoid doing freqs too,

--- a/OOps/pvsanal.c
+++ b/OOps/pvsanal.c
@@ -195,8 +195,8 @@ int32_t pvsanalset(CSOUND *csound, PVSANAL *p)
 #endif
     halfwinsize = M/2;
     buflen = M*4;
-    p->arate = (float)(csound->esr / (MYFLT) overlap);
-    p->fund = (float)(csound->esr / (MYFLT) N);
+    p->arate = (float)(CS_ESR / (MYFLT) overlap);
+    p->fund = (float)(CS_ESR / (MYFLT) N);
 
     nBins = N/2 + 1;
     /* we can exclude/simplify all sorts of stuff in CARL
@@ -242,10 +242,10 @@ int32_t pvsanalset(CSOUND *csound, PVSANAL *p)
       *(analwinhalf + i) *= sum;
 
 
-  /*    p->invR = (float)(FL(1.0) / csound->esr); */
+  /*    p->invR = (float)(FL(1.0) / CS_ESR); */
     p->RoverTwoPi = (float)(p->arate / TWOPI_F);
     p->TwoPioverR = (float)(TWOPI_F / p->arate);
-    p->Fexact =  (float)(csound->esr / (MYFLT)N);
+    p->Fexact =  (float)(CS_ESR / (MYFLT)N);
     p->nI = -((int64_t)(halfwinsize/overlap))*overlap; /* input time (in samples) */
     /*Dd = halfwinsize + p->nI + 1;                     */
     /* in streaming mode, Dd = ovelap all the time */
@@ -658,7 +658,7 @@ int32_t pvssanal(CSOUND *csound, PVSANAL *p)
         angleDif =  mod2Pi(angleDif);
         angleDif =  angleDif * N /TWOPI;
         ff[j].re = thismag;
-        ff[j].im = csound->esr * (j + angleDif)/N;
+        ff[j].im = CS_ESR * (j + angleDif)/N;
       }
 /*       if (i==9) { */
 /*         printf("Frame as Amp/Freq %d\n", i); */
@@ -732,8 +732,8 @@ int32_t pvsynthset(CSOUND *csound, PVSYNTH *p)
     buflen = M*4;
     IO = (double)overlap;         /* always, no time-scaling possible */
 
-    p->arate = csound->esr / (MYFLT) overlap;
-    p->fund = csound->esr / (MYFLT) N;
+    p->arate = CS_ESR / (MYFLT) overlap;
+    p->fund = CS_ESR / (MYFLT) N;
     nBins = N/2 + 1;
     Lf = Mf = 1 - M%2;
     /* deal with iinit later on! */
@@ -826,10 +826,10 @@ int32_t pvsynthset(CSOUND *csound, PVSYNTH *p)
   for (i = -halfwinsize; i <= halfwinsize; i++)
       *(synwinhalf + i) *= sum;
 
-/*  p->invR = FL(1.0) / csound->esr; */
+/*  p->invR = FL(1.0) / CS_ESR; */
     p->RoverTwoPi = p->arate / TWOPI_F;
     p->TwoPioverR = TWOPI_F / p->arate;
-    p->Fexact =  csound->esr / (MYFLT)N;
+    p->Fexact =  CS_ESR / (MYFLT)N;
     p->nO = -(halfwinsize / overlap) * overlap; /* input time (in samples) */
     p->Ii = 0;                          /* number of new outputs to write */
     p->IOi = 0;
@@ -1027,9 +1027,9 @@ int32_t pvssynth(CSOUND *csound, PVSYNTH *p)
 
         tmp = ff[k].im; /* Actually frequency */
         /* subtract bin mid frequency */
-        tmp -= (double)k * csound->esr/N;
+        tmp -= (double)k * CS_ESR/N;
         /* get bin deviation from freq deviation */
-        tmp *= TWOPI /csound->esr;
+        tmp *= TWOPI /CS_ESR;
         /* add the overlap phase advance back in */
         tmp += (double)k*TWOPI/N;
         h[k] = phase = mod2Pi(h[k] + tmp);

--- a/OOps/schedule.c
+++ b/OOps/schedule.c
@@ -293,7 +293,7 @@ int32_t lfoa(CSOUND *csound, LFO *p)
     MYFLT       *ar, amp;
 
     phs = p->phs;
-    inc = (int32_t)((*p->xcps * (MYFLT)MAXPHASE) * csound->onedsr);
+    inc = (int32_t)((*p->xcps * (MYFLT)MAXPHASE) * CS_ONEDSR);
     amp = *p->kamp;
     ar = p->res;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -116,7 +116,7 @@ static int32_t getsndinfo(CSOUND *csound, SNDINFO *p, SFLIB_INFO *hdr, int32_t s
       }
       if (csFileType == CSFTYPE_UNKNOWN) {
         memset(&sfinfo, 0, sizeof(SFLIB_INFO));
-        sfinfo.samplerate = (int32_t)(csound->esr + FL(0.5));
+        sfinfo.samplerate = (int32_t)(CS_ESR + FL(0.5));
         sfinfo.channels = 1;
         sfinfo.format = (int32_t)FORMAT2SF(csound->oparms->outformat)
                         | (int32_t)TYPE2SF(TYP_RAW);

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -56,7 +56,7 @@ int32_t s_opcode(CSOUND *csound, STRGET_OP *p){
 
 int32_t s_opcode_k(CSOUND *csound, STRGET_OP *p){
   snprintf(p->r->data, p->r->size, "%f", *p->indx);
-  p->r->timestamp = csound->GetKcounter(p->h.insdshead);
+  p->r->timestamp = p->h.insdshead->kcounter;
   return OK;
 }
 
@@ -182,7 +182,7 @@ static CS_NOINLINE int32_t StrOp_ErrMsg(void *p, const char *msg)
 
 int32_t strassign_k(CSOUND *csound, STRCPY_OP *p) {
   if(p->r != p->str) {
-  if((uint64_t)p->str->timestamp == csound->GetKcounter(p->h.insdshead)) {
+  if((uint64_t)p->str->timestamp == p->h.insdshead->kcounter) {
   CS_TYPE *strType = csound->GetTypeForArg(p->str);    
   strType->copyValue(csound, strType, p->r, p->str);
   //printf("copy \n");
@@ -258,7 +258,7 @@ int32_t str_changed_k(CSOUND *csound, STRCHGD *p)
 /* rewritten VL Feb 22 */
 int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
+  int64_t kcnt = p->h.insdshead->kcounter;
   size_t size = strlen(p->str1->data) + strlen(p->str2->data);
   if(size >= MAX_STRINGDAT_SIZE) {
      if(is_perf_thread(&p->h))
@@ -545,7 +545,7 @@ int32_t sprintf_opcode(CSOUND *csound, SPRINTF_OP *p)
     ((char*) p->r->data)[0] = '\0';
     return NOTOK;
   }
-  p->r->timestamp = csound->GetKcounter(p->h.insdshead);
+  p->r->timestamp = p->h.insdshead->kcounter;
   return OK;
 }
 
@@ -784,7 +784,7 @@ int32_t strtol_opcode_p(CSOUND *csound, STRTOD_OP *p)
 
 int32_t strsub_opcode(CSOUND *csound, STRSUB_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
+  int64_t kcnt = p->h.insdshead->kcounter;
     const char  *src;
     char        *dst;
     int32_t      strt, end, rev = 0;
@@ -918,7 +918,7 @@ int32_t strlen_opcode(CSOUND *csound, STRLEN_OP *p)
 
 int32_t strupper_opcode(CSOUND *csound, STRUPPER_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
+  int64_t kcnt = p->h.insdshead->kcounter;
     const char  *src;
     char        *dst;
     int32_t         i;
@@ -946,7 +946,7 @@ int32_t strupper_opcode(CSOUND *csound, STRUPPER_OP *p)
 int32_t strlower_opcode(CSOUND *csound, STRUPPER_OP *p)
 {
 
-  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
+  int64_t kcnt = p->h.insdshead->kcounter;
     const char  *src;
     char        *dst;
     int32_t         i;

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -56,7 +56,7 @@ int32_t s_opcode(CSOUND *csound, STRGET_OP *p){
 
 int32_t s_opcode_k(CSOUND *csound, STRGET_OP *p){
   snprintf(p->r->data, p->r->size, "%f", *p->indx);
-  p->r->timestamp = csound->GetKcounter(csound);
+  p->r->timestamp = csound->GetKcounter(p->h.insdshead);
   return OK;
 }
 
@@ -182,7 +182,7 @@ static CS_NOINLINE int32_t StrOp_ErrMsg(void *p, const char *msg)
 
 int32_t strassign_k(CSOUND *csound, STRCPY_OP *p) {
   if(p->r != p->str) {
-  if((uint64_t)p->str->timestamp == csound->GetKcounter(csound)) {
+  if((uint64_t)p->str->timestamp == csound->GetKcounter(p->h.insdshead)) {
   CS_TYPE *strType = csound->GetTypeForArg(p->str);    
   strType->copyValue(csound, strType, p->r, p->str);
   //printf("copy \n");
@@ -258,7 +258,7 @@ int32_t str_changed_k(CSOUND *csound, STRCHGD *p)
 /* rewritten VL Feb 22 */
 int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(csound);
+  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
   size_t size = strlen(p->str1->data) + strlen(p->str2->data);
   if(size >= MAX_STRINGDAT_SIZE) {
      if(is_perf_thread(&p->h))
@@ -545,7 +545,7 @@ int32_t sprintf_opcode(CSOUND *csound, SPRINTF_OP *p)
     ((char*) p->r->data)[0] = '\0';
     return NOTOK;
   }
-  p->r->timestamp = csound->GetKcounter(csound);
+  p->r->timestamp = csound->GetKcounter(p->h.insdshead);
   return OK;
 }
 
@@ -784,7 +784,7 @@ int32_t strtol_opcode_p(CSOUND *csound, STRTOD_OP *p)
 
 int32_t strsub_opcode(CSOUND *csound, STRSUB_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(csound);
+  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
     const char  *src;
     char        *dst;
     int32_t      strt, end, rev = 0;
@@ -918,7 +918,7 @@ int32_t strlen_opcode(CSOUND *csound, STRLEN_OP *p)
 
 int32_t strupper_opcode(CSOUND *csound, STRUPPER_OP *p)
 {
-  int64_t kcnt = csound->GetKcounter(csound);
+  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
     const char  *src;
     char        *dst;
     int32_t         i;
@@ -946,7 +946,7 @@ int32_t strupper_opcode(CSOUND *csound, STRUPPER_OP *p)
 int32_t strlower_opcode(CSOUND *csound, STRUPPER_OP *p)
 {
 
-  int64_t kcnt = csound->GetKcounter(csound);
+  int64_t kcnt = csound->GetKcounter(p->h.insdshead);
     const char  *src;
     char        *dst;
     int32_t         i;

--- a/OOps/ugens1.c
+++ b/OOps/ugens1.c
@@ -32,7 +32,7 @@ int32_t linset(CSOUND *csound, LINE *p)
 {
     double       dur;
     if (LIKELY((dur = *p->idur) > FL(0.0))) {
-      p->incr = (*p->ib - *p->ia) / dur * csound->onedsr;
+      p->incr = (*p->ib - *p->ia) / dur * CS_ONEDSR;
       p->kincr = p->incr*CS_KSMPS;
       p->val = *p->ia;
     }
@@ -83,7 +83,7 @@ int32_t expset(CSOUND *csound, EXPON *p)
       a = *p->ia;
       b = *p->ib;
       if (LIKELY((a * b) > FL(0.0))) {
-        p->mlt = POWER(b/a, csound->onedsr/dur);
+        p->mlt = POWER(b/a, CS_ONEDSR/dur);
         p->kmlt = POWER(b/a, CS_ONEDKR/dur);
         p->val = a;
       }
@@ -171,7 +171,7 @@ int32_t lsgset(CSOUND *csound, LINSEG *p)
       segp->nxtpt = (double)**argp++;
       if (UNLIKELY((segp->cnt = (int32_t)(dur * CS_EKR + FL(0.5))) < 0))
         segp->cnt = 0;
-      if (UNLIKELY((segp->acnt = (int32_t)(dur * csound->esr + FL(0.5))) < 0))
+      if (UNLIKELY((segp->acnt = (int32_t)(dur * CS_ESR + FL(0.5))) < 0))
         segp->acnt = 0;
       segp++;
     } while (--nsegs);
@@ -333,7 +333,7 @@ static int32_t adsrset1(CSOUND *csound, LINSEG *p, int32_t midip)
     dur = (double)*argp[0];
     segp->nxtpt = FL(1.0);
     segp->cnt = (int32_t)(dur * CS_EKR + FL(0.5));
-    if (UNLIKELY((segp->acnt = (int32_t)(dur * csound->esr + FL(0.5))) < 0))
+    if (UNLIKELY((segp->acnt = (int32_t)(dur * CS_ESR + FL(0.5))) < 0))
         segp->acnt = 0;
     //printf("attack: dur=%f cnt=%d acnt=%d nxt=%f\n",
     //       dur, segp->cnt, segp->acnt, segp->nxtpt);
@@ -342,7 +342,7 @@ static int32_t adsrset1(CSOUND *csound, LINSEG *p, int32_t midip)
     dur = *argp[1];
     segp->nxtpt = *argp[2];
     segp->cnt = (int32_t)(dur * CS_EKR + FL(0.5));
-    if (UNLIKELY((segp->acnt = (int32_t)(dur * csound->esr + FL(0.5))) < 0))
+    if (UNLIKELY((segp->acnt = (int32_t)(dur * CS_ESR + FL(0.5))) < 0))
       segp->acnt = 0;
     //printf("decay: dur=%f cnt=%d acnt=%d nxt=%f\n",
     //       dur, segp->cnt, segp->acnt, segp->nxtpt);
@@ -354,7 +354,7 @@ static int32_t adsrset1(CSOUND *csound, LINSEG *p, int32_t midip)
       csound->Warning(csound, Str("length of ADSR note too short"));
     segp->nxtpt = *argp[2];
     segp->cnt = (int32_t)(dur * CS_EKR + FL(0.5));
-    if (UNLIKELY((segp->acnt = (int32_t)(dur * csound->esr + FL(0.5))) < 0))
+    if (UNLIKELY((segp->acnt = (int32_t)(dur * CS_ESR + FL(0.5))) < 0))
       segp->acnt = 0;
     //printf("sustain: dur=%f cnt=%d acnt=%d nxt=%f\n",
     //       dur, segp->cnt, segp->acnt, segp->nxtpt);
@@ -363,7 +363,7 @@ static int32_t adsrset1(CSOUND *csound, LINSEG *p, int32_t midip)
     // **FIXME is this needed? dur = *argp[3];
     segp->nxtpt = FL(0.0);
     segp->cnt = (int32_t)(release * CS_EKR + FL(0.5));
-    if (UNLIKELY((segp->acnt = (int32_t)(release * csound->esr + FL(0.5))) < 0))
+    if (UNLIKELY((segp->acnt = (int32_t)(release * CS_ESR + FL(0.5))) < 0))
       segp->acnt = 0;
     //printf("release: dur=%f cnt=%d acnt=%d nxt=%f\n",
     //       dur, segp->cnt, segp->acnt, segp->nxtpt);
@@ -537,7 +537,7 @@ int32_t xsgset(CSOUND *csound, EXXPSEG *p)
       segp->val = val;
       segp->mlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
       segp->cnt = (int32_t) (d + FL(0.5));
-      d = dur * csound->esr;
+      d = dur * CS_ESR;
       segp->amlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
       segp->acnt = (int32_t) (d + FL(0.5));
     } while (--nsegs);
@@ -596,7 +596,7 @@ int32_t xsgset_bkpt(CSOUND *csound, EXXPSEG *p)
       segp->val = val;
       segp->mlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
       segp->cnt = (int32_t) (d + FL(0.5));
-      d = dur * csound->esr;
+      d = dur * CS_ESR;
       segp->amlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
       segp->acnt = (int32_t) (d + FL(0.5));
     } while (--nsegs);
@@ -652,11 +652,11 @@ int32_t xsgset2b(CSOUND *csound, EXPSEG2 *p)
 /*       if (dur > FL(0.0)) { */
       if (UNLIKELY(val * nxtval <= FL(0.0)))
           goto experr;
-        d = dur * csound->esr;
+        d = dur * CS_ESR;
         segp->val = val;
         segp->mlt = POWER((nxtval / val), FL(1.0)/d);
         segp->cnt = (int32_t) (d + FL(0.5));
-         d = dur * csound->esr;
+         d = dur * CS_ESR;
          segp->amlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
          segp->acnt = (int32_t) (d + FL(0.5));
 /*       } */
@@ -708,11 +708,11 @@ int32_t xsgset2(CSOUND *csound, EXPSEG2 *p)   /*gab-A1 (G.Maldonado) */
 /*       if (dur > FL(0.0)) { */
       if (UNLIKELY(val * nxtval <= FL(0.0)))
           goto experr;
-        d = dur * csound->esr;
+        d = dur * CS_ESR;
         segp->val = val;
         segp->mlt = POWER((nxtval / val), FL(1.0)/d);
         segp->cnt = (int32_t) (d + FL(0.5));
-        d = dur * csound->esr;
+        d = dur * CS_ESR;
         segp->amlt = (MYFLT) pow((double)(nxtval / val), (1.0/(double)d));
         segp->acnt = (int32_t) (d + FL(0.5));
 /*       } */
@@ -1271,7 +1271,7 @@ int32_t alnrset(CSOUND *csound, LINENR *p)
       if (UNLIKELY(*p->iatdec <= FL(0.0))) {
         return csound->InitError(csound, Str("non-positive iatdec"));
       }
-      else p->mlt2 = POWER(*p->iatdec, csound->onedsr / *p->idec);
+      else p->mlt2 = POWER(*p->iatdec, CS_ONEDSR / *p->idec);
     }
     else p->mlt2 = FL(1.0);
     p->lin1 = FL(0.0);
@@ -1522,7 +1522,7 @@ int32_t aevxset(CSOUND *csound, ENVLPX *p)
         if (UNLIKELY(*p->iatdec <= FL(0.0))) {
           return csound->InitError(csound, Str("non-positive iatdec"));
         }
-        p->mlt2 = POWER(*p->iatdec, (csound->onedsr / *p->idec));
+        p->mlt2 = POWER(*p->iatdec, (CS_ONEDSR / *p->idec));
       }
       p->cnt1 = cnt1;
       p->asym = asym;
@@ -1702,7 +1702,7 @@ int32_t aevrset(CSOUND *csound, ENVLPR *p)
     if (UNLIKELY(!(*(ftp->ftable + ftp->flen)))) {
       return csound->InitError(csound, Str("rise func ends with zero"));
     }
-    p->mlt1 = POWER(iatss, csound->onedsr);
+    p->mlt1 = POWER(iatss, CS_ONEDSR);
     if (*p->idec > FL(0.0)) {
       int32_t rlscnt = (int32_t)(*p->idec * CS_EKR + FL(0.5));
       if ((p->rindep = (int32_t)*p->irind))

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -1235,7 +1235,7 @@ int32_t osckk(CSOUND *csound, OSC *p)
     if (UNLIKELY(ftp==NULL)) goto err1;
     ftbl = ftp->ftable;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     lobits = ftp->lobits;
     amp = *p->xamp;
     ar = p->sr;
@@ -1266,7 +1266,7 @@ int32_t oscka(CSOUND *csound, OSC *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;
@@ -1308,7 +1308,7 @@ int32_t oscak(CSOUND *csound, OSC *p)
     ftbl = ftp->ftable;
     lobits = ftp->lobits;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     ampp = p->xamp;
     ar = p->sr;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -1335,7 +1335,7 @@ int32_t oscaa(CSOUND *csound, OSC *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;
@@ -1397,7 +1397,7 @@ int32_t osckki(CSOUND *csound, OSC   *p)
     if (UNLIKELY((ftp = p->ftp)==NULL)) goto err1;
     lobits = ftp->lobits;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     amp = *p->xamp;
     ar = p->sr;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -1428,7 +1428,7 @@ int32_t osckai(CSOUND *csound, OSC   *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;
@@ -1473,7 +1473,7 @@ int32_t oscaki(CSOUND *csound, OSC   *p)
     if (UNLIKELY(ftp==NULL)) goto err1;
     lobits = ftp->lobits;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     ampp = p->xamp;
     ar = p->sr;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -1504,7 +1504,7 @@ int32_t oscaai(CSOUND *csound, OSC   *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;
@@ -1592,7 +1592,7 @@ int32_t osckk3(CSOUND *csound, OSC   *p)
     ftab = ftp->ftable;
     lobits = ftp->lobits;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     amp = *p->xamp;
     ar = p->sr;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -1645,7 +1645,7 @@ int32_t oscka3(CSOUND *csound, OSC   *p)
     uint32_t n, nsmps = CS_KSMPS;
     int32_t   x0;
     MYFLT   y0, y1, ym1, y2;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;
@@ -1707,7 +1707,7 @@ int32_t oscak3(CSOUND *csound, OSC   *p)
     ftab = ftp->ftable;
     lobits = ftp->lobits;
     phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * csound->sicvt);
+    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
     ampp = p->xamp;
     ar = p->sr;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -1754,7 +1754,7 @@ int32_t oscaa3(CSOUND *csound, OSC   *p)
     uint32_t n, nsmps = CS_KSMPS;
     int32_t    x0;
     MYFLT    y0, y1, ym1, y2;
-    MYFLT    sicvt = csound->sicvt;
+    MYFLT    sicvt = CS_SICVT;
 
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1;

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -73,7 +73,7 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
     uint32_t    offset = p->h.insdshead->ksmps_offset;
     uint32_t    early  = p->h.insdshead->ksmps_no_end;
     uint32_t    n, nsmps = CS_KSMPS;
-    MYFLT       *rs, *aphs, onedsr = csound->onedsr;
+    MYFLT       *rs, *aphs, onedsr = CS_ONEDSR;
     double      b = p->b;
     double      incr, R = *p->kR;
 
@@ -144,7 +144,7 @@ int32_t phsor(CSOUND *csound, PHSOR *p)
     uint32_t    offset = p->h.insdshead->ksmps_offset;
     uint32_t    early  = p->h.insdshead->ksmps_no_end;
     uint32_t    n, nsmps = CS_KSMPS;
-    MYFLT       *rs, onedsr = csound->onedsr;
+    MYFLT       *rs, onedsr = CS_ONEDSR;
     double      incr;
 
     rs = p->sr;
@@ -1090,7 +1090,7 @@ int32_t oscnset(CSOUND *csound, OSCILN *p)
     FUNC        *ftp;
     if (LIKELY((ftp = csound->FTnp2Finde(csound, p->ifn)) != NULL)) {
       p->ftp = ftp;
-      p->inc = ftp->flen * *p->ifrq * csound->onedsr;
+      p->inc = ftp->flen * *p->ifrq * CS_ONEDSR;
       p->index = FL(0.0);
       p->maxndx = ftp->flen - FL(1.0);
       p->ntimes = (int32_t)*p->itimes;

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -1463,7 +1463,7 @@ int32_t adsyn(CSOUND *csound, ADSYN *p)
     }
     /* IV - Jul 11 2002 */
     ampscale = *p->kamod * csound->e0dbfs;      /* since 15-bit sine table */
-    frqscale = *p->kfmod * ISINSIZ * csound->onedsr;
+    frqscale = *p->kfmod * ISINSIZ * CS_ONEDSR;
     /* 1024 * msecs of analysis */
     memset(p->rslt,0,sizeof(MYFLT)*nsmps);
     if (UNLIKELY(early)) nsmps -= early;

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -50,7 +50,7 @@ int32_t foscil(CSOUND *csound, FOSC *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT   sicvt = csound->sicvt;
+    MYFLT   sicvt = CS_SICVT;
 
     ar = p->rslt;
     ftp = p->ftp;
@@ -127,7 +127,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    MYFLT  sicvt = csound->sicvt;
+    MYFLT  sicvt = CS_SICVT;
     MYFLT  *ft;
 
     ar = p->rslt;

--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -58,7 +58,7 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1; /* RWD fix */
     ftbl = ftp->ftable;
-    sicvt2 = csound->sicvt * FL(0.5); /* for theta/2  */
+    sicvt2 = CS_SICVT * FL(0.5); /* for theta/2  */
     lobits = ftp->lobits;
     lenmask = ftp->lenmask;
     ampp = p->xamp;
@@ -177,7 +177,7 @@ int32_t gbuzz(CSOUND *csound, GBUZZ *p)
       p->prvn = (int16)nn;
     }
     scal =  *ampp * p->rsumr;
-    inc = (int32_t)(*cpsp * csound->sicvt);
+    inc = (int32_t)(*cpsp * CS_SICVT);
     ar = p->ar;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -188,7 +188,7 @@ int32_t gbuzz(CSOUND *csound, GBUZZ *p)
       if (p->ampcod)
         scal =  p->rsumr * ampp[n];
       if (p->cpscod)
-        inc = (int32_t)(cpsp[n] * csound->sicvt);
+        inc = (int32_t)(cpsp[n] * CS_SICVT);
       phs = lphs >>lobits;
       denom = p->rsqp1 - p->twor * ftbl[phs];
       num = ftbl[phs * k & lenmask]
@@ -653,7 +653,7 @@ int32_t randh(CSOUND *csound, RANDH *p)
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
-    inc = (int64_t)(*cpsp++ * csound->sicvt);
+    inc = (int64_t)(*cpsp++ * CS_SICVT);
     for (n=offset;n<nsmps;n++) {
       /* IV - Jul 11 2002 */
       ar[n] = base + p->num1 * *ampp;   /* rslt = num * amp */
@@ -661,7 +661,7 @@ int32_t randh(CSOUND *csound, RANDH *p)
         ampp++;
       phs += inc;                               /* phs += inc       */
       if (p->cpscod)
-        inc = (int64_t)(*cpsp++ * csound->sicvt);
+        inc = (int64_t)(*cpsp++ * CS_SICVT);
       if (phs >= MAXLEN) {                      /* when phs o'flows, */
         phs &= PHMASK;
         if (!p->new) {
@@ -780,7 +780,7 @@ int32_t randi(CSOUND *csound, RANDI *p)
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
-    inc = (int64_t)(*cpsp++ * csound->sicvt);
+    inc = (int64_t)(*cpsp++ * CS_SICVT);
     for (n=offset;n<nsmps;n++) {
       /* IV - Jul 11 2002 */
       ar[n] = base + (p->num1 + (MYFLT)phs * p->dfdmax) * *ampp;
@@ -788,7 +788,7 @@ int32_t randi(CSOUND *csound, RANDI *p)
         ampp++;
       phs += inc;                               /* phs += inc       */
       if (p->cpscod)
-        inc = (int64_t)(*cpsp++ * csound->sicvt);  /*   (nxt inc)      */
+        inc = (int64_t)(*cpsp++ * CS_SICVT);  /*   (nxt inc)      */
       if (phs >= MAXLEN) {                      /* when phs o'flows, */
         phs &= PHMASK;
         if (!p->new) {
@@ -935,7 +935,7 @@ int32_t randc(CSOUND *csound, RANDC *p)
     MYFLT a3         =   p->num2;
     cpsp = p->xcps;
     ampp = p->xamp;
-    inc = (int64_t)(*cpsp++ * csound->sicvt);
+    inc = (int64_t)(*cpsp++ * CS_SICVT);
     ar = p->ar;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -954,7 +954,7 @@ int32_t randc(CSOUND *csound, RANDC *p)
       phs += inc;
       //printf("mu = %g  phs, inc, MAXLEN = %ld, %ld, %d\n", mu, phs, inc, MAXLEN);
       if (p->cpscod)
-        inc = (int64_t)(*cpsp++ * csound->sicvt);  /*   (nxt inc)      */
+        inc = (int64_t)(*cpsp++ * CS_SICVT);  /*   (nxt inc)      */
       if (phs >= MAXLEN) {                      /* when phs o'flows, */
         phs &= PHMASK;
         if (!p->new) {

--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -226,7 +226,7 @@ int plukset(CSOUND *csound, PLUCK *p)
     MYFLT       *ap, *fp;
     MYFLT       phs, phsinc;
 
-    if (UNLIKELY((npts = (int32_t)(csound->esr / *p->icps)) < PLUKMIN)) {
+    if (UNLIKELY((npts = (int32_t)(CS_ESR / *p->icps)) < PLUKMIN)) {
                                         /* npts is wavelen in sampls */
       npts = PLUKMIN;                   /*  (but at least min size)  */
     }
@@ -252,7 +252,7 @@ int plukset(CSOUND *csound, PLUCK *p)
     *ap = *(MYFLT *)auxp;                       /* last = copy of 1st */
     p->npts = npts;
     /* tuned pitch convt */
-    p->sicps = (npts * FL(256.0) + FL(128.0)) * csound->onedsr;
+    p->sicps = (npts * FL(256.0) + FL(128.0)) * CS_ONEDSR;
     p->phs256 = 0;
     p->method = (int16)*p->imeth;
     p->param1 = *p->ipar1;

--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -69,7 +69,7 @@ int32_t tonset(CSOUND *csound, TONE *p)
 {
     double b;
     p->prvhp = (double)*p->khp;
-    b = 2.0 - cos((double)(p->prvhp * csound->tpidsr));
+    b = 2.0 - cos((double)(p->prvhp * CS_TPIDSR));
     p->c2 = b - sqrt(b * b - 1.0);
     p->c1 = 1.0 - p->c2;
 
@@ -110,7 +110,7 @@ int32_t tone(CSOUND *csound, TONE *p)
     if (*p->khp != (MYFLT)p->prvhp) {
       double b;
       p->prvhp = (double)*p->khp;
-      b = 2.0 - cos((double)(p->prvhp * csound->tpidsr));
+      b = 2.0 - cos((double)(p->prvhp * CS_TPIDSR));
       p->c2 = c2 = b - sqrt(b * b - 1.0);
       p->c1 = c1 = 1.0 - c2;
     }
@@ -134,7 +134,7 @@ int32_t tonsetx(CSOUND *csound, TONEX *p)
     {
       double b;
       p->prvhp = *p->khp;
-      b = 2.0 - cos((double)(*p->khp * csound->tpidsr));
+      b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
       p->c2 = b - sqrt(b * b - 1.0);
       p->c1 = 1.0 - p->c2;
     }
@@ -161,7 +161,7 @@ int32_t tonex(CSOUND *csound, TONEX *p)      /* From Gabriel Maldonado, modified
     if (*p->khp != p->prvhp) {
       double b;
       p->prvhp = (double)*p->khp;
-      b = 2.0 - cos(p->prvhp * (double)csound->tpidsr);
+      b = 2.0 - cos(p->prvhp * (double)CS_TPIDSR);
       p->c2 = b - sqrt(b * b - 1.0);
       p->c1 = 1.0 - p->c2;
     }
@@ -217,7 +217,7 @@ int32_t atone(CSOUND *csound, TONE *p)
     if (*p->khp != p->prvhp) {
       double b;
       p->prvhp = *p->khp;
-      b = 2.0 - cos((double)(*p->khp * csound->tpidsr));
+      b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
       p->c2 = c2 = b - sqrt(b * b - 1.0);
 /*      p->c1 = c1 = 1.0 - c2; */
     }
@@ -250,7 +250,7 @@ int32_t atonex(CSOUND *csound, TONEX *p)      /* Gabriel Maldonado, modified */
     if (*p->khp != p->prvhp) {
       double b;
       p->prvhp = *p->khp;
-      b = 2.0 - cos((double)(*p->khp * csound->tpidsr));
+      b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
       p->c2 = b - sqrt(b * b - 1.0);
       /*p->c1 = 1. - p->c2;*/
     }
@@ -354,7 +354,7 @@ int32_t reson(CSOUND *csound, RESON *p)
       MYFLT bw = asigw ? p->kbw[n] : *p->kbw;
       if (cf != (MYFLT)p->prvcf) {
         p->prvcf = (double)cf;
-        p->cosf = cos(cf * (double)(csound->tpidsr));
+        p->cosf = cos(cf * (double)(CS_TPIDSR));
         flag = 1;                 /* Mark as changed */
       }
       if (bw != (MYFLT)p->prvbw) {
@@ -438,7 +438,7 @@ int32_t resonx(CSOUND *csound, RESONX *p)   /* Gabriel Maldonado, modified  */
         MYFLT bw = asgw ? p->kbw[n] : *p->kbw;
         if (cf != (MYFLT)p->prvcf) {
           p->prvcf = (double)cf;
-          p->cosf = cos(cf * (double)(csound->tpidsr));
+          p->cosf = cos(cf * (double)(CS_TPIDSR));
           flag = 1;
         }
         if (bw != (MYFLT)p->prvbw) {
@@ -531,7 +531,7 @@ int32_t areson(CSOUND *csound, RESON *p)
 
     if (*p->kcf != (MYFLT)p->prvcf) {
       p->prvcf = (double)*p->kcf;
-      p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+      p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
       flag = 1;
     }
     if (*p->kbw != (MYFLT)p->prvbw) {
@@ -1210,7 +1210,7 @@ int32_t rmsset(CSOUND *csound, RMS *p)
 {
     double   b;
 
-    b = 2.0 - cos((double)(*p->ihp * csound->tpidsr));
+    b = 2.0 - cos((double)(*p->ihp * CS_TPIDSR));
     p->c2 = b - sqrt(b*b - 1.0);
     p->c1 = 1.0 - p->c2;
     if (!*p->istor)
@@ -1222,7 +1222,7 @@ int32_t gainset(CSOUND *csound, GAIN *p)
 {
     double   b;
 
-    b = 2.0 - cos((double)(*p->ihp * csound->tpidsr));
+    b = 2.0 - cos((double)(*p->ihp * CS_TPIDSR));
     p->c2 = b - sqrt(b*b - 1.0);
     p->c1 = 1.0 - p->c2;
     if (!*p->istor)
@@ -1234,7 +1234,7 @@ int32_t balnset(CSOUND *csound, BALANCE *p)
 {
     double   b;
 
-    b = 2.0 - cos((double)(*p->ihp * csound->tpidsr));
+    b = 2.0 - cos((double)(*p->ihp * CS_TPIDSR));
     p->c2 = b - sqrt(b*b - 1.0);
     p->c1 = 1.0 - p->c2;
     if (!*p->istor)

--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -641,7 +641,7 @@ int32_t lprdset_(CSOUND *csound, LPREAD *p, int32_t stringname)
         csound->Warning(csound, Str("lpheader overriding inputs"));
       }
       /* Check orc/analysis sample rate compatibility */
-      if (lph->srate != csound->esr) {
+      if (lph->srate != CS_ESR) {
         csound->Warning(csound, Str("lpfile srate != orch sr"));
       }
       p->npoles = lph->npoles;                /* note npoles, etc. */
@@ -962,7 +962,7 @@ int32_t lpformantset(CSOUND *csound, LPFORM *p)
 int32_t lpformant(CSOUND *csound, LPFORM *p)
 {
     LPREAD  *q = p->lpread;
-    MYFLT   *coefp, sr = csound->esr;
+    MYFLT   *coefp, sr = CS_ESR;
     MYFLT   *cfs = (MYFLT*)p->aux.auxp;
     MYFLT   *bws = cfs+p->lpread->npoles/2;
     int32_t i, j, ndx = *p->kfor;
@@ -1050,7 +1050,7 @@ int32_t lpreson(CSOUND *csound, LPRESON *p)
         pm = *coefp++;
         pp = *coefp++;
         /*       csound->Message(csound, "pole %d, fr=%.2f, BW=%.2f\n", i,
-                        pp*(csound->esr)/6.28, -csound->esr*log(pm)/3.14);
+                        pp*(CS_ESR)/6.28, -CS_ESR*log(pm)/3.14);
         */
         if (fabs(pm)>0.999999)
           pm = 1/pm;

--- a/OOps/ugens6.c
+++ b/OOps/ugens6.c
@@ -262,7 +262,7 @@ int32_t delset(CSOUND *csound, DELAY *p)
     if (UNLIKELY(*p->istor && p->auxch.auxp != NULL))
       return OK;
     /* Round not truncate */
-    if (UNLIKELY((npts = MYFLT2LRND(*p->idlt * csound->esr)) <= 0)) {
+    if (UNLIKELY((npts = MYFLT2LRND(*p->idlt * CS_ESR)) <= 0)) {
       return csound->InitError(csound, Str("illegal delay time"));
     }
 
@@ -304,7 +304,7 @@ int32_t delrset(CSOUND *csound, DELAYR *p)
     if (UNLIKELY(*p->istor != FL(0.0) && p->auxch.auxp != NULL))
       return OK;
     /* ksmps is min dely */
-    if (UNLIKELY((npts=(uint32_t)MYFLT2LRND(*p->idlt*csound->esr)) < CS_KSMPS)) {
+    if (UNLIKELY((npts=(uint32_t)MYFLT2LRND(*p->idlt*CS_ESR)) < CS_KSMPS)) {
       return csound->InitError(csound, Str("illegal delay time"));
     }
     if ((auxp = (MYFLT*)p->auxch.auxp) == NULL ||       /* new space if reqd */
@@ -474,7 +474,7 @@ int32_t deltap(CSOUND *csound, DELTAP *p)
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
-    tap = q->curp - MYFLT2LRND(*p->xdlt * csound->esr);
+    tap = q->curp - MYFLT2LRND(*p->xdlt * CS_ESR);
     while (tap < (MYFLT *) q->auxch.auxp)
       tap += q->npts;
     endp = (MYFLT *) q->auxch.endp;
@@ -510,7 +510,7 @@ int32_t deltapi(CSOUND *csound, DELTAP *p)
     endp = (MYFLT *) q->auxch.endp;
     if (!IS_ASIG_ARG(p->xdlt)) {
       if (*p->xdlt == INFINITY) goto err2;
-      delsmps = *p->xdlt * csound->esr;
+      delsmps = *p->xdlt * CS_ESR;
       idelsmps = (int32_t)delsmps;
       delfrac = delsmps - idelsmps;
       tap = q->curp - idelsmps;
@@ -528,7 +528,7 @@ int32_t deltapi(CSOUND *csound, DELTAP *p)
       MYFLT *timp = p->xdlt, *curq = q->curp;
       for (n=offset; n<nsmps; n++) {
         if (timp[n] == INFINITY) goto err2;
-        delsmps = timp[n] * csound->esr;
+        delsmps = timp[n] * CS_ESR;
         idelsmps = (int32_t)delsmps;
         delfrac = delsmps - idelsmps;
         tap = curq++ - idelsmps;
@@ -624,7 +624,7 @@ int32_t deltap3(CSOUND *csound, DELTAP *p)
     endp = (MYFLT *) q->auxch.endp;
     if (!IS_ASIG_ARG(p->xdlt)) {
       if (*p->xdlt == INFINITY) goto err2;
-      delsmps = *p->xdlt * csound->esr;
+      delsmps = *p->xdlt * CS_ESR;
       idelsmps = (int32_t)delsmps;
       delfrac = delsmps - idelsmps;
       tap = q->curp - idelsmps;
@@ -659,7 +659,7 @@ int32_t deltap3(CSOUND *csound, DELTAP *p)
       for (n=offset; n<nsmps; n++) {
         MYFLT ym1, y0, y1, y2;
         if (timp[n] == INFINITY) goto err2;
-        delsmps = *timp++ * csound->esr;
+        delsmps = *timp++ * CS_ESR;
         idelsmps = (int32_t)delsmps;
         delfrac = delsmps - idelsmps;
         if (UNLIKELY((tap = curq++ - idelsmps) < begp))
@@ -741,7 +741,7 @@ int32_t deltapx(CSOUND *csound, DELTAPX *p)                 /* deltapx opcode */
         /* x2: sine of x1 (for interpolation) */
         /* xpos: integer part of delay time (buffer position to read from) */
 
-        x1 = (double)indx - (double)*(del++) * (double)csound->esr;
+        x1 = (double)indx - (double)*(del++) * (double)CS_ESR;
         while (x1 < 0.0) x1 += (double)maxd;
         xpos = (int32_t)x1; x1 -= (double)xpos;
         while (xpos >= maxd) xpos -= maxd;
@@ -774,7 +774,7 @@ int32_t deltapx(CSOUND *csound, DELTAPX *p)                 /* deltapx opcode */
     else {                          /* window size = 4, cubic interpolation */
       double  x, am1, a0, a1, a2;
       for (n=offset; n<nsmps; n++) {
-        am1 = (double)indx - (double)*(del++) * (double)csound->esr;
+        am1 = (double)indx - (double)*(del++) * (double)CS_ESR;
         while (am1 < 0.0) am1 += (double)maxd;
         xpos = (int32_t) am1; am1 -= (double)xpos;
 
@@ -826,7 +826,7 @@ int32_t deltapxw(CSOUND *csound, DELTAPX *p)                /* deltapxw opcode *
         /* x2: sine of x1 (for interpolation) */
         /* xpos: integer part of delay time (buffer position to read from) */
 
-        x1 = (double)indx - (double)*(del++) * (double)csound->esr;
+        x1 = (double)indx - (double)*(del++) * (double)CS_ESR;
         while (x1 < 0.0) x1 += (double)maxd;
         xpos = (int32_t) x1; x1 -= (double)xpos;
         while (xpos >= maxd) xpos -= maxd;
@@ -858,7 +858,7 @@ int32_t deltapxw(CSOUND *csound, DELTAPX *p)                /* deltapxw opcode *
     else {                          /* window size = 4, cubic interpolation */
       double  x, am1, a0, a1, a2;
       for (n=offset; n<nsmps; n++) {
-        am1 = (double)indx - (double)*(del++) * (double)csound->esr;
+        am1 = (double)indx - (double)*(del++) * (double)CS_ESR;
         while (am1 < 0.0) am1 += (double)maxd;
         xpos = (int32_t) am1; am1 -= (double)xpos;
 
@@ -923,7 +923,7 @@ int32_t cmbset(CSOUND *csound, COMB *p)
         return csound->InitError(csound, Str("illegal loop time"));
       }
     }
-    else if (UNLIKELY((lpsiz = MYFLT2LRND(*p->ilpt * csound->esr)) <= 0)) {
+    else if (UNLIKELY((lpsiz = MYFLT2LRND(*p->ilpt * CS_ESR)) <= 0)) {
       return csound->InitError(csound, Str("illegal loop time"));
     }
     nbytes = lpsiz * sizeof(MYFLT);
@@ -991,7 +991,7 @@ int32_t comb(CSOUND *csound, COMB *p)
 
 int32_t invcomb(CSOUND *csound, COMB *p)
 {
-    int32_t n, nsmps = csound->ksmps;
+    int32_t n, nsmps = CS_KSMPS;
     MYFLT       *ar, *asig, *xp, *endp;
     MYFLT       coef = p->coef;
 
@@ -1068,26 +1068,24 @@ int32_t alpass(CSOUND *csound, COMB *p)
 static const MYFLT revlptimes[6] = {FL(0.0297), FL(0.0371), FL(0.0411),
                                     FL(0.0437), FL(0.0050), FL(0.0017)};
 
-void reverbinit(CSOUND *csound)         /* called once by oload */
-{                                       /*  to init reverb data */
+void reverbinit(CSOUND *csound, REVERB *p)       
+{                                     
     const MYFLT *lptimp = revlptimes;
-    int32_t     *lpsizp = csound->revlpsiz;
+    int32_t     *lpsizp = p->revlpsiza;
     int32_t n = 6;
-
-    if (csound->revlpsum==0) {
-      csound->revlpsum = 0;
-      for (n=0; n<6; n++) {
-        lpsizp[n] = MYFLT2LRND(lptimp[n] * csound->esr);
-        csound->revlpsum += lpsizp[n];
+    p->revlpsum = 0;
+    for (n=0; n<6; n++) {
+        lpsizp[n] = MYFLT2LRND(lptimp[n] * CS_ESR);
+        p->revlpsum += lpsizp[n];
       }
-    }
 }
 
 int32_t rvbset(CSOUND *csound, REVERB *p)
 {
     if (p->auxch.auxp == NULL) {                        /* if no space yet, */
-      int32      *sizp = csound->revlpsiz;               /*    allocate it   */
-      csound->AuxAlloc(csound, csound->revlpsum * sizeof(MYFLT), &p->auxch);
+      int32      *sizp = p->revlpsiza;               /*    allocate it   */
+      reverbinit(csound, p);
+      csound->AuxAlloc(csound, p->revlpsum * sizeof(MYFLT), &p->auxch);
       p->adr1 = p->p1 = (MYFLT *) p->auxch.auxp;
       p->adr2 = p->p2 = p->adr1 + *sizp++;
       p->adr3 = p->p3 = p->adr2 + *sizp++;              /*    & init ptrs   */
@@ -1100,7 +1098,7 @@ int32_t rvbset(CSOUND *csound, REVERB *p)
       p->prvt = FL(0.0);
     }
     else if (!(*p->istor)) {                    /* else if istor = 0 */
-      memset(p->adr1, '\0', csound->revlpsum * sizeof(MYFLT));
+      memset(p->adr1, '\0', p->revlpsum * sizeof(MYFLT));
       p->p1 = p->adr1;                          /*  and reset   */
       p->p2 = p->adr2;
       p->p3 = p->adr3;

--- a/OOps/ugrw1.c
+++ b/OOps/ugrw1.c
@@ -182,7 +182,7 @@ int32_t printkset(CSOUND *csound, PRINTK *p)
     if (*p->ptime < CS_ONEDKR)
       p->ctime = FL(0.0);
     else
-      p->ctime = *p->ptime * csound->ekr;
+      p->ctime = *p->ptime * CS_EKR;
 
     /* Set up the number of spaces.
        Limit to 120 for people with big screens or printers.
@@ -220,7 +220,7 @@ int32_t printk(CSOUND *csound, PRINTK *p)
       csound->MessageS(csound, CSOUNDMSG_ORCH, " i%4d ",
                                (int32_t)p->h.insdshead->p1.value);
       csound->MessageS(csound, CSOUNDMSG_ORCH, Str("time %11.5f: "),
-                               csound->icurTime/csound->esr-CS_ONEDKR);
+                               csound->icurTime/CS_ESR-CS_ONEDKR);
       /* Print spaces and then the value we want to read.   */
       if (p->pspace > 0L) {
         char  s[128];   /* p->pspace is limited to 120 in printkset() above */
@@ -255,7 +255,7 @@ int32_t printksset_(CSOUND *csound, PRINTKS *p, char *sarg)
     if (*p->ptime < CS_ONEDKR)
       p->ctime = CS_ONEDKR;
     else
-      p->ctime = *p->ptime * csound->ekr;
+      p->ctime = *p->ptime * CS_EKR;
     if(!p->h.insdshead->reinitflag)
        p->printat = CS_KCNT;
     memset(p->txtstring, 0, 8192);   /* This line from matt ingalls */

--- a/OOps/vdelay.c
+++ b/OOps/vdelay.c
@@ -31,8 +31,8 @@
 #include <math.h>
 #include "vdelay.h"
 
-//#define ESR     (csound->esr/FL(1000.0))
-#define ESR     (csound->esr*FL(0.001))
+//#define ESR     (CS_ESR/FL(1000.0))
+#define ESR     (CS_ESR*FL(0.001))
 
 int32_t vdelset(CSOUND *csound, VDEL *p)            /*  vdelay set-up   */
 {
@@ -260,7 +260,7 @@ int32_t vdelay3(CSOUND *csound, VDEL *p)    /*  vdelay routine with cubic interp
 
 int32_t vdelxset(CSOUND *csound, VDELX *p)      /*  vdelayx set-up (1 channel) */
 {
-    uint32_t n = (int32_t)(*p->imaxd * csound->esr);
+    uint32_t n = (int32_t)(*p->imaxd * CS_ESR);
 
     if (UNLIKELY(n == 0)) n = 1;          /* fix due to Troxler */
 
@@ -281,7 +281,7 @@ int32_t vdelxset(CSOUND *csound, VDELX *p)      /*  vdelayx set-up (1 channel) *
 
 int32_t vdelxsset(CSOUND *csound, VDELXS *p)    /*  vdelayxs set-up (stereo) */
 {
-    uint32_t n = (int32_t)(*p->imaxd * csound->esr);
+    uint32_t n = (int32_t)(*p->imaxd * CS_ESR);
 
     if (UNLIKELY(n == 0)) n = 1;          /* fix due to Troxler */
 
@@ -307,7 +307,7 @@ int32_t vdelxsset(CSOUND *csound, VDELXS *p)    /*  vdelayxs set-up (stereo) */
 
 int32_t vdelxqset(CSOUND *csound, VDELXQ *p) /* vdelayxq set-up (quad channels) */
 {
-    uint32_t n = (int32_t)(*p->imaxd * csound->esr);
+    uint32_t n = (int32_t)(*p->imaxd * CS_ESR);
 
     if (UNLIKELY(n == 0)) n = 1;          /* fix due to Troxler */
 
@@ -373,7 +373,7 @@ int32_t vdelayx(CSOUND *csound, VDELX *p)               /*      vdelayx routine 
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx - ((double)del[nn] * (double)csound->esr);
+      x1 = (double)indx - ((double)del[nn] * (double)CS_ESR);
       while (x1 < 0.0) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -441,7 +441,7 @@ int32_t vdelayxw(CSOUND *csound, VDELX *p)      /*      vdelayxw routine  */
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx + ((double)del[nn] * (double)csound->esr);
+      x1 = (double)indx + ((double)del[nn] * (double)CS_ESR);
       while (x1 < 0.0) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -520,7 +520,7 @@ int32_t vdelayxs(CSOUND *csound, VDELXS *p)     /*      vdelayxs routine  */
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx - ((double)del[n] * (double)csound->esr);
+      x1 = (double)indx - ((double)del[n] * (double)CS_ESR);
       while (UNLIKELY(x1 < 0.0)) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -595,7 +595,7 @@ int32_t vdelayxws(CSOUND *csound, VDELXS *p)    /*      vdelayxws routine  */
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx + ((double)del[n] * (double)csound->esr);
+      x1 = (double)indx + ((double)del[n] * (double)CS_ESR);
       while (UNLIKELY(x1 < 0.0)) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -688,7 +688,7 @@ int32_t vdelayxq(CSOUND *csound, VDELXQ *p)     /*      vdelayxq routine  */
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx - ((double)*del++ * (double)csound->esr);
+      x1 = (double)indx - ((double)*del++ * (double)CS_ESR);
       while (UNLIKELY(x1 < 0.0)) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -779,7 +779,7 @@ int32_t vdelayxwq(CSOUND *csound, VDELXQ *p)    /*      vdelayxwq routine  */
       /* x2: sine of x1 (for interpolation) */
       /* xpos: integer part of delay time (buffer position to read from) */
 
-      x1 = (double)indx + ((double)del[n] * (double)csound->esr);
+      x1 = (double)indx + ((double)del[n] * (double)CS_ESR);
       while (UNLIKELY(x1 < 0.0)) x1 += (double)maxd;
       xpos = (int32_t)x1;
       x1 -= (double)xpos;
@@ -838,7 +838,7 @@ int32_t multitap_set(CSOUND *csound, MDEL *p)
       if (max < *p->ndel[i]) max = *p->ndel[i];
     }
 
-    n = (uint32_t)(csound->esr * max * sizeof(MYFLT));
+    n = (uint32_t)(CS_ESR * max * sizeof(MYFLT));
     if (p->aux.auxp == NULL ||    /* allocate space for delay buffer */
         n > p->aux.size)
       csound->AuxAlloc(csound, n, &p->aux);
@@ -847,7 +847,7 @@ int32_t multitap_set(CSOUND *csound, MDEL *p)
     }
 
     p->left = 0;
-    p->max = (int32_t)(csound->esr * max);
+    p->max = (int32_t)(CS_ESR * max);
     return OK;
 }
 
@@ -873,7 +873,7 @@ int32_t multitap_play(CSOUND *csound, MDEL *p)
 
       if (UNLIKELY(++indx == max)) indx = 0;   /*      Advance input pointer   */
       for (i = 0; i < p->INOCOUNT - 1; i += 2) {
-        delay = indx - (int32_t)(csound->esr * *p->ndel[i]);
+        delay = indx - (int32_t)(CS_ESR * *p->ndel[i]);
         if (UNLIKELY(delay < 0))
           delay += (int32_t)max;
         v += buf[delay] * *p->ndel[i+1]; /*      Write output    */
@@ -1084,7 +1084,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
           c_time = (int32_t) -ftime;
         else {
           /* convert from to seconds to samples, and make prime */
-          c_time = (int32_t) (ftime * csound->esr);
+          c_time = (int32_t) (ftime * CS_ESR);
           /* Mangle sample number to primes. */
           if (c_time % 2 == 0)
             c_time += 1;
@@ -1094,7 +1094,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
         p->c_time[i] = (MYFLT) c_time;
         n += c_time;
         p->c_gain[i] = (MYFLT) exp((double)(LOG001 * (p->c_time[i]
-                                                       * csound->onedsr)
+                                                       * CS_ONEDSR)
                                              / (p->c_orggains[i] * *p->time)));
         p->g[i] = *p->hdif;
         p->c_gain[i] = p->c_gain[i] * (FL(1.0) - p->g[i]);
@@ -1109,7 +1109,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
       for (i = 0; i < p->numCombs; i++) {
         p->pcbuf_cur[i + 1] = p->cbuf_cur[i + 1] =
           p->cbuf_cur[i] + (int32_t) p->c_time[i];
-        p->c_time[i] *= csound->onedsr; /* Scale to save division in reverbx */
+        p->c_time[i] *= CS_ONEDSR; /* Scale to save division in reverbx */
       }
       n = 0;
       for (i = 0; i < p->numAlpas; i++) {
@@ -1118,7 +1118,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
           a_time = (int32_t) -ftime;
         else {
           /* convert seconds to samples and make prime */
-          a_time = (int32_t) (ftime * csound->esr);
+          a_time = (int32_t) (ftime * CS_ESR);
           if (a_time % 2 == 0)
             a_time += 1;
           while (!prime(a_time))
@@ -1126,7 +1126,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
         }
         p->a_time[i] = (MYFLT) a_time;
         p->a_gain[i] = (MYFLT) exp((double)(LOG001 * (p->a_time[i]
-                                                       * csound->onedsr)
+                                                       * CS_ONEDSR)
                                              / (p->a_orggains[i] * *p->time)));
         n += a_time;
       }
@@ -1139,7 +1139,7 @@ int32_t reverbx_set(CSOUND *csound, NREV2 *p)
       for (i = 0; i < p->numAlpas; i++) {
         p->pabuf_cur[i + 1] = p->abuf_cur[i + 1] =
           p->abuf_cur[i] + (int32_t) p->a_time[i];
-        p->a_time[i] *= csound->onedsr; /* Scale to save division in reverbx */
+        p->a_time[i] *= CS_ONEDSR; /* Scale to save division in reverbx */
       }
     }
 

--- a/Opcodes/Vosim.c
+++ b/Opcodes/Vosim.c
@@ -101,7 +101,7 @@ void vosim_event(CSOUND* csound, VOSIM *p)
                           *p->kfund);
         }
     }
-    p->pulseinc = (int32)(*p->kform * csound->sicvt);
+    p->pulseinc = (int32)(*p->kform * CS_SICVT);
     p->pulsephs = (p->pulseinc >= 0)? MAXLEN : -1;   /* starts a new pulse */
     p->ampdecay = *p->kdamp;
     /* increase initial amp, since it's reduced at pulse start */

--- a/Opcodes/afilters.c
+++ b/Opcodes/afilters.c
@@ -51,12 +51,12 @@ static int32_t aresonaa(CSOUND *csound, RESON *p)
         double ans;
         if (p->kcf[n] != (MYFLT)p->prvcf) {
           p->prvcf = (double)p->kcf[n];
-          p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+          p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
           flag = 1;
         }
         if (p->kbw[n] != (MYFLT)p->prvbw) {
           p->prvbw = (double)p->kbw[n];
-          p->c3 = exp(p->prvbw * (double)(csound->mtpdsr));
+          p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
           flag = 1;
         }
         if (flag) {
@@ -83,12 +83,12 @@ static int32_t aresonaa(CSOUND *csound, RESON *p)
         double ans;
         if (p->kcf[n] != (MYFLT)p->prvcf) {
           p->prvcf = (double)p->kcf[n];
-          p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+          p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
           flag = 1;
         }
         if (p->kbw[n] != (MYFLT)p->prvbw) {
           p->prvbw = (double)p->kbw[n];
-          p->c3 = exp(p->prvbw * (double)(csound->mtpdsr));
+          p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
           flag = 1;
         }
         if (flag) {
@@ -125,7 +125,7 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
 
     if (*p->kbw != (MYFLT)p->prvbw) {
       p->prvbw = (double)*p->kbw;
-      p->c3 = exp(p->prvbw * (double)(csound->mtpdsr));
+      p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
       c3p1 = p->c3 + 1.0;
       c3t4 = p->c3 * 4.0;
       omc3 = 1.0 - p->c3;
@@ -151,7 +151,7 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
         double ans;
         if (p->kcf[n] != (MYFLT)p->prvcf) {
           p->prvcf = (double)p->kcf[n];
-          p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+          p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
           c3p1 = p->c3 + 1.0;
           c3t4 = p->c3 * 4.0;
           omc3 = 1.0 - p->c3;
@@ -175,7 +175,7 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
         double ans;
         if (p->kcf[n] != (MYFLT)p->prvcf) {
           p->prvcf = (double)p->kcf[n];
-          p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+          p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
           c3p1 = p->c3 + 1.0;
           c3t4 = p->c3 * 4.0;
           omc3 = 1.0 - p->c3;
@@ -209,7 +209,7 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
 
     if (*p->kcf != (MYFLT)p->prvcf) {
       p->prvcf = (double)*p->kcf;
-      p->cosf = cos(p->prvcf * (double)(csound->tpidsr));
+      p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
       c3p1 = p->c3 + 1.0;
       c3t4 = p->c3 * 4.0;
       omc3 = 1.0 - p->c3;
@@ -235,7 +235,7 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
         double ans;
         if (p->kbw[n] != (MYFLT)p->prvbw) {
           p->prvbw = (double)p->kbw[n];
-          p->c3 = exp(p->prvbw * (double)(csound->mtpdsr));
+          p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
           c3p1 = p->c3 + 1.0;
           c3t4 = p->c3 * 4.0;
           omc3 = 1.0 - p->c3;
@@ -259,7 +259,7 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
         double ans;
         if (p->kbw[n] != (MYFLT)p->prvbw) {
           p->prvbw = (double)p->kbw[n];
-          p->c3 = exp(p->prvbw * (double)(csound->mtpdsr));
+          p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
           c3p1 = p->c3 + 1.0;
           c3t4 = p->c3 * 4.0;
           omc3 = 1.0 - p->c3;
@@ -305,7 +305,7 @@ static int32_t atonea(CSOUND *csound, TONE *p)
       if (p->khp[n] != p->prvhp) {
         double b;
         p->prvhp = p->khp[n];
-        b = 2.0 - cos((double)(p->khp[n] * csound->tpidsr));
+        b = 2.0 - cos((double)(p->khp[n] * CS_TPIDSR));
         p->c2 = c2 = b - sqrt(b * b - 1.0);
         /*      p->c1 = c1 = 1.0 - c2; */
       }
@@ -338,7 +338,7 @@ static int32_t tonea(CSOUND *csound, TONE *p)
       if (p->khp[n] != prvhp) {
         double b;
         prvhp = (double)p->khp[n];
-        b = 2.0 - cos((double)(prvhp * csound->tpidsr));
+        b = 2.0 - cos((double)(prvhp * CS_TPIDSR));
         c2 = b - sqrt(b * b - 1.0);
         c1 = 1.0 - c2;
       }
@@ -374,7 +374,7 @@ static int32_t tonexa(CSOUND *csound, TONEX *p) /* From G Maldonado, modified */
         if (p->khp[n] != p->prvhp) {
           double b;
           p->prvhp = (double)p->khp[n];
-          b = 2.0 - cos(p->prvhp * (double)csound->tpidsr);
+          b = 2.0 - cos(p->prvhp * (double)CS_TPIDSR);
           p->c2 = b - sqrt(b * b - 1.0);
           p->c1 = 1.0 - p->c2;
         }
@@ -409,7 +409,7 @@ static int32_t atonexa(CSOUND *csound, TONEX *p) /* Gabriel Maldonado, modified 
         if (p->khp[n] != prvhp) {
           double b;
           prvhp = p->khp[n];
-          b = 2.0 - cos((double)(p->prvhp * csound->tpidsr));
+          b = 2.0 - cos((double)(p->prvhp * CS_TPIDSR));
           c2 = b - sqrt(b * b - 1.0);
         }
         x = c2 * (yt1[j] + sig);
@@ -479,7 +479,7 @@ static int32_t hibuta(CSOUND *csound, BFIL *p) /*      Hipass filter       */
 
     /* if (p->afc[0] != p->lkf)      { */
     /*   p->lkf = p->afc[0]; */
-    /*   c = tan((double)(csound->pidsr * p->lkf)); */
+    /*   c = tan((double)(CS_PIDSR * p->lkf)); */
 
     /*   a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c); */
     /*   a[2] = -(a[1] + a[1]); */
@@ -491,7 +491,7 @@ static int32_t hibuta(CSOUND *csound, BFIL *p) /*      Hipass filter       */
       if (p->afc[nn] != p->lkf)      {
         double c;
         p->lkf = p->afc[nn];
-        c = tan((double)(csound->pidsr * p->lkf));
+        c = tan((double)(CS_PIDSR * p->lkf));
 
         a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c);
         a[2] = -(a[1] + a[1]);
@@ -535,7 +535,7 @@ static int32_t lobuta(CSOUND *csound, BFIL *p)       /*      Lopass filter      
 
     /* if (p->afc[0] != p->lkf)      { */
     /*   p->lkf = p->afc[0]; */
-    /*   c = 1.0 / tan((double)(csound->pidsr * p->lkf)); */
+    /*   c = 1.0 / tan((double)(CS_PIDSR * p->lkf)); */
     /*   a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c); */
     /*   a[2] = a[1] + a[1]; */
     /*   a[3] = a[1]; */
@@ -547,7 +547,7 @@ static int32_t lobuta(CSOUND *csound, BFIL *p)       /*      Lopass filter      
       if (p->afc[nn] != p->lkf) {
         double c;
         p->lkf = p->afc[nn];
-        c = 1.0 / tan((double)(csound->pidsr * p->lkf));
+        c = 1.0 / tan((double)(CS_PIDSR * p->lkf));
         a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c);
         a[2] = a[1] + a[1];
         a[3] = a[1];
@@ -589,8 +589,8 @@ static int32_t bppasxx(CSOUND *csound, BBFIL *p)      /*      Bandpass filter   
     /* if (p->kbw[0] != p->lkb || p->kfo[0] != p->lkf) { */
     /*   p->lkf = p->kfo[0]; */
     /*   p->lkb = p->kbw[0]; */
-    /*   c = 1.0 / tan((double)(csound->pidsr * p->lkb)); */
-    /*   d = 2.0 * cos((double)(csound->tpidsr * p->lkf)); */
+    /*   c = 1.0 / tan((double)(CS_PIDSR * p->lkb)); */
+    /*   d = 2.0 * cos((double)(CS_TPIDSR * p->lkf)); */
     /*   a[1] = 1.0 / (1.0 + c); */
     /*   a[2] = 0.0; */
     /*   a[3] = -a[1]; */
@@ -606,8 +606,8 @@ static int32_t bppasxx(CSOUND *csound, BBFIL *p)      /*      Bandpass filter   
         double c, d;
         p->lkf = fr;
         p->lkb = bw;
-        c = 1.0 / tan((double)(csound->pidsr * bw));
-        d = 2.0 * cos((double)(csound->tpidsr * fr));
+        c = 1.0 / tan((double)(CS_PIDSR * bw));
+        d = 2.0 * cos((double)(CS_TPIDSR * fr));
         a[1] = 1.0 / (1.0 + c);
         a[2] = 0.0;
         a[3] = -a[1];
@@ -657,8 +657,8 @@ static int32_t bpcutxx(CSOUND *csound, BBFIL *p)      /*      Band reject filter
         double c, d;
         p->lkf = fr;
         p->lkb = bw;
-        c = tan((double)(csound->pidsr * bw));
-        d = 2.0 * cos((double)(csound->tpidsr * fr));
+        c = tan((double)(CS_PIDSR * bw));
+        d = 2.0 * cos((double)(CS_TPIDSR * fr));
         a[1] = 1.0 / (1.0 + c);
         a[2] = - d * a[1];
         a[3] = a[1];

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -4423,7 +4423,7 @@ int32_t mfb(CSOUND *csound, MFB *p) {
     MYFLT sum = FL(0.0);
     MYFLT *out = p->out->data;
     MYFLT *in = p->in->data;
-    MYFLT sr = csound->GetSr(csound);
+    MYFLT sr = CS_ESR;
 
     start = f2mel(*p->low);
     end = f2mel(*p->up);
@@ -4478,7 +4478,7 @@ int32_t array_centroid(CSOUND *csound, CENTR *p) {
 
     MYFLT *in = p->in->data,a=FL(0.0),b=FL(0.0);
     int32_t NP1 = p->in->sizes[0];
-    MYFLT f = csound->GetSr(csound)/(2*(NP1 - 1)),cf;
+    MYFLT f = CS_ESR/(2*(NP1 - 1)),cf;
     int32_t i;
     cf = f*FL(0.5);
     for (i=0; i < NP1-1; i++, cf+=f) {
@@ -4590,7 +4590,7 @@ static int32 taninv2_Aa(CSOUND* csound, TABARITH* p)
     k = 0;
     for (i=0; i<ans->dimensions; i++) {
       for (j=0; j<aa->sizes[i]; j++)
-        for (m=0; m<csound->ksmps; m++) {
+        for (m=0; m<CS_KSMPS; m++) {
           ans->data[k] = ATAN2(aa->data[k], bb->data[k]);
           k++;
         }

--- a/Opcodes/babo.c
+++ b/Opcodes/babo.c
@@ -260,7 +260,7 @@ BaboTapline_create(CSOUND *csound, BaboTapline *this, MYFLT x, MYFLT y, MYFLT z)
 static inline MYFLT
 BaboTapline_maxtime(CSOUND *csound, BaboDelay *this)
 {
-    return (((MYFLT) BaboMemory_samples(&this->core)) * csound->onedsr);
+  return (((MYFLT) BaboMemory_samples(&this->core)) * (1./this->sr));
 }
 
 static inline MYFLT

--- a/Opcodes/babo.c
+++ b/Opcodes/babo.c
@@ -194,7 +194,7 @@ static void
 _Babo_common_delay_create(CSOUND *csound, BaboDelay *this, MYFLT max_time)
 {
     size_t num_floats =
-      (size_t)MYFLT2LRND((MYFLT)ceil((double)(max_time*CS_ESR)));
+      (size_t)MYFLT2LRND((MYFLT)ceil((double)(max_time*this->sr)));
 
     BaboMemory_create(csound, &this->core, num_floats);
 }
@@ -273,6 +273,7 @@ typedef struct
 {
     MYFLT   attenuation;
     MYFLT   delay_size;
+    MYFLT   sr;
 } BaboTapParameter;
 
 typedef struct
@@ -329,7 +330,7 @@ static inline void BaboTapline_preload_parameter(CSOUND *csound,
      *          direct_att=(1/2) when distance is 1 m
      *          direct_att=1     when distance is 0 m.
      */
-    this->delay_size    = (distance / sound_speed) * CS_ESR;
+    this->delay_size    = (distance / sound_speed) * this->sr;
     this->attenuation   = FL(1.0) / (FL(1.0) + distance);
 }
 
@@ -772,10 +773,11 @@ static int32_t
 baboset(CSOUND *csound, void *entry)
 {
     BABO *p = (BABO *) entry;   /* assuming the engine is right... :)   */
-
+    p->tapline.sr = CS_ESR;
+    p->matrix_delay.sr = CS_ESR;
     set_defaults(csound,p);
     verify_coherence(csound,p);        /* exits if call is wrong */
-
+    
     BaboTapline_create(csound,&p->tapline, *(p->lx), *(p->ly), *(p->lz));
     BaboDelay_create(csound, &p->matrix_delay,
                      BaboTapline_maxtime(csound, &p->tapline));
@@ -845,6 +847,14 @@ babo(CSOUND *csound, void *entry)
     return OK;
 }
 
+/*
+typedef struct
+{
+    BaboTapParameter    direct;
+    BaboTapParameter    tap[BABO_TAPS];
+} BaboTaplineParameters;
+*/
+
 static int32_t
 babo2(CSOUND *csound, void *entry)
 {
@@ -855,9 +865,14 @@ babo2(CSOUND *csound, void *entry)
     MYFLT   *outleft    = p->outleft,
             *outright   = p->outright,
             *input      = p->input;
+    int i;
 
     BaboTaplineParameters left = { {FL(0.0)}, {{FL(0.0)}} },
                           right = { {FL(0.0)}, {{FL(0.0)}} };
+    left.direct.sr = CS_ESR;
+    right.direct.sr = CS_ESR;
+    for(i = 0; i < BABO_TAPS; i++)
+      left.tap[i].sr = right.tap[i].sr = CS_ESR;
 
     BaboTapline_precalculate_parameters(csound, &left,
                                         p->receiver_x - p->inter_receiver_distance,

--- a/Opcodes/babo.h
+++ b/Opcodes/babo.h
@@ -51,6 +51,7 @@ typedef struct
 {
     BaboMemory   core;
     MYFLT       *input;
+    MYFLT         sr;
 } BaboDelay;
 
 typedef BaboDelay BaboTapline;

--- a/Opcodes/bformdec2.cpp
+++ b/Opcodes/bformdec2.cpp
@@ -156,7 +156,7 @@ class hrtf {
   hrtf() {}
   virtual ~hrtf() {}
   virtual void init(void) = 0;
-  virtual int32_t hrtfstat_init(CSOUND *csound, MYFLT elev, MYFLT angle, MYFLT radius, STRINGDAT *filel, STRINGDAT *filer) = 0;
+  virtual int32_t hrtfstat_init(CSOUND *csound, MYFLT elev, MYFLT angle, MYFLT radius, STRINGDAT *filel, STRINGDAT *filer, MYFLT srxl) = 0;
   virtual int32_t hrtfstat_process(CSOUND *csound, MYFLT *in, MYFLT *outsigl, MYFLT *outsigr, uint32_t offset, uint32_t early, uint32_t nsmps) = 0;
 };
 
@@ -206,7 +206,9 @@ public:
   }
 
   /* HRTF functions (adapted from csound/Opcodes/hrtfopcodes.c) */
-  virtual int32_t hrtfstat_init(CSOUND *csound, MYFLT elev, MYFLT angle, MYFLT r, STRINGDAT *ifilel, STRINGDAT *ifiler)
+  virtual int32_t hrtfstat_init(CSOUND *csound,
+                                MYFLT elev, MYFLT angle, MYFLT r, STRINGDAT *ifilel, STRINGDAT *ifiler,
+                                MYFLT sr)
   {
       /* left and right data files: spectral mag, phase format. */
 
@@ -263,7 +265,7 @@ public:
 
       /* sr */
 
-      sr_p = csound->GetSr(csound);
+      sr_p = sr;
 
       //char filel[MAXNAME] = "hrtf-44100-left.dat"; //../hrtf/
       //char filer[MAXNAME] = "hrtf-44100-right.dat";
@@ -271,7 +273,7 @@ public:
       if (sr_p != FL(44100.0) && sr_p != FL(48000.0) && sr_p != FL(96000.0))
         sr_p = FL(44100.0);
 
-      if (UNLIKELY(csound->GetSr(csound) != sr_p))
+      if (UNLIKELY(sr != sr_p))
         csound->Message(csound,
                         Str("\n\nWARNING!!:\nOrchestra SR not compatible with "
                             "HRTF processing SR of: %.0f\n\n"), sr_p);
@@ -884,7 +886,7 @@ typedef struct FCOMPLEX {double r,i;} fcomplex;
 
 static double readFilter(HOAMBDEC*, int32_t, int);
 static void insertFilter(HOAMBDEC*,double, int);
-static void process_nfc(CSOUND*,HOAMBDEC*, int, int, int, int, int);
+static void process_nfc(CSOUND*,HOAMBDEC*, int, int, int, int, int, int);
 
 #ifndef MAX
 #define MAX(a,b) ((a>b)?(a):(b))
@@ -1002,7 +1004,7 @@ static int32_t ihoambdec(CSOUND *csound, HOAMBDEC* p)
     }
 
 
-    double k = tan(freq * PI / csound->GetSr(csound));
+    double k = tan(freq * PI / CS_ESR);
     double k2 = (k*k + 2*k + 1);
 
     double b0_lf = k*k/k2; //b0
@@ -1668,7 +1670,7 @@ static int32_t ihoambdec(CSOUND *csound, HOAMBDEC* p)
           csound->AuxAlloc(csound, sizeof(hrtf_c), &p->binaural_mem[j]);
         p->binaural[j] = new (p->binaural_mem[j].auxp) hrtf_c;
 
-        p->binaural[j]->hrtfstat_init(csound, elev, angle[j], r, p->ifilel, p->ifiler);
+        p->binaural[j]->hrtfstat_init(csound, elev, angle[j], r, p->ifilel, p->ifiler, CS_ESR);
       }
     }
 
@@ -1687,7 +1689,7 @@ static int32_t ihoambdec(CSOUND *csound, HOAMBDEC* p)
         if (p->binaural_mem[j].auxp == NULL)
           csound->AuxAlloc(csound, sizeof(hrtf_c), &p->binaural_mem[j]);
         p->binaural[j] = new (p->binaural_mem[j].auxp) hrtf_c;
-        p->binaural[j]->hrtfstat_init(csound, elev[j], angle[j], r, p->ifilel, p->ifiler);
+        p->binaural[j]->hrtfstat_init(csound, elev[j], angle[j], r, p->ifilel, p->ifiler, CS_ESR);
       }
     }
 
@@ -1722,7 +1724,7 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
     int j;
     //char buffer [50];
     //int n1;
-    int ksmps = csound->GetKsmps(csound);
+    int ksmps = CS_KSMPS;
     int n_outs = p->out->sizes[0];
 
     //int n_ins = p->in->sizes[0];
@@ -1811,7 +1813,7 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
 
         if (signal_order != 0) {
           if ((int)*(p->r)!=-1)
-            process_nfc(csound,p,signal_order,n,j,in_ix,csound->GetSr(csound));
+            process_nfc(csound,p,signal_order,n,j,in_ix,CS_ESR,CS_KSMPS);
         }
 
         // band splitting
@@ -1931,9 +1933,9 @@ static void insertFilter(HOAMBDEC* p, double val, int j)
  * This code was adapted from The Ambisonic Decoder Toolbox
  *
  */
-static void process_nfc(CSOUND *csound, HOAMBDEC* p, int signal_order, int n, int j, int in_ix, int sr)
+static void process_nfc(CSOUND *csound, HOAMBDEC* p, int signal_order, int n, int j, int in_ix, int sr,
+                        int ksmps)
 {
-    int ksmps = csound->GetKsmps(csound);
     //char buffer[50];
 
     double d; // meters

--- a/Opcodes/bilbar.c
+++ b/Opcodes/bilbar.c
@@ -53,7 +53,7 @@ static int32_t bar_init(CSOUND *csound, BAR *p)
                                    (keep small) */
 
       /* %%%%%%%%%%%%%%%%%% derived parameters */
-      double  dt = (double)csound->onedsr;
+      double  dt = (double)CS_ONEDSR;
       double  sig = (2.0*(double)CS_ESR)*(pow(10.0,3.0*dt/T30)-1.0);
       double  dxmin = sqrt(dt*(b+hypot(b, K+K)));
       int32_t N = (int32_t) (1.0/dxmin);
@@ -268,7 +268,7 @@ int32_t init_pp(CSOUND *csound, CSPP *p)
                           /* and lowest string in set */
                           /* initialize prepared objects and hammer */
                           /* derived parameters */
-      double dt = (double)csound->onedsr;
+      double dt = (double)CS_ONEDSR;
       double sig = (2.0*(double)CS_ESR)*(pow(10.0,3.0*dt/T30)-1.0);
 
       uint32_t N, n;
@@ -360,7 +360,7 @@ int32_t play_pp(CSOUND *csound, CSPP *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t t, n, nsmps = CS_KSMPS;
-    double dt = csound->onedsr;
+    double dt = CS_ONEDSR;
     MYFLT *w = p->w, *w1 = p->w1, *w2 = p->w2,
           *rub = p->rub, *rub1 = p->rub1, *rub2 = p->rub2,
           *rat = p->rat, *rat1 = p->rat1, *rat2 = p->rat2;

--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -633,7 +633,7 @@ static int32_t vco(CSOUND *csound, VCO *p)
     /* End of VDelay insert */
 
     ftbl = ftp->ftable;
-    sicvt2 = csound->sicvt * FL(0.5);  /* for theta/2 */
+    sicvt2 = CS_SICVT * FL(0.5);  /* for theta/2 */
     lobits = ftp->lobits;
     lenmask = ftp->lenmask;
     ampp = p->xamp;

--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -923,7 +923,7 @@ static int32_t pareq(CSOUND *csound, PAREQ *p)
     uint32_t n, nsmps = CS_KSMPS;
 
     if (*p->fc != p->prv_fc || *p->v != p->prv_v || *p->q != p->prv_q) {
-      double omega = (double)(csound->tpidsr * *p->fc), k, kk, vkk, vk, vkdq, a0;
+      double omega = (double)(CS_TPIDSR * *p->fc), k, kk, vkk, vk, vkdq, a0;
       p->prv_fc = *p->fc; p->prv_v = *p->v; p->prv_q = *p->q;
       switch (p->imode) {
         /* Low Shelf */
@@ -1390,7 +1390,7 @@ static int32_t bqrez(CSOUND *csound, REZZY *p)
     rez    = (double)*rezptr;
 
     if ((p->rezcod == 0) && (p->fcocod == 0)) {
-      theta = fco * (double)csound->tpidsr;
+      theta = fco * (double)CS_TPIDSR;
       sin2 = sin(theta) * 0.5;
       cos2 = cos(theta);
       beta = (rez - sin2) / (rez + sin2);
@@ -1430,7 +1430,7 @@ static int32_t bqrez(CSOUND *csound, REZZY *p)
           rez = (double)rezptr[n];
         }
         if ((p->rezcod == 1) || (p->fcocod == 1)) {
-          theta = fco * (double) csound->tpidsr;
+          theta = fco * (double) CS_TPIDSR;
           sin2 = sin(theta) * 0.5;
           cos2 = cos(theta);
           beta = (rez - sin2) / (rez + sin2);
@@ -1459,7 +1459,7 @@ static int32_t bqrez(CSOUND *csound, REZZY *p)
           rez = (double)rezptr[n];
         }
         if ((p->rezcod == 1) || (p->fcocod == 1)) {
-          theta = fco * (double) csound->tpidsr;
+          theta = fco * (double) CS_TPIDSR;
           sin2  = sin(theta) * 0.5;
           cos2  = cos(theta);
           beta  = (rez - sin2) / (rez + sin2);
@@ -1487,7 +1487,7 @@ static int32_t bqrez(CSOUND *csound, REZZY *p)
           rez = (double)rezptr[n];
         }
         if ((p->rezcod == 1) || (p->fcocod == 1)) {
-          theta = fco * (double) csound->tpidsr;
+          theta = fco * (double) CS_TPIDSR;
           sin2 = sin(theta) * 0.5;
           cos2 = cos(theta);
           beta = (rez - sin2) / (rez + sin2);

--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -159,7 +159,7 @@ static int32_t moogvcf(CSOUND *csound, MOOGVCF *p)
   /* Only need to calculate once */
     if (UNLIKELY((p->rezcod==0) && (p->fcocod==0))) {
       double fcon;
-      fcon  = 2.0*fco*(double)csound->onedsr; /* normalised freq. 0 to Nyquist */
+      fcon  = 2.0*fco*(double)CS_ONEDSR; /* normalised freq. 0 to Nyquist */
       kp    = 3.6*fcon-1.6*fcon*fcon-1.0;     /* Emperical tuning   */
       pp1d2 = (kp+1.0)*0.5;                   /* Timesaver          */
       scale = exp((1.0-pp1d2)*1.386249);      /* Scaling factor     */
@@ -180,7 +180,7 @@ static int32_t moogvcf(CSOUND *csound, MOOGVCF *p)
       }
       if ((p->rezcod!=0) || (p->fcocod!=0)) {
         double fcon;
-        fcon  = 2.0*fco*(double)csound->onedsr; /* normalised frq. 0 to Nyquist */
+        fcon  = 2.0*fco*(double)CS_ONEDSR; /* normalised frq. 0 to Nyquist */
         kp    = 3.6*fcon-1.6*fcon*fcon-1.0;     /* Emperical tuning */
         pp1d2 = (kp+1.0)*0.5;                   /* Timesaver */
         scale = exp((1.0-pp1d2)*1.386249);      /* Scaling factor */
@@ -1323,7 +1323,7 @@ static int32_t tbvcf(CSOUND *csound, TBVCF *p)
       q1   = res/(1.0 + sqrt(dist));
       fco1 = pow(fco*260.0/(1.0+q1*0.5),0.58);
       q    = q1*fco1*fco1*0.0005;
-      fc   = fco1*(double)csound->onedsr*(44100.0/8.0);
+      fc   = fco1*(double)CS_ONEDSR*(44100.0/8.0);
     }
     if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -1342,7 +1342,7 @@ static int32_t tbvcf(CSOUND *csound, TBVCF *p)
         q1  = res/(1.0 + sqrt(dist));
         fco1 = pow(fco*260.0/(1.0+q1*0.5),0.58);
         q  = q1*fco1*fco1*0.0005;
-        fc  = fco1*(double)csound->onedsr*(44100.0/8.0);
+        fc  = fco1*(double)CS_ONEDSR*(44100.0/8.0);
       }
       x  = (double)in[n];
       fdbk = q*y/(1.0 + exp(-3.0*y)*asym);
@@ -1524,7 +1524,7 @@ static int32_t bqrez(CSOUND *csound, REZZY *p)
     }
     p->lfq = -FL(1.0); p->lq = -FL(1.0);
     /* set a limit below theoretical sr/pi */
-    p->limit = csound->GetSr(csound)*(FL(1.0)/PI_F-FL(1.0)/FL(100.0));
+    p->limit = CS_ESR*(FL(1.0)/PI_F-FL(1.0)/FL(100.0));
     //printf("*** limit = %lf\n", p->limit);
     return OK;
 }
@@ -1603,7 +1603,7 @@ int mvmfilterset(CSOUND *csound, MVMFILT *p)
 int mvmfilter(CSOUND *csound, MVMFILT *p) {
   uint32_t      offset   = p->h.insdshead->ksmps_offset;
   uint32_t      early    = p->h.insdshead->ksmps_no_end;
-  MYFLT fs       = csound->GetSr(csound);
+  MYFLT fs       = CS_ESR;
   uint32_t      n, nsmps = CS_KSMPS;
   int32_t       asigtau, asigf0;
   asigtau = IS_ASIG_ARG(p->tau);
@@ -1618,7 +1618,7 @@ int mvmfilter(CSOUND *csound, MVMFILT *p) {
   MYFLT theta,r1,x1,y1,x,y,limit;
   x  = p->x;
   y  = p->y;
-  limit = csound->GetSr(csound) / FL(2.0);
+  limit = CS_ESR / FL(2.0);
 
   MYFLT f0val=*p->f0;
   f0val = f0val > limit ? limit : f0val;

--- a/Opcodes/bowedbar.c
+++ b/Opcodes/bowedbar.c
@@ -157,7 +157,7 @@ int32_t bowedbar(CSOUND *csound, BOWEDBAR *p)
         return csound->InitError(csound,
                                  Str("Bowedbar: cannot have zero modes\n"));
       for (i=0; i<p->nr_modes; i++) {
-        MYFLT R = FL(1.0) - p->freq * p->modes[i] * csound->pidsr;
+        MYFLT R = FL(1.0) - p->freq * p->modes[i] * CS_PIDSR;
         BiQuad_clear(&p->bandpass[i]);
         BiQuad_setFreqAndReson(p->bandpass[i], p->freq * p->modes[i], R);
         BiQuad_setEqualGainZeroes(p->bandpass[i]);

--- a/Opcodes/bowedbar.c
+++ b/Opcodes/bowedbar.c
@@ -85,7 +85,7 @@ int32_t bowedbarset(CSOUND *csound, BOWEDBAR *p)
     make_BiQuad(&p->bandpass[1]);
     make_BiQuad(&p->bandpass[2]);
     make_BiQuad(&p->bandpass[3]);
-    make_ADSR(&p->adsr);
+    make_ADSR(&p->adsr, CS_ESR);
     ADSR_setAllTimes(csound, &p->adsr, FL(0.02), FL(0.005), FL(0.9), FL(0.01));
 
     if (LIKELY(*p->lowestFreq>=FL(0.0))) {      /* If no init skip */

--- a/Opcodes/brass.h
+++ b/Opcodes/brass.h
@@ -91,7 +91,7 @@ typedef BiQuad LipFilt;
 
 void make_LipFilt(LipFilt*);
 void LipFilt_clear(LipFilt*);
-void LipFilt_setFreq(CSOUND*,LipFilt*, MYFLT frequency);
+//void LipFilt_setFreq(CSOUND*,LipFilt*, MYFLT frequency);
 MYFLT LipFilt_tick(LipFilt*, MYFLT mouthSample,MYFLT boreSample);
 MYFLT LipFilt_lastOut(LipFilt*);
 

--- a/Opcodes/buchla.c
+++ b/Opcodes/buchla.c
@@ -54,7 +54,7 @@ int32_t poly_LPG_init(CSOUND* csound, BUCHLA *p)
     warn++;
 #define C1 (1e-09)
 #define C2 (2.2e-10)
-    p->f = 0.5/csound->GetSr(csound);
+    p->f = 0.5/CS_ESR;
     return OK;
 }
 
@@ -178,7 +178,7 @@ typedef struct {
 int32_t vactrol_init(CSOUND *csound, VACTROL* p)
 {
     p->s1 = 0;
-    p->a_base = 1000.0*PI/(csound->GetSr(csound));
+    p->a_base = 1000.0*PI/(CS_ESR);
     p->t_down = *p->down<FL(0.0) ? 3.0e3 : (double)*p->down;
     p->t_up   = *p->up<FL(0.0) ? 20.0 : (double)*p->up;
     return OK;

--- a/Opcodes/butter.c
+++ b/Opcodes/butter.c
@@ -81,7 +81,7 @@ static int32_t hibut(CSOUND *csound, BFIL *p)       /*      Hipass filter       
 
       a = p->a;
       p->lkf = *p->kfc;
-      c = tan((double)(csound->pidsr * p->lkf));
+      c = tan((double)(CS_PIDSR * p->lkf));
 
       a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c);
       a[2] = -(a[1] + a[1]);
@@ -118,7 +118,7 @@ static int32_t lobut(CSOUND *csound, BFIL *p)       /*      Lopass filter       
       double     *a, c;
       a = p->a;
       p->lkf = *p->kfc;
-      c = 1.0 / tan((double)(csound->pidsr * p->lkf));
+      c = 1.0 / tan((double)(CS_PIDSR * p->lkf));
       a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c);
       a[2] = a[1] + a[1];
       a[3] = a[1];

--- a/Opcodes/clfilt.c
+++ b/Opcodes/clfilt.c
@@ -44,7 +44,7 @@ static int32_t clfiltset(CSOUND *csound, CLFILT *p)
     int32_t m, nsec;
     MYFLT pbr = *p->pbr, sbr = *p->sbr;        /* As cannot change */
     p->prvfreq = *p->freq;
-    tanfpi = (MYFLT)tan(-csound->mpidsr*(*p->freq));
+    tanfpi = (MYFLT)tan(-CS_MPIDSR*(*p->freq));
     tanfpi2 = tanfpi*tanfpi;
     cotfpi = FL(1.0)/tanfpi;
     cotfpi2 = cotfpi*cotfpi;
@@ -310,7 +310,7 @@ static int32_t clfilt(CSOUND *csound, CLFILT *p)
     }
     if (*p->freq != p->prvfreq) {      /* Only reset if freq changes */
       p->prvfreq = *p->freq;
-      tanfpi = (MYFLT)tan(-csound->mpidsr*(*p->freq));
+      tanfpi = (MYFLT)tan(-CS_MPIDSR*(*p->freq));
       tanfpi2 = tanfpi*tanfpi;
       cotfpi = FL(1.0)/tanfpi;
       cotfpi2 = cotfpi*cotfpi;

--- a/Opcodes/compress.c
+++ b/Opcodes/compress.c
@@ -213,7 +213,7 @@ static int32_t distset(CSOUND *csound, DIST *p)
     p->midphs = p->maxphs * FL(0.5);
     p->begval = ftp->ftable[0];
     p->endval = ftp->ftable[ftp->flen];
-    b = 2.0 - cos((double) (*p->ihp * csound->tpidsr)); /*  and rms coefs */
+    b = 2.0 - cos((double) (*p->ihp * CS_TPIDSR)); /*  and rms coefs */
     p->c2 = b - sqrt(b * b - 1.0);
     p->c1 = 1.0 - p->c2;
     p->min_rms = csound->e0dbfs * DV32768;

--- a/Opcodes/compress.c
+++ b/Opcodes/compress.c
@@ -59,7 +59,7 @@ static int32_t compset(CSOUND *csound, CMPRS *p)
     p->curatt = (MYFLT) MAXPOS;
     p->currls = (MYFLT) MAXPOS;
     /* round to nearest integer */
-    if (UNLIKELY((delsmps = MYFLT2LONG(*p->ilook * csound->GetSr(csound))) <= 0L))
+    if (UNLIKELY((delsmps = MYFLT2LONG(*p->ilook * CS_ESR)) <= 0L))
       delsmps = 1L;                             /* alloc 2 delay bufs   */
     csound->AuxAlloc(csound, delsmps * 2 * sizeof(MYFLT), &p->auxch);
     p->abuf = (MYFLT *)p->auxch.auxp;
@@ -120,17 +120,17 @@ static int32_t compress(CSOUND *csound, CMPRS *p)
         p->kneemul = FL(1.0);
     }
     if (*p->katt != p->curatt) {
-      if ((p->curatt = *p->katt) < csound->onedsr)
+      if ((p->curatt = *p->katt) < CS_ONEDSR)
         p->c2 = 0.0;
       else
-        p->c2 = pow(0.5, csound->onedsr / p->curatt);
+        p->c2 = pow(0.5, CS_ONEDSR / p->curatt);
       p->c1 = 1.0 - p->c2;
     }
     if (*p->krls != p->currls) {
-      if ((p->currls = *p->krls) < csound->onedsr)
+      if ((p->currls = *p->krls) < CS_ONEDSR)
         p->d2 = 0.0;
       else
-        p->d2 = pow(0.5, csound->onedsr / p->currls);
+        p->d2 = pow(0.5, CS_ONEDSR / p->currls);
       p->d1 = 1.0 - p->d2;
     }
     ar = p->ar;

--- a/Opcodes/cpumeter.c
+++ b/Opcodes/cpumeter.c
@@ -100,7 +100,7 @@ int32_t cpupercent_init(CSOUND *csound, CPUMETER* p)
     csound->AuxAlloc(csound,k*sizeof(CPU_t), &(p->cpu_a));
     p->cpus = (CPU_t *) p->cpu_a.auxp;
     k = cpupercent_renew(csound, p);
-    p->cnt = (p->trig = (int32_t)(*p->itrig * csound->GetSr(csound)));
+    p->cnt = (p->trig = (int32_t)(*p->itrig * CS_ESR));
     // Would it be better to add a deinit process so the closing happens in perf?
     //csound->CreateFileHandle(csound, &p->fp, CSFILE_STD, "/proc/stat");
     csound->RegisterDeinitCallback(csound, (void *) p, deinit_cpupercent);

--- a/Opcodes/crossfm.c
+++ b/Opcodes/crossfm.c
@@ -78,7 +78,7 @@ int32_t xfm(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;
@@ -149,7 +149,7 @@ int32_t xfmi(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;
@@ -223,7 +223,7 @@ int32_t xpm(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;
@@ -294,7 +294,7 @@ int32_t xpmi(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;
@@ -368,7 +368,7 @@ int32_t xfmpm(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;
@@ -439,7 +439,7 @@ int32_t xfmpmi(CSOUND *csound, CROSSFM *p)
     tbl1 = p->ftp1->ftable;
     tbl2 = p->ftp2->ftable;
     cps = *p->kcps;
-    k = csound->onedsr;
+    k = CS_ONEDSR;
 
     phase1 = p->phase1;
     phase2 = p->phase2;

--- a/Opcodes/dam.c
+++ b/Opcodes/dam.c
@@ -51,8 +51,8 @@ static int32_t daminit(CSOUND *csound, DAM *p)
    /* the computed values are stored in the opcode data structure p */
    /* for later use in the main processing                          */
 
-    p->rspeed = (*p->rtime)*csound->onedsr*FL(1000.0);
-    p->fspeed = (*p->ftime)*csound->onedsr*FL(1000.0);
+    p->rspeed = (*p->rtime)*CS_ONEDSR*FL(1000.0);
+    p->fspeed = (*p->ftime)*CS_ONEDSR*FL(1000.0);
     p->kthr = -FL(1.0);
     return OK;
 }

--- a/Opcodes/doppler.cpp
+++ b/Opcodes/doppler.cpp
@@ -137,7 +137,7 @@ public:
   int32_t currentIndex;
 
   int32_t init(CSOUND *csound) {
-    sampleRate = csound->GetSr(csound);
+    sampleRate = csound->GetSr(opds.insdshead);
     blockRate = opds.insdshead->ekr;
     blockSize = opds.insdshead->ksmps;
     // Take care of default values.

--- a/Opcodes/doppler.cpp
+++ b/Opcodes/doppler.cpp
@@ -137,7 +137,7 @@ public:
   int32_t currentIndex;
 
   int32_t init(CSOUND *csound) {
-    sampleRate = csound->GetSr(opds.insdshead);
+    sampleRate = opds.insdshead->esr;
     blockRate = opds.insdshead->ekr;
     blockSize = opds.insdshead->ksmps;
     // Take care of default values.

--- a/Opcodes/dssi4cs/src/dssi4cs.c
+++ b/Opcodes/dssi4cs/src/dssi4cs.c
@@ -24,11 +24,6 @@
 #include <dlfcn.h>
 #include <dirent.h>
 
-#undef CS_KSMPS
-#define CS_KSMPS     (csound->GetKsmps(csound))
-
-//#define DEBUG 1
-
 #define DSSI4CS_MAX_NUM_EVENTS 128
 
 #if !defined(HAVE_STRLCAT) && !defined(strlcat)
@@ -102,7 +97,7 @@ strNcpy(char *dst, const char *src, size_t siz)
 *****************************************************************************/
 void info(CSOUND * csound, DSSI4CS_PLUGIN * DSSIPlugin_)
 {
-    int32_t     Ksmps = csound->GetKsmps(csound);
+    int32_t     Ksmps = DSSIPlugin_->ksmps;
     uint64_t PortCount = 0;
     LADSPA_Descriptor *Descriptor;
     uint32 i;
@@ -266,6 +261,7 @@ int32_t dssiinit(CSOUND * csound, DSSIINIT * p)
     DSSI4CS_PLUGIN *DSSIPlugin =
         (DSSI4CS_PLUGIN *) csound->QueryGlobalVariable(csound, "$DSSI4CS");
     CS_TYPE* argType = csound->GetTypeForArg(p->iplugin);
+    DSSIPlugin->ksmps = Ksmps;
 
     if (strcmp("S", argType->varTypeName) == 0)
       strNcpy(dssiFilename,((STRINGDAT *)p->iplugin)->data, MAXNAME);
@@ -813,7 +809,7 @@ int32_t dssiaudio(CSOUND * csound, DSSIAUDIO * p)
     uint32_t i, j;
     uint32_t icnt = csound->GetInputArgCnt(p) - 1;
     uint32_t ocnt = csound->GetOutputArgCnt(p);
-    uint64_t Ksmps = (uint64_t) csound->GetKsmps(csound);
+    uint64_t Ksmps = (uint64_t) CS_KSMPS;
 
     if (p->DSSIPlugin_->Active == 1) {
       for (j = 0; j < icnt; j++) {

--- a/Opcodes/dssi4cs/src/dssi4cs.c
+++ b/Opcodes/dssi4cs/src/dssi4cs.c
@@ -248,8 +248,8 @@ int32_t dssiinit(CSOUND * csound, DSSIINIT * p)
 {
     /* TODO check if plugin has already been loaded and use same function */
     csound = p->h.insdshead->csound;
-    int32_t     SampleRate = (int32_t) MYFLT2LRND(csound->GetSr(csound));
-    int32_t     Ksmps = csound->GetKsmps(csound);
+    int32_t     SampleRate = (int32_t) MYFLT2LRND(CS_ESR);
+    int32_t     Ksmps = CS_KSMPS;
     uint64_t     i;
     int32_t     verbose = (int32_t)*p->iverbose;
     LADSPA_Descriptor_Function pfDescriptorFunction;
@@ -868,7 +868,7 @@ int32_t dssictls_init(CSOUND * csound, DSSICTLS * p)
             Crash if audio port selected */
     const LADSPA_Descriptor *Descriptor;
     int32_t     Number = *p->iDSSIhandle;
-    int32_t     Sr = (int32_t) MYFLT2LRND(csound->GetSr(csound));
+    int32_t     Sr = (int32_t) MYFLT2LRND(CS_ESR);
     uint64_t PortIndex = *p->iport;
     uint32_t  i;
     uint64_t ControlPort = 0;

--- a/Opcodes/dssi4cs/src/dssi4cs.h
+++ b/Opcodes/dssi4cs/src/dssi4cs.h
@@ -42,6 +42,7 @@ typedef struct DSSI4CS_PLUGIN_ {
     int32_t PluginNumber;
     int32_t * PluginCount;
     void * NextPlugin;
+    int43_t ksmps;
     /* float * kinputs_[]; */
     /* float * koutputs_[]; */
 } DSSI4CS_PLUGIN;

--- a/Opcodes/dssi4cs/src/dssi4cs.h
+++ b/Opcodes/dssi4cs/src/dssi4cs.h
@@ -42,7 +42,7 @@ typedef struct DSSI4CS_PLUGIN_ {
     int32_t PluginNumber;
     int32_t * PluginCount;
     void * NextPlugin;
-    int43_t ksmps;
+    int32_t ksmps;
     /* float * kinputs_[]; */
     /* float * koutputs_[]; */
 } DSSI4CS_PLUGIN;

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2517,7 +2517,7 @@ static int32_t
 lastcycle_init(CSOUND *csound, LASTCYCLE *p) {
     MYFLT p3 = p->h.insdshead->p3.value;
     p->numcycles = p3 < 0 ? 0 :
-        (int)(p->h.insdshead->offtim * csound->GetKr(csound) + 0.5);
+        (int)(p->h.insdshead->offtim * CS_EKR + 0.5);
     p->extracycles = p->h.insdshead->xtratim;
     if(p->extracycles == 0) {
         p->h.insdshead->xtratim = 1;

--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -106,7 +106,7 @@ static int32_t lag0_init_no_initial_value(CSOUND *csound, LAG0 *p) {
     p->lag = -1;
     p->started = 0;
     p->b1 = FL(0.0);
-    p->sr = csound->GetKr(csound);
+    p->sr = CS_EKR;
     p->y1 = 0;
     return OK;
 }
@@ -117,7 +117,7 @@ static int32_t lag0_init_initial_value(CSOUND *csound, LAG0 *p) {
     p->started = 1;
     p->y1 = *(p->initial_value);
     p->b1 = FL(0.0);
-    p->sr = csound->GetKr(csound);
+    p->sr = CS_EKR;
     return OK;
 }
 
@@ -163,7 +163,7 @@ static int32_t laga_init_no_initial_value(CSOUND *csound, LAG0 *p) {
     IGN(csound);
     p->lag = -1;
     p->b1 = FL(0.0);
-    p->sr = csound->GetSr(csound);
+    p->sr = CS_ESR;
     p->started = 0;
     p->y1 = -INF;
     return OK;
@@ -173,7 +173,7 @@ static int32_t laga_init_initial_value(CSOUND *csound, LAG0 *p) {
     IGN(csound);
     p->lag = -1;
     p->b1 = FL(1.0);
-    p->sr = csound->GetSr(csound);
+    p->sr = CS_ESR;
     p->started = 1;
     p->y1 = *p->initial_value;
     return OK;
@@ -248,7 +248,7 @@ static int32_t _lagud_init(CSOUND *csound, LagUD *p, int started) {
     p->b1u = started ? FL(1.0) : FL(0.0);
     p->b1d = p->b1u;
     p->started = started;
-    p->sr = csound->GetKr(csound);
+    p->sr = CS_EKR;
     return OK;
 }
 
@@ -342,7 +342,7 @@ lagud_a(CSOUND *csound, LagUD *p) {
             out[n]= y1;
         }
     } else {
-        MYFLT sr = csound->GetSr(csound);
+        MYFLT sr = CS_ESR;
         // faust uses tau2pole = exp(-1 / (lag*sr))
         p->b1u = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
         MYFLT b1u_slope = CALCSLOPE(p->b1u, b1u, nsmps);
@@ -392,7 +392,7 @@ trig_a(CSOUND *csound, Trig *p) {
 
     MYFLT *in = p->in;
     MYFLT dur = *p->dur;
-    MYFLT sr = csound->GetSr(csound);
+    MYFLT sr = CS_ESR;
     MYFLT prevtrig = p->prevtrig;
     MYFLT level = p->level;
     unsigned long counter = p->counter;
@@ -425,7 +425,7 @@ static int
 trig_k(CSOUND *csound, Trig *p) {
     MYFLT curtrig = *p->in;
     MYFLT dur = *p->dur;
-    MYFLT kr = csound->GetKr(csound);
+    MYFLT kr = CS_EKR;
     MYFLT prevtrig = p->prevtrig;
     MYFLT level = p->level;
     uint64_t counter = p->counter;

--- a/Opcodes/exciter.c
+++ b/Opcodes/exciter.c
@@ -64,9 +64,9 @@ static inline double process(double st[7], double in/*, char *s */)
      * @param fc     resonant frequency
      * @param q      resonance (gain at fc)
      */
-static inline void set_hp_rbj(CSOUND *csound, double hp[7], double fc, double q)
+static inline void set_hp_rbj(CSOUND *csound, double hp[7], double fc, double q, MYFLT sr)
 {
-    double omega= (TWOPI*fc/(double)csound->GetSr(csound));
+    double omega= (TWOPI*fc/(double) sr);
     double sn=sin(omega);
     double cs=cos(omega);
     double alpha=(double)(sn/(2.0*q));
@@ -110,11 +110,11 @@ static int32_t exciter_init(CSOUND *csound, EXCITER *p)
     p->rdrive = p->rbdr = p->kpa = p->kpb = p->kna = p->knb = p->ap =
       p->an = p->imr = p->kc = p->srct = p->sq = p->pwrq = p->prev_med =
       p->prev_out = 0.0;
-    p->over = csound->GetSr(csound) * 2 > 96000 ? 1 : 2;
+    p->over = CS_ESR * 2 > 96000 ? 1 : 2;
     p->blend_old = p->drive_old = -1.0;
     //resample_set_params(csound, p);
     {
-      double srate = (double)csound->GetSr(csound);
+      double srate = (double)CS_ESR;
       double ff = 25000.0;
       if (srate>50000) ff = srate*0.5;
       // set all filters
@@ -202,7 +202,7 @@ static inline void set_distort(CSOUND *csound, EXCITER *p)
 {
     // set distortion coeffs
     if ((p->drive_old != *p->pdrive) || (p->blend_old != *p->pblend)) {
-      double srate = csound->GetSr(csound);
+      double srate = CS_ESR;
       /* printf("drive %f->%f; blend %f->%f\n", */
       /*        p->drive_old, *p->pdrive, p->blend_old, *p->pblend); */
       p->drive_old = *p->pdrive;
@@ -234,7 +234,7 @@ static inline void params_changed(CSOUND *csound, EXCITER *p)
 {
     // set the params of all filters
     if (UNLIKELY(*p->pfreq != p->freq_old)) {
-      set_hp_rbj(csound, p->hp1, *p->pfreq, 0.707);
+      set_hp_rbj(csound, p->hp1, *p->pfreq, 0.707, CS_ESR);
       memcpy(p->hp2, p->hp1, 5*sizeof(double));
       memcpy(p->hp3, p->hp1, 5*sizeof(double));
       memcpy(p->hp4, p->hp1, 5*sizeof(double));
@@ -242,7 +242,7 @@ static inline void params_changed(CSOUND *csound, EXCITER *p)
     }
     // set the params of all filters
     if (UNLIKELY(*p->pceil != p->ceil_old)) {
-      set_lp_rbj(p->lp1, *p->pceil, 0.707, (double)csound->GetSr(csound));
+      set_lp_rbj(p->lp1, *p->pceil, 0.707, (double)CS_ESR);
       memcpy(p->lp2, p->lp1, 5*sizeof(double));
       p->ceil_old = *p->pceil;
     }

--- a/Opcodes/flanger.c
+++ b/Opcodes/flanger.c
@@ -122,7 +122,7 @@ static int32_t wguide1(CSOUND *csound, WGUIDE1 *p)
     if (*p->filt_khp != p->prvhp) {
       double b;
       p->prvhp               = *p->filt_khp;
-      b                      = 2.0 - cos((double)(p->prvhp * csound->tpidsr));
+      b                      = 2.0 - cos((double)(p->prvhp * CS_TPIDSR));
       p->c2                  = (MYFLT)(b - sqrt(b * b - 1.0));
       p->c1                  = FL(1.0) - p->c2;
     }
@@ -242,14 +242,14 @@ static int32_t wguide2(CSOUND *csound, WGUIDE2 *p)
     if (*p->filt_khp1 != p->prvhp1) {
       double b;
       p->prvhp1 = *p->filt_khp1;
-      b = 2.0 - cos((double)(p->prvhp1 * csound->tpidsr));
+      b = 2.0 - cos((double)(p->prvhp1 * CS_TPIDSR));
       p->c2_1 = (MYFLT)(b - sqrt((b * b) - 1.0));
       p->c1_1 = FL(1.0) - p->c2_1;
     }
     if (*p->filt_khp2 != p->prvhp2) {
       double b;
       p->prvhp2 = *p->filt_khp2;
-      b = 2.0 - cos((double)(p->prvhp2 * csound->tpidsr));
+      b = 2.0 - cos((double)(p->prvhp2 * CS_TPIDSR));
       p->c2_2 = (MYFLT)(b - sqrt((double)(b * b) - 1.0));
       p->c1_2 = FL(1.0) - p->c2_2;
     }

--- a/Opcodes/fm4op.c
+++ b/Opcodes/fm4op.c
@@ -283,13 +283,13 @@ int32_t tubebellset(CSOUND *csound, FM4OP *p)
     /*      ADSR_setAll(csound, &p->adsr[2], 0.07f,0.00002f,FL(0.0),0.02f); */
     /*      ADSR_setAll(csound, &p->adsr[3], FL(0.04),0.00001f,FL(0.0),0.02f); */
     p->twozero.gain = FL(0.5);
-    p->v_rate = FL(2.0) * p->vibWave->flen * csound->onedsr; /* Vib rate */
+    p->v_rate = FL(2.0) * p->vibWave->flen * CS_ONEDSR; /* Vib rate */
     /* Set Freq */
     p->baseFreq = *p->frequency;
-    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * csound->onedsr;
-    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * csound->onedsr;
-    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * csound->onedsr;
-    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * csound->onedsr;
+    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * CS_ONEDSR;
+    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * CS_ONEDSR;
+    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * CS_ONEDSR;
+    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * CS_ONEDSR;
     ADSR_keyOn(&p->adsr[0]);
     ADSR_keyOn(&p->adsr[1]);
     ADSR_keyOn(&p->adsr[2]);
@@ -313,11 +313,11 @@ int32_t tubebell(CSOUND *csound, FM4OP *p)
     p->gains[1] = amp * FM4Op_gains[76];
     p->gains[2] = amp * FM4Op_gains[99];
     p->gains[3] = amp * FM4Op_gains[71];
-    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * csound->onedsr;
-    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * csound->onedsr;
-    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * csound->onedsr;
-    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * csound->onedsr;
-    p->v_rate = *p->vibFreq * p->vibWave->flen * csound->onedsr;
+    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * CS_ONEDSR;
+    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * CS_ONEDSR;
+    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * CS_ONEDSR;
+    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * CS_ONEDSR;
+    p->v_rate = *p->vibFreq * p->vibWave->flen * CS_ONEDSR;
 
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -362,13 +362,13 @@ int32_t rhodeset(CSOUND *csound, FM4OP *p)
     /*      ADSR_setAll(&p->adsr[2], 0.05f,0.00005f,FL(0.0),0.02f); */
     /*      ADSR_setAll(&p->adsr[3], 0.05f,0.0002f,FL(0.0),0.02f); */
     p->twozero.gain = FL(1.0);
-    p->v_rate = FL(2.0) * p->vibWave->flen * csound->onedsr; /* Vib rate */
+    p->v_rate = FL(2.0) * p->vibWave->flen * CS_ONEDSR; /* Vib rate */
     /* Set Freq */
     p->baseFreq = *p->frequency;
-    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * csound->onedsr;
-    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * csound->onedsr;
-    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * csound->onedsr;
-    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * csound->onedsr;
+    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * CS_ONEDSR;
+    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * CS_ONEDSR;
+    p->w_rate[2] = p->baseFreq * p->ratios[2] * p->waves[2]->flen * CS_ONEDSR;
+    p->w_rate[3] = p->baseFreq * p->ratios[3] * p->waves[3]->flen * CS_ONEDSR;
     ADSR_keyOn(&p->adsr[0]);
     ADSR_keyOn(&p->adsr[1]);
     ADSR_keyOn(&p->adsr[2]);
@@ -409,10 +409,10 @@ int32_t wurleyset(CSOUND *csound, FM4OP *p)
     p->twozero.gain = FL(2.0);
     /* Set Freq */
     p->baseFreq = *p->frequency;
-    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * csound->onedsr;
-    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * csound->onedsr;
-    p->w_rate[2] =               p->ratios[2] * p->waves[2]->flen * csound->onedsr;
-    p->w_rate[3] =               p->ratios[3] * p->waves[3]->flen * csound->onedsr;
+    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * CS_ONEDSR;
+    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * CS_ONEDSR;
+    p->w_rate[2] =               p->ratios[2] * p->waves[2]->flen * CS_ONEDSR;
+    p->w_rate[3] =               p->ratios[3] * p->waves[3]->flen * CS_ONEDSR;
     ADSR_keyOn(&p->adsr[0]);
     ADSR_keyOn(&p->adsr[1]);
     ADSR_keyOn(&p->adsr[2]);
@@ -436,11 +436,11 @@ int32_t wurley(CSOUND *csound, FM4OP *p)
     p->gains[1] = amp * FM4Op_gains[82];
     p->gains[2] = amp * FM4Op_gains[82];
     p->gains[3] = amp * FM4Op_gains[68];
-    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * csound->onedsr;
-    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * csound->onedsr;
-    p->w_rate[2] =               p->ratios[2] * p->waves[2]->flen * csound->onedsr;
-    p->w_rate[3] =               p->ratios[3] * p->waves[3]->flen * csound->onedsr;
-    p->v_rate = *p->vibFreq * p->vibWave->flen * csound->onedsr;
+    p->w_rate[0] = p->baseFreq * p->ratios[0] * p->waves[0]->flen * CS_ONEDSR;
+    p->w_rate[1] = p->baseFreq * p->ratios[1] * p->waves[1]->flen * CS_ONEDSR;
+    p->w_rate[2] =               p->ratios[2] * p->waves[2]->flen * CS_ONEDSR;
+    p->w_rate[3] =               p->ratios[3] * p->waves[3]->flen * CS_ONEDSR;
+    p->v_rate = *p->vibFreq * p->vibWave->flen * CS_ONEDSR;
 
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -521,7 +521,7 @@ int32_t heavymetset(CSOUND *csound, FM4OP *p)
     /*      ADSR_setAll(&p->adsr[2], FL(0.001), 0.0020f, FL(1.0), 0.0002f); */
     /*      ADSR_setAll(&p->adsr[3], 0.050f, 0.0010f, FL(0.2), 0.0002f); */
     p->twozero.gain = FL(2.0);
-    /*     p->v_rate = 5.5 * p->vibWave->flen * csound->onedsr;  Vib rate */
+    /*     p->v_rate = 5.5 * p->vibWave->flen * CS_ONEDSR;  Vib rate */
     ADSR_keyOn(&p->adsr[0]);
     ADSR_keyOn(&p->adsr[1]);
     ADSR_keyOn(&p->adsr[2]);
@@ -546,12 +546,12 @@ int32_t heavymet(CSOUND *csound, FM4OP *p)
     p->gains[2] = amp * FM4Op_gains[91];
     p->gains[3] = amp * FM4Op_gains[68];
 
-    temp         = p->baseFreq * csound->onedsr;
+    temp         = p->baseFreq * CS_ONEDSR;
     p->w_rate[0] = temp * p->ratios[0] * p->waves[0]->flen;
     p->w_rate[1] = temp * p->ratios[1] * p->waves[1]->flen;
     p->w_rate[2] = temp * p->ratios[2] * p->waves[2]->flen;
     p->w_rate[3] = temp * p->ratios[3] * p->waves[3]->flen;
-    p->v_rate = *p->vibFreq * p->vibWave->flen * csound->onedsr;
+    p->v_rate = *p->vibFreq * p->vibWave->flen * CS_ONEDSR;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -615,7 +615,7 @@ MYFLT FM4Alg8_tick(FM4OP *p, MYFLT c1, MYFLT c2)
 int32_t b3set(CSOUND *csound, FM4OP *p)
 {
     MYFLT       amp = *p->amp * AMP_RSCALE; /* Normalised */
-    MYFLT       temp = p->baseFreq * csound->onedsr;
+    MYFLT       temp = p->baseFreq * CS_ONEDSR;
 
     if (UNLIKELY(make_FM4Op(csound,p))) return NOTOK;
     if (UNLIKELY(FM4Op_loadWaves(csound,p))) return NOTOK;         /* sines */
@@ -669,11 +669,11 @@ int32_t hammondB3(CSOUND *csound, FM4OP *p)
     for (n=offset;n<nsmps;n++) {
       MYFLT   lastOutput;
       if (moddep > FL(0.0)) {
-        p->v_rate = *p->vibFreq * p->vibWave->flen * csound->onedsr;
+        p->v_rate = *p->vibFreq * p->vibWave->flen * CS_ONEDSR;
         temp = FL(1.0) + (moddep * FL(0.1) *
                           Wave_tick(&p->v_time, (int32_t)p->vibWave->flen,
                                     p->vibWave->ftable, p->v_rate, FL(0.0)));
-        temp *= p->baseFreq * csound->onedsr;
+        temp *= p->baseFreq * CS_ONEDSR;
         p->w_rate[0] = p->ratios[0] * temp * p->waves[0]->flen;
         p->w_rate[1] = p->ratios[1] * temp * p->waves[1]->flen;
         p->w_rate[2] = p->ratios[2] * temp * p->waves[2]->flen;
@@ -712,7 +712,7 @@ MYFLT FM4Alg6_tick(CSOUND *csound, FM4OPV *q)
     temp2 = Wave_tick(&p->v_time, (int32_t)p->vibWave->flen, p->vibWave->ftable,
                       p->v_rate, FL(0.0)) * *p->modDepth * FL(0.1);
 
-    temp2 = (FL(1.0) + temp2) * p->baseFreq * csound->onedsr;
+    temp2 = (FL(1.0) + temp2) * p->baseFreq * CS_ONEDSR;
     p->w_rate[0] = temp2 * p->ratios[0] * p->waves[0]->flen;
     p->w_rate[1] = temp2 * p->ratios[1] * p->waves[1]->flen;
     p->w_rate[2] = temp2 * p->ratios[2] * p->waves[2]->flen;
@@ -1054,7 +1054,7 @@ MYFLT FM4Alg4_tick(CSOUND *csound, FM4OP *p, MYFLT c1, MYFLT c2)
     temp = Wave_tick(&p->v_time, (int32_t)p->vibWave->flen,
                      p->vibWave->ftable, p->v_rate, FL(0.0)) *
       *p->modDepth * FL(0.2);
-    temp = p-> baseFreq * (FL(1.0) + temp)* csound->onedsr;
+    temp = p-> baseFreq * (FL(1.0) + temp)* CS_ONEDSR;
     p->w_rate[0] = p->ratios[0] * temp * p->waves[0]->flen;
     p->w_rate[1] = p->ratios[1] * temp * p->waves[1]->flen;
     p->w_rate[2] = p->ratios[2] * temp * p->waves[2]->flen;
@@ -1131,7 +1131,7 @@ int32_t percflute(CSOUND *csound, FM4OP *p)
     p->gains[1] = amp * FM4Op_gains[71] * FL(0.5);
     p->gains[2] = amp * FM4Op_gains[93] * FL(0.5);
     p->gains[3] = amp * FM4Op_gains[85] * FL(0.5);
-    p->v_rate = *p->vibFreq * p->vibWave->flen * csound->onedsr;
+    p->v_rate = *p->vibFreq * p->vibWave->flen * CS_ONEDSR;
 
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {

--- a/Opcodes/fm4op.c
+++ b/Opcodes/fm4op.c
@@ -141,10 +141,10 @@ int32_t make_FM4Op(CSOUND *csound, FM4OP *p)
 
     if (!FM_tabs_built) build_FM(); /* Ensure tables exist */
 
-    make_ADSR(&p->adsr[0]);
-    make_ADSR(&p->adsr[1]);
-    make_ADSR(&p->adsr[2]);
-    make_ADSR(&p->adsr[3]);
+    make_ADSR(&p->adsr[0], CS_ESR);
+    make_ADSR(&p->adsr[1], CS_ESR);
+    make_ADSR(&p->adsr[2], CS_ESR);
+    make_ADSR(&p->adsr[3], CS_ESR);
     make_TwoZero(&p->twozero);
     if (UNLIKELY((ftp = csound->FTnp2Finde(csound, p->vifn)) == NULL))
       goto err1;

--- a/Opcodes/follow.c
+++ b/Opcodes/follow.c
@@ -82,12 +82,12 @@ static int32_t envset(CSOUND *csound, ENV *p)
                                 /* Note - 6.90775527898 -- log(0.001) */
     p->lastatt = *p->attack;
     if (p->lastatt<=FL(0.0))
-      p->ga = EXP(- FL(69.0775527898)*csound->onedsr);
+      p->ga = EXP(- FL(69.0775527898)*CS_ONEDSR);
     else
       p->ga = EXP(- FL(6.90775527898)/(CS_ESR* p->lastatt));
     p->lastrel = *p->release;
     if (p->lastrel<=FL(0.0))
-      p->gr = EXP(- FL(69.0775527898)*csound->onedsr);
+      p->gr = EXP(- FL(69.0775527898)*CS_ONEDSR);
     else
       p->gr = EXP(- FL(6.90775527898)/(CS_ESR* p->lastrel));
     p->envelope = FL(0.0);
@@ -105,8 +105,8 @@ static int32_t envext(CSOUND *csound, ENV *p)
     if (p->lastatt!=*p->attack) {
       p->lastatt = *p->attack;
       if (p->lastatt<=FL(0.0))
-        ga = p->ga = EXP(- FL(69.0775527898)*csound->onedsr);
-      // EXP(-FL(10000.0)*csound->onedsr);
+        ga = p->ga = EXP(- FL(69.0775527898)*CS_ONEDSR);
+      // EXP(-FL(10000.0)*CS_ONEDSR);
       else
         ga = p->ga = EXP(- FL(6.90775527898)/(CS_ESR* p->lastatt));
       //EXP(-FL(1.0)/(CS_ESR* p->lastatt));
@@ -115,8 +115,8 @@ static int32_t envext(CSOUND *csound, ENV *p)
     if (p->lastrel!=*p->release) {
       p->lastrel = *p->release;
       if (p->lastrel<=FL(0.0))
-        gr = p->gr = EXP(- FL(69.0775527898)*csound->onedsr);
-      //EXP(-FL(100.0)*csound->onedsr);
+        gr = p->gr = EXP(- FL(69.0775527898)*CS_ONEDSR);
+      //EXP(-FL(100.0)*CS_ONEDSR);
       else
         gr = p->gr = EXP(- FL(6.90775527898)/(CS_ESR* p->lastrel));
       //EXP(-FL(1.0)/(CS_ESR* p->lastrel));

--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -100,7 +100,7 @@ int32_t OLABuffer_initialise(CSOUND *csound, OLABuffer *self)
     csound->AuxAlloc(csound, self->framesCount * sizeof(MYFLT *),
                      &self->framePointerMemory);
     self->frames = self->framePointerMemory.auxp;
-    self->ksmps = csound->GetKsmps(csound);
+    self->ksmps = csound->GetKsmps(self->h.insdshead);
 
     int32_t i;
     for (i = 0; i < self->framesCount; ++i) {
@@ -227,7 +227,7 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
     }
 
     if (UNLIKELY(frameSampleCount / (int32_t)overlapCount <
-                 (int32_t) csound->GetKsmps(csound))) {
+                 (int32_t) csound->GetKsmps(self->h.insdshead))) {
 
       csound->Die(csound, "%s", Str("olabuffer: Error, k-rate array size divided "
                               "by overlap factor must be larger than or equal "
@@ -240,7 +240,7 @@ int32_t Framebuffer_initialise(CSOUND *csound, Framebuffer *self)
     self->inputType = Framebuffer_getArgumentType(csound, self->inputArgument);
     self->outputType = Framebuffer_getArgumentType(csound, self->outputArgument);
     self->elementCount = *self->sizeArgument;
-    self->ksmps = csound->GetKsmps(csound);
+    self->ksmps = csound->GetKsmps(self->h.insdshead);
 
     Framebuffer_checkArgumentSanity(csound, self);
 
@@ -339,7 +339,7 @@ int32_t Framebuffer_process(CSOUND *csound, Framebuffer *self)
 
 void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self)
 {
-    if (UNLIKELY((uint32_t)self->elementCount < csound->GetKsmps(csound))) {
+    if (UNLIKELY((uint32_t)self->elementCount < csound->GetKsmps(self->h.insdshead))) {
 
       csound->Die(csound, "%s", Str("framebuffer: Error, specified element "
                               "count less than ksmps value, Exiting"));

--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -100,7 +100,7 @@ int32_t OLABuffer_initialise(CSOUND *csound, OLABuffer *self)
     csound->AuxAlloc(csound, self->framesCount * sizeof(MYFLT *),
                      &self->framePointerMemory);
     self->frames = self->framePointerMemory.auxp;
-    self->ksmps = csound->GetKsmps(self->h.insdshead);
+    self->ksmps = self->h.insdshead->ksmps;
 
     int32_t i;
     for (i = 0; i < self->framesCount; ++i) {
@@ -227,7 +227,7 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
     }
 
     if (UNLIKELY(frameSampleCount / (int32_t)overlapCount <
-                 (int32_t) csound->GetKsmps(self->h.insdshead))) {
+                 (int32_t) self->h.insdshead->ksmps)) {
 
       csound->Die(csound, "%s", Str("olabuffer: Error, k-rate array size divided "
                               "by overlap factor must be larger than or equal "
@@ -240,7 +240,7 @@ int32_t Framebuffer_initialise(CSOUND *csound, Framebuffer *self)
     self->inputType = Framebuffer_getArgumentType(csound, self->inputArgument);
     self->outputType = Framebuffer_getArgumentType(csound, self->outputArgument);
     self->elementCount = *self->sizeArgument;
-    self->ksmps = csound->GetKsmps(self->h.insdshead);
+    self->ksmps = self->h.insdshead->ksmps;
 
     Framebuffer_checkArgumentSanity(csound, self);
 
@@ -339,7 +339,7 @@ int32_t Framebuffer_process(CSOUND *csound, Framebuffer *self)
 
 void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self)
 {
-    if (UNLIKELY((uint32_t)self->elementCount < csound->GetKsmps(self->h.insdshead))) {
+  if (UNLIKELY((uint32_t)self->elementCount < self->h.insdshead->ksmps)) {
 
       csound->Die(csound, "%s", Str("framebuffer: Error, specified element "
                               "count less than ksmps value, Exiting"));

--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -533,7 +533,7 @@ static int32_t adsynt2(CSOUND *csound,ADSYNT2 *p)
       amp2 = prevAmp[c];
       amp = amptbl[c] * amp0;
       cps = freqtbl[c] * cps0;
-      inc = (int32) (cps * csound->sicvt);
+      inc = (int32) (cps * CS_SICVT);
       phs = lphs[c];
       ampIncr = (amp - amp2) * CS_ONEDKSMPS;
       for (n=offset; n<nsmps; n++) {

--- a/Opcodes/gammatone.c
+++ b/Opcodes/gammatone.c
@@ -50,7 +50,7 @@ static int32_t gammatone_init(CSOUND *csound, GAMMA *p)
     if (p->n<0 || p->n>10)
       return csound->InitError(csound, Str("Invalid order %d\n"), p->n);
     else if (p->n==0) p->n = 4;
-    p->expmbt = EXP(-2.0*PI_F* *p->decay/*/csound->GetSr(csound)*/);
+    p->expmbt = EXP(-2.0*PI_F* *p->decay/*/CS_ESR*/);
     p->cosft = FL(1.0);
     p->sinft = FL(0.0);
     p->oldf = FL(0.0);
@@ -78,8 +78,8 @@ static int32_t gammatone_perf(CSOUND *csound, GAMMA *p)
     }
     if (*p->freq != freq) {
       freq = p->oldf = *p->freq;
-      p->cosft = COS(2.0*PI_F*freq/csound->GetSr(csound));
-      p->sinft = SIN(2.0*PI_F*freq/csound->GetSr(csound));
+      p->cosft = COS(2.0*PI_F*freq/CS_ESR);
+      p->sinft = SIN(2.0*PI_F*freq/CS_ESR);
       //printf("**** cos/sin = %f / %f\n", p->cosft, p->sinft);
       //printf("**** expmbt = %f\n", p->expmbt);
     }

--- a/Opcodes/gendy.c
+++ b/Opcodes/gendy.c
@@ -174,7 +174,7 @@ static int32_t kgendy(CSOUND *csound, GENDY *p)
         p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
       memdur[index] = p->dur;
       p->speed =
-        (minfreq + (maxfreq - minfreq) * p->dur) * csound->onedsr * knum;
+        (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
     }
     *p->out = *p->kamp * ((FL(1.0) - p->phase) * p->amp + p->phase * p->nextamp);
     p->phase += p->speed;
@@ -229,7 +229,7 @@ static int32_t agendy(CSOUND *csound, GENDY *p)
           p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
         memdur[index] = p->dur;
         p->speed =
-          (minfreq + (maxfreq - minfreq) * p->dur) * csound->onedsr * knum;
+          (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
       }
       out[n] = *p->kamp * ((FL(1.0) - p->phase) * p->amp + p->phase * p->nextamp);
       p->phase += p->speed;
@@ -304,7 +304,7 @@ static int32_t kgendyx(CSOUND *csound, GENDYX *p)
         p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
       memdur[index] = p->dur;
       p->speed =
-        (minfreq + (maxfreq - minfreq) * p->dur) * csound->onedsr * knum;
+        (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
     }
     if (*p->kcurveup < FL(0.0))
       *p->kcurveup = FL(0.0);
@@ -364,7 +364,7 @@ static int32_t agendyx(CSOUND *csound, GENDYX *p)
           p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
         memdur[index] = p->dur;
         p->speed =
-          (minfreq + (maxfreq - minfreq) * p->dur) * csound->onedsr * knum;
+          (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
       }
       if (*p->kcurveup < FL(0.0))
         *p->kcurveup = FL(0.0);
@@ -449,7 +449,7 @@ static int32_t kgendyc(CSOUND *csound, GENDYC *p)
       memdur[index] = p->dur;
       fphase = (minfreq + (maxfreq - minfreq) * p->dur) * knum;
       fphase = (fphase > FL(0.001) ? fphase : FL(0.001));
-      p->phase = (int32)(csound->GetSr(csound) / fphase);
+      p->phase = (int32)(CS_ESR / fphase);
       if (p->phase < 2) p->phase = 2;
       p->curve = FL(2.0) * (next_midpnt - p->midpnt - p->phase * p->slope);
       p->curve = p->curve / (p->phase * p->phase + p->phase);
@@ -512,7 +512,7 @@ static int32_t agendyc(CSOUND *csound, GENDYC *p)
         memdur[index] = p->dur;
         fphase = (minfreq + (maxfreq - minfreq) * p->dur) * knum;
         fphase = (fphase > FL(0.001) ? fphase : FL(0.001));
-        p->phase = (int32)(csound->GetSr(csound) / fphase);
+        p->phase = (int32)(CS_ESR / fphase);
         if (p->phase < 2) p->phase = 2;
         p->curve = FL(2.0) * (next_midpnt - p->midpnt - p->phase * p->slope);
         p->curve = p->curve / (p->phase * p->phase + p->phase);

--- a/Opcodes/grain.c
+++ b/Opcodes/grain.c
@@ -102,14 +102,14 @@ static int32_t ags(CSOUND *csound, PGRA *p) /*  Granular U.G. a-rate main routin
     gtp  = p->gftp;
     gtbl = gtp->ftable;
     glen = gtp->flen;
-    gcvt = glen/csound->GetSr(csound);
+    gcvt = glen/CS_ESR;
 
     pow2tab = ISPOW2(glen);
 
     etp  = p->eftp;
     etbl = etp->ftable;
     elen = etp->flen;
-    ecvt = elen/csound->GetSr(csound);
+    ecvt = elen/CS_ESR;
 
     lb   = gtp->lobits;
     lb2  = etp->lobits;
@@ -172,7 +172,7 @@ static int32_t ags(CSOUND *csound, PGRA *p) /*  Granular U.G. a-rate main routin
         }
       }
       xdns += p->dnsadv;
-      gcount += *xdns * csound->onedsr;
+      gcount += *xdns * CS_ONEDSR;
       xamp += p->ampadv;
       xlfr += p->lfradv;
     }

--- a/Opcodes/grain.c
+++ b/Opcodes/grain.c
@@ -122,7 +122,7 @@ static int32_t ags(CSOUND *csound, PGRA *p) /*  Granular U.G. a-rate main routin
     if (kglen > *p->imkglen) kglen = *p->imkglen;
 
     ekglen  = (int32)(CS_ESR * kglen);   /* Useful constant */
-    inc2    = (int32)(csound->sicvt / kglen); /* Constant for each cycle */
+    inc2    = (int32)(CS_SICVT / kglen); /* Constant for each cycle */
     einc =  (1./kglen) * ecvt;
     bufsize = CS_KSMPS + ekglen;
     xdns    = p->xdns;
@@ -146,7 +146,7 @@ static int32_t ags(CSOUND *csound, PGRA *p) /*  Granular U.G. a-rate main routin
         isc2 = 0;
         if(pow2tab) {
           /* VL 21/11/18 original code, fixed-point indexing */
-        inc = (int32) ((*xlfr + Unirand(csound, *p->kbnd)) * csound->sicvt);
+        inc = (int32) ((*xlfr + Unirand(csound, *p->kbnd)) * CS_SICVT);
         do {
           *temp++ += amp  * *(gtbl + (isc >> lb)) *
                      *(etbl + (isc2 >> lb2));

--- a/Opcodes/harmon.c
+++ b/Opcodes/harmon.c
@@ -101,9 +101,9 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
     p->hmrngflg = 0;
     /*if (p->auxch.auxp == NULL || minoct < p->minoct ) */ {
       MYFLT minfrq = POWER(FL(2.0), minoct) * ONEPT;
-      int16 nbufs = (int16)(csound->ekr * 3 / minfrq) + 1;/* recalc max pulse prd */
+      int16 nbufs = (int16)(CS_EKR * 3 / minfrq) + 1;/* recalc max pulse prd */
       int16 nbufsmps = nbufs * CS_KSMPS;
-      int16 maxprd = (int16)(csound->esr * 2 / minfrq);   /* incl sigmoid ends */
+      int16 maxprd = (int16)(CS_ESR * 2 / minfrq);   /* incl sigmoid ends */
       int16 cnt;
       int32  totalsiz = nbufsmps * 2 + maxprd * 4 + (SLEN+1);
       MYFLT *pulsbuf, *sigp;                            /*  & realloc buffers */
@@ -124,7 +124,7 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
       p->n2bufsmps = nbufsmps * 2;
     }
     //p->minoct = minoct;
-    p->sicvt = FL(65536.0) * csound->onedsr;
+    p->sicvt = FL(65536.0) * CS_ONEDSR;
     //printf("sicvt = %f\n", p->sicvt);
     //    p->polarity = (int16)*p->ipolarity;
     p->poslead = 0;
@@ -137,7 +137,7 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
     p->curpuls = NULL;
     p->pbufcnt = 0;
     p->vocamp = FL(0.0);                        /* begin unvoiced */
-    p->ampinc = FL(10.0) * csound->onedsr;      /* .1 sec lin ramp for uv to v */
+    p->ampinc = FL(10.0) * CS_ONEDSR;      /* .1 sec lin ramp for uv to v */
     //printf("ampinc = %f\n", p->ampinc);
     p->switching = 0;
     return OK;
@@ -160,7 +160,7 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         MYFLT cps = POWER(FL(2.0), koct) * ONEPT;     /*   recalc pulse period */
         p->period = (int16) (CS_ESR / cps);
         if (!p->cpsmode)
-          p->sicvt = cps * FL(65536.0) * csound->onedsr; /* k64dsr;*/
+          p->sicvt = cps * FL(65536.0) * CS_ONEDSR; /* k64dsr;*/
       }
       p->prvoct = koct;
     }
@@ -344,7 +344,6 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
     for (vdp=p->vocdat; vdp<p->vlim; vdp++)     /* get new frequencies  */
       vdp->phsinc = (int32)(*vdp->kfrq * p->sicvt);
     outp = p->ar;
-    //nsmps = csound->ksmps;
     vocamp = p->vocamp;
     diramp = FL(1.0) - vocamp;
     dirp = p->asig;

--- a/Opcodes/ifd.c
+++ b/Opcodes/ifd.c
@@ -356,7 +356,7 @@ static int32_t tifd_process(CSOUND * csound, IFD * p)
   uint32_t nsmps = CS_KSMPS;
 
   if(p->cnt >= hopsize){
-    MYFLT  pos = *p->in*csound->GetSr(csound);
+    MYFLT  pos = *p->in*CS_ESR;
     MYFLT  *sigframe = (MYFLT *) p->sigframe.auxp;
     MYFLT  pit = *p->p3;
     int32_t     fftsize = p->fftsize;

--- a/Opcodes/lufs.c
+++ b/Opcodes/lufs.c
@@ -86,7 +86,7 @@ static int32_t lufs_init(CSOUND *csound, LUFS *p)
                 p->filter2.b1 = -2.0;
                 p->filter2.b2 = 1.0;
 
-        if (csound->GetSr(csound) == 48000) {
+        if (CS_ESR == 48000) {
                 p->filter1.a1 = -1.69065929318241;
                 p->filter1.a2 =  0.73248077421585;
                 p->filter1.b0 = 1.53512485958697;
@@ -96,7 +96,7 @@ static int32_t lufs_init(CSOUND *csound, LUFS *p)
                 p->filter2.a2 = 0.99007225036621;
         }
 
-        else if (csound->GetSr(csound) == 44100) {
+        else if (CS_ESR == 44100) {
                 p->filter1.a1 = -1.663655113256020;
                 p->filter1.a2 = 0.712595428073225;
                 p->filter1.b0 = 1.530841230049836;
@@ -111,7 +111,7 @@ static int32_t lufs_init(CSOUND *csound, LUFS *p)
             MYFLT f0 = 1681.9744509555319;
             MYFLT G  = 3.99984385397;
             MYFLT Q  = 0.7071752369554193;
-            MYFLT fs = csound->GetSr(csound);
+            MYFLT fs = CS_ESR;
 
             MYFLT K  = TAN(PI * f0 / fs);
             MYFLT Vh = POWER(10.0, G / 20.0);
@@ -131,7 +131,7 @@ static int32_t lufs_init(CSOUND *csound, LUFS *p)
             p->filter2.a2 = (1.0 - K2 / Q2 + K2 * K2) / (1.0 + K2 / Q2 + K2 * K2);
         }
 
-        p->q = FLOOR(csound->GetSr(csound) * 0.1); // 100 ms grain
+        p->q = FLOOR(CS_ESR * 0.1); // 100 ms grain
 
         p->m = 0;
         p->mP = 0;
@@ -232,7 +232,7 @@ static int32_t lufs_init2(CSOUND *csound, LUFS2 *p)
                 p->filter2.b1 = -2.0;
                 p->filter2.b2 = 1.0;
 
-        if (csound->GetSr(csound) == 48000) {
+        if (CS_ESR == 48000) {
                 p->filter1.a1 = -1.69065929318241;
                 p->filter1.a2 =  0.73248077421585;
                 p->filter1.b0 = 1.53512485958697;
@@ -242,7 +242,7 @@ static int32_t lufs_init2(CSOUND *csound, LUFS2 *p)
                 p->filter2.a2 = 0.99007225036621;
         }
 
-        else if (csound->GetSr(csound) == 44100) {
+        else if (CS_ESR == 44100) {
                 p->filter1.a1 = -1.663655113256020;
                 p->filter1.a2 = 0.712595428073225;
                 p->filter1.b0 = 1.530841230049836;
@@ -257,7 +257,7 @@ static int32_t lufs_init2(CSOUND *csound, LUFS2 *p)
             MYFLT f0 = 1681.9744509555319;
             MYFLT G  = 3.99984385397;
             MYFLT Q  = 0.7071752369554193;
-            MYFLT fs = csound->GetSr(csound);
+            MYFLT fs = CS_ESR;
 
             MYFLT K  = TAN(PI * f0 / fs);
             MYFLT Vh = POWER(10.0, G / 20.0);
@@ -279,7 +279,7 @@ static int32_t lufs_init2(CSOUND *csound, LUFS2 *p)
 
                 p->filter3 = p->filter1;
                 p->filter4 = p->filter2;
-                p->q = FLOOR(csound->GetSr(csound) * 0.1); // 100 ms grain
+                p->q = FLOOR(CS_ESR * 0.1); // 100 ms grain
                 p->m = 0;
                 p->mP = 0;
                 p->mPk = 0;

--- a/Opcodes/midiops3.c
+++ b/Opcodes/midiops3.c
@@ -177,7 +177,7 @@ static int32_t slider64(CSOUND *csound, SLIDER64 *p)
                 /*----- init filtering coeffs*/                   \
         *yt1++ = FL(0.0);                                         \
         b = (MYFLT)(2.0 - cos((double)(*(sld++)->ihp              \
-                                       * csound->tpidsr           \
+                                       * CS_TPIDSR           \
                                        * CS_KSMPS)));        \
         *c2 = (MYFLT)(b - sqrt((double)(b * b - FL(1.0))));       \
         *c1++ = FL(1.0) - *c2++;                                  \

--- a/Opcodes/mixer.cpp
+++ b/Opcodes/mixer.cpp
@@ -18,7 +18,8 @@
     You should have received a copy of the GNU Lesser General Public
     License along with Csound; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-    02110-1301 USA
+    02110-1301 USA58
+
 */
 #include <map>
 #include <vector>
@@ -46,7 +47,7 @@ using namespace csound;
 /**
  * Creates the buss if it does not already exist.
  */
-static void createBuss(CSOUND *csound, size_t buss) {
+static void createBuss(CSOUND *csound, size_t buss, int ksmps) {
 #ifdef ENABLE_MIXER_IDEBUG
   csound->Message(csound, "createBuss: csound %p buss %d...\n", csound, buss);
 #endif
@@ -55,7 +56,7 @@ static void createBuss(CSOUND *csound, size_t buss) {
   csound::QueryGlobalPointer(csound, "busses", busses);
   if ((*busses)[csound].find(buss) == (*busses)[csound].end()) {
     size_t channels = csound->GetNchnls(csound);
-    size_t frames = csound->GetKsmps(csound);
+    size_t frames = ksmps;
     (*busses)[csound][buss].resize(channels);
     for (size_t channel = 0; channel < channels; channel++) {
       (*busses)[csound][buss][channel].resize(frames);
@@ -92,7 +93,7 @@ struct MixerSetLevel : public OpcodeBase<MixerSetLevel> {
     csound::QueryGlobalPointer(csound, "matrix", matrix);
     send = static_cast<size_t>(*isend);
     buss = static_cast<size_t>(*ibuss);
-    createBuss(csound, buss);
+    createBuss(csound, buss, opds.insdshead->ksmps);
     (*matrix)[csound][send][buss] = *kgain;
 #ifdef ENABLE_MIXER_IDEBUG
     warn(csound, "MixerSetLevel::init: csound %p send %d buss %d gain %f\n",
@@ -133,7 +134,7 @@ struct MixerGetLevel : public OpcodeBase<MixerGetLevel> {
     csound::QueryGlobalPointer(csound, "matrix", matrix);
     send = static_cast<size_t>(*isend);
     buss = static_cast<size_t>(*ibuss);
-    createBuss(csound, buss);
+    createBuss(csound, buss, opds.insdshead->ksmps);
     return OK;
   }
   int noteoff(CSOUND *) { return OK; }
@@ -174,7 +175,7 @@ struct MixerSend : public OpcodeBase<MixerSend> {
     csound::QueryGlobalPointer(csound, "matrix", matrix);
     send = static_cast<size_t>(*isend);
     buss = static_cast<size_t>(*ibuss);
-    createBuss(csound, buss);
+    createBuss(csound, buss, opds.insdshead->ksmps);
     channel = static_cast<size_t>(*ichannel);
     frames = opds.insdshead->ksmps;
     busspointer = &(*busses)[csound][buss][channel].front();
@@ -227,7 +228,7 @@ struct MixerReceive : public OpcodeBase<MixerReceive> {
     buss = static_cast<size_t>(*ibuss);
     channel = static_cast<size_t>(*ichannel);
     frames = opds.insdshead->ksmps;
-    createBuss(csound, buss);
+    createBuss(csound, buss, opds.insdshead->ksmps);
 #ifdef ENABLE_MIXER_IDEBUG
     warn(csound, "MixerReceive::init...\n");
 #endif

--- a/Opcodes/modal4.c
+++ b/Opcodes/modal4.c
@@ -19,7 +19,7 @@
     License along with Csound; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
-*/
+ */
 
 /*******************************************/
 /*  4 Resonance Modal Synthesis Instrument */
@@ -96,12 +96,12 @@ void Modal4_setRatioAndReson(CSOUND *csound,
                              Modal4 *m, int32_t whichOne, MYFLT ratio,MYFLT reson)
 {
     MYFLT temp;
-    if (ratio* m->baseFreq < CS_ESR * FL(0.5)) {
+    if (ratio* m->baseFreq < m->sr * FL(0.5)) {
       m->ratios[whichOne] = ratio;
     }
     else {
       temp = ratio;
-      while (temp* m->baseFreq > FL(0.5)*CS_ESR) temp *= FL(0.5);
+      while (temp* m->baseFreq > FL(0.5)*m->sr) temp *= FL(0.5);
       m->ratios[whichOne] = temp;
     }
     m->resons[whichOne] = reson;
@@ -240,6 +240,7 @@ int32_t marimbaset(CSOUND *csound, MARIMBA *p)
     MYFLT       temp,temp2;
     int32_t         itemp;
     FUNC        *ftp;
+    p->m4.sr = CS_ESR;
 
     if (LIKELY((ftp = csound->FTnp2Find(csound, p->ifn)) != NULL))
       p->m4.wave = ftp;
@@ -362,6 +363,7 @@ int32_t vibraphnset(CSOUND *csound, VIBRAPHN *p)
     Modal4      *m = &(p->m4);
     MYFLT       temp;
     FUNC        *ftp;
+    p->m4.sr = CS_ESR;
 
     if (LIKELY((ftp = csound->FTnp2Find(csound, p->ifn)) != NULL))
       p->m4.wave = ftp;         /* Expect an impulslything */
@@ -450,6 +452,7 @@ int32_t agogobelset(CSOUND *csound, VIBRAPHN *p)
     Modal4      *m = &(p->m4);
     FUNC        *ftp;
     MYFLT       temp;
+    p->m4.sr = CS_ESR;
 
     /* Expect an impulslything */
     if (LIKELY((ftp = csound->FTnp2Find(csound, p->ifn)) != NULL)) p->m4.wave = ftp;

--- a/Opcodes/modal4.h
+++ b/Opcodes/modal4.h
@@ -57,6 +57,7 @@ typedef struct Modal4 {
     MYFLT       baseFreq;
     MYFLT       ratios[4];
     MYFLT       resons[4];
+    MYFLT       sr;
 } Modal4;
 
 void Modal4_clear(Modal4 *);

--- a/Opcodes/moog1.c
+++ b/Opcodes/moog1.c
@@ -83,7 +83,7 @@ void FormSwep_setTargets(FormSwep *p, MYFLT aFreq, MYFLT aReson, MYFLT aGain)
     p->sweepState  = FL(0.0);
 }
 
-MYFLT FormSwep_tick(CSOUND *csound,
+MYFLT FormSwep_tick(OPDS *pp,
                     FormSwep *p, MYFLT sample) /* Perform Filter Operation */
 {
     MYFLT temp;
@@ -104,7 +104,7 @@ MYFLT FormSwep_tick(CSOUND *csound,
       }
       p->poleCoeffs[1] = - (p->currentReson * p->currentReson);
       p->poleCoeffs[0] = FL(2.0) * p->currentReson *
-        COS(csound->tpidsr * p->currentFreq);
+        COS(2*pp->insdshead->pidsr * p->currentFreq);
     }
 
     temp = p->currentGain * sample;
@@ -278,7 +278,7 @@ int32_t Moog1(CSOUND *csound, MOOG1 *p)
 #ifdef DEBUG
       csound->Message(csound, "TwoZero0_tick: %f\n", output);
 #endif
-      output = FormSwep_tick(csound, &p->filters[0], output);
+      output = FormSwep_tick((OPDS *)p, &p->filters[0], output);
 #ifdef DEBUG
       csound->Message(csound, "Filters0_tick: %f\n", output);
 #endif
@@ -286,7 +286,7 @@ int32_t Moog1(CSOUND *csound, MOOG1 *p)
 #ifdef DEBUG
       csound->Message(csound, "TwoZero1_tick: %f\n", output);
 #endif
-      output = FormSwep_tick(csound, &p->filters[1], output);
+      output = FormSwep_tick((OPDS *)p, &p->filters[1], output);
 #ifdef DEBUG
       csound->Message(csound, "Filter2_tick: %f\n", output);
 #endif

--- a/Opcodes/moog1.c
+++ b/Opcodes/moog1.c
@@ -193,8 +193,8 @@ int32_t Moog1(CSOUND *csound, MOOG1 *p)
     MYFLT       vib = *p->vibAmt;
 
     p->baseFreq = *p->frequency;
-    p->attk.rate = p->baseFreq * FL(0.01) * p->attk.wave->flen * csound->onedsr;
-    p->loop.rate = p->baseFreq            * p->loop.wave->flen * csound->onedsr;
+    p->attk.rate = p->baseFreq * FL(0.01) * p->attk.wave->flen * CS_ONEDSR;
+    p->loop.rate = p->baseFreq            * p->loop.wave->flen * CS_ONEDSR;
     p->attackGain = amp * FL(0.5);
     p->loopGain = amp;
     if (*p->filterQ != p->oldfilterQ) {
@@ -215,7 +215,7 @@ int32_t Moog1(CSOUND *csound, MOOG1 *p)
       p->filters[0].sweepRate = p->oldfilterRate * RATE_NORM;
       p->filters[1].sweepRate = p->oldfilterRate * RATE_NORM;
     }
-    p->vibr.rate = *p->vibf * p->vibr.wave->flen * csound->onedsr;
+    p->vibr.rate = *p->vibf * p->vibr.wave->flen * CS_ONEDSR;
 
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -231,7 +231,7 @@ int32_t Moog1(CSOUND *csound, MOOG1 *p)
       if (vib != FL(0.0)) {
         temp = vib * Samp_tick(&p->vibr);
         p->loop.rate = p->baseFreq * (FL(1.0) + temp) *
-                       (MYFLT)(p->loop.wave->flen) * csound->onedsr;
+                       (MYFLT)(p->loop.wave->flen) * CS_ONEDSR;
       }
 
       p->attk.time += p->attk.rate;           /*  Update current time    */

--- a/Opcodes/moog1.c
+++ b/Opcodes/moog1.c
@@ -154,7 +154,7 @@ int32_t Moog1set(CSOUND *csound, MOOG1 *p)
     FUNC        *ftp;
     MYFLT       tempCoeffs[2] = {FL(0.0),-FL(1.0)};
 
-    make_ADSR(&p->adsr);
+    make_ADSR(&p->adsr, CS_ESR);
     make_OnePole(&p->filter);
     make_TwoZero(&p->twozeroes[0]);
     TwoZero_setZeroCoeffs(&p->twozeroes[0], tempCoeffs);

--- a/Opcodes/moog1.h
+++ b/Opcodes/moog1.h
@@ -69,7 +69,7 @@ typedef struct FormSwep {
 #define FormSwep_setSweepRate(p,aRate)  (p.sweepRate = aRate)
 #define FormSwep_clear(p)               (p.outputs[0]=p.outputs[1]=FL(0.0))
 void FormSwep_setTargets(FormSwep *, MYFLT, MYFLT, MYFLT);
-MYFLT FormSwep_tick(CSOUND *, FormSwep *, MYFLT);
+MYFLT FormSwep_tick(OPDS *, FormSwep *, MYFLT);
 
 typedef struct Wave {
     FUNC        *wave;

--- a/Opcodes/mp3in.c
+++ b/Opcodes/mp3in.c
@@ -846,7 +846,7 @@ static int32_t sprocess3(CSOUND *csound, DATASPACE *p)
     p->curframe = curframe;
     p->pos = spos;
     p->tstamp = tstamp + incrt;
-    *p->kstamp = (*p->skip + p->tstamp/csound->GetSr(csound))/p->resamp;
+    *p->kstamp = (*p->skip + p->tstamp/CS_ESR)/p->resamp;
     p->incr = incrt;
     return OK;
 
@@ -1158,7 +1158,7 @@ static int32_t filinit(CSOUND *csound, LOADER *pp)
     buffiller((void *)p);
     buffiller((void *)p);
 
-    p->pos = skip*csound->GetSr(csound)/p->orsr;
+    p->pos = skip*CS_ESR/p->orsr;
     p->tscale  = 0;
     p->accum = 0;
     p->tab[0] = (MYFLT *) p->fdata[0].auxp;

--- a/Opcodes/newfils.c
+++ b/Opcodes/newfils.c
@@ -878,7 +878,7 @@ static int32_t statevar_process(CSOUND *csound,statevar *p)
     MYFLT fr = (asgfr ? freq[i] : *freq);
     MYFLT rs = (asgrs ? res[i] : *res);
     if (p->oldfreq != fr|| p->oldres != rs) {
-      f = 2.0*sin(fr*(double)csound->pidsr/ostimes);
+      f = 2.0*sin(fr*(double)CS_PIDSR/ostimes);
       q = 1.0/rs;
       lim = ((2.0 - f) *0.05)/ostimes;
       /* csound->Message(csound, "lim: %f, q: %f \n", lim, q); */
@@ -950,7 +950,7 @@ static int32_t fofilter_process(CSOUND *csound,fofilter *p)
     MYFLT dc = asgdc ? dec[i] : *dec;
     if (frq != lfrq || rs != lrs || dc != ldc) {
       lfrq = frq; lrs = rs; ldc = dc;
-      ang = (double)csound->tpidsr*frq;         /* pole angle */
+      ang = (double)CS_TPIDSR*frq;         /* pole angle */
       fsc = sin(ang) - 3.0;                      /* freq scl   */
       rrad1 =  pow(10.0, fsc/(dc*CS_ESR));  /* filter radii */
       rrad2 =  pow(10.0, fsc/(rs*CS_ESR));

--- a/Opcodes/newfils.c
+++ b/Opcodes/newfils.c
@@ -1013,7 +1013,7 @@ int32_t mvclpf24_perf1(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 10.82)/csound->GetSr(csound);
+    w = exp2ap(fr + 10.82)/CS_ESR;
     if (w < 0.8) w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
       w *= 0.6;
@@ -1076,7 +1076,7 @@ int32_t mvclpf24_perf1_ak(CSOUND *csound, mvclpf24 *p){
     t  = ldexp(1 + t * (0.6930 +
                         t * (0.2416 + t * (0.0517 +
                                            t * 0.0137))), wi);
-    w  = t/csound->GetSr(csound);
+    w  = t/CS_ESR;
     if (w < 0.8)
       w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
@@ -1116,7 +1116,7 @@ int32_t mvclpf24_perf1_ka(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 10.82)/csound->GetSr(csound);
+    w = exp2ap(fr + 10.82)/CS_ESR;
     if (w < 0.8) w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
       w *= 0.6;
@@ -1177,7 +1177,7 @@ int32_t mvclpf24_perf1_aa(CSOUND *csound, mvclpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.8)
       w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
@@ -1218,7 +1218,7 @@ int32_t mvclpf24_perf2(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 10.71)/csound->GetSr(csound);
+    w = exp2ap(fr + 10.71)/CS_ESR;
     if (w < 0.8) w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
       w *= 0.6;
@@ -1280,7 +1280,7 @@ int32_t mvclpf24_perf2_ak(CSOUND *csound, mvclpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.8)
       w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
@@ -1318,7 +1318,7 @@ int32_t mvclpf24_perf2_ka(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 10.71)/csound->GetSr(csound);
+    w = exp2ap(fr + 10.71)/CS_ESR;
     if (w < 0.8) w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
       w *= 0.6;
@@ -1377,7 +1377,7 @@ int32_t mvclpf24_perf2_aa(CSOUND *csound, mvclpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.8)
       w *= 1 - 0.4 * w - 0.125 * w * w;
     else {
@@ -1416,7 +1416,7 @@ int32_t mvclpf24_perf3(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 9.70)/csound->GetSr(csound);
+    w = exp2ap(fr + 9.70)/CS_ESR;
     if (w < 0.75) w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
       w *= 0.6748;
@@ -1501,7 +1501,7 @@ int32_t mvclpf24_perf3_ak(CSOUND *csound, mvclpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.75)
       w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
@@ -1565,7 +1565,7 @@ int32_t mvclpf24_perf3_ka(CSOUND *csound, mvclpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 9.70)/csound->GetSr(csound);
+    w = exp2ap(fr + 9.70)/CS_ESR;
     if (w < 0.75) w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
       w *= 0.6748;
@@ -1651,7 +1651,7 @@ int32_t mvclpf24_perf3_aa(CSOUND *csound, mvclpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.75)
       w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
@@ -1739,7 +1739,7 @@ int32_t mvclpf24_perf4(CSOUND *csound, mvclpf24_4 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 9.70)/csound->GetSr(csound);
+    w = exp2ap(fr + 9.70)/CS_ESR;
     if (w < 0.75) w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
       w *= 0.6748;
@@ -1848,7 +1848,7 @@ int32_t mvclpf24_perf4_ak(CSOUND *csound, mvclpf24_4 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.75)
       w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
@@ -1914,7 +1914,7 @@ int32_t mvclpf24_perf4_ka(CSOUND *csound, mvclpf24_4 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = exp2ap(fr + 9.70)/csound->GetSr(csound);
+    w = exp2ap(fr + 9.70)/CS_ESR;
     if (w < 0.75) w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
       w *= 0.6748;
@@ -2020,7 +2020,7 @@ int32_t mvclpf24_perf4_aa(CSOUND *csound, mvclpf24_4 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = t/csound->GetSr(csound);
+    w = t/CS_ESR;
     if (w < 0.75)
       w *= 1.005 - w * (0.624 - w * (0.65 - w * 0.54));
     else {
@@ -2109,7 +2109,7 @@ int32_t mvchpf24_perf(CSOUND *csound, mvchpf24 *p){
   if (p->fr != *p->freq) {
     MYFLT fr = log2(*p->freq/CBASE);
     p->fr  = *p->freq;
-    w = csound->GetSr(csound)/exp2ap(fr+ 9.2);
+    w = CS_ESR/exp2ap(fr+ 9.2);
     if (w < FL(2.0)) w = FL(2.0);
     p->w = w;
   } else w = p->w;
@@ -2187,7 +2187,7 @@ int32_t mvchpf24_perf_a(CSOUND *csound, mvchpf24 *p){
     t = ldexp(1 + t * (0.6930 +
                        t * (0.2416 + t * (0.0517 +
                                           t * 0.0137))), wi);
-    w = csound->GetSr(csound)/t;
+    w = CS_ESR/t;
     if (w < FL(2.0)) w = FL(2.0);
 
     x = y = in[i]/scal  - 0.3 * x;
@@ -2287,7 +2287,7 @@ static int32_t bob_process(CSOUND *csound,BOB *p)
   MYFLT  *sat  = p->sat;
 
   int32_t ostimes = p->ostimes,j;
-  double stepsize = 1./(ostimes * csound->GetSr(csound));
+  double stepsize = 1./(ostimes * CS_ESR);
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i,l, nsmps = CS_KSMPS;
@@ -2387,7 +2387,7 @@ typedef struct vcf {
 
 int vcf_init(CSOUND *csound, VCF *p) {
   double g, *G = p->G;
-  p->piosr = PI/csound->GetSr(csound);
+  p->piosr = PI/CS_ESR;
   p->ff = *p->f;
   g = TAN(p->ff*p->piosr);
   G[0] = g/(1+g);
@@ -2581,7 +2581,7 @@ typedef struct _spf {
 int spf_init(CSOUND *csound, SPF *p) {
   double w, w2, fac;
   double *sh = p->sh, *sl = p->sl, *sb = p->sb, *s = p->s;
-  p->piosr = PI/csound->GetSr(csound);
+  p->piosr = PI/CS_ESR;
   w = TAN(*p->f*p->piosr);
   w2 = w*w;
   p->R = *p->r >  0 ? (*p->r <= 2. ? *p->r : 2.) : 0.;
@@ -2808,7 +2808,7 @@ typedef struct _skf {
 int skf_init(CSOUND *csound, SKF *p) {
   double w, w2, fac;
   double *s = p->s;
-  p->piosr = PI/csound->GetSr(csound);
+  p->piosr = PI/CS_ESR;
   w = TAN(*p->f*p->piosr);
   w2 = w*w;
   p->KK = (*p->K > 1 ? (*p->K <= 3. ? *p->K : 3.) : 1.);
@@ -3015,7 +3015,7 @@ typedef struct _svn {
 int svn_init(CSOUND *csound, SVN *p) {
   double w2;
   double *s = p->s;
-  p->piosr = PI/csound->GetSr(csound);
+  p->piosr = PI/CS_ESR;
   p->w = TAN(*p->f*p->piosr);
   w2 = p->w*p->w;
   p->Q = *p->q >  0.5 ? *p->q : 0.5;

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -435,7 +435,7 @@ static int32_t oscbnk(CSOUND *csound, OSCBNK *p)
     /* some constants */
     pm_enabled = (p->ilfomode & 0x22 ? 1 : 0);
     am_enabled = (p->ilfomode & 0x44 ? 1 : 0);
-    p->frq_scl = csound->onedsr;                 /* osc. freq.   */
+    p->frq_scl = CS_ONEDSR;                 /* osc. freq.   */
     p->lf1_scl = (*(p->args[8]) - *(p->args[7])) * CS_ONEDKR;
     p->lf1_ofs = *(p->args[7]) * CS_ONEDKR;      /* LFO1 freq.   */
     p->lf2_scl = (*(p->args[10]) - *(p->args[9])) * CS_ONEDKR;
@@ -710,10 +710,10 @@ static int32_t grain2(CSOUND *csound, GRAIN2 *p)
     if (UNLIKELY((ftp == NULL) || ((ft = ftp->ftable) == NULL))) return NOTOK;
     oscbnk_flen_setup(ftp->flen, &mask, &lobits, &pfrac);
 
-    p->grain_frq = grain_frq = *(p->kcps) * csound->onedsr; /* grain freq. */
-    p->frq_scl   = frq_scl = *(p->kfmd) * csound->onedsr;
+    p->grain_frq = grain_frq = *(p->kcps) * CS_ONEDSR; /* grain freq. */
+    p->frq_scl   = frq_scl = *(p->kfmd) * CS_ONEDSR;
 
-    f            = csound->onedsr / *(p->kgdur);    /* window frequency    */
+    f            = CS_ONEDSR / *(p->kgdur);    /* window frequency    */
     w_frq        = OSCBNK_PHS2INT(f);
 
     /* initialisation */
@@ -908,7 +908,7 @@ static int32_t grain3(CSOUND *csound, GRAIN3 *p)
     /* convert phase modulation to frequency modulation */
     f = (MYFLT) ((double) p->phs0 - (double) f) / (nsmps-offset);
     f -= (MYFLT) ((int32) f); g_frq = OSCBNK_PHS2INT(f);
-    f = *(p->kcps) * csound->onedsr;            /* grain frequency      */
+    f = *(p->kcps) * CS_ONEDSR;            /* grain frequency      */
     frq = (g_frq + OSCBNK_PHS2INT(f)) & OSCBNK_PHSMSK;
     if (p->mode & 0x40) g_frq = frq;            /* phase sync   */
     /* calculate phase offset values for this k-cycle */
@@ -916,14 +916,14 @@ static int32_t grain3(CSOUND *csound, GRAIN3 *p)
       phs[nn] = g_ph; g_ph = (g_ph + g_frq) & OSCBNK_PHSMSK;
     }
 
-    w_frq_f = csound->onedsr / *(p->kgdur);     /* window frequency     */
+    w_frq_f = CS_ONEDSR / *(p->kgdur);     /* window frequency     */
     if (UNLIKELY((w_frq_f < (FL(1.0) / (MYFLT) OSCBNK_PHSMAX)) ||
                  (w_frq_f >= FL(1.0)))) {
       return csound->PerfError(csound, &(p->h),
                                Str("grain3: invalid grain duration"));
     }
     w_frq = OSCBNK_PHS2INT(w_frq_f);
-    x_frq_f = csound->onedsr * *(p->kdens);     /* density              */
+    x_frq_f = CS_ONEDSR * *(p->kdens);     /* density              */
     if (UNLIKELY((x_frq_f < (FL(1.0) / (MYFLT) OSCBNK_PHSMAX)) ||
                  (x_frq_f >= FL(1.0)))) {
       return csound->PerfError(csound, &(p->h),
@@ -932,7 +932,7 @@ static int32_t grain3(CSOUND *csound, GRAIN3 *p)
     x_frq = OSCBNK_PHS2INT(x_frq_f);
     wfdivxf = w_frq_f / ((MYFLT) OSCBNK_PHSMAX * x_frq_f);
     p->grain_frq = frq;                 /* grain frequency      */
-    p->frq_scl = frq_scl = *(p->kfmd) * csound->onedsr;
+    p->frq_scl = frq_scl = *(p->kfmd) * CS_ONEDSR;
     p->pm_wrap = (fabs((double) *(p->kpmd)) > 0.9 ? 1 : 0);
 
     /* initialise grains (if enabled) */
@@ -1209,7 +1209,7 @@ static int32_t osckkikt(CSOUND *csound, OSCKT *p)
     ft = p->ft; phs = p->phs; a = *(p->xamp); ar = p->sr;
     lobits = p->lobits; mask = p->mask; pfrac = p->pfrac;
     /* read from table with interpolation */
-    v = *(p->xcps) * csound->onedsr; frq = OSCBNK_PHS2INT(v);
+    v = *(p->xcps) * CS_ONEDSR; frq = OSCBNK_PHS2INT(v);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -1256,7 +1256,7 @@ static int32_t osckaikt(CSOUND *csound, OSCKT *p)
       n = phs >> lobits;
       v = ft[n++]; v += (ft[n] - v) * (MYFLT) ((int32) (phs & mask)) * pfrac;
       ar[nn] = v * a;
-      v = *(xcps++) * csound->onedsr;
+      v = *(xcps++) * CS_ONEDSR;
       phs = (phs + OSCBNK_PHS2INT(v)) & OSCBNK_PHSMSK;
     }
     /* save new phase */
@@ -1299,7 +1299,7 @@ static int32_t oscakikt(CSOUND *csound, OSCKT *p)
     ft = p->ft; phs = p->phs; xamp = p->xamp; ar = p->sr;
     lobits = p->lobits; mask = p->mask; pfrac = p->pfrac;
     /* read from table with interpolation */
-    v = *(p->xcps) * csound->onedsr; frq = OSCBNK_PHS2INT(v);
+    v = *(p->xcps) * CS_ONEDSR; frq = OSCBNK_PHS2INT(v);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
      if (UNLIKELY(early)) {
       nsmps -= early;
@@ -1346,7 +1346,7 @@ static int32_t oscaaikt(CSOUND *csound, OSCKT *p)
       n = phs >> lobits;
       v = ft[n++]; v += (ft[n] - v) * (MYFLT) ((int32) (phs & mask)) * pfrac;
       ar[nn] = v * xamp[nn];
-      v = xcps[nn] * csound->onedsr;
+      v = xcps[nn] * CS_ONEDSR;
       phs = (phs + OSCBNK_PHS2INT(v)) & OSCBNK_PHSMSK;
     }
     /* save new phase */
@@ -1391,7 +1391,7 @@ static int32_t oscktp(CSOUND *csound, OSCKTP *p)
     /* copy object data to local variables */
     ft = p->ft; phs = p->phs; ar = p->ar;
     lobits = p->lobits; mask = p->mask; pfrac = p->pfrac;
-    v = *(p->kcps) * csound->onedsr;
+    v = *(p->kcps) * CS_ONEDSR;
     frq = OSCBNK_PHS2INT(v);
     /* initialise phase if 1st k-cycle */
     if (p->init_k) {
@@ -1465,7 +1465,7 @@ static int32_t osckts(CSOUND *csound, OSCKTS *p)
     phs = p->phs; ar = p->ar; xcps = p->xcps; xamp = p->xamp; async = p->async;
     lobits = p->lobits; mask = p->mask; pfrac = p->pfrac;
     if (!a_cps) {
-      v = *xcps * csound->onedsr;
+      v = *xcps * CS_ONEDSR;
       frq = OSCBNK_PHS2INT(v);
     }
     /* initialise phase if 1st k-cycle */
@@ -1490,7 +1490,7 @@ static int32_t osckts(CSOUND *csound, OSCKTS *p)
       ar[nn] = v * *xamp;
       if (a_amp) xamp++;
       if (a_cps) {
-        v = xcps[nn] * csound->onedsr;
+        v = xcps[nn] * CS_ONEDSR;
         frq = OSCBNK_PHS2INT(v);
       }
       phs = (phs + frq) & OSCBNK_PHSMSK;
@@ -2042,7 +2042,7 @@ static int32_t vco2set(CSOUND *csound, VCO2 *p)
       x = *(p->kphs); x -= (MYFLT) ((int32) x);
       p->phs = OSCBNK_PHS2INT(x);
     }
-    p->f_scl = csound->onedsr;
+    p->f_scl = CS_ONEDSR;
     x = (p->INOCOUNT < 6 ? FL(0.5) : *(p->inyx));
     if (x < FL(0.001)) x = FL(0.001);
     if (x > FL(0.5)) x = FL(0.5);

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -446,8 +446,8 @@ static int32_t oscbnk(CSOUND *csound, OSCBNK *p)
 
      /* VL: min freq cannot be > max freq */
       fmin = fmin < fmax ? fmin : fmax;
-      p->eqo_scl = (fmax - fmin) * csound->tpidsr;
-      p->eqo_ofs = fmin * csound->tpidsr;   /* EQ omega */
+      p->eqo_scl = (fmax - fmin) * CS_TPIDSR;
+      p->eqo_ofs = fmin * CS_TPIDSR;   /* EQ omega */
       p->eql_scl = *(p->args[15]) - (p->eql_ofs= *(p->args[14]));/* EQ level */
       p->eqq_scl = *(p->args[17]) - (p->eqq_ofs= *(p->args[16]));/* EQ Q     */
     }

--- a/Opcodes/padsynth_gen.cpp
+++ b/Opcodes/padsynth_gen.cpp
@@ -471,7 +471,7 @@ static int padsynth_gen(FGDATA *ff, FUNC *ftp) {
   int p9_profile_shape = (int)ff->e.p[9];
   // base_function_t base_function = get_base_function(p9_profile_shape);
   MYFLT p10_profile_parameter = ff->e.p[10];
-  MYFLT samplerate = csound->GetSr(csound);
+  MYFLT samplerate = ftp->sr;
   log(csound, "samplerate:                  %12d\n", (int)samplerate);
   log(csound, "p1_function_table_number:            %9.4f\n",
       p1_function_table_number);

--- a/Opcodes/partikkel.c
+++ b/Opcodes/partikkel.c
@@ -483,8 +483,8 @@ static int32_t schedule_grain(CSOUND *csound, PARTIKKEL *p, NODE *node, int32 n,
             curwav->gain *= normalize;
         }
 
-        curwav->delta = startfreq*csound->onedsr;
-        enddelta = endfreq*csound->onedsr;
+        curwav->delta = startfreq*CS_ONEDSR;
+        enddelta = endfreq*CS_ONEDSR;
 
         if (i != WAV_TRAINLET) {
             /* set wavphase to samplepos parameter */
@@ -496,7 +496,7 @@ static int32_t schedule_grain(CSOUND *csound, PARTIKKEL *p, NODE *node, int32 n,
         }
         /* place grain between samples. this is especially important to make
          * high frequency synchronous grain streams sounds right */
-        curwav->phase += phase_corr*startfreq*csound->onedsr;
+        curwav->phase += phase_corr*startfreq*CS_ONEDSR;
 
         /* clamp phase in case it's out of bounds */
         curwav->phase = curwav->phase > 1.0 ? 1.0 : curwav->phase;
@@ -652,7 +652,7 @@ static int32_t schedule_grains(CSOUND *csound, PARTIKKEL *p)
 
         if (p->grainfreq_arate)
             grainfreq = fabs(p->grainfreq[n]);
-        p->graininc = grainfreq*csound->onedsr;
+        p->graininc = grainfreq*CS_ONEDSR;
         p->grainphase += p->graininc;
     }
     return OK;

--- a/Opcodes/phisem.c
+++ b/Opcodes/phisem.c
@@ -202,7 +202,7 @@ static int32_t cabasaset(CSOUND *csound, CABASA *p)
     p->gain = LOG((MYFLT)CABA_NUM_BEADS)*CABA_GAIN/(MYFLT)CABA_NUM_BEADS;
     p->resons = CABA_RESON;
     p->coeffs1 = CABA_RESON * CABA_RESON;
-    p->coeffs0 = - CABA_RESON * FL(2.0) * COS(CABA_CENTER_FREQ * csound->tpidsr);
+    p->coeffs0 = - CABA_RESON * FL(2.0) * COS(CABA_CENTER_FREQ * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * MAX_SHAKE * FL(0.1);
     if (p->shakeEnergy > MAX_SHAKE) p->shakeEnergy = MAX_SHAKE;
@@ -308,7 +308,7 @@ static int32_t sekereset(CSOUND *csound, SEKERE *p)
     p->resons = SEKE_RESON;
     p->coeffs1 = SEKE_RESON * SEKE_RESON;
     p->coeffs0 = - SEKE_RESON * FL(2.0) *
-      COS(SEKE_CENTER_FREQ * csound->tpidsr);
+      COS(SEKE_CENTER_FREQ * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * MAX_SHAKE * FL(0.1);
     if (p->shakeEnergy > MAX_SHAKE) p->shakeEnergy = MAX_SHAKE;
@@ -419,7 +419,7 @@ static int32_t sandset(CSOUND *csound, SEKERE *p)
     p->resons = SANDPAPR_RESON;
     p->coeffs1 = SANDPAPR_RESON * SANDPAPR_RESON;
     p->coeffs0 = - SANDPAPR_RESON * FL(2.0) *
-      COS(SANDPAPR_CENTER_FREQ * csound->tpidsr);
+      COS(SANDPAPR_CENTER_FREQ * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     if (p->shakeEnergy > MAX_SHAKE) p->shakeEnergy = MAX_SHAKE;
@@ -446,7 +446,7 @@ static int32_t stixset(CSOUND *csound, SEKERE *p)
     p->resons = STIX1_RESON;
     p->coeffs1 = STIX1_RESON * STIX1_RESON;
     p->coeffs0 = - STIX1_RESON * FL(2.0) *
-      COS(STIX1_CENTER_FREQ * csound->tpidsr);
+      COS(STIX1_CENTER_FREQ * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     if (p->shakeEnergy > MAX_SHAKE) p->shakeEnergy = MAX_SHAKE;
@@ -471,7 +471,7 @@ static int32_t crunchset(CSOUND *csound, CABASA *p)
     p->resons = CRUNCH1_RESON;
     p->coeffs1 = CRUNCH1_RESON * CRUNCH1_RESON;
     p->coeffs0 = - CRUNCH1_RESON * FL(2.0) *
-      COS(CRUNCH1_CENTER_FREQ * csound->tpidsr);
+      COS(CRUNCH1_CENTER_FREQ * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     if (p->shakeEnergy > MAX_SHAKE) p->shakeEnergy = MAX_SHAKE;
@@ -514,11 +514,11 @@ static int32_t guiroset(CSOUND *csound, GUIRO *p)
 
     p->coeffs01 = GUIR_GOURD_RESON * GUIR_GOURD_RESON;
     p->coeffs00 = -GUIR_GOURD_RESON * FL(2.0) *
-      COS(GUIR_GOURD_FREQ * csound->tpidsr);
+      COS(GUIR_GOURD_FREQ * CS_TPIDSR);
 
     p->coeffs11 = GUIR_GOURD_RESON2 * GUIR_GOURD_RESON2;
     p->coeffs10 = -GUIR_GOURD_RESON2 * FL(2.0) *
-      COS(GUIR_GOURD_FREQ2 * csound->tpidsr);
+      COS(GUIR_GOURD_FREQ2 * CS_TPIDSR);
 
     p->ratchet = FL(0.0);
     p->ratchetPos = 10;
@@ -559,12 +559,12 @@ static int32_t guiro(CSOUND *csound, GUIRO *p)
     if (*p->freq != FL(0.0) && *p->freq !=  p->res_freqSave) {
       p->res_freqSave = *p->freq;
       p->coeffs00 = -GUIR_GOURD_RESON * FL(2.0) *
-        COS(p->res_freqSave * csound->tpidsr);
+        COS(p->res_freqSave * CS_TPIDSR);
     }
     if (*p->freq2 != p->res_freq2) {
       p->res_freq2 = *p->freq2;
       p->coeffs10 = -GUIR_GOURD_RESON2 * FL(2.0) *
-        COS(p->res_freq2 * csound->tpidsr);
+        COS(p->res_freq2 * CS_TPIDSR);
     }
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -685,13 +685,13 @@ static int32_t tambourset(CSOUND *csound, TAMBOURINE *p)
     p->gains2          = temp;
     p->coeffs01        = TAMB_SHELL_RESON * TAMB_SHELL_RESON;
     p->coeffs00        = -TAMB_SHELL_RESON * FL(2.0) *
-      COS(TAMB_SHELL_FREQ * csound->tpidsr);
+      COS(TAMB_SHELL_FREQ * CS_TPIDSR);
     p->coeffs11        = TAMB_CYMB_RESON * TAMB_CYMB_RESON;
     p->coeffs10        = -TAMB_CYMB_RESON * FL(2.0) *
-      COS(TAMB_CYMB_FREQ1 * csound->tpidsr);
+      COS(TAMB_CYMB_FREQ1 * CS_TPIDSR);
     p->coeffs21        = TAMB_CYMB_RESON * TAMB_CYMB_RESON;
     p->coeffs20        = -TAMB_CYMB_RESON * FL(2.0) *
-      COS(TAMB_CYMB_FREQ2 * csound->tpidsr);
+      COS(TAMB_CYMB_FREQ2 * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     p->shake_damp = FL(0.0);
@@ -717,7 +717,7 @@ static int32_t tambourine(CSOUND *csound, TAMBOURINE *p)
     if (*p->freq != FL(0.0) && *p->freq != p->res_freq) {
       p->res_freq = *p->freq;
       p->coeffs00 = -TAMB_SHELL_RESON * FL(2.0) *
-        COS(p->res_freq * csound->tpidsr);
+        COS(p->res_freq * CS_TPIDSR);
     }
     if (*p->damp != FL(0.0) && *p->damp != p->shake_damp) {
       p->shake_damp = *p->damp;
@@ -731,12 +731,12 @@ static int32_t tambourine(CSOUND *csound, TAMBOURINE *p)
     if (*p->freq1 != FL(0.0) && *p->freq1 != p->res_freq1) {
       p->res_freq1 = *p->freq1;
       p->coeffs10 = -TAMB_CYMB_RESON * FL(2.0) *
-        COS(p->res_freq1 * csound->tpidsr);
+        COS(p->res_freq1 * CS_TPIDSR);
     }
     if (*p->freq2 != FL(0.0) && *p->freq2 != p->res_freq2) {
       p->res_freq2 = *p->freq2;
       p->coeffs20 = -TAMB_CYMB_RESON * FL(2.0) *
-        COS(p->res_freq2 * csound->tpidsr);
+        COS(p->res_freq2 * CS_TPIDSR);
     }
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -760,10 +760,10 @@ static int32_t tambourine(CSOUND *csound, TAMBOURINE *p)
           sndLevel += p->gain * shakeEnergy;
           temp_rand = p->res_freq1 * (FL(1.0) + (FL(0.05)*noise_tick(csound)));
           p->coeffs10 = -TAMB_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq2 * (FL(1.0) + (FL(0.05)*noise_tick(csound)));
           p->coeffs20 = -TAMB_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
         }
         inputs0 = sndLevel * noise_tick(csound);  /* Actual Sound is Random */
         inputs1 = inputs0;
@@ -826,13 +826,13 @@ static int32_t bambooset(CSOUND *csound, BAMBOO *p)
     p->gain            = temp;
     p->coeffs01        = BAMB_RESON * BAMB_RESON;
     p->coeffs00        = -BAMB_RESON * FL(2.0) *
-      COS(BAMB_CENTER_FREQ0 * csound->tpidsr);
+      COS(BAMB_CENTER_FREQ0 * CS_TPIDSR);
     p->coeffs11        = BAMB_RESON * BAMB_RESON;
     p->coeffs10        = -BAMB_RESON * FL(2.0) *
-      COS(BAMB_CENTER_FREQ1 * csound->tpidsr);
+      COS(BAMB_CENTER_FREQ1 * CS_TPIDSR);
     p->coeffs21        = BAMB_RESON * BAMB_RESON;
     p->coeffs20        = -BAMB_RESON * FL(2.0) *
-      COS(BAMB_CENTER_FREQ2 * csound->tpidsr);
+      COS(BAMB_CENTER_FREQ2 * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy     = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     p->shake_damp      = FL(0.0);
@@ -857,7 +857,7 @@ static int32_t bamboo(CSOUND *csound, BAMBOO *p)
     if (*p->freq != FL(0.0) && *p->freq != p->res_freq0) {
       p->res_freq0 = *p->freq;
       p->coeffs00 = -BAMB_RESON * FL(2.0) *
-        COS(p->res_freq0 * csound->tpidsr);
+        COS(p->res_freq0 * CS_TPIDSR);
     }
     if (*p->damp != FL(0.0) && *p->damp != p->shake_damp) {
       p->shake_damp = *p->damp;
@@ -871,12 +871,12 @@ static int32_t bamboo(CSOUND *csound, BAMBOO *p)
     if (*p->freq1 != FL(0.0) && *p->freq1 != p->res_freq1) {
       p->res_freq1 = *p->freq1;
       p->coeffs10 = -BAMB_RESON * FL(2.0) *
-        COS(p->res_freq1 * csound->tpidsr);
+        COS(p->res_freq1 * CS_TPIDSR);
     }
     if (*p->freq2 != FL(0.0) && *p->freq2 != p->res_freq2) {
       p->res_freq2 = *p->freq2;
       p->coeffs20 = -BAMB_RESON * FL(2.0) *
-        COS(p->res_freq2 * csound->tpidsr);
+        COS(p->res_freq2 * CS_TPIDSR);
     }
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -900,15 +900,15 @@ static int32_t bamboo(CSOUND *csound, BAMBOO *p)
           sndLevel += shakeEnergy;
           temp_rand = p->res_freq0 * (FL(1.0) + (FL(0.2) * noise_tick(csound)));
           p->coeffs00 = -BAMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq1 * (FL(1.0) +
                                       (FL(0.2) * noise_tick(csound)));
           p->coeffs10 = -BAMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq2 * (FL(1.0) +
                                       (FL(0.2) * noise_tick(csound)));
           p->coeffs20 = -BAMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
         }
         inputs0 = sndLevel * noise_tick(csound); /* Actual Sound is Random */
         inputs1      = inputs0;
@@ -967,13 +967,13 @@ static int32_t wuterset(CSOUND *csound, WUTER *p)
     p->gains0          = p->gains1 = p->gains2 = temp;
     p->coeffs01        = WUTR_RESON * WUTR_RESON;
     p->coeffs00        = -WUTR_RESON * FL(2.0) *
-      COS(WUTR_CENTER_FREQ0 * csound->tpidsr);
+      COS(WUTR_CENTER_FREQ0 * CS_TPIDSR);
     p->coeffs11        = WUTR_RESON * WUTR_RESON;
     p->coeffs10        = -WUTR_RESON * FL(2.0) *
-      COS(WUTR_CENTER_FREQ1 * csound->tpidsr);
+      COS(WUTR_CENTER_FREQ1 * CS_TPIDSR);
     p->coeffs21        = WUTR_RESON * WUTR_RESON;
     p->coeffs20        = -WUTR_RESON * FL(2.0) *
-      COS(WUTR_CENTER_FREQ2 * csound->tpidsr);
+      COS(WUTR_CENTER_FREQ2 * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy     = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     p->shake_damp      = FL(0.0);
@@ -1000,7 +1000,7 @@ static int32_t wuter(CSOUND *csound, WUTER *p)
     if (*p->freq != FL(0.0) && *p->freq != p->res_freq0) {
       p->res_freq0 = *p->freq;
       p->coeffs00 = -WUTR_RESON * FL(2.0) *
-        COS(p->res_freq0 * csound->tpidsr);
+        COS(p->res_freq0 * CS_TPIDSR);
     }
     if (*p->damp != FL(0.0) && *p->damp != p->shake_damp) {
       p->shake_damp = *p->damp;
@@ -1014,12 +1014,12 @@ static int32_t wuter(CSOUND *csound, WUTER *p)
     if (*p->freq1 != FL(0.0) && *p->freq1 != p->res_freq1) {
       p->res_freq1 = *p->freq1;
       p->coeffs10 = -WUTR_RESON * FL(2.0) *
-        COS(p->res_freq1 * csound->tpidsr);
+        COS(p->res_freq1 * CS_TPIDSR);
     }
     if (*p->freq2 != FL(0.0) && *p->freq2 != p->res_freq2) {
       p->res_freq2 = *p->freq2;
       p->coeffs20 = -WUTR_RESON * FL(2.0) *
-        COS(p->res_freq2 * csound->tpidsr);
+        COS(p->res_freq2 * CS_TPIDSR);
     }
     //if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -1068,19 +1068,19 @@ static int32_t wuter(CSOUND *csound, WUTER *p)
         if (p->gains0 >  FL(0.001)) {
           p->center_freqs0  *= WUTR_FREQ_SWEEP;
           p->coeffs00 = -WUTR_RESON * FL(2.0) *
-            COS(p->center_freqs0 * csound->tpidsr);
+            COS(p->center_freqs0 * CS_TPIDSR);
         }
         p->gains1 *= WUTR_RESON;
         if (p->gains1 > FL(0.001)) {
           p->center_freqs1 *= WUTR_FREQ_SWEEP;
           p->coeffs10 = -WUTR_RESON * FL(2.0) *
-            COS(p->center_freqs1 * csound->tpidsr);
+            COS(p->center_freqs1 * CS_TPIDSR);
         }
         p->gains2 *= WUTR_RESON;
         if (p->gains2 > FL(0.001)) {
           p->center_freqs2 *= WUTR_FREQ_SWEEP;
           p->coeffs20 = -WUTR_RESON * FL(2.0) *
-            COS(p->center_freqs2 * csound->tpidsr);
+            COS(p->center_freqs2 * CS_TPIDSR);
         }
 
         sndLevel    *= soundDecay;          /* Each (all) event(s)  */
@@ -1153,19 +1153,19 @@ static int32_t sleighset(CSOUND *csound, SLEIGHBELLS *p)
     p->gain            = temp;
     p->coeffs01        = SLEI_CYMB_RESON * SLEI_CYMB_RESON;
     p->coeffs00        = -SLEI_CYMB_RESON * FL(2.0) *
-      COS(SLEI_CYMB_FREQ0 * csound->tpidsr);
+      COS(SLEI_CYMB_FREQ0 * CS_TPIDSR);
     p->coeffs11        = SLEI_CYMB_RESON * SLEI_CYMB_RESON;
     p->coeffs10        = -SLEI_CYMB_RESON * FL(2.0) *
-      COS(SLEI_CYMB_FREQ1 * csound->tpidsr);
+      COS(SLEI_CYMB_FREQ1 * CS_TPIDSR);
     p->coeffs21        = SLEI_CYMB_RESON * SLEI_CYMB_RESON;
     p->coeffs20        = -SLEI_CYMB_RESON * FL(2.0) *
-      COS(SLEI_CYMB_FREQ2 * csound->tpidsr);
+      COS(SLEI_CYMB_FREQ2 * CS_TPIDSR);
     p->coeffs31        = SLEI_CYMB_RESON * SLEI_CYMB_RESON;
     p->coeffs30        = -SLEI_CYMB_RESON * FL(2.0) *
-      COS(SLEI_CYMB_FREQ3 * csound->tpidsr);
+      COS(SLEI_CYMB_FREQ3 * CS_TPIDSR);
     p->coeffs41        = SLEI_CYMB_RESON * SLEI_CYMB_RESON;
     p->coeffs40        = -SLEI_CYMB_RESON * FL(2.0) *
-      COS(SLEI_CYMB_FREQ4 * csound->tpidsr);
+      COS(SLEI_CYMB_FREQ4 * CS_TPIDSR);
                                 /* Note On */
     p->shakeEnergy = *p->amp * csound->dbfs_to_float * MAX_SHAKE * FL(0.1);
     p->shake_damp = FL(0.0);
@@ -1190,7 +1190,7 @@ static int32_t sleighbells(CSOUND *csound, SLEIGHBELLS *p)
     if (*p->freq != FL(0.0) && *p->freq != p->res_freq0) {
       p->res_freq0 = *p->freq;
       p->coeffs00 = -SLEI_CYMB_RESON * FL(2.0) *
-        COS(p->res_freq0 * csound->tpidsr);
+        COS(p->res_freq0 * CS_TPIDSR);
     }
     if (*p->damp != FL(0.0) && *p->damp != p->shake_damp) {
       p->shake_damp = *p->damp;
@@ -1204,12 +1204,12 @@ static int32_t sleighbells(CSOUND *csound, SLEIGHBELLS *p)
     if (*p->freq1 != FL(0.0) && *p->freq1 != p->res_freq1) {
       p->res_freq1 = *p->freq1;
       p->coeffs10 = -SLEI_CYMB_RESON * FL(2.0) *
-        COS(p->res_freq1 * csound->tpidsr);
+        COS(p->res_freq1 * CS_TPIDSR);
     }
     if (*p->freq2 != FL(0.0) && *p->freq2 != p->res_freq2) {
       p->res_freq2 = *p->freq2;
       p->coeffs20 = -SLEI_CYMB_RESON * FL(2.0) *
-        COS(p->res_freq2 * csound->tpidsr);
+        COS(p->res_freq2 * CS_TPIDSR);
     }
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -1233,19 +1233,19 @@ static int32_t sleighbells(CSOUND *csound, SLEIGHBELLS *p)
           sndLevel += p->gain * shakeEnergy;
           temp_rand = p->res_freq0 * (FL(1.0) + (FL(0.03)*noise_tick(csound)));
           p->coeffs00 = -SLEI_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq1 * (FL(1.0) + (FL(0.03)*noise_tick(csound)));
           p->coeffs10 = -SLEI_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq2 * (FL(1.0) + (FL(0.03)*noise_tick(csound)));
           p->coeffs20 = -SLEI_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq3 * (FL(1.0) + (FL(0.03)*noise_tick(csound)));
           p->coeffs30 = -SLEI_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
           temp_rand = p->res_freq4 * (FL(1.0) + (FL(0.03)*noise_tick(csound)));
           p->coeffs40 = -SLEI_CYMB_RESON * FL(2.0) *
-            COS(temp_rand * csound->tpidsr);
+            COS(temp_rand * CS_TPIDSR);
         }
         inputs0 = sndLevel * noise_tick(csound);  /* Actual Sound is Random */
         inputs1      = inputs0;

--- a/Opcodes/physmod.c
+++ b/Opcodes/physmod.c
@@ -757,14 +757,14 @@ MYFLT DLineA_tick(DLineA *p, MYFLT sample)   /*   Take sample, yield sample */
 
 #define make_LipFilt(p) make_BiQuad(p)
 
-void LipFilt_setFreq(CSOUND *csound, LipFilt *p, MYFLT frequency)
+void LipFilt_setFreq(BRASS *p, LipFilt *pp, MYFLT frequency)
 {
     MYFLT coeffs[2];
     coeffs[0] = FL(2.0) * FL(0.997) *
-      (MYFLT)cos(csound->tpidsr * (double)frequency);   /* damping should  */
+      (MYFLT)cos(CS_TPIDSR * (double)frequency);   /* damping should  */
     coeffs[1] = -FL(0.997) * FL(0.997);                 /* change with lip */
-    BiQuad_setPoleCoeffs(p, coeffs);                    /* parameters, but */
-    BiQuad_setGain(*p, FL(0.03));                       /* not yet.        */
+    BiQuad_setPoleCoeffs(pp, coeffs);                    /* parameters, but */
+    BiQuad_setGain(*pp, FL(0.03));                       /* not yet.        */
 }
 
 /*  NOTE:  Here we should add lip tension                 */
@@ -885,7 +885,7 @@ int32_t brass(CSOUND *csound, BRASS *p)
     } /* End of set frequency */
     if (*p->liptension != p->lipT) {
       p->lipT = *p->liptension;
-      LipFilt_setFreq(csound, &p->lipFilter,
+      LipFilt_setFreq(p, &p->lipFilter,
                       p->lipTarget * (MYFLT)pow(4.0,(2.0* p->lipT) -1.0));
     }
 

--- a/Opcodes/physmod.c
+++ b/Opcodes/physmod.c
@@ -177,7 +177,7 @@ int32_t clarin(CSOUND *csound, CLARIN *p)
     p->outputGain = amp + FL(0.001);
     DLineL_setDelay(&p->delayLine, /* length - approx filter delay */
         (CS_ESR/ *p->frequency) * FL(0.5) - FL(1.5));
-    p->v_rate = *p->vibFreq * p->vibr->flen * csound->onedsr;
+    p->v_rate = *p->vibFreq * p->vibr->flen * CS_ONEDSR;
                                 /* Check to see if into decay yet */
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
@@ -366,7 +366,7 @@ int32_t flute(CSOUND *csound, FLUTE *p)
       p->outputGain = amp + FL(0.001);
       p->lastamp = amp;
     }
-    p->v_rate = *p->vibFreq * v_len * csound->onedsr;
+    p->v_rate = *p->vibFreq * v_len * CS_ONEDSR;
                                 /* Start SetFreq */
     if (p->lastFreq != *p->frequency) { /* It changed */
       p->lastFreq = *p->frequency;
@@ -596,7 +596,7 @@ int32_t bowed(CSOUND *csound, BOWED *p)
       DLineL_setDelay(&p->neckDelay, /* bow to nut (finger) length */
                       p->baseDelay *(FL(1.0) - p->lastbeta));
     }
-    p->v_rate = *p->vibFreq * p->vibr->flen * csound->onedsr;
+    p->v_rate = *p->vibFreq * p->vibr->flen * CS_ONEDSR;
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;
     if ((--p->kloop) == 0) {
       ADSR_setDecayRate(csound, &p->adsr, (FL(1.0) - p->adsr.value) * FL(0.005));
@@ -862,7 +862,7 @@ int32_t brass(CSOUND *csound, BRASS *p)
     MYFLT vibGain = *p->vibAmt;
     MYFLT vTime = p->v_time;
 
-    p->v_rate = *p->vibFreq * v_len * csound->onedsr;
+    p->v_rate = *p->vibFreq * v_len * CS_ONEDSR;
     /*   vibr->setFreq(6.137); */
     /* vibrGain = 0.05; */            /* breath periodic vibrato component  */
     if (p->kloop>0 && p->h.insdshead->relesing) p->kloop=1;

--- a/Opcodes/physmod.c
+++ b/Opcodes/physmod.c
@@ -310,7 +310,7 @@ int32_t fluteset(CSOUND *csound, FLUTE *p)
       make_OnePole(&p->filter);
       make_DCBlock(&p->dcBlock);
       make_Noise(p->noise);
-      make_ADSR(&p->adsr);
+      make_ADSR(&p->adsr, CS_ESR);
                                 /* Clear */
 /*     OnePole_clear(&p->filter); */
 /*     DCBlock_clear(&p->dcBlock); */
@@ -530,7 +530,7 @@ int32_t bowedset(CSOUND *csound, BOWED *p)
       p->bowTabl.slope = FL(3.0);
       make_OnePole(&p->reflFilt);
       make_BiQuad(&p->bodyFilt);
-      make_ADSR(&p->adsr);
+      make_ADSR(&p->adsr, CS_ESR);
 
       DLineL_setDelay(&p->neckDelay, FL(100.0));
       DLineL_setDelay(&p->bridgeDelay, FL(29.0));
@@ -815,7 +815,7 @@ int32_t brassset(CSOUND *csound, BRASS *p)
       make_DLineA(csound, &p->delayLine, p->length);
       make_LipFilt(&p->lipFilter);
       make_DCBlock(&p->dcBlock);
-      make_ADSR(&p->adsr);
+      make_ADSR(&p->adsr, CS_ESR);
       ADSR_setAllTimes(csound, &p->adsr, FL(0.005), FL(0.001), FL(1.0), FL(0.010));
 /*        ADSR_setAll(&p->adsr, 0.02f, 0.05f, FL(1.0), 0.001f); */
 

--- a/Opcodes/physutil.c
+++ b/Opcodes/physutil.c
@@ -277,7 +277,7 @@ MYFLT DCBlock_tick(DCBlock* p, MYFLT sample)
 /*  2 = S, 3 = R)                          */
 /*******************************************/
 
-void make_ADSR(ADSR *a)
+void make_ADSR(ADSR *a, MYFLT sr)
 {
     make_Envelope((Envelope*)a);
     a->target = FL(0.0);
@@ -287,6 +287,7 @@ void make_ADSR(ADSR *a)
     a->sustainLevel = FL(0.5);
     a->releaseRate = FL(0.01);
     a->state = ATTACK;
+    a->sr = sr;
 }
 
 void ADSR_keyOn(ADSR *a)
@@ -351,9 +352,9 @@ void ADSR_setAttackTime(CSOUND *csound, ADSR *a, MYFLT aTime)
     if (UNLIKELY(aTime < FL(0.0))) {
       csound->Warning(csound,
                       Str("negative times not allowed!!, correcting\n"));
-      a->attackRate = FL(1.0) /(-aTime*CS_ESR);
+      a->attackRate = FL(1.0) /(-aTime*a->sr);
     }
-    else a->attackRate = FL(1.0) / (aTime*CS_ESR);
+    else a->attackRate = FL(1.0) / (aTime*a->sr);
 }
 
 void ADSR_setDecayTime(CSOUND *csound, ADSR *a, MYFLT aTime)
@@ -361,9 +362,9 @@ void ADSR_setDecayTime(CSOUND *csound, ADSR *a, MYFLT aTime)
     if (UNLIKELY(aTime < FL(0.0))) {
       csound->Warning(csound,
                       Str("negative times not allowed!!, correcting\n"));
-      a->decayRate = FL(1.0) /(-aTime*CS_ESR);
+      a->decayRate = FL(1.0) /(-aTime*a->sr);
     }
-    else a->decayRate = FL(1.0) / (aTime*CS_ESR);
+    else a->decayRate = FL(1.0) / (aTime*a->sr);
 }
 
 void ADSR_setReleaseTime(CSOUND *csound, ADSR *a, MYFLT aTime)
@@ -371,9 +372,9 @@ void ADSR_setReleaseTime(CSOUND *csound, ADSR *a, MYFLT aTime)
     if (UNLIKELY(aTime < FL(0.0))) {
       csound->Warning(csound,
                       Str("negative times not allowed!!, correcting\n"));
-      a->releaseRate = FL(1.0) /(-aTime*CS_ESR);
+      a->releaseRate = FL(1.0) /(-aTime*a->sr);
     }
-    else a->releaseRate = FL(1.0) / (aTime*CS_ESR);
+    else a->releaseRate = FL(1.0) / (aTime*a->sr);
 }
 
 void ADSR_setAllTimes(CSOUND *csound, ADSR *a, MYFLT attTime, MYFLT decTime,

--- a/Opcodes/physutil.h
+++ b/Opcodes/physutil.h
@@ -177,9 +177,10 @@ typedef struct ADSR {
     MYFLT       decayRate;
     MYFLT       sustainLevel;
     MYFLT       releaseRate;
+    MYFLT       sr;
 } ADSR;
 
-void make_ADSR(ADSR*);
+void make_ADSR(ADSR*, MYFLT sr);
 void dest_ADSR(ADSR*);
 void ADSR_keyOn(ADSR*);
 void ADSR_keyOff(ADSR*);

--- a/Opcodes/pinker.c
+++ b/Opcodes/pinker.c
@@ -93,7 +93,7 @@ static int pink_perf(CSOUND* csound, PINKER *p)
     int32 lfsr   =   p->lfsr;
     int cnt    =   p->cnt;
     int bit;
-    int n, nn, nsmps = csound->ksmps;
+    int n, nn, nsmps = CS_KSMPS;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     int mask;

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1196,7 +1196,7 @@ int32_t kphsorbnk(CSOUND *csound, PHSORBNK *p)
     }
 
     *p->sr = (MYFLT)(phs = curphs[index]);
-    if (UNLIKELY((phs += *p->xcps * csound->onedkr) >= 1.0))
+    if (UNLIKELY((phs += *p->xcps * CS_ONEDKR) >= 1.0))
       phs -= 1.0;
     else if (UNLIKELY(phs < 0.0)) /* patch from Matthew Scala */
       phs += 1.0;

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -715,7 +715,7 @@ int32_t adsynt(CSOUND *csound, ADSYNT *p)
     for (c=0; c<count; c++) {
       amp = amptbl[c] * amp0;
       cps = freqtbl[c] * cps0;
-      inc = (int32) (cps * csound->sicvt);
+      inc = (int32) (cps * CS_SICVT);
       phs = lphs[c];
       for (n=offset; n<nsmps; n++) {
         ar[n] += *(ftbl + (phs >> lobits)) * amp;
@@ -814,7 +814,7 @@ int32_t hsboscil(CSOUND *csound, HSBOSC   *p)
       amp = mtab[(int32_t)((octoffs / (MYFLT)octcnt) * mtablen)] * amp0;
       if (UNLIKELY(freq > hesr))
         amp = FL(0.0);
-      inc = (int32)(freq * csound->sicvt);
+      inc = (int32)(freq * CS_SICVT);
       for (n=offset; n<nsmps; n++) {
         fract = PFRAC(phs);
         ftab = ftp->ftable + (phs >> lobits);

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1235,7 +1235,7 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     if (IS_ASIG_ARG(p->xcps)) {
       MYFLT *cps = p->xcps;
       for (n=offset; n<nsmps; n++) {
-        incr = (double)(cps[n] * csound->onedsr);
+        incr = (double)(cps[n] * CS_ONEDSR);
         rs[n] = (MYFLT)phase;
         phase += incr;
         if (UNLIKELY(phase >= 1.0))
@@ -1245,7 +1245,7 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
       }
     }
     else {
-      incr = (double)(*p->xcps * csound->onedsr);
+      incr = (double)(*p->xcps * CS_ONEDSR);
       for (n=offset; n<nsmps; n++) {
         rs[n] = (MYFLT)phase;
         phase += incr;
@@ -2182,7 +2182,7 @@ int32_t lpf18db(CSOUND *csound, LPF18 *p)
       dist       = (double)(asgd ? p->dist[n] : *p->dist);
       if (fco != lfc || flag) {
         lfc = fco;
-        kfcn = FL(2.0) * fco * csound->onedsr;
+        kfcn = FL(2.0) * fco * CS_ONEDSR;
         kp   = ((-FL(2.7528)*kfcn + FL(3.0429))*kfcn +
                 FL(1.718))*kfcn - FL(0.9984);
         kp1 = kp+FL(1.0);

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -67,7 +67,7 @@ int32_t pitchset(CSOUND *csound, PITCH *p)  /* pitch - uses spectra technology *
     MYFLT   weight, weightsum, dbthresh, ampthresh;
 
                                 /* RMS of input signal */
-    b = 2.0 - cos(10.0*(double)csound->tpidsr);
+    b = 2.0 - cos(10.0*(double)CS_TPIDSR);
     p->c2 = b - sqrt(b * b - 1.0);
     p->c1 = 1.0 - p->c2;
     if (!*p->istor) p->prvq = 0.0;

--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -557,13 +557,13 @@ typedef struct plltrack_
 
 } PLLTRACK;
 
-void update_coefs(CSOUND *csound, double fr, double Q, BIQUAD *biquad, int32_t TYPE)
+void update_coefs(PLLTRACK *p, double fr, double Q, BIQUAD *biquad, int32_t TYPE)
 {
     double k, ksq, div, ksqQ;
 
     switch(TYPE){
     case LP2:
-      k = tan(fr*csound->pidsr);
+      k = tan(fr*CS_PIDSR);
       ksq = k*k;
       ksqQ = ksq*Q;
       div = ksqQ+k+Q;
@@ -575,7 +575,7 @@ void update_coefs(CSOUND *csound, double fr, double Q, BIQUAD *biquad, int32_t T
       break;
 
     case LP1:
-      k = 1.0/tan(csound->pidsr*fr);
+      k = 1.0/tan(CS_PIDSR*fr);
       ksq = k*k;
       biquad->a0 = 1.0 / ( 1.0 + ROOT2 * k + ksq);
       biquad->a1 = 2.0*biquad->a0;
@@ -585,7 +585,7 @@ void update_coefs(CSOUND *csound, double fr, double Q, BIQUAD *biquad, int32_t T
       break;
 
     case HP:
-      k = tan(csound->pidsr*fr);
+      k = tan(CS_PIDSR*fr);
       ksq = k*k;
       biquad->a0 = 1.0 / ( 1.0 + ROOT2 * k + ksq);
       biquad->a1 = -2.*biquad->a0;
@@ -604,7 +604,7 @@ int32_t plltrack_set(CSOUND *csound, PLLTRACK *p)
     p->x1 = p->cos_x = p->sin_x = 0.0;
     p->x2 = 1.0;
     p->klpf_o = p->klpfQ_o = p->klf_o = p->khf_o = 0.0;
-    update_coefs(csound,10.0, 0.0, &p->fils[4], LP1);
+    update_coefs(p,10.0, 0.0, &p->fils[4], LP1);
     p->ace = p->xce = 0.0;
     for (i=0; i < 6; i++)
       p->fils[i].del1 = p->fils[i].del2 = 0.0;
@@ -630,7 +630,7 @@ int32_t plltrack_perf(CSOUND *csound, PLLTRACK *p)
     _0dbfs = csound->e0dbfs;
     ksmps = CS_KSMPS;
     esr = CS_ESR;
-    scal = 2.0*csound->pidsr;
+    scal = 2.0*CS_PIDSR;
 
     /* check for muted input & bypass */
     if (ksmps > 1){
@@ -663,19 +663,19 @@ int32_t plltrack_perf(CSOUND *csound, PLLTRACK *p)
 
 
     if (p->khf_o != khf) {
-      update_coefs(csound, khf, 0.0, &biquad[0], LP1);
-      update_coefs(csound, khf, 0.0, &biquad[1], LP1);
-      update_coefs(csound, khf, 0.0, &biquad[2], LP1);
+      update_coefs(p, khf, 0.0, &biquad[0], LP1);
+      update_coefs(p, khf, 0.0, &biquad[1], LP1);
+      update_coefs(p, khf, 0.0, &biquad[2], LP1);
       p->khf_o = khf;
     }
 
     if (p->klf_o != klf) {
-      update_coefs(csound, klf, 0.0, &biquad[3], HP);
+      update_coefs(p, klf, 0.0, &biquad[3], HP);
       p->klf_o = klf;
     }
 
     if (p->klpf_o != klpf || p->klpfQ_o != klpfQ ) {
-      update_coefs(csound, klpf, klpfQ, &biquad[5], LP2);
+      update_coefs(p, klpf, klpfQ, &biquad[5], LP2);
       p->klpf_o = klpf; p->klpfQ_o = klpfQ;
     }
 

--- a/Opcodes/platerev.c
+++ b/Opcodes/platerev.c
@@ -54,8 +54,8 @@ static int32_t platerev_init(CSOUND *csound, PLATE *p)
 {
     FUNC *inp, *outp;
     double a = *p->asp;
-    double dt = (p->dt = 1.0/csound->GetSr(csound)); /* time step */
-    double sig = (csound->GetSr(csound)+csound->GetSr(csound))*
+    double dt = (p->dt = 1.0/CS_ESR); /* time step */
+    double sig = (CS_ESR+CS_ESR)*
                  (POWER(10.0, FL(3.0)*dt/(*p->decay))-FL(1.0)); /* loss constant */
     double b2 = *p->loss;
     double dxmin = 2.0*sqrt(dt*(b2+hypot(*p->loss, *p->stiff)));

--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -312,7 +312,7 @@ static void waveguideWaveguide(CSOUND *csound,
     wg->excited = 0;
     wg->p       = FL(0.0); /* tuning filter state variable */
     wg->f0      = freq;
-    wg->w0      = 2*M_PI*freq/sr;
+    wg->w0      = 2*PI*freq/sr;
     wg->sr = sr;
 
 #ifdef WG_VERBOSE

--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -138,7 +138,7 @@ static void pluckSetFilters(CSOUND *csound, WGPLUCK* p, MYFLT A_w0, MYFLT A_PI)
     /* Define the required magnitude response of H1 at w0 and PI */
 
     /* Constrain attenuation specification to dB per second */
-    MYFLT NRecip = p->wg.f0 * csound->onedsr;  /*  N=t*CS_ESR/f0  */
+    MYFLT NRecip = p->wg.f0 * CS_ONEDSR;  /*  N=t*CS_ESR/f0  */
     MYFLT H1_w0 = POWER(FL(10.0),-A_w0*FL(0.05)*NRecip);
     MYFLT H1_PI = POWER(FL(10.0),-A_PI*FL(0.05)*NRecip);
     {
@@ -343,7 +343,7 @@ static void waveguideWaveguide(CSOUND *csound,
 /* Set the allpass tuning filter coefficient */
 static void waveguideSetTuning(CSOUND *csound, waveguide* wg, MYFLT df)
 {
-    MYFLT k=csound->onedsr * wg->w0;
+  MYFLT k= (1/wg->sr) * wg->w0;
 
   /*c = (1.0-df)/(1.0+df);*/ /* Solve for coefficient from df */
     wg->c = -sinf((k-k*df)/FL(2.0))/sinf((k+k*df)/FL(2.0));

--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -312,7 +312,7 @@ static void waveguideWaveguide(CSOUND *csound,
     wg->excited = 0;
     wg->p       = FL(0.0); /* tuning filter state variable */
     wg->f0      = freq;
-    wg->w0      = csound->tpidsr*freq;
+    wg->w0      = 2*M_PI*freq/sr;
     wg->sr = sr;
 
 #ifdef WG_VERBOSE

--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -116,7 +116,7 @@ static int32_t pluckPluck(CSOUND *csound, WGPLUCK* p)
                        (waveguide*)&p->wg,             /* waveguide       */
                        (MYFLT)*p->freq,                /* f0 frequency    */
                        (MYFLT*)p->upperData.auxp,      /* upper rail data */
-                       (MYFLT*)p->lowerData.auxp);     /* lower rail data */
+                       (MYFLT*)p->lowerData.auxp, CS_ESR);     /* lower rail data */
 #ifdef WG_VERBOSE
     csound->Message(csound, "done.\n");
 #endif
@@ -305,7 +305,7 @@ static void waveguideWaveguide(CSOUND *csound,
                         waveguide* wg,
                         MYFLT  freq,
                         MYFLT* upperData,
-                        MYFLT* lowerData)
+                        MYFLT* lowerData, MYFLT sr)
 {
     MYFLT size, df;
 
@@ -313,6 +313,7 @@ static void waveguideWaveguide(CSOUND *csound,
     wg->p       = FL(0.0); /* tuning filter state variable */
     wg->f0      = freq;
     wg->w0      = csound->tpidsr*freq;
+    wg->sr = sr;
 
 #ifdef WG_VERBOSE
     csound->Message(csound, "f0=%f, w0=%f\n", wg->f0, wg->w0);
@@ -320,7 +321,7 @@ static void waveguideWaveguide(CSOUND *csound,
 
     /* Calculate the size of the delay lines and set them */
     /* Set pointers to appropriate positions in instrument memory */
-    size = CS_ESR / freq - FL(1.0);
+    size = wg->sr / freq - FL(1.0);
 
     /* construct the fractional part of the delay */
     df = (size - (len_t)size); /* fractional delay amount */

--- a/Opcodes/psynth.c
+++ b/Opcodes/psynth.c
@@ -105,7 +105,7 @@ static int32_t psynth_init(CSOUND *csound, _PSYN *p)
     p->hopsize = p->fin->overlap;
     p->pos = 0;
     p->numbins = numbins;
-    p->factor = p->hopsize * csound->onedsr;
+    p->factor = p->hopsize * CS_ONEDSR;
     p->facsqr = p->factor * p->factor;
     if(*p->thresh == -1) p->min = 0.00002*csound->Get0dBFS(csound);
     else p->min = *p->thresh*csound->Get0dBFS(csound);
@@ -161,7 +161,7 @@ static int32_t psynth_process(CSOUND *csound, _PSYN *p)
     int32_t     *trackID = (int32_t *) p->trackID.auxp;
     int32_t     hopsize = p->hopsize;
     double  min = p->min;
-    ratio = size * csound->onedsr;
+    ratio = size * CS_ONEDSR;
     factor = p->factor;
 
     maxtracks = p->numbins > maxtracks ? maxtracks : p->numbins;
@@ -272,7 +272,7 @@ static int32_t psynth2_init(CSOUND *csound, _PSYN2 *p)
     p->hopsize = p->fin->overlap;
     p->pos = 0;
     p->numbins = numbins;
-    p->factor = p->hopsize * csound->onedsr;
+    p->factor = p->hopsize * CS_ONEDSR;
     p->facsqr = p->factor * p->factor;
     if(*p->thresh == -1) p->min = 0.00002*csound->Get0dBFS(csound);
     else p->min = *p->thresh*csound->Get0dBFS(csound);
@@ -331,7 +331,7 @@ static int32_t psynth2_process(CSOUND *csound, _PSYN2 *p)
     int32_t     hopsize = p->hopsize;
     double  min = p->min;
 
-    incrph = csound->onedsr;
+    incrph = CS_ONEDSR;
     lotwopi = (double)(size) / TWOPI_F;
     factor = p->factor;
     facsqr = p->facsqr;
@@ -475,7 +475,7 @@ static int32_t psynth3_process(CSOUND *csound, _PSYN *p)
     int32_t     hopsize = p->hopsize;
     double  min = p->min;
 
-    incrph = csound->onedsr;
+    incrph = CS_ONEDSR;
     lotwopi = (double) (size) / TWOPI_F;
     factor = p->factor;
     facsqr = p->facsqr;

--- a/Opcodes/pvadd.c
+++ b/Opcodes/pvadd.c
@@ -180,7 +180,7 @@ int32_t pvadd(CSOUND *csound, PVADD *p)
         amp = FL(0.0);
       }
       else {
-        MYFLT tmp = frq * csound->sicvt;
+        MYFLT tmp = frq * CS_SICVT;
         incr = (int32) MYFLT2LONG(tmp);
         amp = p->buf[i * 2];
       }

--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -1407,7 +1407,7 @@ static int32_t sprocess3(CSOUND *csound, DATASPACE *p)
     p->cnt = cnt;
     p->curframe = curframe;
     p->pos = spos;
-    //printf("%f s  \n", tstamp/csound->GetSr(csound));
+    //printf("%f s  \n", tstamp/CS_ESR);
     p->tstamp = tstamp + incrt;
     p->incr = incrt;
     return OK;
@@ -1626,7 +1626,7 @@ typedef struct amfm {
 
 int32_t am_fm_init(CSOUND *csound, AMFM *p) {
     p->ph = FL(0.0);
-    p->scal = csound->GetSr(csound)/(2*PI);
+    p->scal = CS_ESR/(2*PI);
     return OK;
 }
 

--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -155,7 +155,7 @@ static int32_t pvsinit(CSOUND *csound, PVSINI *p)
       for (i = 0; i < N + 2; i += 2) {
         bframe[i+n*NB] = FL(0.0);
         bframe[i+n*NB + 1] =
-          (n<offset || n>nsmps-early ? FL(0.0) :(i >>1) * N * csound->onedsr);
+          (n<offset || n>nsmps-early ? FL(0.0) :(i >>1) * N * CS_ONEDSR);
       }
   }
   else {
@@ -166,7 +166,7 @@ static int32_t pvsinit(CSOUND *csound, PVSINI *p)
     bframe = (float *) p->fout->frame.auxp;
     for (i = 0; i < N + 2; i += 2) {
       //bframe[i] = 0.0f;
-      bframe[i + 1] = (i >>1) * N * csound->onedsr;
+      bframe[i + 1] = (i >>1) * N * CS_ONEDSR;
     }
   }
   p->lastframe = 0;
@@ -1082,7 +1082,7 @@ static int32_t pvsoscset(CSOUND *csound, PVSOSC *p)
     for (n=0; n<nsmps; n++)
       for (i = 0; i < NB; i++) {
         bframe[i+NB*n].re = FL(0.0);
-        bframe[i+NB*n].im = (n<offset ? FL(0.0) : i * N * csound->onedsr);
+        bframe[i+NB*n].im = (n<offset ? FL(0.0) : i * N * CS_ONEDSR);
       }
     return OK;
 #endif
@@ -1097,7 +1097,7 @@ static int32_t pvsoscset(CSOUND *csound, PVSOSC *p)
       bframe = (float *) p->fout->frame.auxp;
       for (i = j = 0; i < N + 2; i += 2, j++) {
         //bframe[i] = 0.0f;
-        bframe[i + 1] = j * N * csound->onedsr;
+        bframe[i + 1] = j * N * CS_ONEDSR;
       }
       p->lastframe = 1;
       p->incr = (MYFLT)CS_KSMPS/p->fout->overlap;
@@ -1897,9 +1897,9 @@ static int32_t pvsshift(CSOUND *csound, PVSSHIFT *p)
 {
   int32_t    i, chan, newchan, N = p->fout->N;
   MYFLT   pshift = (MYFLT) *p->kshift;
-  int32_t     lowest = abs((int32_t) (*p->lowest * N * csound->onedsr));
+  int32_t     lowest = abs((int32_t) (*p->lowest * N * CS_ONEDSR));
   float   max = 0.0f;
-  int32_t     cshift = (int32_t) (pshift * N * csound->onedsr);
+  int32_t     cshift = (int32_t) (pshift * N * CS_ONEDSR);
   int32_t     keepform = (int32_t) *p->keepform;
   float   g = (float) *p->gain;
   float   *fin = (float *) p->fin->frame.auxp;
@@ -2113,7 +2113,7 @@ static int32_t pvswarp(CSOUND *csound, PVSWARP *p)
   float   max = 0.0f;
   MYFLT   pscal = FABS(*p->kscal);
   MYFLT   pshift = (*p->kshift);
-  int32_t     cshift = (int32_t) (pshift * N * csound->onedsr);
+  int32_t     cshift = (int32_t) (pshift * N * CS_ONEDSR);
   int32_t     keepform = (int32_t) *p->keepform;
   float   g = (float) *p->gain;
   float   *fin = (float *) p->fin->frame.auxp;
@@ -2121,7 +2121,7 @@ static int32_t pvswarp(CSOUND *csound, PVSWARP *p)
   MYFLT   *fenv = (MYFLT *) p->fenv.auxp;
   MYFLT   *ceps = (MYFLT *) p->ceps.auxp;
   float sr = CS_ESR, binf;
-  int32_t lowest =  abs((int32_t) (*p->klowest * N * csound->onedsr));;
+  int32_t lowest =  abs((int32_t) (*p->klowest * N * CS_ONEDSR));;
   int32_t coefs = (int32_t) *p->coefs;
 
   lowest = lowest ? (lowest > N / 2 ? N / 2 : lowest << 1) : 2;

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -325,8 +325,8 @@ struct Gtadsr : public csnd::Plugin<1,6> {
     s = s  > 0  ? (s < 1 ? s : 1.) : 0.;
     if(gate > 0) {
       if(t == 0) {
-        a = inargs[1]*csound->kr();
-	d = inargs[2]*csound->kr();
+        a = inargs[1]*this->kr();
+	d = inargs[2]*this->kr();
 	if(a < 1) a = 1;
 	if(d < 1) d = 1;
 	ainc = 1./a;
@@ -343,7 +343,7 @@ struct Gtadsr : public csnd::Plugin<1,6> {
       if (e < 0.00001)
         e = 0;
       else
-        e *= pow(0.001, 1. / (inargs[4]*csound->kr()));
+        e *= pow(0.001, 1. / (inargs[4]*this->kr()));
       t = 0;   
     }
     outargs[0] = e*inargs[0];
@@ -364,8 +364,8 @@ struct Gtadsr : public csnd::Plugin<1,6> {
     for(auto n = offset; n < nsmps; n++) {
        if(gate > 0) {
       if(t == 0) {
-        a = inargs[1]*csound->sr();
-	d = inargs[2]*csound->sr();
+        a = inargs[1]*this->sr();
+	d = inargs[2]*this->sr();
 	if(a < 1) a = 1;
 	if(d < 1) d = 1;
 	ainc = 1./a;
@@ -382,7 +382,7 @@ struct Gtadsr : public csnd::Plugin<1,6> {
       if (e < 0.00001)
         e = 0;
       else
-        e *= pow(0.001, 1. / (inargs[4]*csound->sr()));
+        e *= pow(0.001, 1. / (inargs[4]*this->sr()));
       t = 0;   
     }
        out[n] = sig ? sig[n]*e : amp*e;

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -402,7 +402,7 @@ static int32_t scsnu_init(CSOUND *csound, PSCSNU *p)
       p->rate = 0;
     }
     else
-      p->rate = (int32_t)(*p->i_rate * csound->GetSr(csound));
+      p->rate = (int32_t)(*p->i_rate * CS_ESR);
 
       /* Initialize index */
     p->idx = 0;
@@ -637,7 +637,7 @@ static int32_t scsns_init(CSOUND *csound, PSCSNS *p)
     /* Reset oscillator phase */
     p->phs = FL(0.0);
     /* Oscillator ratio */
-    p->fix = (MYFLT)p->tlen*(1.0/csound->GetSr(csound));
+    p->fix = (MYFLT)p->tlen*(1.0/CS_ESR);
     return OK;
 }
 

--- a/Opcodes/scansynx.c
+++ b/Opcodes/scansynx.c
@@ -419,7 +419,7 @@ static int32_t scsnux_init_(CSOUND *csound, PSCSNUX *p, int32_t istring)
         p->v[i] = f->ftable[i];
     }
     /* Cache update rate over to local structure */
-    p->rate = (int32_t)(*p->i_rate * csound->GetSr(csound));
+    p->rate = (int32_t)(*p->i_rate * CS_ESR);
 
       /* Initialize index */
     p->idx  = 0;
@@ -634,7 +634,7 @@ static int32_t scsnsx_init(CSOUND *csound, PSCSNSX *p)
     /* Reset oscillator phase */
     p->phs = FL(0.0);
     /* Oscillator ratio */
-    p->fix = (MYFLT)p->tlen*(1.0/csound->GetSr(csound));
+    p->fix = (MYFLT)p->tlen*(1.0/CS_ESR);
     return OK;
 }
 

--- a/Opcodes/sequencer.c
+++ b/Opcodes/sequencer.c
@@ -112,7 +112,7 @@ static int32_t sequencer(CSOUND *csound, SEQ *p)
         p->time = 0;
       }
       else {
-        p->time = csound->ksmps;
+        p->time = CS_KSMPS;
         *p->res = -FL(1.0);
         return OK;
       }
@@ -121,9 +121,9 @@ static int32_t sequencer(CSOUND *csound, SEQ *p)
       if (*p->verbos) printf("RESET!!\n");
       goto minus7;
     }
-    else if (p->time > csound->ksmps) {         /* Not yet time to act */
+    else if (p->time > CS_KSMPS) {         /* Not yet time to act */
       //printf("**time= %d", p->time);
-      p->time -= csound->ksmps;
+      p->time -= CS_KSMPS;
       *p->res = -FL(1.0);
       //printf(" -> %d\n", p->time);
       return OK;
@@ -214,7 +214,7 @@ static int32_t sequencer(CSOUND *csound, SEQ *p)
         //printf("***Score;ine:%s", buff);
         csoundReadScore(csound, buff); /* schedule instr for event */
       }
-      p->time = (p->riff->data[i] * csound->esr * 60.0) / *p->kbpm;
+      p->time = (p->riff->data[i] * CS_ESR * 60.0) / *p->kbpm;
             /* printf("Step %d riff %d instr %0.4f len %f\n", */
             /*    i,p->seq[i], p->instr->data[p->seq[i]], p->riff->data[p->seq[i]]); */
       // Mutate every mode events

--- a/Opcodes/sfont.c
+++ b/Opcodes/sfont.c
@@ -428,13 +428,13 @@ static int32_t SfPlay_set(CSOUND *csound, SFPLAY *p)
             if (flag) {
               freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection);
               p->si[spltNum]= (freq/(orgfreq*orgfreq))*
-                               sample->dwSampleRate*csound->onedsr;
+                               sample->dwSampleRate*CS_ONEDSR;
             }
             else {
               freq = orgfreq*
                 pow(2.0, ONETWELTH * tuneCorrection)*
                 pow(2.0, ONETWELTH * (split->scaleTuning*0.01) * (nm-orgkey));
-              p->si[spltNum]= (freq/orgfreq) * sample->dwSampleRate*csound->onedsr;
+              p->si[spltNum]= (freq/orgfreq) * sample->dwSampleRate*CS_ONEDSR;
             }
               ;
             attenuation = (MYFLT) (layer->initialAttenuation +
@@ -784,12 +784,12 @@ static int32_t SfPlayMono_set(CSOUND *csound, SFPLAYMONO *p)
             if (flag) {
               freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection);
               p->si[spltNum]= (freq/(orgfreq*orgfreq))*
-                               sample->dwSampleRate*csound->onedsr;
+                               sample->dwSampleRate*CS_ONEDSR;
             }
             else {
               freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection) *
                 pow( 2.0, ONETWELTH* (split->scaleTuning*0.01) * (nn-orgkey));
-              p->si[spltNum]= (freq/orgfreq) * sample->dwSampleRate*csound->onedsr;
+              p->si[spltNum]= (freq/orgfreq) * sample->dwSampleRate*CS_ONEDSR;
             }
             p->attenuation[spltNum] =
               POWER(FL(2.0), (-FL(1.0)/FL(60.0)) * (layer->initialAttenuation +
@@ -1047,12 +1047,12 @@ static int32_t SfInstrPlay_set(CSOUND *csound, SFIPLAY *p)
           if (flag) {
             freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection);
             p->si[spltNum] = (freq/(orgfreq*orgfreq))*
-                              sample->dwSampleRate*csound->onedsr;
+                              sample->dwSampleRate*CS_ONEDSR;
           }
           else {
             freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection)
               * pow( 2.0, ONETWELTH* (split->scaleTuning*0.01)*(nn-orgkey));
-            p->si[spltNum] = (freq/orgfreq)*(sample->dwSampleRate*csound->onedsr);
+            p->si[spltNum] = (freq/orgfreq)*(sample->dwSampleRate*CS_ONEDSR);
           }
           attenuation = (MYFLT) (split->initialAttenuation);
           attenuation = POWER(FL(2.0), (-FL(1.0)/FL(60.0)) * attenuation) *
@@ -1323,12 +1323,12 @@ static int32_t SfInstrPlayMono_set(CSOUND *csound, SFIPLAYMONO *p)
           if (flag) {
             freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection);
             p->si[spltNum] = (freq/(orgfreq*orgfreq))*
-                              sample->dwSampleRate*csound->onedsr;
+                              sample->dwSampleRate*CS_ONEDSR;
           }
           else {
             freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection)
               * pow( 2.0, ONETWELTH* (split->scaleTuning*0.01) * (nn-orgkey));
-            p->si[spltNum] = (freq/orgfreq)*(sample->dwSampleRate*csound->onedsr);
+            p->si[spltNum] = (freq/orgfreq)*(sample->dwSampleRate*CS_ONEDSR);
           }
           p->attenuation[spltNum] = (MYFLT) pow(2.0, (-1.0/60.0)*
                                                 split->initialAttenuation)
@@ -2400,12 +2400,12 @@ static int32_t sflooper_init(CSOUND *csound, sflooper *p)
             if (*p->iflag) {
               freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection);
               p->freq[spltNum]= (freq/(orgfreq*orgfreq))*
-                               sample->dwSampleRate*csound->onedsr;
+                               sample->dwSampleRate*CS_ONEDSR;
             }
             else {
               freq = orgfreq * pow(2.0, ONETWELTH * tuneCorrection) *
                 pow(2.0, ONETWELTH * (split->scaleTuning*0.01) * (notnum-orgkey));
-              p->freq[spltNum]= (freq/orgfreq) * sample->dwSampleRate*csound->onedsr;
+              p->freq[spltNum]= (freq/orgfreq) * sample->dwSampleRate*CS_ONEDSR;
             }
 
             attenuation = (MYFLT) (layer->initialAttenuation +

--- a/Opcodes/shaker.c
+++ b/Opcodes/shaker.c
@@ -60,7 +60,7 @@ int32_t shakerset(CSOUND *csound, SHAKER *p)
 
     p->shake_speed = FL(0.0008) + (amp * FL(0.0004));
     make_BiQuad(&p->filter);
-    make_ADSR(&p->envelope);
+    make_ADSR(&p->envelope, CS_ESR);
     p->res_freq = FL(3200.0);
     BiQuad_setFreqAndReson(p->filter, p->res_freq, FL(0.96));
     BiQuad_setEqualGainZeroes(p->filter);

--- a/Opcodes/shape.c
+++ b/Opcodes/shape.c
@@ -462,7 +462,7 @@ int32_t SyncPhasor(CSOUND *csound, SYNCPHASOR *p)
           syncout[n] = FL(1.0);        /* send sync whenever syncin */
         }
         else {
-          incr = (double)(cps[n] * csound->onedsr);
+          incr = (double)(cps[n] * CS_ONEDSR);
           out[n] = (MYFLT)phase;
           phase += incr;
           if (phase >= 1.0) {
@@ -478,7 +478,7 @@ int32_t SyncPhasor(CSOUND *csound, SYNCPHASOR *p)
       }
     }
     else {
-      incr = (double)(*p->xcps * csound->onedsr);
+      incr = (double)(*p->xcps * CS_ONEDSR);
       for (n=offset; n<nsmps; n++) {
         if (syncin[n] != FL(0.0)) {        /* non-zero triggers reset */
           phase = 0.0;

--- a/Opcodes/singwave.c
+++ b/Opcodes/singwave.c
@@ -96,7 +96,7 @@ static int32_t make_Modulatr(CSOUND *csound,Modulatr *p, MYFLT *i)
 }
 
 #define Modulatr_setVibFreq(p,vibFreq)  \
-        (p.v_rate = vibFreq * (MYFLT)p.wave->flen*csound->onedsr)
+        (p.v_rate = vibFreq * (MYFLT)p.wave->flen*CS_ONEDSR)
 #define Modulatr_setVibAmt(p,vibAmount) (p.vibAmt = vibAmount)
 
 static MYFLT Modulatr_tick(CSOUND *csound, Modulatr *p)
@@ -152,7 +152,7 @@ static void SingWave_setFreq(CSOUND *csound, SingWave *p, MYFLT aFreq)
 {
     MYFLT temp = p->rate;
 
-    p->rate = (MYFLT)p->wave->flen * aFreq * csound->onedsr;
+    p->rate = (MYFLT)p->wave->flen * aFreq * CS_ONEDSR;
     temp -= p->rate;
     temp = FABS(temp);
     Envelope_setTarget(&p->pitchEnvelope, p->rate);
@@ -331,7 +331,7 @@ int32_t voicformset(CSOUND *csound, VOICF *p)
       return NOTOK;
     Envelope_setRate(csound, &(p->voiced.envelope), FL(0.001));
     Envelope_setTarget(&(p->voiced.envelope), FL(0.0));
-
+    p->voiced.h = p->h;
     make_Noise(p->noise);
 
     for (i=0; i<4; i++) {

--- a/Opcodes/singwave.c
+++ b/Opcodes/singwave.c
@@ -415,13 +415,13 @@ int32_t voicform(CSOUND *csound, VOICF *p)
       //      printf("%d: temp=%f ", n, temp);
       temp  += Envelope_tick(&p->noiseEnv) * Noise_tick(csound, &p->noise);
       //      printf("%f\n", temp);
-      lastOutput  = FormSwep_tick(csound, &p->filters[0], temp);
+      lastOutput  = FormSwep_tick((OPDS *) p, &p->filters[0], temp);
       //      printf("%d: output=%f ", lastOutput);
-      lastOutput  = FormSwep_tick(csound, &p->filters[1], lastOutput);
+      lastOutput  = FormSwep_tick((OPDS *) p, &p->filters[1], lastOutput);
       //      printf("%f ", lastOutput);
-      lastOutput  = FormSwep_tick(csound, &p->filters[2], lastOutput);
+      lastOutput  = FormSwep_tick((OPDS *) p, &p->filters[2], lastOutput);
       //      printf("%f ", lastOutput);
-      lastOutput  = FormSwep_tick(csound, &p->filters[3], lastOutput);
+      lastOutput  = FormSwep_tick((OPDS *) p, &p->filters[3], lastOutput);
       //      printf("%f ", lastOutput);
       lastOutput *= p->lastGain;
       //      printf("%f ", lastOutput);

--- a/Opcodes/singwave.h
+++ b/Opcodes/singwave.h
@@ -72,6 +72,7 @@ typedef struct Modulatr {
 } Modulatr;
 
 typedef struct SingWave {
+  OPDS        h;
     Modulatr    modulator;
     Envelope    envelope;
     Envelope    pitchEnvelope;

--- a/Opcodes/spat3d.c
+++ b/Opcodes/spat3d.c
@@ -70,7 +70,7 @@ static int32_t    spat3d_init_window(CSOUND *csound, SPAT3D *p)
 
 /* initialise parameric equalizer (code taken from pareq opcode) */
 
-static int32_t spat3d_init_eq(CSOUND *csound, SPAT3D_WALL *wstruct, MYFLT *ftable)
+static int32_t spat3d_init_eq(SPAT3D *p, SPAT3D_WALL *wstruct, MYFLT *ftable)
 {
     int32_t eqmode;
     double  omega, k, kk, vk, vkk, vkdq, sq, a0, a1, a2, b0, b1, b2;
@@ -78,7 +78,7 @@ static int32_t spat3d_init_eq(CSOUND *csound, SPAT3D_WALL *wstruct, MYFLT *ftabl
     /* EQ code taken from biquad.c */
 
     eqmode = (int32_t) ((double) ftable[3] + 0.5);              /* mode      */
-    omega = (double) ftable[0] * (double) csound->tpidsr;       /* frequency */
+    omega = (double) ftable[0] * (double) CS_TPIDSR;       /* frequency */
     sq = sqrt(2.0 * (double) ftable[1]);                        /* level     */
 
     k = tan((eqmode > 1 ? (PI - omega) : omega) * 0.5); kk = k * k;
@@ -122,7 +122,6 @@ spat3d_init_wall(SPAT3D *p,             /* opcode struct                    */
     SPAT3D_WALL     *ws;
     MYFLT           *ft, a, d, w, x, y, z;
     double          d0, d1;
-    CSOUND          *csound = p->h.insdshead->csound;
 
     /* update random seed */
 
@@ -155,7 +154,7 @@ spat3d_init_wall(SPAT3D *p,             /* opcode struct                    */
     /* read wall parameters from ftable */
 
     if (ft != NULL) {
-      spat3d_init_eq(csound, ws, ft + 4);     /* EQ                */
+      spat3d_init_eq(p, ws, ft + 4);     /* EQ                */
       a = -ft[3];                             /* scale             */
       ws->b0 *= a; ws->b1 *= a; ws->b2 *= a;  /* apply scale to EQ */
       ws->cnum = (6 - wallno) >> 1;           /* select wall       */

--- a/Opcodes/squinewave.c
+++ b/Opcodes/squinewave.c
@@ -101,7 +101,7 @@ static inline MYFLT Clamp(const MYFLT x, const MYFLT minval, const MYFLT maxval)
 
 int32_t squinewave_init(CSOUND* csound, SQUINEWAVE *p)
 {
-    const double sr = csound->GetSr(csound);
+    const double sr = CS_ESR;
 
     // Skip setting phase only if we have been inited at least once
     p->init_phase = (*p->iphase < 0 && p->Min_Sweep > 1.0) ? 0 : 1;

--- a/Opcodes/sterrain.c
+++ b/Opcodes/sterrain.c
@@ -190,7 +190,7 @@ static int32_t wtPerf(CSOUND *csound, SUPERTER *p)
       aout[i] = p->xarr[xloc] * p->yarr[yloc] * amp;
 
       /* MOVE SCANNING POINT ROUND THE ELLIPSE */
-      theta += pch*((period*TWOPI_F) / csound->GetSr(csound));
+      theta += pch*((period*TWOPI_F) / CS_ESR);
     }
 
     p->theta = theta;

--- a/Opcodes/tl/fractalnoise.cpp
+++ b/Opcodes/tl/fractalnoise.cpp
@@ -437,7 +437,7 @@ int32_t fractalnoise_cleanup(CSOUND *csound, FRACTALNOISE *p) {
 int32_t fractalnoise_init(CSOUND *csound, FRACTALNOISE *p) {
   p->faust = new mydsp;
   p->cs_interface = new csUI;
-  p->faust->init((int32_t)csound->GetSr(p->h.insdshead));
+  p->faust->init((int32_t)CS_ESR);
   p->faust->buildUserInterface(p->cs_interface);
   csound->RegisterDeinitCallback(
       csound, p, (int32_t (*)(CSOUND *, void *))fractalnoise_cleanup);

--- a/Opcodes/tl/fractalnoise.cpp
+++ b/Opcodes/tl/fractalnoise.cpp
@@ -437,7 +437,7 @@ int32_t fractalnoise_cleanup(CSOUND *csound, FRACTALNOISE *p) {
 int32_t fractalnoise_init(CSOUND *csound, FRACTALNOISE *p) {
   p->faust = new mydsp;
   p->cs_interface = new csUI;
-  p->faust->init((int32_t)csound->GetSr(csound));
+  p->faust->init((int32_t)csound->GetSr(p->h.insdshead));
   p->faust->buildUserInterface(p->cs_interface);
   csound->RegisterDeinitCallback(
       csound, p, (int32_t (*)(CSOUND *, void *))fractalnoise_cleanup);

--- a/Opcodes/tl/sc_noise.c
+++ b/Opcodes/tl/sc_noise.c
@@ -67,7 +67,7 @@ static int32_t dust_process_krate(CSOUND *csound, DUST *p)
     density = *p->kdensity;
 
     if (density != p->density0) {
-      thresh = p->thresh = density * csound->onedsr*csound->ksmps;
+      thresh = p->thresh = density * CS_ONEDSR*CS_KSMPS;
       scale  = p->scale  = (thresh > FL(0.0) ? FL(1.0) / thresh : FL(0.0));
       p->density0 = density;
     }
@@ -91,7 +91,7 @@ static int32_t dust_process_arate(CSOUND *csound, DUST *p)
     density = *p->kdensity;
 
     if (density != p->density0) {
-      thresh = p->thresh = density * csound->onedsr;
+      thresh = p->thresh = density * CS_ONEDSR;
       scale  = p->scale  = (thresh > FL(0.0) ? FL(1.0) / thresh : FL(0.0));
       p->density0 = density;
     }
@@ -120,7 +120,7 @@ static int32_t dust2_process_krate(CSOUND *csound, DUST *p)
     density = *p->kdensity;
 
     if (density != p->density0) {
-      thresh = p->thresh = density * csound->onedsr*csound->ksmps;
+      thresh = p->thresh = density * CS_ONEDSR*CS_KSMPS;
       scale = p->scale = (thresh > FL(0.0) ? FL(2.0) / thresh : FL(0.0));
       p->density0 = density;
     }
@@ -144,7 +144,7 @@ static int32_t dust2_process_arate(CSOUND *csound, DUST *p)
     density = *p->kdensity;
 
     if (density != p->density0) {
-      thresh = p->thresh = density * csound->onedsr;
+      thresh = p->thresh = density * CS_ONEDSR;
       scale = p->scale = (thresh > FL(0.0) ? FL(2.0) / thresh : FL(0.0));
       p->density0 = density;
     }
@@ -264,7 +264,7 @@ static int32_t gausstrig_process_krate(CSOUND* csound, GAUSSTRIG *p)
       int32_t     nextsamps;
       MYFLT   nextcount, r1, r2;
       /* this very line of k-time fix. Changed GetSt to GetKr */
-      nextsamps = (int32_t)(csound->GetKr(csound) / frq);
+      nextsamps = (int32_t)(CS_EKR / frq);
       p->rand = csoundRand31(&p->rand);
       r1 = (MYFLT)p->rand * dv2_31;
       p->rand = csoundRand31(&p->rand);
@@ -285,7 +285,7 @@ static int32_t gausstrig_process_krate(CSOUND* csound, GAUSSTRIG *p)
       int32_t     nextsamps;
       MYFLT   nextcount, r1, r2;
 /* this very line of k-time fix. Changed GetSt to GetKr */
-      nextsamps = (int32_t)(csound->GetKr(csound) / frq);
+      nextsamps = (int32_t)(CS_EKR / frq);
       p->rand = csoundRand31(&p->rand);
       r1 = (MYFLT)p->rand * dv2_31;
       p->rand = csoundRand31(&p->rand);
@@ -335,7 +335,7 @@ static int32_t gausstrig_process_arate(CSOUND* csound, GAUSSTRIG *p)
       //p->frq0 = *p->kfrq;
       //frq = (p->frq0 > FL(0.001) ? p->frq0 : FL(0.001));
       dev = *p->kdev;
-      nextsamps = (int32_t)(csound->GetSr(csound) / frq);
+      nextsamps = (int32_t)(CS_ESR / frq);
       p->rand = csoundRand31(&p->rand);
       r1 = (MYFLT)p->rand * dv2_31;
       p->rand = csoundRand31(&p->rand);
@@ -356,7 +356,7 @@ static int32_t gausstrig_process_arate(CSOUND* csound, GAUSSTRIG *p)
       if (p->count <= 0) {
         int32_t     nextsamps;
         MYFLT   nextcount, r1, r2;
-        nextsamps = (int32_t)(csound->GetSr(csound) / frq);
+        nextsamps = (int32_t)(CS_ESR / frq);
         p->rand = csoundRand31(&p->rand);
         r1 = (MYFLT)p->rand * dv2_31;
         p->rand = csoundRand31(&p->rand);

--- a/Opcodes/trigEnvSegs.cpp
+++ b/Opcodes/trigEnvSegs.cpp
@@ -33,7 +33,7 @@ struct TrigLinseg : csnd::Plugin<1, 64>
     {
         uint32_t argCnt = 1;
         totalLength = 0;
-        samplingRate = csound->sr();
+        samplingRate = this->sr();
         playEnv = 0;
         counter = 0;
         outargs[0] = inargs[1];
@@ -124,7 +124,7 @@ struct TrigExpseg : csnd::Plugin<1, 64>
     int init()
     {
         uint32_t argCnt = 1;
-        samplingRate = csound->sr();
+        samplingRate = this->sr();
         playEnv = 0;
         counter = 0;
         outargs[0] = inargs[1];

--- a/Opcodes/ugens7.c
+++ b/Opcodes/ugens7.c
@@ -204,7 +204,7 @@ static int32_t newpulse(CSOUND *csound,
     ovp->forminc = (int32)(*form * CS_SICVT);
     if (*p->kband != p->prvband) {                    /* bw: exp dec */
       p->prvband = *p->kband;
-      p->expamp =  EXP(*p->kband * csound->mpidsr);
+      p->expamp =  EXP(*p->kband * CS_MPIDSR);
       newexp = 1;
     }
     /* Init grain rise ftable phase. Negative kform values make
@@ -335,7 +335,7 @@ static int32_t harmon(CSOUND *csound, HARMON *p)
     if (*p->kest != p->prvest &&
         *p->kest != FL(0.0)) {    /* if new pitch estimate */
       MYFLT estperiod = CS_ESR / *p->kest;
-      double b = 2.0 - cos((double)(*p->kest * csound->tpidsr));
+      double b = 2.0 - cos((double)(*p->kest * CS_TPIDSR));
       p->c2 = (MYFLT)(b - sqrt(b*b - 1.0)); /*   recalc lopass coefs */
       p->c1 = FL(1.0) - p->c2;
       p->prvest = *p->kest;

--- a/Opcodes/ugens7.c
+++ b/Opcodes/ugens7.c
@@ -210,7 +210,7 @@ static int32_t newpulse(CSOUND *csound,
     /* Init grain rise ftable phase. Negative kform values make
        the kris (ifnb) initial index go negative and crash csound.
        So insert another if-test with compensating code. */
-    if (*p->kris >= csound->onedsr && *form != FL(0.0)) {   /* init fnb ris */
+    if (*p->kris >= CS_ONEDSR && *form != FL(0.0)) {   /* init fnb ris */
       if (*form < FL(0.0) && ovp->formphs != 0)
         ovp->risphs = (int32)((MAXLEN - ovp->formphs) / -*form / *p->kris);
       else
@@ -283,7 +283,7 @@ static int32_t harmset(CSOUND *csound, HARMON *p)
     p->autokcnt = 1;              /* init for immediate autocorr attempt */
     printf("ekr = %f iptrk = %f, autocnt = %d; autotim = %d\n",
            CS_EKR, *p->iptrkprd, p->autokcnt, p->autoktim);
-    p->lsicvt = FL(65536.0) * csound->onedsr;
+    p->lsicvt = FL(65536.0) * CS_ONEDSR;
     p->cpsmode = ((*p->icpsmode != FL(0.0)));
     p->inp1 = p->bufp;
     p->inp2 = p->midp;

--- a/Opcodes/ugens7.c
+++ b/Opcodes/ugens7.c
@@ -102,13 +102,13 @@ static int32_t fof(CSOUND *csound, FOFS *p)
     form = p->xform;
     ftp1 = p->ftp1;
     ftp2 = p->ftp2;
-    fund_inc = (int32)(*fund * csound->sicvt);
+    fund_inc = (int32)(*fund * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
-    form_inc = (int32)(*form * csound->sicvt);
+    form_inc = (int32)(*form * CS_SICVT);
     for (n=offset; n<nsmps; n++) {
       if (p->fundphs & MAXLEN) {               /* if phs has wrapped */
         p->fundphs &= PHMASK;
@@ -167,8 +167,8 @@ static int32_t fof(CSOUND *csound, FOFS *p)
       p->fundphs += fund_inc;
       if (p->xincod) {
         if (p->ampcod)    amp++;
-        if (p->fundcod)   fund_inc = (int32)(*++fund * csound->sicvt);
-        if (p->formcod)   form_inc = (int32)(*++form * csound->sicvt);
+        if (p->fundcod)   fund_inc = (int32)(*++fund * CS_SICVT);
+        if (p->formcod)   form_inc = (int32)(*++form * CS_SICVT);
       }
       p->durtogo--;
     }
@@ -201,7 +201,7 @@ static int32_t newpulse(CSOUND *csound,
     if (*fund == FL(0.0))                               /* formant phs */
       ovp->formphs = 0;
     else ovp->formphs = (int32)(p->fundphs * *form / *fund) & PHMASK;
-    ovp->forminc = (int32)(*form * csound->sicvt);
+    ovp->forminc = (int32)(*form * CS_SICVT);
     if (*p->kband != p->prvband) {                    /* bw: exp dec */
       p->prvband = *p->kband;
       p->expamp =  EXP(*p->kband * csound->mpidsr);
@@ -215,7 +215,7 @@ static int32_t newpulse(CSOUND *csound,
         ovp->risphs = (int32)((MAXLEN - ovp->formphs) / -*form / *p->kris);
       else
         ovp->risphs = (int32)(ovp->formphs / *form / *p->kris);
-      ovp->risinc = (int32)(csound->sicvt / *p->kris);
+      ovp->risinc = (int32)(CS_SICVT / *p->kris);
       rismps = MAXLEN / ovp->risinc;
     }
     else {
@@ -230,7 +230,7 @@ static int32_t newpulse(CSOUND *csound,
     ovp->curamp = octamp * p->preamp;                /* set startamp  */
     ovp->expamp = p->expamp;
     if ((ovp->dectim = (int32)(*p->kdec * CS_ESR)) > 0) /*  fnb dec  */
-      ovp->decinc = (int32)(csound->sicvt / *p->kdec);
+      ovp->decinc = (int32)(CS_SICVT / *p->kdec);
     ovp->decphs = PHMASK;
     if (!p->foftype) {
       /* Make fof take k-rate phase increment:

--- a/Opcodes/ugensa.c
+++ b/Opcodes/ugensa.c
@@ -195,7 +195,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
       p->expamp = EXP(*p->kband * csound->mpidsr);
       newexp = 1;
     }
-    if (*p->kris >= csound->onedsr && form != 0.0) {  /* init fnb ris */
+    if (*p->kris >= CS_ONEDSR && form != 0.0) {  /* init fnb ris */
       ovp->risphs = (uint32)(ovp->formphs / (fabs(form))
                                     / *p->kris); /* JPff fix */
       ovp->risinc = (int32)(csound->sicvt / *p->kris);

--- a/Opcodes/ugensa.c
+++ b/Opcodes/ugensa.c
@@ -192,7 +192,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
     /*ovp->forminc = *form * CS_SICVT;*/
     if (*p->kband != p->prvband) {                    /* bw: exp dec */
       p->prvband = *p->kband;
-      p->expamp = EXP(*p->kband * csound->mpidsr);
+      p->expamp = EXP(*p->kband * CS_MPIDSR);
       newexp = 1;
     }
     if (*p->kris >= CS_ONEDSR && form != 0.0) {  /* init fnb ris */

--- a/Opcodes/ugensa.c
+++ b/Opcodes/ugensa.c
@@ -95,8 +95,8 @@ static int32_t fog(CSOUND *csound, FOGS *p)
     speed = p->xspd;
     ftp1 = p->ftp1;
     ftp2 = p->ftp2;
-    fund_inc = (int32)(*fund * csound->sicvt);
-    form_inc = (int32)(*ptch * fogcvt);  /*form_inc = *form * csound->sicvt;*/
+    fund_inc = (int32)(*fund * CS_SICVT);
+    form_inc = (int32)(*ptch * fogcvt);  /*form_inc = *form * CS_SICVT;*/
 /*      speed_inc = *speed * fogcvt; */   /*JMC for FOG--out for phs version*/
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -153,9 +153,9 @@ static int32_t fog(CSOUND *csound, FOGS *p)
       p->spdphs &= PHMASK; /*JMC for FOG*/
       if (p->xincod) {
         if (p->ampcod)    amp++;
-        if (p->fundcod)   fund_inc = (int32)(*++fund * csound->sicvt);
+        if (p->fundcod)   fund_inc = (int32)(*++fund * CS_SICVT);
         if (p->formcod)   form_inc = (int32)(*++ptch * fogcvt);
-/*form_inc = *++form * csound->sicvt;*/
+/*form_inc = *++form * CS_SICVT;*/
 /*      if (p->speedcod)  speed_inc = *++speed * fogcvt; */  /*JMC for FOG*/
       }
       p->durtogo--;
@@ -170,7 +170,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
                     MYFLT *fund, MYFLT *ptch)
 {
     MYFLT       octamp = *amp, oct;
-    MYFLT       form = *ptch / csound->sicvt, fogcvt = p->fogcvt;
+    MYFLT       form = *ptch / CS_SICVT, fogcvt = p->fogcvt;
     int32   rismps, newexp = 0;
     if ((ovp->timrem = (int32)(*p->kdur * CS_ESR)) > p->durtogo &&
         (*p->iskip==FL(0.0)))  /* ringtime    */
@@ -189,7 +189,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
      ovp->formphs = (int32)((p->fundphs * form / *fund) + p->spdphs) & PHMASK; */
     else ovp->formphs = (int32)(p->fundphs * form / *fund) & PHMASK;
     ovp->forminc = (int32)(*ptch * fogcvt);/*JMC for FOG*/
-    /*ovp->forminc = *form * csound->sicvt;*/
+    /*ovp->forminc = *form * CS_SICVT;*/
     if (*p->kband != p->prvband) {                    /* bw: exp dec */
       p->prvband = *p->kband;
       p->expamp = EXP(*p->kband * csound->mpidsr);
@@ -198,7 +198,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
     if (*p->kris >= CS_ONEDSR && form != 0.0) {  /* init fnb ris */
       ovp->risphs = (uint32)(ovp->formphs / (fabs(form))
                                     / *p->kris); /* JPff fix */
-      ovp->risinc = (int32)(csound->sicvt / *p->kris);
+      ovp->risinc = (int32)(CS_SICVT / *p->kris);
       rismps = MAXLEN / ovp->risinc;
     }
     else {
@@ -219,7 +219,7 @@ static int32_t newpulse(CSOUND *csound, FOGS *p, OVERLAP *ovp, MYFLT   *amp,
     ovp->curamp = octamp * p->preamp;                /* set startamp  */
     ovp->expamp = p->expamp;
     if ((ovp->dectim = (int32)(*p->kdec * CS_ESR)) > 0) /*      fnb dec  */
-      ovp->decinc = (int32)(csound->sicvt / *p->kdec);
+      ovp->decinc = (int32)(CS_SICVT / *p->kdec);
     ovp->decphs = PHMASK;
     return(1);
 }

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -242,7 +242,7 @@ static int32_t posc_set(CSOUND *csound, POSC *p)
       return csound->InitError(csound, Str("table not found in poscil"));
     p->ftp        = ftp;
     p->tablen     = ftp->flen;
-    p->tablenUPsr = p->tablen * csound->onedsr;
+    p->tablenUPsr = p->tablen * CS_ONEDSR;
     if (*p->iphs>=FL(0.0))
       p->phs      = *p->iphs * p->tablen;
     while (UNLIKELY(p->phs >= p->tablen))
@@ -415,7 +415,7 @@ static int32_t posc3kk(CSOUND *csound, POSC *p)
     MYFLT       *out = p->out, *ftab;
     MYFLT       fract;
     double      phs  = p->phs;
-    double      si   = *p->freq * p->tablen * csound->onedsr;
+    double      si   = *p->freq * p->tablen * CS_ONEDSR;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -470,7 +470,7 @@ static int32_t posc3ak(CSOUND *csound, POSC *p)
     MYFLT       *out = p->out, *ftab;
     MYFLT       fract;
     double      phs  = p->phs;
-    double      si   = *p->freq * p->tablen * csound->onedsr;
+    double      si   = *p->freq * p->tablen * CS_ONEDSR;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -525,7 +525,7 @@ static int32_t posc3ka(CSOUND *csound, POSC *p)
     MYFLT       *out = p->out, *ftab;
     MYFLT       fract;
     double      phs  = p->phs;
-    /*double      si   = *p->freq * p->tablen * csound->onedsr;*/
+    /*double      si   = *p->freq * p->tablen * CS_ONEDSR;*/
     MYFLT       *freq = p->freq;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
@@ -582,7 +582,7 @@ static int32_t posc3aa(CSOUND *csound, POSC *p)
     MYFLT       *out = p->out, *ftab;
     MYFLT       fract;
     double      phs  = p->phs;
-    /*double      si   = *p->freq * p->tablen * csound->onedsr;*/
+    /*double      si   = *p->freq * p->tablen * CS_ONEDSR;*/
     MYFLT       *freq = p->freq;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
@@ -705,7 +705,7 @@ static int32_t lposc(CSOUND *csound, LPOSC *p)
 {
     MYFLT       *out = p->out, *ft = p->ftp->ftable;
     MYFLT       *curr_samp, fract;
-    double      phs= p->phs, si= *p->freq * (p->fsr*csound->onedsr);
+    double      phs= p->phs, si= *p->freq * (p->fsr*CS_ONEDSR);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -737,7 +737,7 @@ static int32_t lposc3(CSOUND *csound, LPOSC *p)
 {
     MYFLT       *out = p->out, *ftab = p->ftp->ftable;
     MYFLT       fract;
-    double      phs = p->phs, si= *p->freq * (p->fsr*csound->onedsr);
+    double      phs = p->phs, si= *p->freq * (p->fsr*CS_ONEDSR);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -1651,7 +1651,7 @@ static int32_t jittersa(CSOUND *csound, JITTERS *p)
       if (phs >= 1.0) {
         MYFLT   slope, resd1, resd0, f2, f1;
       next:
-        si =  (randGab  * (cpsMax - cpsMin) + cpsMin)*csound->onedsr;
+        si =  (randGab  * (cpsMax - cpsMin) + cpsMin)*CS_ONEDSR;
         if (si == 0) si = 1; /* Is this necessary? */
         while (phs > 1.0)
           phs -= 1.0;
@@ -2044,7 +2044,7 @@ static int32_t random3a(CSOUND *csound, RANDOM3 *p)
       if (phs >= 1.0) {
         MYFLT   slope, resd1, resd0, f2, f1;
       next:
-        si =  (randGab  * (cpsMax - cpsMin) + cpsMin)*csound->onedsr;
+        si =  (randGab  * (cpsMax - cpsMin) + cpsMin)*CS_ONEDSR;
         while (phs > 1.0) phs -= 1.0;
         f0     = p->num0 = p->num1;
         f1     = p->num1 = p->num2;

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -915,11 +915,11 @@ static int32_t resony(CSOUND *csound, RESONY *p)
       for (j = 0; j < loop; j++) {
         if (flag)                     /* linear separation in hertz */
           cosf = (MYFLT) cos((cf = (double) (*p->kcf * sep * j))
-                             * (double) csound->tpidsr);
+                             * (double) CS_TPIDSR);
         else                          /* logarithmic separation in octaves */
           cosf = (MYFLT) cos((cf = (double) (*p->kcf * pow(2.0, sep * j)))
-                             * (double) csound->tpidsr);
-        c3 = EXP(*p->kbw * (cf / *p->kcf) * csound->mtpdsr);
+                             * (double) CS_TPIDSR);
+        c3 = EXP(*p->kbw * (cf / *p->kcf) * CS_MTPIDSR);
         c3p1 = c3 + FL(1.0);
         c3t4 = c3 * FL(4.0);
         c2 = c3t4 * cosf / c3p1;

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -1884,7 +1884,7 @@ static int32_t randomi(CSOUND *csound, RANDOMI *p)
     min = *p->min;
     amp =  (*p->max - min);
     ar = p->ar;
-    inc = (int32)(*cpsp++ * csound->sicvt);
+    inc = (int32)(*cpsp++ * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -1894,7 +1894,7 @@ static int32_t randomi(CSOUND *csound, RANDOMI *p)
       ar[n] = (p->num1 + (MYFLT)phs * p->dfdmax) * amp + min;
       phs += inc;
       if (p->cpscod)
-        inc = (int32)(*cpsp++ * csound->sicvt);
+        inc = (int32)(*cpsp++ * CS_SICVT);
       if (phs >= MAXLEN) {
         phs &= PHMASK;
         p->num1 = p->num2;
@@ -1951,7 +1951,7 @@ static int32_t randomh(CSOUND *csound, RANDOMH *p)
     min  = *p->min;
     amp  = (*p->max - min);
     ar   = p->ar;
-    inc  = (int32)(*cpsp++ * csound->sicvt);
+    inc  = (int32)(*cpsp++ * CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -1961,7 +1961,7 @@ static int32_t randomh(CSOUND *csound, RANDOMH *p)
       ar[n]     = p->num1 * amp + min;
       phs      += inc;
       if (p->cpscod)
-        inc     = (int32)(*cpsp++ * csound->sicvt);
+        inc     = (int32)(*cpsp++ * CS_SICVT);
       if (phs >= MAXLEN) {
         phs    &= PHMASK;
         p->num1 = randGab;

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -1191,7 +1191,7 @@ static int32_t atsaddnzset(CSOUND *csound, ATSADDNZ *p)
     /* p->nfreq[24] = 4500.0; */
 
     {
-      double tmp = TWOPI * csound->onedsr;
+      double tmp = TWOPI * CS_ONEDSR;
 
       /* initialise frequencies to modulate noise by */
       p->phaseinc[0] = 50.0 * tmp;
@@ -1361,7 +1361,7 @@ static int32_t atsaddnzset_S(CSOUND *csound, ATSADDNZ *p)
     /* p->nfreq[24] = 4500.0; */
 
     {
-      double tmp = TWOPI * csound->onedsr;
+      double tmp = TWOPI * CS_ONEDSR;
 
       /* initialise frequencies to modulate noise by */
       p->phaseinc[0] = 50.0 * tmp;
@@ -1669,7 +1669,7 @@ static int32_t atssinnoiset(CSOUND *csound, ATSSINNOI *p)
     p->prFlg = 1;               /* true */
 
     {
-      double tmp = TWOPI * csound->onedsr;
+      double tmp = TWOPI * CS_ONEDSR;
       p->phaseinc[0] = 50.0 * tmp;
       p->phaseinc[1] = 150.0 * tmp;
       p->phaseinc[2] = 250.0 * tmp;
@@ -1858,7 +1858,7 @@ static int32_t atssinnoiset_S(CSOUND *csound, ATSSINNOI *p)
     p->prFlg = 1;               /* true */
 
     {
-      double tmp = TWOPI * csound->onedsr;
+      double tmp = TWOPI * CS_ONEDSR;
       p->phaseinc[0] = 50.0 * tmp;
       p->phaseinc[1] = 150.0 * tmp;
       p->phaseinc[2] = 250.0 * tmp;
@@ -1962,7 +1962,7 @@ static int32_t atssinnoi(CSOUND *csound, ATSSINNOI *p)
         ar = p->aoutput;
         amp = oscbuf[i].amp;
         freq = (MYFLT) oscbuf[i].freq * *p->kfreq;
-        inc = TWOPI * freq * csound->onedsr;
+        inc = TWOPI * freq * CS_ONEDSR;
         nzamp =
             sqrt(*(p->nzbuf + i) / (p->atshead->winsz * ATSA_NOISE_VARIANCE));
         for (n=offset; n<nsmps;n++) {
@@ -1991,7 +1991,7 @@ static int32_t atssinnoi(CSOUND *csound, ATSSINNOI *p)
         ar = p->aoutput;
         amp = oscbuf[i].amp;
         freq = (MYFLT) oscbuf[i].freq * *p->kfreq;
-        inc = TWOPI * freq * csound->onedsr;
+        inc = TWOPI * freq * CS_ONEDSR;
         for (n=offset; n<nsmps;n++) {
           /* calc sine wave */
           sinewave = cos(phase) * amp;

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -908,7 +908,7 @@ static int32_t atsadd(CSOUND *csound, ATSADD *p)
       inca = (amp-oldamps[i])/nsmps;
       a = oldamps[i];
       /* put in * kfmod */
-      inc = MYFLT2LONG(p->buf[i].freq * csound->sicvt * *p->kfmod);
+      inc = MYFLT2LONG(p->buf[i].freq * CS_SICVT * *p->kfmod);
       for (n=offset; n<nsmps; n++) {
         ftab = ftp->ftable + (phase >> lobits);
         v1 = *ftab++;
@@ -2920,7 +2920,7 @@ static int32_t atscross(CSOUND *csound, ATSCROSS *p)
       ar = p->aoutput;         /* ar is a pointer to the audio output */
       inca = (amp-oldamps[i])/nsmps;
       /* put in * kfmod */
-      inc = MYFLT2LONG(p->buf[i].freq * csound->sicvt * *p->kfmod);
+      inc = MYFLT2LONG(p->buf[i].freq * CS_SICVT * *p->kfmod);
       a =  oldamps[i];
       for (n=offset; n<nsmps; n++) {
         ftab = ftp->ftable + (phase >> lobits);

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -1010,9 +1010,9 @@ static void AtsAmpGate(            /* adaption of PvAmpGate by Richard Karpen */
  * the intermediate values.
  */
 
-static void randiats_setup(CSOUND *csound, MYFLT freq, RANDIATS *radat)
+static void randiats_setup(CSOUND *csound, MYFLT freq, RANDIATS *radat, MYFLT sr)
 {
-    radat->size = (int32_t) MYFLT2LRND(CS_ESR / freq);
+    radat->size = (int32_t) MYFLT2LRND(sr / freq);
     radat->cnt = 0;
     radat->a1 = (int32) csound->Rand31(&(csound->randSeed1));
     radat->a2 = (int32) csound->Rand31(&(csound->randSeed1));
@@ -1250,7 +1250,7 @@ static int32_t atsaddnzset(CSOUND *csound, ATSADDNZ *p)
 
     /* initialise band limited noise parameters */
     for (i = 0; i < 25; i++) {
-      randiats_setup(csound, p->nfreq[i], &(p->randinoise[i]));
+      randiats_setup(csound, p->nfreq[i], &(p->randinoise[i]), CS_ESR);
     }
 
     /* flag set to reduce the amount of warnings sent out */
@@ -1420,7 +1420,7 @@ static int32_t atsaddnzset_S(CSOUND *csound, ATSADDNZ *p)
 
     /* initialise band limited noise parameters */
     for (i = 0; i < 25; i++) {
-      randiats_setup(csound, p->nfreq[i], &(p->randinoise[i]));
+      randiats_setup(csound, p->nfreq[i], &(p->randinoise[i]), CS_ESR);
     }
 
     /* flag set to reduce the amount of warnings sent out */
@@ -1727,7 +1727,7 @@ static int32_t atssinnoiset(CSOUND *csound, ATSSINNOI *p)
 
     /* initialise band limited noise parameters */
     for (i = 0; i < (int32_t) *p->iptls; i++) {
-      randiats_setup(csound, freqs[i], &(p->randinoise[i]));
+      randiats_setup(csound, freqs[i], &(p->randinoise[i]), CS_ESR);
     }
 
     return OK;
@@ -1891,7 +1891,7 @@ static int32_t atssinnoiset_S(CSOUND *csound, ATSSINNOI *p)
 
     /* initialise band limited noise parameters */
     for (i = 0; i < (int32_t) *p->iptls; i++) {
-      randiats_setup(csound, freqs[i], &(p->randinoise[i]));
+      randiats_setup(csound, freqs[i], &(p->randinoise[i]), CS_ESR);
     }
 
     return OK;

--- a/Opcodes/ugsc.c
+++ b/Opcodes/ugsc.c
@@ -134,7 +134,7 @@ static int32_t hilbertset(CSOUND *csound, HILBERT *p)
       polefreq = poles[j] * 15.0;
       rc = 1.0 / (2.0 * PI * polefreq);
       alpha = 1.0 / rc;
-      alpha = alpha * 0.5 * (double)csound->onedsr;
+      alpha = alpha * 0.5 * (double)CS_ONEDSR;
       beta = (1.0 - alpha) / (1.0 + alpha);
       p->xnm1[j] = p->ynm1[j] = FL(0.0);
       p->coef[j] = -(MYFLT)beta;

--- a/Opcodes/ugsc.c
+++ b/Opcodes/ugsc.c
@@ -88,7 +88,7 @@ static int32_t svf(CSOUND *csound, SVF *p)
       if (fco != lfco || q != lq) {
         lfco = fco; lq = q;
         /* calculate frequency and Q coefficients */
-        f1 = FL(2.0) * (MYFLT)sin((double)(fco * csound->pidsr));
+        f1 = FL(2.0) * (MYFLT)sin((double)(fco * CS_PIDSR));
         /* Protect against division by zero */
         if (UNLIKELY(q<FL(0.000001))) q = FL(1.0);
         q1 = FL(1.0) / q;
@@ -263,8 +263,8 @@ static int32_t resonr(CSOUND *csound, RESONZ *p)
       MYFLT bw = asgw ? kbw[n] : *kbw;
       if (cf != lcf || bw != lbw) {
         lcf = cf; lbw = bw;
-        r = exp((double)(bw * csound->mpidsr));
-        c1 = 2.0 * r * cos((double)(cf * csound->tpidsr));
+        r = exp((double)(bw * CS_MPIDSR));
+        c1 = 2.0 * r * cos((double)(cf * CS_TPIDSR));
         c2 = r * r;
         if (p->scaletype == 1)
           scale = 1.0 - r;
@@ -331,8 +331,8 @@ static int32_t resonz(CSOUND *csound, RESONZ *p)
       MYFLT bw = asgw ? kbw[n] : *kbw;
       if (cf != lcf || bw != lbw) {
         lcf = cf; lbw = bw;
-        r = exp(-(double)(bw * csound->pidsr));
-        c1 = 2.0 * r * cos((double)(csound->tpidsr*cf));
+        r = exp(-(double)(bw * CS_PIDSR));
+        c1 = 2.0 * r * cos((double)(CS_TPIDSR*cf));
         c2 = r * r;
         if (p->scaletype == 1)
           scale = (1.0 - c2) * 0.5;
@@ -409,7 +409,7 @@ static int32_t phaser1(CSOUND *csound, PHASER1 *p)
      * frequency value into a useable coefficient for the
      * allpass filters.
      */
-    wp = csound->pidsr * coef;
+    wp = CS_PIDSR * coef;
     beta = (FL(1.0) - wp)/(FL(1.0) + wp);
 
     if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
@@ -519,8 +519,8 @@ static int32_t phaser2(CSOUND *csound, PHASER2 *p)
          * notch, while the pole radius determines the q of
          * the notch.
          */
-        r = EXP(-(freq * csound->pidsr / kq));
-        b = -FL(2.0) * r * COS(freq * csound->tpidsr);
+        r = EXP(-(freq * CS_PIDSR / kq));
+        b = -FL(2.0) * r * COS(freq * CS_TPIDSR);
         a = r * r;
 
         /* Difference equations for implementing canonical
@@ -560,9 +560,9 @@ static int32_t lp2(CSOUND *csound, LP2 *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    temp = (double)(csound->mpidsr * kfco / kres);
+    temp = (double)(CS_MPIDSR * kfco / kres);
       /* (-PI_F * kfco / (kres * CS_ESR)); */
-    a = 2.0 * cos((double) (kfco * csound->tpidsr)) * exp(temp);
+    a = 2.0 * cos((double) (kfco * CS_TPIDSR)) * exp(temp);
     b = exp(temp+temp);
     c = 1.0 - a + b;
 
@@ -597,9 +597,9 @@ static int32_t lp2aa(CSOUND *csound, LP2 *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    temp = (double)(csound->mpidsr * fco / res);
+    temp = (double)(CS_MPIDSR * fco / res);
       /* (-PI_F * kfco / (kres * CS_ESR)); */
-    a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+    a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
     b = exp(temp+temp);
     c = 1.0 - a + b;
 
@@ -616,9 +616,9 @@ static int32_t lp2aa(CSOUND *csound, LP2 *p)
     for (n=offset; n<nsmps; n++) {
       if (res!=resp[n] || fco!=fcop[n]) {
         res=resp[n]; fco=fcop[n];
-        temp = (double)(csound->mpidsr * fco / res);
+        temp = (double)(CS_MPIDSR * fco / res);
         /* (-PI_F * kfco / (kres * CS_ESR)); */
-        a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+        a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
         b = exp(temp+temp);
         c = 1.0 - a + b;
       }
@@ -642,9 +642,9 @@ static int32_t lp2ka(CSOUND *csound, LP2 *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    temp = (double)(csound->mpidsr * fco / res);
+    temp = (double)(CS_MPIDSR * fco / res);
       /* (-PI_F * kfco / (kres * CS_ESR)); */
-    a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+    a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
     b = exp(temp+temp);
     c = 1.0 - a + b;
 
@@ -661,9 +661,9 @@ static int32_t lp2ka(CSOUND *csound, LP2 *p)
     for (n=offset; n<nsmps; n++) {
       if (res!=resp[n]) {
         res=resp[n];
-        temp = (double)(csound->mpidsr * fco / res);
+        temp = (double)(CS_MPIDSR * fco / res);
         /* (-PI_F * kfco / (kres * CS_ESR)); */
-        a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+        a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
         b = exp(temp+temp);
         c = 1.0 - a + b;
       }
@@ -687,9 +687,9 @@ static int32_t lp2ak(CSOUND *csound, LP2 *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    temp = (double)(csound->mpidsr * fco / res);
+    temp = (double)(CS_MPIDSR * fco / res);
       /* (-PI_F * kfco / (kres * CS_ESR)); */
-    a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+    a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
     b = exp(temp+temp);
     c = 1.0 - a + b;
 
@@ -706,9 +706,9 @@ static int32_t lp2ak(CSOUND *csound, LP2 *p)
     for (n=offset; n<nsmps; n++) {
       if (fco!=fcop[n]) {
         fco=fcop[n];
-        temp = (double)(csound->mpidsr * fco / res);
+        temp = (double)(CS_MPIDSR * fco / res);
         /* (-PI_F * kfco / (kres * CS_ESR)); */
-        a = 2.0 * cos((double) (fco * csound->tpidsr)) * exp(temp);
+        a = 2.0 * cos((double) (fco * CS_TPIDSR)) * exp(temp);
         b = exp(temp+temp);
         c = 1.0 - a + b;
       }

--- a/Opcodes/wave-terrain.c
+++ b/Opcodes/wave-terrain.c
@@ -218,7 +218,7 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
     FUNC *fstiff = p->fstiff;
     FUNC *fdamp  = p->fdamp;
     FUNC *fvel   = p->fvel;
-    MYFLT inc    = p->size * *(p->kpch) * csound->onedsr;
+    MYFLT inc    = p->size * *(p->kpch) * CS_ONEDSR;
     MYFLT amp    = *(p->kamp);
     MYFLT pos    = p->pos;
     MYFLT *aout  = p->aout;
@@ -272,7 +272,7 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
       /* NO INTERPOLATION */
       aout[i] = fpoint->ftable[(int32_t)pos] * amp;
 
-      pos += inc /* p->size * *(p->kpch) * csound->onedsr */;
+      pos += inc /* p->size * *(p->kpch) * CS_ONEDSR */;
       if (UNLIKELY(pos > p->size)) {
         pos -= p->size;
       }

--- a/Opcodes/wave-terrain.c
+++ b/Opcodes/wave-terrain.c
@@ -66,7 +66,7 @@ static int32_t wtPerf(CSOUND *csound, WAVETER *p)
     MYFLT krx = *(p->krx), kry = *(p->kry);
     MYFLT sizx = p->sizx, sizy = p->sizy;
     MYFLT theta = p->theta;
-    MYFLT dtpidsr = csound->tpidsr;
+    MYFLT dtpidsr = CS_TPIDSR;
     MYFLT *aout = p->aout;
 
     if (UNLIKELY(offset)) memset(aout, '\0', offset*sizeof(MYFLT));

--- a/Opcodes/wavegde.h
+++ b/Opcodes/wavegde.h
@@ -92,12 +92,13 @@ typedef struct{
   MYFLT p;             /* The tuning fitler state */
   MYFLT w0;            /* The fundamental frequency (PI normalized) */
   MYFLT f0;            /* The fundamental frequency (Hertz) */
+  MYFLT sr;
 } waveguide;
 
 static MYFLT filterAllpass(waveguide*,MYFLT);/* 1st-order allpass filtering*/
 
 /* waveguide member functions */
-static void waveguideWaveguide(CSOUND *, waveguide*, MYFLT, MYFLT*, MYFLT*);
+static void waveguideWaveguide(CSOUND *, waveguide*, MYFLT, MYFLT*, MYFLT*, MYFLT);
 static void waveguideSetTuning(CSOUND *,waveguide*, MYFLT); /* Set tuning filters */
 #endif
 

--- a/Opcodes/wpfilters.c
+++ b/Opcodes/wpfilters.c
@@ -63,7 +63,7 @@ static int32_t zdf_1pole_mode_perf(CSOUND* csound, ZDF_1POLE_MODE* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -139,7 +139,7 @@ static int32_t zdf_1pole_perf(CSOUND* csound, ZDF_1POLE* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
     int32_t mode = MYFLT2LONG(*p->mode);
@@ -235,7 +235,7 @@ static int32_t zdf_2pole_mode_perf(CSOUND* csound, ZDF_2POLE_MODE* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -333,7 +333,7 @@ static int32_t zdf_2pole_perf(CSOUND* csound, ZDF_2POLE* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -458,7 +458,7 @@ static int32_t zdf_ladder_perf(CSOUND* csound, ZDF_LADDER* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -625,7 +625,7 @@ static int32_t diode_ladder_perf(CSOUND* csound,
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -815,7 +815,7 @@ static int32_t k35_lpf_perf(CSOUND* csound, K35_LPF* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 
@@ -954,7 +954,7 @@ static int32_t k35_hpf_perf(CSOUND* csound, K35_HPF* p) {
     uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    double T = csound->onedsr;
+    double T = CS_ONEDSR;
     double Tdiv2 = T / 2.0;
     double two_div_T = 2.0 / T;
 

--- a/Opcodes/wterrain2.c
+++ b/Opcodes/wterrain2.c
@@ -215,7 +215,7 @@ static int32_t wtPerf(CSOUND *csound, WAVETER *p)
       aout[i] = p->xarr[xloc] * p->yarr[yloc] * amp;
 
       /* MOVE SCANNING POINT ROUND THE ELLIPSE */
-      theta += pch*((period*TWOPI_F) / csound->GetSr(csound));
+      theta += pch*((period*TWOPI_F) / CS_ESR);
     }
 
     p->theta = theta;

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -1293,7 +1293,7 @@ const INITFN staticmodules[] = { hrtfopcodes_localops_init, babo_localops_init,
 */
 typedef NGFENS* (*FGINITFN)(CSOUND *);
 
-NGFENS *quadbezier_fgens_init(CSOUND *, void *);
+NGFENS *quadbezier_fgens_init(CSOUND *);
 NGFENS *ftest_fgens_init(CSOUND *);
 NGFENS *farey_fgens_init(CSOUND *);
 

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -283,32 +283,11 @@ MYFLT csoundSystemSr(CSOUND *csound, MYFLT val) {
 }
 
 
-static MYFLT csoundGetLocalSr(INSDS *ip){
-  return ip->esr;
-}
-
-static MYFLT csoundGetLocalKr(INSDS *ip){
-  return ip->ekr;
-}
-
-static uint32_t csoundGetLocalKsmps(INSDS *ip){
-  return ip->ksmps;
-}
-
-static uint64_t csoundGetLocalKcounter(INSDS *ip){
-  return ip->kcounter;
-}
-
-
 static const CSOUND cenviron_ = {
     /* attributes  */
-    csoundGetLocalSr,
-    csoundGetLocalKr,
-    csoundGetLocalKsmps,
     csoundGetNchnls,
     csoundGetNchnlsInput,
     csoundGet0dBFS,
-    csoundGetLocalKcounter,
     csoundGetCurrentTimeSamples,
     csoundGetInputBufferSize,
     csoundGetOutputBufferSize,

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -282,15 +282,33 @@ MYFLT csoundSystemSr(CSOUND *csound, MYFLT val) {
   return csound->_system_sr;
 }
 
+
+static MYFLT csoundGetLocalSr(INSDS *ip){
+  return ip->esr;
+}
+
+static MYFLT csoundGetLocalKr(INSDS *ip){
+  return ip->ekr;
+}
+
+static uint32_t csoundGetLocalKsmps(INSDS *ip){
+  return ip->ksmps;
+}
+
+static uint64_t csoundGetLocalKcounter(INSDS *ip){
+  return ip->kcounter;
+}
+
+
 static const CSOUND cenviron_ = {
     /* attributes  */
-    csoundGetSr,
-    csoundGetKr,
-    csoundGetKsmps,
+    csoundGetLocalSr,
+    csoundGetLocalKr,
+    csoundGetLocalKsmps,
     csoundGetNchnls,
     csoundGetNchnlsInput,
     csoundGet0dBFS,
-    csoundGetKcounter,
+    csoundGetLocalKcounter,
     csoundGetCurrentTimeSamples,
     csoundGetInputBufferSize,
     csoundGetOutputBufferSize,

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -760,6 +760,7 @@ static const CSOUND cenviron_ = {
     0,
     FL(0.0),  /* esr */
     FL(0.0),
+    FL(0.0),
     0,       /* overmode */
     0,
     FL(0.0),

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -737,9 +737,11 @@ static const CSOUND cenviron_ = {
     0,
     0.0,
     0.0,
-    NULL,
+    //    NULL,
     NULL,
     0,
+    FL(0.0),  /* esr */
+    FL(0.0), 
     0,
     FL(0.0),
     FL(0.0), FL(0.0), FL(0.0),

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -759,7 +759,8 @@ static const CSOUND cenviron_ = {
     NULL,
     0,
     FL(0.0),  /* esr */
-    FL(0.0), 
+    FL(0.0),
+    0,       /* overmode */
     0,
     FL(0.0),
     FL(0.0), FL(0.0), FL(0.0),

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -739,6 +739,7 @@ static const CSOUND cenviron_ = {
     FL(0.0),  /* esr */
     FL(0.0),
     FL(0.0),
+    FL(0.0),
     0,       /* overmode */
     0,
     FL(0.0),

--- a/Top/server.c
+++ b/Top/server.c
@@ -110,7 +110,7 @@ static uintptr_t udp_recv(void *pdata){
   int sock = 0;
   int received, cont = 0;
   char *start = orchestra;
-  size_t timout = (size_t) lround(1000/csound->GetKr(csound));
+  size_t timout = (size_t) lround(1000/csoundGetKr(csound));
 
   csound->Message(csound, Str("UDP server started on port %d\n"),port);
   while (p->status) {

--- a/include/csound.h
+++ b/include/csound.h
@@ -559,6 +559,8 @@ extern "C" {
     int     sampleFormat;
     /** sample rate in Hz */
     float   sampleRate;
+    /** ksmps */
+    int ksmps;
   } csRtAudioParams;
 
   typedef struct RTCLOCK_S {

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -562,7 +562,7 @@ typedef struct CORFIL {
     /* pointer to Csound engine and API for externals */
     CSOUND  *csound;
     uint64_t kcounter;
-    MYFLT    esr, sicvt;                  /* local sr */
+    MYFLT    esr, sicvt, pidsr;                  /* local sr */
     MYFLT    onedsr;
     int     overmode;
     unsigned int ksmps;     /* Instrument copy of ksmps */
@@ -606,6 +606,10 @@ typedef struct CORFIL {
 #define CS_ESR       (p->h.insdshead->esr)
 #define CS_ONEDSR    (p->h.insdshead->onedsr)
 #define CS_SICVT     (p->h.insdshead->sicvt)
+#define CS_TPIDSR    (2*p->h.insdshead->pidsr)
+#define CS_PIDSR     (p->h.insdshead->pidsr)
+#define CS_MPIDSR    (-p->h.insdshead->pidsr)
+#define CS_MTPIDSR   (-2*p->h.insdshead->pidsr)
 #define CS_PDS       (p->h.insdshead->pds)
 #define CS_SPIN      (p->h.insdshead->spin)
 #define CS_SPOUT     (p->h.insdshead->spout)

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -692,6 +692,8 @@ typedef struct CORFIL {
     int32    nchanls;
     /** table number */
     int32    fno;
+    /** table number */
+    MYFLT   sr;
     /** args  */
     MYFLT args[PMAX - 4];
     /** arg count */
@@ -1036,16 +1038,16 @@ typedef struct _message_queue_t_ {
 
     /** @name Attributes */
     /**@{ */
-    MYFLT (*GetSr)(CSOUND *);
-    MYFLT (*GetKr)(CSOUND *);
-    uint32_t (*GetKsmps)(CSOUND *);
+    MYFLT (*GetSr)(INSDS *);
+    MYFLT (*GetKr)(INSDS *);
+    uint32_t (*GetKsmps)(INSDS *);
      /** Get number of output channels */
     uint32_t (*GetNchnls)(CSOUND *);
     /** Get number of input channels */
     uint32_t (*GetNchnls_i)(CSOUND *);
     MYFLT (*Get0dBFS) (CSOUND *);
     /** Get number of control blocks elapsed */
-    uint64_t (*GetKcounter)(CSOUND *);
+    uint64_t (*GetKcounter)(INSDS *);
     int64_t (*GetCurrentTimeSamples)(CSOUND *);
     long (*GetInputBufferSize)(CSOUND *);
     long (*GetOutputBufferSize)(CSOUND *);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -559,13 +559,14 @@ typedef struct CORFIL {
     double   offbet;
     /* Time to turn off event, in seconds (negative on indef/tie) */
     double   offtim;
-    /* Python namespace for just this instance. */
-    void    *pylocal;
     /* pointer to Csound engine and API for externals */
     CSOUND  *csound;
     uint64_t kcounter;
-    unsigned int     ksmps;     /* Instrument copy of ksmps */
+    MYFLT esr;                  /* local sr */
+    MYFLT    onedsr;
+    unsigned int ksmps;     /* Instrument copy of ksmps */
     MYFLT    ekr;                /* and of rates */
+
     MYFLT    onedksmps, onedkr, kicvt;
     struct opds  *pds;          /* Used for jumping */
     MYFLT    scratchpad[4];      /* Persistent data */
@@ -601,7 +602,8 @@ typedef struct CORFIL {
 #define CS_ONEDKSMPS (p->h.insdshead->onedksmps)
 #define CS_ONEDKR    (p->h.insdshead->onedkr)
 #define CS_KICVT     (p->h.insdshead->kicvt)
-#define CS_ESR       (csound->esr)
+#define CS_ESR       (p->h.insdshead->esr)
+#define CS_ONEDSR    (p->h.insdshead->onedsr)
 #define CS_PDS       (p->h.insdshead->pds)
 #define CS_SPIN      (p->h.insdshead->spin)
 #define CS_SPOUT     (p->h.insdshead->spout)

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -564,6 +564,7 @@ typedef struct CORFIL {
     uint64_t kcounter;
     MYFLT esr;                  /* local sr */
     MYFLT    onedsr;
+    int     overmode;
     unsigned int ksmps;     /* Instrument copy of ksmps */
     MYFLT    ekr;                /* and of rates */
 

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1040,9 +1040,9 @@ typedef struct _message_queue_t_ {
 
     /** @name Attributes */
     /**@{ */
-    MYFLT (*GetSr)(INSDS *);
-    MYFLT (*GetKr)(INSDS *);
-    uint32_t (*GetKsmps)(INSDS *);
+    MYFLT (*GetLocalSr)(INSDS *);
+    MYFLT (*GetLocalKr)(INSDS *);
+    uint32_t (*GetLocalKsmps)(INSDS *);
      /** Get number of output channels */
     uint32_t (*GetNchnls)(CSOUND *);
     /** Get number of input channels */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1040,16 +1040,11 @@ typedef struct _message_queue_t_ {
 
     /** @name Attributes */
     /**@{ */
-    MYFLT (*GetLocalSr)(INSDS *);
-    MYFLT (*GetLocalKr)(INSDS *);
-    uint32_t (*GetLocalKsmps)(INSDS *);
      /** Get number of output channels */
     uint32_t (*GetNchnls)(CSOUND *);
     /** Get number of input channels */
     uint32_t (*GetNchnls_i)(CSOUND *);
     MYFLT (*Get0dBFS) (CSOUND *);
-    /** Get number of control blocks elapsed */
-    uint64_t (*GetKcounter)(INSDS *);
     int64_t (*GetCurrentTimeSamples)(CSOUND *);
     long (*GetInputBufferSize)(CSOUND *);
     long (*GetOutputBufferSize)(CSOUND *);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -562,7 +562,7 @@ typedef struct CORFIL {
     /* pointer to Csound engine and API for externals */
     CSOUND  *csound;
     uint64_t kcounter;
-    MYFLT esr;                  /* local sr */
+    MYFLT    esr, sicvt;                  /* local sr */
     MYFLT    onedsr;
     int     overmode;
     unsigned int ksmps;     /* Instrument copy of ksmps */
@@ -605,6 +605,7 @@ typedef struct CORFIL {
 #define CS_KICVT     (p->h.insdshead->kicvt)
 #define CS_ESR       (p->h.insdshead->esr)
 #define CS_ONEDSR    (p->h.insdshead->onedsr)
+#define CS_SICVT     (p->h.insdshead->sicvt)
 #define CS_PDS       (p->h.insdshead->pds)
 #define CS_SPIN      (p->h.insdshead->spin)
 #define CS_SPOUT     (p->h.insdshead->spout)

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -101,11 +101,11 @@ public:
 
   /** system sampling rate
    */
-  MYFLT sr() { return GetSr(this); }
+  //MYFLT sr() { return GetSr(this); }
 
   /** system control rate
    */
-  MYFLT kr() { return GetKr(this); }
+  //MYFLT kr() { return GetKr(this); }
 
   /** system max amp reference
    */
@@ -129,9 +129,9 @@ public:
 
   /** time count (seconds)
    */
-  double current_time_seconds() {
-    return GetCurrentTimeSamples(this) / GetSr(this);
-  }
+  //double current_time_seconds() {
+  //  return GetCurrentTimeSamples(this) / GetSr(this);
+  //}
 
   /** check for audio signal variable argument
    */
@@ -949,7 +949,7 @@ template <std::size_t N> struct InPlug : OPDS {
 
    /** sampling rate
    */
-  MYFLT sr() { return csound->sr(); }
+  MYFLT sr() { return insdshead->esr; }
 
   /** midi channel number for this instrument
    */
@@ -1081,7 +1081,7 @@ template <std::size_t N, std::size_t M> struct Plugin : OPDS {
 
    /** sampling rate
    */
-  MYFLT sr() { return csound->sr(); }
+  MYFLT sr() { return insdshead->esr; }
 
   /** midi channel number for this instrument
    */

--- a/include/soundfile.h
+++ b/include/soundfile.h
@@ -275,7 +275,5 @@ extern "C" {
   const char *sflib_strerror(void *);  
 #ifdef __cplusplus
 }
-#endif
-
-  
+#endif  
 #endif /* _SOUNDFILE_H_ */


### PR DESCRIPTION
This PR introduces a local sr to INSDS with a view to supporting oversampling in UDOs.
The macro CS_ESR has been redefined. A new macro defining CS_ONEDSR has been introduced.

- csound->onedsr still needs to be replaced in all opcodes using it. 
- A check for the use of csound->esr and csound->GetSr() in opcodes needs to be made.
- We will probably have to remove GetSr(), GetKr(), GetKsmps() to avoid further use in opcodes.

Not ready to be merged yet.

