### PR TITLE
 FIX loops in UDO (#1879) and crash with no newline in score include (#1880) 

### DIFF
--- a/Engine/csound_prs.lex
+++ b/Engine/csound_prs.lex
@@ -783,6 +783,7 @@ static void do_include(CSOUND *csound, int term, yyscan_t yyscanner)
     else PARM->alt_stack[PARM->macro_stack_ptr].path = NULL;
     PARM->alt_stack[PARM->macro_stack_ptr++].s = NULL;
     csound_prspush_buffer_state(YY_CURRENT_BUFFER, yyscanner);
+    // this inserts a new line in included score to avoid lexer crash
     strcat(cf->body, "\n");
     csound_prs_scan_string(cf->body, yyscanner);
     corfile_rm(csound, &cf);

--- a/Engine/csound_prs.lex
+++ b/Engine/csound_prs.lex
@@ -783,6 +783,7 @@ static void do_include(CSOUND *csound, int term, yyscan_t yyscanner)
     else PARM->alt_stack[PARM->macro_stack_ptr].path = NULL;
     PARM->alt_stack[PARM->macro_stack_ptr++].s = NULL;
     csound_prspush_buffer_state(YY_CURRENT_BUFFER, yyscanner);
+    strcat(cf->body, "\n");
     csound_prs_scan_string(cf->body, yyscanner);
     corfile_rm(csound, &cf);
     csound->DebugMsg(csound,"Set line number to 1\n");

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1544,8 +1544,8 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
     buf->parent_ip = p->parent_ip = parent_ip;
   } else
 
-  /* copy parameters from the caller instrument into our subinstrument */
-  lcurip = p->ip;
+    /* copy parameters from the caller instrument into our subinstrument */
+    lcurip = p->ip;
   lcurip->esr = CS_ESR;
   lcurip->pidsr = CS_PIDSR;
   lcurip->sicvt = CS_SICVT;
@@ -2197,8 +2197,8 @@ int subinstr(CSOUND *csound, SUBINST *p)
 // local ksmps and global sr
 int useropcd1(CSOUND *csound, UOPCODE *p)
 {
-  OPDS    *saved_pds = CS_PDS;
   int    g_ksmps, ofs, early, offset, i;
+  OPDS *opstart;
   OPCODINFO   *inm;
   CS_VARIABLE* current;
   INSDS    *this_instr = p->ip;
@@ -2274,19 +2274,15 @@ int useropcd1(CSOUND *csound, UOPCODE *p)
         current = current->next;
       }
 
-      if ((CS_PDS = (OPDS *) (this_instr->nxtp)) != NULL) {
+      if ((opstart = (OPDS *) (this_instr->nxtp)) != NULL) {
         int error = 0;
-        CS_PDS->insdshead->pds = NULL;
         do {
           if(UNLIKELY(!ATOMIC_GET8(p->ip->actflg))) goto endop;
-          error = (*CS_PDS->perf)(csound, CS_PDS);
-          if (CS_PDS->insdshead->pds != NULL &&
-              CS_PDS->insdshead->pds->insdshead) {
-            CS_PDS = CS_PDS->insdshead->pds;
-            CS_PDS->insdshead->pds = NULL;
-          }
+          opstart->insdshead->pds = opstart;
+          error = (*opstart->perf)(csound, opstart);
+          opstart = opstart->insdshead->pds;
         } while (error == 0 && p->ip != NULL
-                 && (CS_PDS = CS_PDS->nxtp));
+                 && (opstart = opstart->nxtp));
       }
 
       /* copy a-sig outputs, accounting for offset */
@@ -2383,19 +2379,15 @@ int useropcd1(CSOUND *csound, UOPCODE *p)
       }
 
       /*  run each opcode  */
