### PR TITLE
dynamically construct path to csound.exe

### DIFF
--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -225,7 +225,7 @@ def runTest():
             print(command)
             retVal = os.system(command)
         elif(os.sep == '\\' or os.name == 'nt'):
-            executable = (csoundExecutable == "") and "..\csound.exe" or csoundExecutable
+            executable = (csoundExecutable == "") and os.path.join("..", "csound.exe") or csoundExecutable
             command = "%s %s %s %s/%s 2> %s"%(executable, parserType, runArgs, sourceDirectory, filename, tempfile)
             print(command)
             retVal = os.system(command)


### PR DESCRIPTION
this way, we do not have to use the dreaded backslash in strings and accidentally forget to escape it (something that Python3.12 does not like at all).

I went for the `os.path.join()` route, as the relevant code is protected by https://github.com/csound/csound/blob/b4e8bc58d864d9ec3ed391fcb38bd9d909444ab1/tests/commandline/test.py#L227

at least in theory this could mean that the path seperator is **not** a backslash, so we shouldn't use it...

Closes: https://github.com/csound/csound/issues/1906