### PR TITLE
fix: missing quote in build instructions for macOS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ Optional component requirements:
 - Git: A distributed version control system to let you clone and acquire
 the Csound sources. Although you can download the source as a zip from GitHub,
 having git installed makes it easier to interact with the Csound source. It
-also makes it easier to sync with the very latest source.  
+also makes it easier to sync with the very latest source.
 
 - C++ compiler toolchain: a few components are written in C++. For
 these to be built, a complete installation of C++ development tools is
@@ -100,7 +100,7 @@ and then build Csound.
 ```
 brew install --only-dependencies csound
 brew install bison flex asio jack googletest
-cmake -B build -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake
+cmake -B build -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake"
 cmake --build build --config Release
 ```
 


### PR DESCRIPTION
Missing quote was causing build issues for users at workshop. 