### PR TITLE
Fixes for UDO regression

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1457,6 +1457,20 @@ void insert_opcodes(CSOUND *csound, OPCODINFO *opcodeInfo,
   }
 }
 
+static int inargs_check(OPCODINFO *opinfo, char *inargs) {
+  char *c = opinfo->intypes;
+  int i;
+  if(strcmp(c, inargs) != 0) {
+  for(i = 0; c[i] != 0; i++) {
+    if(c[i] != inargs[i]) {
+       if(c[i] == 'k' && inargs[i] == 'K') continue;
+       else return 1;                                              
+     }
+  }
+  }
+  return 0;
+}
+
 OPCODINFO *find_opcode_info(CSOUND *csound, char *opname, char *outargs,
                             char *inargs) {
   OPCODINFO *opinfo = csound->opcodeInfo;
@@ -1467,7 +1481,7 @@ OPCODINFO *find_opcode_info(CSOUND *csound, char *opname, char *outargs,
 
   while (opinfo != NULL) {
     if (UNLIKELY(strcmp(opinfo->name, opname) == 0 &&
-                 strcmp(opinfo->intypes, inargs) == 0 &&
+                 inargs_check(opinfo, inargs) == 0 &&  // VL: treat the 'K' case
                  strcmp(opinfo->outtypes, outargs) == 0)) {
       return opinfo;
     }

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1776,11 +1776,6 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
   MYFLT parent_sr = udo ? udo->parent_ip->esr : csound->esr;
   MYFLT parent_ksmps = udo ? udo->parent_ip->ksmps : csound->ksmps;
 
-  if(udo) {
-    if(udo->iflag) 
-      return csoundInitError(csound, "can't set ksmps after xin\n");
-  }
-  
   if(CS_ESR != parent_sr) 
     return csoundInitError(csound,
                            "can't set ksmps value if local sr != parent sr\n");

--- a/Opcodes/ftgen.c
+++ b/Opcodes/ftgen.c
@@ -59,7 +59,6 @@ static int32_t ftable_delete(CSOUND *csound, FTGEN *p)
   if (UNLIKELY(err != OK))
     csound->ErrorMsg(csound, Str("Error deleting ftable %d"),
                      p->fno);
-  csound->Free(csound, p);
   return err;
 }
 
@@ -217,7 +216,6 @@ static int32_t ftfree_deinit(CSOUND *csound, FTFREE *p)
     if (UNLIKELY(err != OK))
       csound->ErrorMsg(csound, Str("Error deleting ftable %d"),
                        p->fno);
-    csound->Free(csound, p);
     return err;
   } else return OK;
 }


### PR DESCRIPTION
This PR fixes the UDO regression issue where

- `setksmps` could not be placed after `xin` 
-  `K` type was leading to type check failure because it was checked against `k`

