### PR TITLE
Update readme template to avoid cmake run changes

### DIFF
--- a/README.md.in
+++ b/README.md.in
@@ -1,6 +1,14 @@
 # CSOUND
 Version ${CS_VERSION}.${CS_SUBVER}.${CS_PATCHLEVEL} (beta)
 
+This is the the develop branch of the Csound main code repository. At
+the moment, we are developing the next main version (moving from 6.x
+to 7.0), and this branch reflects current work-in-progress. This is
+still undergoing changes and fixes until the first release, scheduled
+for September 2024. Anyone seeking the latest 6.x version please
+checkout the csound6 branch (or the master branch, containing the
+latest and final release of this version).
+
 ![Build Status](https://github.com/csound/csound/actions/workflows/csound_builds.yml/badge.svg?branch=develop)
 <!--- ![Coverity Status](https://scan.coverity.com/projects/1822/badge.svg) --->
 A sound and music computing system.


### PR DESCRIPTION
I found this will working on my other change - scratching my head wondering if I'd messed up syncing my fork with the main repository.  Doing a cmake generation will create the main readme from this template, so I've updated it with the new blurb about the develop branch that was added to the main one.