### PR TITLE
Allow to optionally enable mingw cross-compilation

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -304,7 +304,7 @@ jobs:
 
   windows_build_mingw:
     name: Windows build (mingw/vcpkg)
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop' || vars.ENABLE_CROSS_COMPILERS == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
Allow running mingw github worker when variable `ENABLE_CROSS_COMPILERS` is set to `true`.