-      if ((CS_PDS = (OPDS *) (this_instr->nxtp)) != NULL) {
+      if ((opstart = (OPDS *) (this_instr->nxtp)) != NULL) {
         int error = 0;
-        CS_PDS->insdshead->pds = NULL;
         do {
           if(UNLIKELY(!ATOMIC_GET8(p->ip->actflg))) goto endop;
-          error = (*CS_PDS->perf)(csound, CS_PDS);
-          if (CS_PDS->insdshead->pds != NULL &&
-              CS_PDS->insdshead->pds->insdshead) {
-            CS_PDS = CS_PDS->insdshead->pds;
-            CS_PDS->insdshead->pds = NULL;
-          }
+          opstart->insdshead->pds = opstart;
+          error = (*opstart->perf)(csound, opstart);
+          opstart = opstart->insdshead->pds;
         } while (error == 0 && p->ip != NULL
-                 && (CS_PDS = CS_PDS->nxtp));
+                 && (opstart = opstart->nxtp));
       }
 
       /* copy a-sig outputs, accounting for offset */
@@ -2424,7 +2416,6 @@ int useropcd1(CSOUND *csound, UOPCODE *p)
           }
 
         }
-
         current = current->next;
       }
 
@@ -2491,7 +2482,6 @@ int useropcd1(CSOUND *csound, UOPCODE *p)
     current = current->next;
   }
  endop:
-  CS_PDS = saved_pds;
   /* check if instrument was deactivated (e.g. by perferror) */
   if (!p->ip)                                         /* loop to last opds */
     while (CS_PDS && CS_PDS->nxtp) CS_PDS = CS_PDS->nxtp;
