### PR TITLE
fix: set install RPATH for built executables on macos to use Framework install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ else()
     set(CS_FRAMEWORK_DEST "$ENV{HOME}/Library/Frameworks" CACHE PATH "Csound framework path")
 endif()
 
+if(APPLE)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH ${CS_FRAMEWORK_DEST})
+endif()
+
 include(TestBigEndian)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
@@ -231,7 +236,7 @@ message(STATUS "Building for bare metal")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -DBARE_METAL")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBARE_METAL")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -DNO_CSOUND_SERVER")
-    
+
     if(CUSTOM_MALLOC)
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -DCUSTOM_MALLOC")
     # the default is for STM32H7: -DMALLOC_BASE=0xC0000000


### PR DESCRIPTION
This change fixes an issue for locally-built csound where LC_RPATH was cleared after running `make install`. This allows running csound and other executables from /usr/local/bin