### PR TITLE
adding selectable install dir to windows installer

### DIFF
--- a/installer/windows/csound7_x64_github.iss
+++ b/installer/windows/csound7_x64_github.iss
@@ -32,6 +32,7 @@
 
 ; Set the default folder to be the Csound root (otherwise defaults to where the script is located)
 SourceDir="../../"
+DisableDirPage=no
 
 ; Microsoft C/C++ runtime libraries
 #define VCREDIST_CRT_DIR GetEnv("VCREDIST_CRT_DIR")


### PR DESCRIPTION
The default location was somehow cached between installs, this fixes that by asking the user to verify the install path