### PR TITLE
squinewave updates

### DIFF
--- a/Opcodes/squinewave.c
+++ b/Opcodes/squinewave.c
@@ -1,10 +1,16 @@
-/* SQUINEWAVE.C: Sine-Square-Pulse-Saw oscillator
+/* SQUINEWAVE.C: Sine-Square-Pulse-Saw morphing oscillator
 * by rasmus ekman 2017, for Csound.
+*
+* Updates in CSound 7:
+* - Allow fractional Min_Sweep (improves chorusing)
+* - Sharper hardsync when Min_Sweep is high
+* - Through-Zero FM: Run "backwards" on neg freq
+*
 * This code is released under the Csound license,
 * GNU Lesser General Public License version 2.1.
 */
 /*
-    Copyright (C) 2017 rasmus ekman 2017
+    Copyright (C) 2017, 2024 rasmus ekman
 
     This file is part of Csound.
 
@@ -39,17 +45,20 @@ typedef struct {
     OPDS h;
     MYFLT *aout, *async_out, *acps, *aclip, *askew, *async_in, *iminsweep, *iphase;
 
-    // phase and warped_phase range 0-2.
-    //This makes skew/clip into simple proportions
+    // phase and sweep_phase range 0-2.
+    // This makes clip/skew into simple proportions
     double phase;
-    double warped_phase;
+    double sweep_phase;
     double hardsync_phase;
     double hardsync_inc;
+    int32_t neg_freq;
 
     // Const inited from environment
     double Min_Sweep;
     double Maxphase_By_sr;
-    double Max_Warp_Freq;
+    double Max_Sweep_Freq;
+    double Max_Sync_Freq;
+    double Sync_Phase_Inc;
 
     MYFLT *sync_sig;        // holds async_in if a-rate
     int32_t init_phase;
@@ -74,21 +83,23 @@ static inline int32_t find_sync(const MYFLT* sync_sig, const uint32_t first,
 /* ================================================================== */
 
 static void hardsync_init(SQUINEWAVE *p, const double freq,
-                          const double warped_phase)
+                          const double sweep_phase)
 {
+    // Ignore sync request if already in hardsync
     if (p->hardsync_phase)
         return;
 
-    // If we're in last flat part, we're just done now
-    if (warped_phase == 2.0) {
+    // If waveform is on last flat part, we're just done now
+    // (could also start a full spike here, it's an option...)
+    if (sweep_phase == 2.0) {
         p->phase = 2.0;
         return;
     }
 
-    if (freq > p->Max_Warp_Freq)
+    if (freq > p->Max_Sync_Freq)
         return;
 
-    p->hardsync_inc = (PI / p->Min_Sweep);
+    p->hardsync_inc = p->Sync_Phase_Inc;
     p->hardsync_phase = p->hardsync_inc * 0.5;
 }
 
@@ -113,7 +124,7 @@ int32_t squinewave_init(CSOUND* csound, SQUINEWAVE *p)
 
     // Allow range 4-sr/100
     if (p->Min_Sweep < 4.0 || p->Min_Sweep > sr * 0.01) {
-      const int32_t minsweep_default = (int32_t)Clamp(sr / 3000.0, 8.0, sr * 0.01);
+      const MYFLT minsweep_default = Clamp(sr / 3000.0, 8.0, sr * 0.01);
       if (p->Min_Sweep != 0.0) {
         csound->Warning(csound,
                         Str("squinewave iminsweep range 4 to sr/100. "
@@ -123,7 +134,9 @@ int32_t squinewave_init(CSOUND* csound, SQUINEWAVE *p)
     }
 
     p->Maxphase_By_sr = 2.0 / sr;
-    p->Max_Warp_Freq = sr / (2.0 * p->Min_Sweep);
+    p->Max_Sweep_Freq = sr / (2.0 * p->Min_Sweep);      // range sr/8 - sr/200
+    p->Max_Sync_Freq = sr / (3.0 * log(p->Min_Sweep));  // range sr/4.1 - sr/13.8
+    p->Sync_Phase_Inc = 1.0 / log(p->Min_Sweep);
 
     p->sync_sig = IS_ASIG_ARG(p->async_in) ? p->async_in : 0;
 
@@ -147,10 +160,11 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
       memset(&p->aout[ksmps_end], 0, p->h.insdshead->ksmps_no_end * sizeof(MYFLT));
     }
 
-    const double Maxphase_By_sr = p->Maxphase_By_sr;
-    const double Max_Warp_Freq = p->Max_Warp_Freq;
-    const double Max_Warp = 1.0 / p->Min_Sweep;
     const double Min_Sweep = p->Min_Sweep;
+    const double Maxphase_By_sr = p->Maxphase_By_sr;
+    const double Max_Sweep_Freq = p->Max_Sweep_Freq;
+    const double Max_Sweep_Inc = 1.0 / Min_Sweep;
+    const double Max_Sync_Freq = p->Max_Sync_Freq;
 
     MYFLT *aout = &p->aout[0];
     const MYFLT * const freq_sig = p->acps;
@@ -158,15 +172,16 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
     const MYFLT * const skew_sig = p->askew;
 
     double phase = p->phase;
-    double warped_phase = p->warped_phase;
+    double sweep_phase = p->sweep_phase;
+    int32_t neg_freq = p->neg_freq;
 
     double hardsync_phase = p->hardsync_phase;
     double hardsync_inc = p->hardsync_inc;
     int32_t sync = find_sync(p->sync_sig, ksmps_offset, ksmps_end);
 
-    // Set main phase so it matches warp
+    // Set main phase so it matches sweep_phase
     if (p->init_phase) {
-      const double freq = fmax(freq_sig[0], 0.0);
+      const double freq = fabs(freq_sig[0]);
       const double phase_inc = Maxphase_By_sr * freq;
       const double min_sweep = phase_inc * Min_Sweep;
       const double skew = 1.0 - Clamp(skew_sig[0], -1.0, 1.0);
@@ -175,38 +190,37 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
 
       // Init phase range 0-2, has 4 segment parts (sweep down,
       // flat -1, sweep up, flat +1)
-      warped_phase = *p->iphase;
-      if (warped_phase < 0.0) {
+      sweep_phase = *p->iphase;
+      if (sweep_phase < 0.0) {
         // "up" 0-crossing
-        warped_phase = 1.25;
+        sweep_phase = 1.25;
       }
-      if (warped_phase > 2.0)
-        warped_phase = fmod(warped_phase, 2.0);
+      if (sweep_phase > 2.0)
+        sweep_phase = fmod(sweep_phase, 2.0);
 
       // Select segment and scale within
-      if (warped_phase < 1.0) {
+      if (sweep_phase < 1.0) {
         const double sweep_length = fmax(clip * midpoint, min_sweep);
-        if (warped_phase < 0.5) {
-          phase = sweep_length * (warped_phase * 2.0);
-          warped_phase *= 2.0;
+        if (sweep_phase < 0.5) {
+          phase = sweep_length * (sweep_phase * 2.0);
+          sweep_phase *= 2.0;
         }
         else {
           const double flat_length = midpoint - sweep_length;
-          phase = sweep_length + flat_length * ((warped_phase - 0.5) * 2.0);
-          warped_phase = 1.0;
+          phase = sweep_length + flat_length * ((sweep_phase - 0.5) * 2.0);
+          sweep_phase = 1.0;
         }
       }
       else {
         const double sweep_length = fmax(clip * (2.0 - midpoint), min_sweep);
-        if (warped_phase < 1.5) {
-          phase = midpoint + sweep_length * ((warped_phase - 1.0) * 2.0);
-          warped_phase = 1.0 + (warped_phase - 1.0) * 2.0;
+        if (sweep_phase < 1.5) {
+          phase = midpoint + sweep_length * ((sweep_phase - 1.0) * 2.0);
+          sweep_phase = 1.0 + (sweep_phase - 1.0) * 2.0;
         }
         else {
           const double flat_length = 2.0 - (midpoint + sweep_length);
-          phase = midpoint + sweep_length +
-            flat_length * ((warped_phase - 1.5) * 2.0);
-          warped_phase = 2.0;
+          phase = midpoint + sweep_length + flat_length * ((sweep_phase - 1.5) * 2.0);
+          sweep_phase = 2.0;
         }
       }
 
@@ -219,13 +233,14 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
 
     for (n = ksmps_offset; n < ksmps_end; ++n)
     {
-      double freq = fmax(freq_sig[n], 0.0);
+      const double raw_freq = freq_sig[n];
+      double freq = fabs(raw_freq);
 
       if (sync == (int32_t)n) {
         p->phase = phase;
         p->hardsync_phase = hardsync_phase;
         p->hardsync_inc = hardsync_inc;
-        hardsync_init(p, freq, warped_phase);
+        hardsync_init(p, freq, sweep_phase);
         phase = p->phase;
         hardsync_phase = p->hardsync_phase;
         hardsync_inc = p->hardsync_inc;
@@ -233,7 +248,7 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
 
       if (hardsync_phase) {
         const double syncsweep = 0.5 * (1.0 - cos(hardsync_phase));
-        freq += syncsweep * ((2.0 * Max_Warp_Freq) - freq);
+        freq += syncsweep * (Max_Sync_Freq - freq);
         hardsync_phase += hardsync_inc;
         if (hardsync_phase > PI) {
           hardsync_phase = PI;
@@ -241,113 +256,121 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
         }
       }
 
+      // Through-Zero modulation: Detect neg freq and zero-crossings
+      {
+        const int zero_crossing = (raw_freq < 0) != neg_freq;
+        if (zero_crossing) {
+          // Jump to opposite side of waveform
+          phase = 1.5 - phase;
+          if (phase < 0) phase += 2.0;
+          // mirror sweep_phase around 1 (cos rad)
+          sweep_phase = 2.0 - sweep_phase;
+        }
+        neg_freq = (raw_freq < 0);
+      }
+
       const double phase_inc = Maxphase_By_sr * freq;
 
       // Pure sine if freq > sr/(2*Min_Sweep)
-      if (freq >= Max_Warp_Freq)
-        {
-          // Continue from warped
-          *aout++ = cos(PI * warped_phase);
-          phase = warped_phase;
-          warped_phase += phase_inc;
-        }
+      if (freq >= Max_Sweep_Freq)
+      {
+        // Continue from sweep_phase
+        *aout++ = cos(PI * sweep_phase);
+        phase = sweep_phase;
+        sweep_phase += phase_inc;
+      }
       else
+      {
+        const double min_sweep = phase_inc * Min_Sweep;
+        const double clip = 1.0 - Clamp(clip_sig[n], 0.0, 1.0);
+        // If neg_freq, invert symmetry for backward waveform
+        const double skew =
+          1.0 - Clamp( neg_freq? -skew_sig[n] : skew_sig[n], -1.0, 1.0);
+        const double midpoint = Clamp(skew, min_sweep, 2.0 - min_sweep);
+
+        // 1st half: Sweep down to cos(sweep_phase <= Pi) then
+        // flat -1 until phase >= midpoint
+        if (sweep_phase < 1.0)
         {
-          const double min_sweep = phase_inc * Min_Sweep;
-          const double skew = 1.0 - Clamp(skew_sig[n], -1.0, 1.0);
-          const double clip = 1.0 - Clamp(clip_sig[n], 0.0, 1.0);
-          const double midpoint = Clamp(skew, min_sweep, 2.0 - min_sweep);
+          const double sweep_length = fmax(clip * midpoint, min_sweep);
 
-          // 1st half: Sweep down to cos(warped_phase <= Pi) then
-          // flat -1 until phase >= midpoint
-          if (warped_phase < 1.0 || (warped_phase == 1.0 && phase < midpoint))
-            {
-              if (warped_phase < 1.0) {
-                const double sweep_length = fmax(clip * midpoint, min_sweep);
+          *aout++ = cos(PI * sweep_phase);
+          sweep_phase += fmin(phase_inc / sweep_length, Max_Sweep_Inc);
 
-                *aout++ = cos(PI * warped_phase);
-                warped_phase += fmin(phase_inc / sweep_length, Max_Warp);
+          // Handle fractional sweep_phase overshoot after sweep ends
+          if (sweep_phase > 1.0) {
+            /* Tricky here: phase and sweep_phase may disagree
+              * where we are in waveform (due to FM + clip/skew changes).
+              * sweep_phase dominates to keep waveform stable,
+              * waveform (flat part) decides where we are.
+              */
+            const double flat_length = midpoint - sweep_length;
+            // sweep_phase overshoot scaled to main phase rate
+            const double phase_overshoot = (sweep_phase - 1.0) * sweep_length;
 
-                // Handle fractional warped_phase overshoot after sweep ends
-                if (warped_phase > 1.0) {
-                  /* Tricky here: phase and warped may disagree where
-                   * we are in waveform (due to FM + skew/clip
-                   * changes).  Warped dominates to keep waveform
-                   * stable, waveform (flat part) decides where we
-                   * are.
-                   */
-                  const double flat_length = midpoint - sweep_length;
-                  // warp overshoot scaled to main phase rate
-                  const double phase_overshoot =
-                    (warped_phase - 1.0) * sweep_length;
+            // phase matches shape
+            phase = midpoint - flat_length + phase_overshoot - phase_inc;
 
-                  // phase matches shape
-                  phase = midpoint - flat_length + phase_overshoot - phase_inc;
-
-                  // Flat if next samp still not at midpoint
-                  if (flat_length >= phase_overshoot) {
-                    warped_phase = 1.0;
-                    // phase may be > midpoint here (which means
-                    // actually no flat part), if so it will be
-                    // corrected in 2nd half (since warped == 1.0)
-                  }
-                  else {
-                    const double next_sweep_length =
-                      fmax(clip * (2.0 - midpoint), min_sweep);
-                    warped_phase =
-                      1.0 + (phase_overshoot - flat_length) / next_sweep_length;
-                  }
-                }
-              }
-              else {
-                // flat up to midpoint
-                *aout++ = -1.0;
-                warped_phase = 1.0;
-              }
+            // Flat if next samp still not at midpoint
+            if (flat_length >= phase_overshoot) {
+              sweep_phase = 1.0;
+              // phase may be > midpoint here (which means actually no flat part),
+              // if so it will be corrected in 2nd half (since sweep_phase == 1.0)
             }
-            // 2nd half: Sweep up to cos(warped_phase <= 2.Pi) then
-            // flat +1 until phase >= 2
             else {
-              if (warped_phase < 2.0) {
-                const double sweep_length =
-                  fmax(clip * (2.0 - midpoint), min_sweep);
-                if (warped_phase == 1.0) {
-                  // warped_phase overshoot after flat part
-                  warped_phase = 1.0 + fmin( fmin(phase - midpoint, phase_inc) /
-                                             sweep_length, Max_Warp);
-                }
-                *aout++ = cos(PI * warped_phase);
-                warped_phase += fmin(phase_inc / sweep_length, Max_Warp);
-                if (warped_phase > 2.0) {
-                  const double flat_length = 2.0 - (midpoint + sweep_length);
-                  const double phase_overshoot =
-                    (warped_phase - 2.0) * sweep_length;
-
-                  phase = 2.0 - flat_length + phase_overshoot - phase_inc;
-
-                  if (flat_length >= phase_overshoot) {
-                    warped_phase = 2.0;
-                  }
-                  else {
-                    const double next_sweep_length =
-                      fmax(clip * midpoint, min_sweep);
-                    warped_phase =
-                      2.0 + (phase_overshoot - flat_length) / next_sweep_length;
-                  }
-                }
-              }
-              else {
-                *aout++ = 1.0;
-                warped_phase = 2.0;
-              }
+              const double next_sweep_length =
+                fmax(clip * (2.0 - midpoint), min_sweep);
+              sweep_phase =
+                1.0 + (phase_overshoot - flat_length) / next_sweep_length;
             }
+          }
         }
+        // flat up to midpoint
+        else if (sweep_phase == 1.0 && phase < midpoint) {
+          *aout++ = -1.0;
+        }
+
+        // 2nd half: Sweep up to cos(sweep_phase <= 2.Pi), 
+        // then flat +1 until phase >= 2
+        else if (sweep_phase < 2.0)
+        {
+          const double sweep_length = fmax(clip * (2.0 - midpoint), min_sweep);
+          if (sweep_phase == 1.0) {
+            // sweep_phase overshoot after flat part
+            sweep_phase = 1.0 + fmin( fmin(phase - midpoint, phase_inc) /
+                                        sweep_length, Max_Sweep_Inc);
+          }
+          *aout++ = cos(PI * sweep_phase);
+          sweep_phase += fmin(phase_inc / sweep_length, Max_Sweep_Inc);
+          if (sweep_phase > 2.0) {
+            const double flat_length = 2.0 - (midpoint + sweep_length);
+            const double phase_overshoot = (sweep_phase - 2.0) * sweep_length;
+
+            phase = 2.0 - flat_length + phase_overshoot - phase_inc;
+
+            if (flat_length >= phase_overshoot) {
+              sweep_phase = 2.0;
+            }
+            else {
+              const double next_sweep_length =
+                fmax(clip * midpoint, min_sweep);
+              sweep_phase =
+                2.0 + (phase_overshoot - flat_length) / next_sweep_length;
+            }
+          }
+        }
+        // flat until endpoint
+        else {
+          *aout++ = 1.0;
+          sweep_phase = 2.0;
+        }
+      }
 
       phase += phase_inc;
-      if (warped_phase >= 2.0 && phase >= 2.0)
+      if (sweep_phase >= 2.0 && phase >= 2.0)
         {
             if (hardsync_phase) {
-              warped_phase = phase = 0.0;
+              sweep_phase = phase = 0.0;
               hardsync_phase = hardsync_inc = 0.0;
 
               sync = find_sync(p->sync_sig, n + 1, ksmps_end);
@@ -358,16 +381,17 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
                 // wild aliasing freq - just reset
                 phase = phase_inc * 0.5;
               }
-              if (freq < Max_Warp_Freq) {
+              if (freq < Max_Sweep_Freq) {
                 const double min_sweep = phase_inc * Min_Sweep;
-                const double skew = 1.0 - Clamp(skew_sig[n], -1.0, 1.0);
                 const double clip = 1.0 - Clamp(clip_sig[n], 0.0, 1.0);
+                const double skew =
+                  1.0 - Clamp( neg_freq? -skew_sig[n] : skew_sig[n], -1.0, 1.0);
                 const double midpoint = Clamp(skew, min_sweep, 2.0 - min_sweep);
                 const double next_sweep_length = fmax(clip * midpoint, min_sweep);
-                warped_phase = fmin(phase / next_sweep_length, Max_Warp);
+                sweep_phase = fmin(phase / next_sweep_length, Max_Sweep_Inc);
               }
               else
-                warped_phase = phase;
+                sweep_phase = phase;
             }
 
             if (p->async_out)
@@ -376,9 +400,10 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
     }
 
     p->phase = phase;
-    p->warped_phase = warped_phase;
+    p->sweep_phase = sweep_phase;
     p->hardsync_phase = hardsync_phase;
     p->hardsync_inc = hardsync_inc;
+    p->neg_freq = neg_freq;
     return OK;
 }
 


### PR DESCRIPTION
- Support Through-zero FM; waveform runs "backwards" on negative frequency
- Sharper hardsync (no longer dependent on Min_Sweep)
- Allow fractional Min_Sweep (slight improvement to chorusing)
