### PR TITLE
fixing #1801

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -386,7 +386,7 @@ statement_list : statement_list statement
                   }
                 ;
 
-statement : out_arg_list assignment expr NEWLINE
+statement : out_arg_list assignment expr_list NEWLINE
                 {
                   $$ = (TREE *)$2;
                   $$->left = (TREE *)$1;
@@ -510,7 +510,6 @@ declare_definition : DECLARE_TOKEN identifier udo_arg_list ':' udo_out_arg_list 
  }
 
 /* Expressions */
-
 expr_list : expr_list ',' expr
               { $$ = appendToTree(csound, $1, $3); }
          | expr_list ',' NEWLINE expr


### PR DESCRIPTION
This PR fixes the issue regarding multiple assignments, where backward compatibility with csound 6 was lost. Test3.csd in the test suite is now passing.

```
<CsoundSynthesizer>

<CsInstruments>
;
sr=44100
ksmps=1
nchnls=2


	instr 1	;untitled

iamp,ifreq = 10000,440

aout	vco2 iamp, ifreq

	outs aout, aout
	endin


</CsInstruments>

<CsScore>

i1	0.0	2	
e

</CsScore>

</CsoundSynthesizer>

```