### PR TITLE
Fix plugins build

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get install cmake libjack-dev libpulse-dev ladspa-sdk dssi-dev autoconf libtool
 
       - name: Configure Build
-        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/linux/custom.cmake"
+        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/linux/custom.cmake" -DBUILD_PLUGINS=1
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -381,7 +381,7 @@ jobs:
 
   android_build_vcpkg:
     name: Android build (vcpkg)
-    if: vars.ANDROID_WORKFLOW_RUN_ID 
+    if: vars.ANDROID_WORKFLOW_RUN_ID
     runs-on: ubuntu-latest
     env:
       VERSION: v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,10 +947,6 @@ set(hrtf_ops_SRCS
     Opcodes/hrtferX.c
 )
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    list(APPEND stdopcod_SRCS Opcodes/socksend.c Opcodes/sockrecv.c)
-endif()
-
 set(cs_pvs_ops_SRCS
     Opcodes/ifd.c
     Opcodes/partials.c


### PR DESCRIPTION
* removes out of date Emscripten-specific code from CMakeLists.txt that caused problems when BUILD_PLUGINS=1
* Add BUILD_PLUGINS=1 to one of the linux builds to test that is working as part of CI