### PR TITLE
fixing typo in gitnub workflows

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -337,7 +337,7 @@ jobs:
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
 
       - name: Configure Build
-        run: cmake -B build -S .-DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/mingw64-linux/Custom.cmake" -DCMAKE_SYSTEM_NAME=MinGW
+        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/mingw64-linux/Custom.cmake" -DCMAKE_SYSTEM_NAME=MinGW
 
       - name: Build Csound
         run: cmake --build build --config Release


### PR DESCRIPTION
Typo in on one of the CIs that was not active under the PR. Fixed.