@@ -2501,7 +2491,6 @@ int useropcd1(CSOUND *csound, UOPCODE *p)
 // global ksmps amd global or local sr
 int useropcd2(CSOUND *csound, UOPCODE *p)
 {
-  OPDS    *saved_pds = CS_PDS;
   MYFLT   **tmp;
   OPCODINFO   *inm;
   CS_VARIABLE* current;
@@ -2517,7 +2506,7 @@ int useropcd2(CSOUND *csound, UOPCODE *p)
   p->ip->spin = p->parent_ip->spin;
   p->ip->spout = p->parent_ip->spout;
   
-  if (UNLIKELY(!(CS_PDS = (OPDS*) (p->ip->nxtp))))
+  if (UNLIKELY(p->ip->nxtp == NULL))
     goto endop; /* no perf code */
   
   p->ip->relesing = p->parent_ip->relesing;
@@ -2532,6 +2521,7 @@ int useropcd2(CSOUND *csound, UOPCODE *p)
   for(ocnt = 0; ocnt < os; ocnt++){
     int error = 0;
     int cvt;
+    OPDS *opstart;
     /* copy inputs */
     current = inm->in_arg_pool->head;
     for (i = cvt = 0; i < inm->inchns; i++) {
@@ -2564,19 +2554,15 @@ int useropcd2(CSOUND *csound, UOPCODE *p)
       current = current->next;
     }
 
-    if ((CS_PDS = (OPDS *) (p->ip->nxtp)) != NULL) { 
-      CS_PDS->insdshead->pds = NULL;
+    if ((opstart = (OPDS *) (p->ip->nxtp)) != NULL) { 
       p->ip->kcounter++;  /* kcount should be incremented BEFORE perf */
       do {
         if(UNLIKELY(!ATOMIC_GET8(p->ip->actflg))) goto endop;
-        error = (*CS_PDS->perf)(csound, CS_PDS);
-        if (CS_PDS->insdshead->pds != NULL &&
-            CS_PDS->insdshead->pds->insdshead) {
-          CS_PDS = CS_PDS->insdshead->pds;
-          CS_PDS->insdshead->pds = NULL;
-        }
+        opstart->insdshead->pds = opstart;
+        error = (*opstart->perf)(csound, opstart);
+        opstart = opstart->insdshead->pds;
       } while (error == 0 && p->ip != NULL
-               && (CS_PDS = CS_PDS->nxtp));
+               && (opstart = opstart->nxtp));
     }
 
     /* copy outputs */
@@ -2613,8 +2599,6 @@ int useropcd2(CSOUND *csound, UOPCODE *p)
   }
 
  endop:
-  /* restore globals */
-  CS_PDS = saved_pds;
   /* check if instrument was deactivated (e.g. by perferror) */
   if (!p->ip)  {                   /* loop to last opds */
     while (CS_PDS && CS_PDS->nxtp) {
@@ -2762,26 +2746,26 @@ static void instance(CSOUND *csound, int insno)
     }  
 
     if (ep->init != NULL) {  /* init */ 
-        prvids = prvids->nxti = opds; /* link into ichain */
-        opds->init = ep->init; /*   & set exec adr */
-        if (UNLIKELY(odebug))
-          csound->Message(csound, "%s init = %p\n",
-                          ep->opname,(void*) opds->init);
-      }
-      if (ep->perf != NULL) {  /* perf */
-        prvpds = prvpds->nxtp = opds; /* link into pchain */
-        opds->perf = ep->perf;  /*     perf   */
-        if (UNLIKELY(odebug))
-          csound->Message(csound, "%s perf = %p\n",
-                          ep->opname,(void*) opds->perf);
-      }
+      prvids = prvids->nxti = opds; /* link into ichain */
+      opds->init = ep->init; /*   & set exec adr */
+      if (UNLIKELY(odebug))
+        csound->Message(csound, "%s init = %p\n",
+                        ep->opname,(void*) opds->init);
+    }
+    if (ep->perf != NULL) {  /* perf */
+      prvpds = prvpds->nxtp = opds; /* link into pchain */
+      opds->perf = ep->perf;  /*     perf   */
+      if (UNLIKELY(odebug))
+        csound->Message(csound, "%s perf = %p\n",
+                        ep->opname,(void*) opds->perf);
+    }
     if(ep->deinit != NULL) {  /* deinit */
       prvpdd = prvpdd->nxtd = opds; /* link into dchain */
       opds->deinit = ep->deinit;  /*   deinit   */
       if (UNLIKELY(odebug))
         csound->Message(csound, "%s deinit = %p\n",
                         ep->opname,(void*) opds->deinit);
-      }
+    }
     
     if (ep->useropinfo == NULL)
       argpp = (MYFLT **) ((char *) opds + sizeof(OPDS));

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -218,7 +218,7 @@ int32_t asignum(CSOUND *csound, ASSIGN *p)
 
 #define RELATN(OPNAME,OP)                                       \
   int32_t OPNAME(CSOUND *csound, RELAT *p)                      \
-  {   IGN(csound); *p->rbool = (*p->a OP *p->b) ? 1 : 0;        \
+  {   IGN(csound); *p->rbool = (*p->a OP *p->b) ? 1 : 0; \
     return OK; }
 
 RELATN(gt,>)

--- a/OOps/goto_ops.c
+++ b/OOps/goto_ops.c
@@ -39,12 +39,6 @@ int32_t kgoto(CSOUND *csound, GOTO *p)
 {
   IGN(csound);
   CS_PDS = p->lblblk->prvp;
-  /* VL 16.2.23 fix for UDOs where the
-     label gets confused */
-  // not sure it's right 1.4.24
-  // with changes to OPDS, this leads to infinite deact loop
-  //if(CS_PDS->insdshead == NULL) 
-  // CS_PDS->insdshead =  p->h.insdshead;
   return OK;
 }
 


### PR DESCRIPTION
This PR addresses two issues

loops in UDO (https://github.com/csound/csound/issues/1879)
score include crash (https://github.com/csound/csound/issues/1880)
The first problem is a longstanding issue with loops in UDOs, which has never been addressed completely. The solution found was to make the perform code inside UDOs as similar as possible
to the one in instrument perform (performKsmps). This fixes the issue and makes the opcode
behave as expected.

The second problem is that the score lexer was crashing on the absence of a newline in an
included file. Adding a newline fixes the problem.