### PR TITLE
replace logging.warn with logging.warning

### DIFF
--- a/Emscripten/examples/httpd.py
+++ b/Emscripten/examples/httpd.py
@@ -82,7 +82,7 @@ class PluggableHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
       delegate_class = getattr(module, 'HTTPRequestHandlerDelegate', None)
       delegate = delegate_class()
       if not delegate:
-        logging.warn(
+        logging.warning(
             'Unable to find symbol HTTPRequestHandlerDelegate in module %s.' %
             handler_script)
 


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.