### PR TITLE
Remove brew asio package from CI macOS builds and BUILD.md docs

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install --only-dependencies csound
-          brew install bison flex asio jack googletest
+          brew install bison flex jack googletest
 
       - name: Configure build
         run: cmake -B build -DBUILD_TESTS=1 -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake"
@@ -163,7 +163,7 @@ jobs:
         run: ./vcpkg/bootstrap-vcpkg.sh
 
       - name: Install dependencies
-        run: brew install bison flex asio
+        run: brew install bison flex
 
       - name: Configure build
         run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake"
@@ -197,7 +197,7 @@ jobs:
         run: ./vcpkg/bootstrap-vcpkg.sh
 
       - name: Install dependencies
-        run: brew install bison flex asio
+        run: brew install bison flex
 
       - name: Configure build
         run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake"

--- a/BUILD.md
+++ b/BUILD.md
@@ -99,7 +99,7 @@ and then build Csound.
 
 ```
 brew install --only-dependencies csound
-brew install bison flex asio jack googletest
+brew install bison flex jack googletest
 cmake -B build -DCUSTOM_CMAKE="./platform/osx/custom-osx.cmake"
 cmake --build build --config Release
 ```


### PR DESCRIPTION
I'm not sure why the asynchronous I/O (asio) package is being referenced, but it is not needed as far as I can tell. Maybe it was needed before but is not needed now? Or maybe it was mistaken for the Windows asio sdk?