### PR TITLE
Fix build RPATH for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,6 @@ else()
 endif()
 
 if(APPLE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH ${CS_FRAMEWORK_DEST})
 endif()
 


### PR DESCRIPTION
Removes use of CMAKE_BUILD_WITH_INSTALL_RPATH which made the built executables link set RPATH to the install RPATH. Removing this makes the RPATH set to the build folder version of CsoundLib.framework and only sets it to the CMAKE_INSTALL_RPATH when `make install` is called. 