### PR TITLE
fixed setting of ksmps, kr and sr in UDOs

### DIFF
--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1550,6 +1550,24 @@ int useropcdset(CSOUND *csound, UOPCODE *p)
   lcurip->onedkr = CS_ONEDKR;
   lcurip->onedksmps = CS_ONEDKSMPS;
   lcurip->kicvt = CS_KICVT;
+
+  /* VL 13-12-13 */
+  /* this sets ksmps and kr local variables */
+  /* create local ksmps variable and init with ksmps */
+  if (lcurip->lclbas != NULL) {
+    CS_VARIABLE *var =
+      csoundFindVariableWithName(csound, lcurip->instr->varPool, "ksmps");
+    *((MYFLT *)(var->memBlockIndex + lcurip->lclbas)) = lcurip->ksmps;
+    /* same for kr */
+    var =
+      csoundFindVariableWithName(csound, lcurip->instr->varPool, "kr");
+    *((MYFLT *)(var->memBlockIndex + lcurip->lclbas)) = lcurip->ekr;
+    /* VL 15-08-24 same for sr */   
+    var =
+      csoundFindVariableWithName(csound, lcurip->instr->varPool, "sr");
+    *((MYFLT *)(var->memBlockIndex + lcurip->lclbas)) = lcurip->esr;
+  }
+  
   lcurip->m_chnbp = parent_ip->m_chnbp;       /* MIDI parameters */
   lcurip->m_pitch = parent_ip->m_pitch;
   lcurip->m_veloc = parent_ip->m_veloc;

--- a/Opcodes/squinewave.c
+++ b/Opcodes/squinewave.c
@@ -128,7 +128,7 @@ int32_t squinewave_init(CSOUND* csound, SQUINEWAVE *p)
       if (p->Min_Sweep != 0.0) {
         csound->Warning(csound,
                         Str("squinewave iminsweep range 4 to sr/100. "
-                            "Set to default %d"), minsweep_default);
+                            "Set to default %f"), minsweep_default);
       }
       p->Min_Sweep = minsweep_default;
     }


### PR DESCRIPTION
This PR fixes an issue where the Csound variables ksmps, kr and sr never got updated when the UDO is initialised, so they carried their old initial values instead.

I have restored the code from 6.x that had been removed and added the setting of sr.

NB: these variables are also updated by setksmps and oversample/undersample.