### PR TITLE
Revert "Trying to resolve #1937 windows installer..."

### DIFF
--- a/installer/windows/csound7_x64_github.iss
+++ b/installer/windows/csound7_x64_github.iss
@@ -33,7 +33,6 @@
 ; Set the default folder to be the Csound root (otherwise defaults to where the script is located)
 SourceDir="../../"
 DisableDirPage=no
-DefaultDirName={pf64}\{#AppName}
 
 ; Microsoft C/C++ runtime libraries
 #define VCREDIST_CRT_DIR GetEnv("VCREDIST_CRT_DIR")


### PR DESCRIPTION
Reverts csound/csound#1945 which is not currently building the Windows installer correctly.