### PR TITLE
Bult-in opcodes build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ else()
     cmake_minimum_required(VERSION 3.13.4)
 endif()
 
+set (CMAKE_CXX_STANDARD 11)
+
 cmake_policy(SET CMP0077 NEW)
 
 include(cmake/cmake-utilities.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,7 +913,18 @@ set(oldpvoc_SRCS
     Opcodes/pvread.c
     Opcodes/ugens8.c
     Opcodes/vpvoc.c
-    Opcodes/pvoc.c)
+    Opcodes/pvoc.c
+)
+
+set(scanops_SRCS
+    Opcodes/scansyn.c   
+    Opcodes/scansynx.c
+)
+
+set(unixops_SRCS
+    Opcodes/control.c
+    Opcodes/urandom.c
+)
 
 set(mp3in_SRCS
     Opcodes/mp3in.c
@@ -925,29 +936,34 @@ set(mp3in_SRCS
     InOut/libmpadec/mpadec.c
     InOut/libmpadec/mp3dec.c)
 
-list(APPEND libcsound_SRCS ${stdopcod_SRCS} ${cs_pvs_ops_SRCS} ${oldpvoc_SRCS} ${mp3in_SRCS})
+set(cppops_SRCS
+   Opcodes/ampmidid.cpp
+   Opcodes/mixer.cpp
+   Opcodes/bformdec2.cpp
+   Opcodes/doppler.cpp
+     Opcodes/ftsamplebank.cpp
+     Opcodes/padsynth_gen.cpp
+     Opcodes/signalflowgraph.cpp
+     Opcodes/arrayops.cpp
+     Opcodes/lfsr.cpp
+     Opcodes/pvsops.cpp
+     Opcodes/trigEnvSegs.cpp
+     Opcodes/tl/fractalnoise.cpp
+)
+
+list(APPEND libcsound_SRCS ${stdopcod_SRCS} ${cs_pvs_ops_SRCS}
+${oldpvoc_SRCS} ${scanops_SRCS} ${mp3in_SRCS} ${cppops_SRCS})
+
+if(UNIX)
+list(APPEND libcsound_SRCS ${unixops_SRCS})
+endif()
 
 if(BUILD_PERFTHREAD_CLASS)
     list(APPEND libcsound_SRCS "Top/csPerfThread.cpp")
 endif()
 
-if(INIT_STATIC_MODULES)
-    set(static_modules_SRCS
-        Top/init_static_modules.c
-        Opcodes/ampmidid.cpp
-        Opcodes/doppler.cpp
-        Opcodes/tl/fractalnoise.cpp
-        Opcodes/ftsamplebank.cpp
-        Opcodes/mixer.cpp
-        Opcodes/signalflowgraph.cpp)
-
-    set_source_files_properties(${static_modules_SRCS} PROPERTIES COMPILE_FLAGS -DINIT_STATIC_MODULES)
-    list(APPEND libcsound_SRCS ${static_modules_SRCS})
-    message(STATUS "Building static modules")
-endif()
 
 # Handling New Parser
-
 set(YACC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/Engine/csound_orc.y)
 set(YACC_OUT ${CMAKE_CURRENT_BINARY_DIR}/csound_orcparse.c)
 set(YACC_OUTH ${CMAKE_CURRENT_BINARY_DIR}/csound_orcparse.h)

--- a/Opcodes/CMakeLists.txt
+++ b/Opcodes/CMakeLists.txt
@@ -1,9 +1,6 @@
 option(BUILD_DSSI_OPCODES "Build the DSSI opcodes" OFF)
 option(BUILD_OSC_OPCODES "Build the OSC Opcodes" ON)
-option(BUILD_PADSYNTH_OPCODES "Build the Padsynth opcode" ON)
-option(BUILD_SCANSYN_OPCODES "Build the scansyn opcodes" ON)
 option(BUILD_DEPRECATED_OPCODES "Build deprecated opcodes" ON)
-option(BUILD_CPP_OPCODES "Build CPP plugins" ON)
 
 ##########################################
 ## Plugin opcodes are in the following categories ##
@@ -19,51 +16,7 @@ option(BUILD_CPP_OPCODES "Build CPP plugins" ON)
 #  See instructions in ../Top/csmodule.c
 ##########################################
 
-if(BUILD_CPP_OPCODES)
-message(STATUS "## Building Plugin Opcodes ##")
-## CPP OPCODE LIBS WITH NO EXTERNAL DEPENDENCIES ##
-make_plugin(doppler doppler.cpp)
-make_plugin(fractalnoise tl/fractalnoise.cpp)
-
-if(DIRENT_H) 
-make_plugin(ftsamplebank ftsamplebank.cpp)
-get_filename_component(DIRENT_INCLUDE_DIR ${DIRENT_H} DIRECTORY)
-target_include_directories(ftsamplebank PRIVATE ${DIRENT_INCLUDE_DIR})
-endif()
-
-make_plugin(lfsr lfsr.cpp)
-make_plugin(bformdec2 bformdec2.cpp)
-make_plugin(mixer mixer.cpp)
-make_plugin(signalflowgraph signalflowgraph.cpp)
-make_plugin(ampmidid ampmidid.cpp)
-
-make_plugin(arrayops arrayops.cpp)
-target_compile_features(arrayops PRIVATE cxx_std_11)
-
-make_plugin(pvsops pvsops.cpp)
-target_compile_features(pvsops PRIVATE cxx_std_11)
-
-make_plugin(trigenvsegs trigEnvSegs.cpp)
-target_compile_features(trigenvsegs PRIVATE cxx_std_11)
-
-make_plugin(padsynth padsynth_gen.cpp)
-target_compile_features(padsynth PRIVATE cxx_std_11)
-
-endif()
-
-## opcodes with special licence conditions ##
-if(BUILD_SCANSYN_OPCODES)
-    set(scansyn_SRCS
-        scansyn.c scansynx.c)
-    make_plugin(scansyn "${scansyn_SRCS}" ${MATH_LIBRARY})
-endif()
-
 ## platform-dependent opcodes ##
-if(UNIX)
-    make_plugin(control control.c)
-    make_plugin(urandom urandom.c)
-endif()
-
 if(LINUX)
     make_plugin(joystick linuxjoystick.c)
 endif()

--- a/Opcodes/ampmidid.cpp
+++ b/Opcodes/ampmidid.cpp
@@ -150,7 +150,7 @@ public:
 };
 
 extern "C" {
-    PUBLIC int csoundModuleInit_ampmidid(CSOUND *csound) {
+    PUBLIC int32_t csoundModuleInit_ampmidid(CSOUND *csound) {
         int status = csound->AppendOpcode(
                          csound, (char *)"ampmidid.k", sizeof(KAMPMIDID), 0, 3, (char *)"k",
                          (char *)"kio",
@@ -182,7 +182,7 @@ extern "C" {
         return status;
     }
 
-#ifndef INIT_STATIC_MODULES
+#ifdef BUILD_PLUGINS
     PUBLIC int csoundModuleCreate(CSOUND *csound) {
         IGN(csound);
         return 0;
@@ -196,5 +196,10 @@ extern "C" {
         IGN(csound);
         return 0;
     }
+#else
+
+
+
+
 #endif
 }

--- a/Opcodes/arrayops.cpp
+++ b/Opcodes/arrayops.cpp
@@ -208,8 +208,7 @@ template <typename T, int I> struct Accum : csnd::Plugin<1, 1> {
 };
 
 
-#include <modload.h>
-void csnd::on_load(Csound *csound) {
+static void onload(csnd::Csound *csound) {
   csnd::plugin<ArrayOp<lim1>>(csound, "limit1", "i[]", "i[]", csnd::thread::i);
   csnd::plugin<ArrayOp<lim1>>(csound, "limit1", "k[]", "k[]", csnd::thread::ik);
   csnd::plugin<ArrayOp<std::ceil>>(csound, "ceil", "i[]", "i[]",
@@ -357,3 +356,17 @@ void csnd::on_load(Csound *csound) {
   csnd::plugin<ArrayOp3<std::fmin>>(csound, "fmin", "k[]", "k[]k",
                                     csnd::thread::ik);
 }
+
+
+
+#ifdef BUILD_PLUGINS
+#include <modload.h>
+void csnd::on_load(csnd::Csound *csound) {
+    onload(csound);
+}
+#else
+extern "C" int32_t arrayops_init_modules(CSOUND *csound) {
+    onload((csnd::Csound *)csound);
+    return OK;
+  }
+#endif

--- a/Opcodes/bformdec2.cpp
+++ b/Opcodes/bformdec2.cpp
@@ -23,7 +23,7 @@
 
 #include <stdlib.h>
 //#include <unistd.h>
-#include "csdl.h"
+//#include "csdl.h"
 #include <math.h>
 #include "csoundCore.h"
 #include <string.h>
@@ -2147,10 +2147,11 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int signal_order, int n, in
 }
 
 #define S(x)    sizeof(x)
-
-static OENTRY localops[] = {
+extern "C" {
+static OENTRY bformdec2_localops[] = {
   { (char*) "bformdec2.A", S(HOAMBDEC), 0, 3, (char*) "a[]", (char*) "ia[]ooooNN",
     (SUBR)ihoambdec, (SUBR)ahoambdec },
 };
 
-LINKAGE_BUILTIN(localops)
+LINKAGE_BUILTIN(bformdec2_localops)
+}

--- a/Opcodes/control.c
+++ b/Opcodes/control.c
@@ -21,9 +21,7 @@
     02110-1301 USA
 */
 
-#include "csdl.h"
 #include "control.h"
-
 #include <sys/time.h>
 #include <sys/types.h>
 #include <signal.h>

--- a/Opcodes/control.h
+++ b/Opcodes/control.h
@@ -26,9 +26,7 @@
 /********************************************/
 
 #pragma once
-
-#include "csdl.h"
-
+#include "csoundCore.h"
 typedef struct CONTROL_GLOBALS_ {
     CSOUND  *csound;
     char    cmd[100];

--- a/Opcodes/doppler.cpp
+++ b/Opcodes/doppler.cpp
@@ -280,7 +280,8 @@ PUBLIC int32_t csoundModuleInit_doppler(CSOUND *csound) {
   }
   return status;
 }
-#ifndef INIT_STATIC_MODULES
+  
+#ifdef BUILD_PLUGINS
 PUBLIC int32_t csoundModuleCreate(CSOUND *csound) {
   IGN(csound);
   return 0;

--- a/Opcodes/ftsamplebank.cpp
+++ b/Opcodes/ftsamplebank.cpp
@@ -19,6 +19,8 @@
     02110-1301 USA
  */
 
+#ifdef HAVE_DIRENT_H
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -326,7 +328,7 @@ std::vector<std::string> searchDir(CSOUND *csound, char *directory,
 
 extern "C" {
 
-PUBLIC int csoundModuleInit_ftsamplebank(CSOUND *csound) {
+PUBLIC int32_t csoundModuleInit_ftsamplebank(CSOUND *csound) {
 
   int status = csound->AppendOpcode(
       csound, (char *)"ftsamplebank.k", sizeof(kftsamplebank), 0, 3,
@@ -359,7 +361,7 @@ PUBLIC int csoundModuleInit_ftsamplebank(CSOUND *csound) {
   return status;
 }
 
-#ifndef INIT_STATIC_MODULES
+#ifdef BUILD_PLUGINS
 PUBLIC int csoundModuleCreate(CSOUND *csound) {
   IGN(csound);
   return 0;
@@ -375,3 +377,4 @@ PUBLIC int csoundModuleDestroy(CSOUND *csound) {
 }
 #endif
 }
+#endif

--- a/Opcodes/lfsr.cpp
+++ b/Opcodes/lfsr.cpp
@@ -133,7 +133,19 @@ struct LFSR : csnd::Plugin<1, 3> {
     }
 };
 
+#ifdef BUILD_PLUGINS
 #include <modload.h>
 void csnd::on_load(Csound *csound) {
   csnd::plugin<LFSR>(csound, "lfsr", "k", "iij", csnd::thread::ik);
 }
+#else 
+extern "C" int32_t lfsr_init_modules(CSOUND *csound) {
+  csnd::plugin<LFSR>((csnd::Csound *) csound, "lfsr", "k", "iij", csnd::thread::ik);
+  return OK;
+}
+
+#endif
+
+
+
+

--- a/Opcodes/padsynth_gen.cpp
+++ b/Opcodes/padsynth_gen.cpp
@@ -565,11 +565,14 @@ static int padsynth_gen(FGDATA *ff, FUNC *ftp) {
   return OK;
 }
 
+extern "C" {
+  
 static NGFENS padsynth_gens[] = {{(char *)"padsynth", padsynth_gen},
                                  {NULL, NULL}};
 
-PUBLIC NGFENS *csound_fgen_init(CSOUND *csound) {
+PUBLIC NGFENS *padsyn_fgen_init(CSOUND *csound) {
   IGN(csound);
   return padsynth_gens;
 }
 };
+}

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -465,8 +465,7 @@ struct TPrint : csnd::Plugin<0, 1> {
 };
 */
 
-#include <modload.h>
-void csnd::on_load(Csound *csound) {
+void onload(csnd::Csound *csound) {
   csnd::plugin<PVTrace>(csound, "pvstrace",  csnd::thread::ik);
   csnd::plugin<PVTrace2>(csound, "pvstrace", csnd::thread::ik);
   csnd::plugin<TVConv>(csound, "tvconv", "a", "aaxxii", csnd::thread::ia);
@@ -474,3 +473,15 @@ void csnd::on_load(Csound *csound) {
   csnd::plugin<Gtadsr>(csound, "gtadsr", "a", "akkkkk", csnd::thread::ia);
   csnd::plugin<Gtadsr>(csound, "gtadsr", "a", "kkkkkk", csnd::thread::ia);
 }
+
+#ifdef BUILD_PLUGINS
+#include <modload.h>
+void csnd::onload(csnd::Csound *csound) {
+    on_load(csound);
+}
+#else
+extern "C" int32_t pvsops_init_modules(CSOUND *csound) {
+    onload((csnd::Csound *)csound);
+    return OK;
+  }
+#endif

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -823,13 +823,13 @@ static OENTRY localops[] =
 
 };
 
-static int32_t scansyn_init_(CSOUND *csound)
+int32_t scansyn_init_(CSOUND *csound)
 {
     return csound->AppendOpcodes(csound, &(localops[0]),
                                  (int32_t) (sizeof(localops) / sizeof(OENTRY)));
 }
 
-
+#ifdef BUILD_PLUGINS
 PUBLIC int32_t csoundModuleCreate(CSOUND *csound)
 {
     (void) csound;
@@ -851,3 +851,4 @@ PUBLIC int32_t csoundModuleInfo(void)
     return ((CS_APIVERSION << 16) + (CS_APISUBVER << 8) + (int32_t
                                                            ) sizeof(MYFLT));
 }
+#endif

--- a/Opcodes/tl/fractalnoise.cpp
+++ b/Opcodes/tl/fractalnoise.cpp
@@ -450,17 +450,13 @@ int32_t fractalnoise_process(CSOUND *csound, FRACTALNOISE *p) {
   return OK;
 }
 
-  static OENTRY localops[] = {{(char *)"fractalnoise", sizeof(FRACTALNOISE), 0, 3,
+
+static OENTRY localops[] = {{(char *)"fractalnoise", sizeof(FRACTALNOISE), 0, 3,
                                (char *)"a", (char *)"kk", (SUBR)fractalnoise_init,
                                (SUBR)fractalnoise_process},
                             {0, 0, 0, 0, 0, 0, 0, 0, 0}};
 
-#ifndef INIT_STATIC_MODULES
-PUBLIC int32_t csoundModuleCreate(CSOUND *csound) {
-  IGN(csound);
-  return OK;
-}
-#endif
+
 PUBLIC int32_t csoundModuleInit_fractalnoise(CSOUND *csound) {
   int32_t status = 0;
   for (OENTRY *oentry = &localops[0]; oentry->opname; oentry++) {
@@ -473,7 +469,13 @@ PUBLIC int32_t csoundModuleInit_fractalnoise(CSOUND *csound) {
   }
   return status;
 }
-#ifndef INIT_STATIC_MODULES
+
+  
+#ifdef BUILD_PLUGINS
+PUBLIC int32_t csoundModuleCreate(CSOUND *csound) {
+  IGN(csound);
+  return OK;
+} 
 PUBLIC int32_t csoundModuleInit(CSOUND *csound) {
   return csoundModuleInit_fractalnoise(csound);
 }

--- a/Opcodes/trigEnvSegs.cpp
+++ b/Opcodes/trigEnvSegs.cpp
@@ -23,8 +23,6 @@
 #include <plugin.h>
 #include <vector>
 #include <numeric>
-#include <modload.h>
-
 
 // linseg type opcode with trigger mechanism
 struct TrigLinseg : csnd::Plugin<1, 64>
@@ -217,7 +215,7 @@ struct TrigExpseg : csnd::Plugin<1, 64>
 
 
 
-void csnd::on_load (Csound* csound)
+static void onload (csnd::Csound* csound)
 {
     csnd::plugin<TrigExpseg> (csound, "trigExpseg.aa", "a", "km", csnd::thread::ia);
     csnd::plugin<TrigExpseg> (csound, "trigExpseg.kk", "k", "km", csnd::thread::ik);
@@ -228,3 +226,15 @@ void csnd::on_load (Csound* csound)
     csnd::plugin<TrigLinseg> (csound, "triglinseg.aa", "a", "km", csnd::thread::ia);
     csnd::plugin<TrigLinseg> (csound, "triglinseg.kk", "k", "km", csnd::thread::ik);
 }
+
+#ifdef BUILD_PLUGINS
+#include <modload.h>
+void csnd::on_load(csnd::Csound *csound) {
+    onload(csound);
+}
+#else
+extern "C" int32_t trigEnv_init_modules(CSOUND *csound) {
+    onload((csnd::Csound *)csound);
+    return OK;
+  }
+#endif

--- a/Opcodes/urandom.c
+++ b/Opcodes/urandom.c
@@ -21,7 +21,7 @@
     02110-1301 USA
 */
 
-#include "csdl.h"
+#include "csoundCore.h"
 //#include <ieee754.h>
 
 #ifdef __HAIKU__

--- a/installer/windows/csound6_x64_github.iss
+++ b/installer/windows/csound6_x64_github.iss
@@ -119,8 +119,8 @@ Source: "{#VCREDIST_OPENMP_DIR}\*"; DestDir: "{#APP_BIN}"; Flags: recursesubdirs
 
 Source: "Python\ctcsound.py"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 
-Source: "{#ReleaseDir}\ampmidid.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\arrayops.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
+
+
 Source: "{#ReleaseDir}\atsa.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\cs.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion skipifsourcedoesntexist; Components: core;
 Source: "{#ReleaseDir}\csanalyze.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
@@ -133,45 +133,35 @@ Source: "{#ReleaseDir}\csound64.lib"; DestDir: "{#APP_LIB}"; Flags: ignoreversio
 Source: "{#ReleaseDir}\libcsound64.lib"; DestDir: "{#APP_LIB}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\cvanal.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\dnoise.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\doppler.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\envext.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\extract.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\extractor.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core
-Source: "{#ReleaseDir}\fractalnoise.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\ftsamplebank.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\het_export.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\het_import.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\hetro.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core
-Source: "{#ReleaseDir}\ipmidi.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\lpanal.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\lpc_export.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\lpc_import.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\makecsd.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion skipifsourcedoesntexist; Components: core;
-Source: "{#ReleaseDir}\mixer.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\mixer.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\osc.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\padsynth.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\pv_export.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\pv_import.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\pvanal.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\pvlook.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\pvsops.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\pmidi.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\rtpa.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion skipifsourcedoesntexist; Components: core;
 Source: "{#ReleaseDir}\rtwinmm.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\scale.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\scansyn.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\scot.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion skipifsourcedoesntexist; Components: core;
 Source: "{#ReleaseDir}\scsort.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion skipifsourcedoesntexist; Components: core;
 Source: "{#ReleaseDir}\sdif2ad.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
-Source: "{#ReleaseDir}\signalflowgraph.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\sndinfo.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\srconv.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\src_conv.exe"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\deprecated.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 Source: "{#ReleaseDir}\stdutil.dll"; DestDir: "{#APP_PLUGINS64}"; Flags: ignoreversion; Components: core;
 
-Source: "{#ReleaseDir}\lfsr.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 ; Source: "{#ReleaseDir}\liblo.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 ; Source: "{#ReleaseDir}\portaudio.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;
 ; Source: "{#ReleaseDir}\portmidi.dll"; DestDir: "{#APP_BIN}"; Flags: ignoreversion; Components: core;


### PR DESCRIPTION
As a first step towards #1865, this PR builds all opcodes that are not deprecated or do not have external dependencies into the Csound Library. This is the full system, when it is either not convenient or not possible to load plugins.

The second step (in a different PR) is to allow an option to build all external opcodes (in ./Opcodes) as plugins.