### PR TITLE
long max table length (2^31) as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ option(BARE_METAL "To configure for bare metal build" OFF)
 option(CUSTOM_MALLOC "Use custom malloc in bare metal builds" OFF)
 option(BUILD_PLUGINS "Build external opcodes as plugins" OFF)
 option(BUILD_WITH_LTO "Build with link-time optimisations" OFF)
+option(USE_SHORT_TABLE_LENGTH  "Build with original max table length 2^24" OFF)
 
 # secret rabbit code
 if (USE_VCPKG)
@@ -214,6 +215,12 @@ endif()
 if(SampleRate_FOUND)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_SRC")
     message(STATUS "Using Secret Rabbit Code")
+endif()
+
+
+if(USE_SHORT_TABLE_LENGTH)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DSHORT_TABLE_LENGTH")
+    message(STATUS "Using short max table length")
 endif()
 
 

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -2563,7 +2563,7 @@ static int32_t gen01raw(FGDATA *ff, FUNC *ftp)
     else ftp->nchanls  = 1;
     ftp->flenfrms = ff->flen / ftp->nchanls;  /* VL fixed 8/10/19: using table nchnls */
     ftp->gen01args.sample_rate = (MYFLT) p->sr;
-    ftp->cvtbas =  p->sr * csound->onedsr; /* VL - LOFACT factor (1024) removed */
+    ftp->cvtbas =  p->sr * csound->onedsr; 
     {
       SFLIB_INSTRUMENT lpd;
       int32_t ans = sflib_command(fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -2563,7 +2563,7 @@ static int32_t gen01raw(FGDATA *ff, FUNC *ftp)
     else ftp->nchanls  = 1;
     ftp->flenfrms = ff->flen / ftp->nchanls;  /* VL fixed 8/10/19: using table nchnls */
     ftp->gen01args.sample_rate = (MYFLT) p->sr;
-    ftp->cvtbas = LOFACT * p->sr * csound->onedsr;
+    ftp->cvtbas =  p->sr * csound->onedsr; /* VL - LOFACT factor (1024) removed */
     {
       SFLIB_INSTRUMENT lpd;
       int32_t ans = sflib_command(fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));

--- a/H/ugens3.h
+++ b/H/ugens3.h
@@ -38,8 +38,8 @@ typedef struct {
   OPDS    h;
   MYFLT   *ar1,*ar2,*xamp,*kcps,*ifn,*ibas,*imod1,*ibeg1,*iend1,
     *imod2,*ibeg2,*iend2;
-  MYFLT   cpscvt;
-  MYFLT   lphs;
+  double   cpscvt;
+  double   lphs;
   int16   mod1, mod2;
   MYFLT   beg1, beg2;
   MYFLT   end1, end2;
@@ -51,8 +51,8 @@ typedef struct {
   OPDS    h;
   MYFLT   *sphs, *ar1,*ar2,*xamp,*kcps,*ifn,*ibas,*imod1,*ibeg1,*iend1,
     *imod2,*ibeg2,*iend2;
-  MYFLT   cpscvt;
-  MYFLT   lphs;
+  double   cpscvt;
+  double   lphs;
   int16   mod1, mod2;
   MYFLT   beg1, beg2;
   MYFLT   end1, end2;

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -289,7 +289,7 @@ int32_t losset(CSOUND *csound, LOSC *p)
     //printf("****ftp cvtbas = %g ibas = %g\n", ftp->cvtbas, *p->ibas);
     p->ftp = ftp;
     if (*p->ibas != FL(0.0))
-      p->cpscvt = (ftp->cvtbas / *p->ibas); /* 1/LOFACT scaling removed */
+      p->cpscvt = (ftp->cvtbas / *p->ibas); 
     else if (UNLIKELY((p->cpscvt = ftp->cpscvt) == FL(0.0))) {
       p->cpscvt = FL(1.0) /FL(261.62556530059862592); /* Middle C */
       csound->Warning(csound, Str("no legal base frequency"));
@@ -384,7 +384,7 @@ int32_t losset_phs(CSOUND *csound, LOSCPHS *p)
     //printf("****maxphs = %d (%x)\n", maxphs, maxphs);
     p->ftp = ftp;
     if (*p->ibas != FL(0.0))
-      p->cpscvt = (ftp->cvtbas / *p->ibas); /* VL - 1/LOFACT scaling removed */ 
+      p->cpscvt = (ftp->cvtbas / *p->ibas); 
     else if (UNLIKELY((p->cpscvt = ftp->cpscvt) == FL(0.0))) {
       p->cpscvt = FL(1.0) /FL(261.62556530059862592); /* Middle C */
       csound->Warning(csound, Str("no legal base frequency"));

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -289,12 +289,11 @@ int32_t losset(CSOUND *csound, LOSC *p)
     //printf("****ftp cvtbas = %g ibas = %g\n", ftp->cvtbas, *p->ibas);
     p->ftp = ftp;
     if (*p->ibas != FL(0.0))
-      p->cpscvt = (ftp->cvtbas / *p->ibas)/LOFACT;
+      p->cpscvt = (ftp->cvtbas / *p->ibas); /* 1/LOFACT scaling removed */
     else if (UNLIKELY((p->cpscvt = ftp->cpscvt) == FL(0.0))) {
       p->cpscvt = FL(1.0) /FL(261.62556530059862592); /* Middle C */
       csound->Warning(csound, Str("no legal base frequency"));
     }
-    else p->cpscvt /= LOFACT;
     //printf("****cpscvt = %g\n", p->cpscvt);
     if ((p->mod1 = (int16) *p->imod1) < 0) {
       if (UNLIKELY((p->mod1 = ftp->loopmode1) == 0)) {
@@ -385,12 +384,11 @@ int32_t losset_phs(CSOUND *csound, LOSCPHS *p)
     //printf("****maxphs = %d (%x)\n", maxphs, maxphs);
     p->ftp = ftp;
     if (*p->ibas != FL(0.0))
-      p->cpscvt = (ftp->cvtbas / *p->ibas)/LOFACT;
+      p->cpscvt = (ftp->cvtbas / *p->ibas); /* VL - 1/LOFACT scaling removed */ 
     else if (UNLIKELY((p->cpscvt = ftp->cpscvt) == FL(0.0))) {
       p->cpscvt = FL(1.0) /FL(261.62556530059862592); /* Middle C */
       csound->Warning(csound, Str("no legal base frequency"));
     }
-    else p->cpscvt /= LOFACT;
     //printf("****cpscvt = %g\n", p->cpscvt);
     if ((p->mod1 = (int16) *p->imod1) < 0) {
       if (UNLIKELY((p->mod1 = ftp->loopmode1) == 0)) {

--- a/Opcodes/loscilx.c
+++ b/Opcodes/loscilx.c
@@ -295,7 +295,7 @@ static int32_t loscilx_opcode_init(CSOUND *csound, LOSCILX_OPCODE *p)
         frqScale = 1.0 / (double) *(p->ibas);
     }
     else if (ftp->cpscvt > FL(0.0)) {
-      frqScale = (double) ftp->cpscvt * (1.0 / (double) LOFACT);
+      frqScale = (double) ftp->cpscvt; /* 1/LOFACT scaling removed */
     }
     else if (ftp->gen01args.sample_rate > FL(0.0))
       frqScale = (double) ftp->gen01args.sample_rate / (double) CS_ESR;
@@ -440,7 +440,7 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
         frqScale = 1.0 / (double) *(p->ibas);
     }
     else if (ftp->cpscvt > FL(0.0)) {
-      frqScale = (double) ftp->cpscvt * (1.0 / (double) LOFACT);
+      frqScale = (double) ftp->cpscvt; /* 1/LOFACT scaling removed */
     }
     else if (ftp->gen01args.sample_rate > FL(0.0))
       frqScale = (double) ftp->gen01args.sample_rate / (double) CS_ESR;

--- a/Opcodes/loscilx.c
+++ b/Opcodes/loscilx.c
@@ -295,7 +295,7 @@ static int32_t loscilx_opcode_init(CSOUND *csound, LOSCILX_OPCODE *p)
         frqScale = 1.0 / (double) *(p->ibas);
     }
     else if (ftp->cpscvt > FL(0.0)) {
-      frqScale = (double) ftp->cpscvt; /* 1/LOFACT scaling removed */
+      frqScale = (double) ftp->cpscvt; 
     }
     else if (ftp->gen01args.sample_rate > FL(0.0))
       frqScale = (double) ftp->gen01args.sample_rate / (double) CS_ESR;
@@ -440,7 +440,7 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
         frqScale = 1.0 / (double) *(p->ibas);
     }
     else if (ftp->cpscvt > FL(0.0)) {
-      frqScale = (double) ftp->cpscvt; /* 1/LOFACT scaling removed */
+      frqScale = (double) ftp->cpscvt; 
     }
     else if (ftp->gen01args.sample_rate > FL(0.0))
       frqScale = (double) ftp->gen01args.sample_rate / (double) CS_ESR;

--- a/Opcodes/mp3in.c
+++ b/Opcodes/mp3in.c
@@ -1039,7 +1039,7 @@ int32_t gen49raw(FGDATA *ff, FUNC *ftp)
     def = 1;
   }
   ftp->gen01args.sample_rate = mpainfo.frequency;
-  ftp->cvtbas = mpainfo.frequency * ftp->sr; /* LOFACT scaling removed */
+  ftp->cvtbas = mpainfo.frequency * ftp->sr; 
   flen = ftp->flen;
   //printf("gen49: flen=%d size=%d bufsize=%d\n", flen, size, bufsize);
   while ((r == MP3DEC_RETCODE_OK) && bufused) {

--- a/Opcodes/mp3in.c
+++ b/Opcodes/mp3in.c
@@ -1039,7 +1039,7 @@ int32_t gen49raw(FGDATA *ff, FUNC *ftp)
     def = 1;
   }
   ftp->gen01args.sample_rate = mpainfo.frequency;
-  ftp->cvtbas = LOFACT * mpainfo.frequency * ftp->sr;
+  ftp->cvtbas = mpainfo.frequency * ftp->sr; /* LOFACT scaling removed */
   flen = ftp->flen;
   //printf("gen49: flen=%d size=%d bufsize=%d\n", flen, size, bufsize);
   while ((r == MP3DEC_RETCODE_OK) && bufused) {

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -225,8 +225,10 @@ static const uint32_t PHMASK = (1U << 31) - 1U;
 #define OCTRES     8192
 #define CPSOCTL(n) ((MYFLT)(1<<((int32_t)(n)>>13))*csound->cpsocfrc[(int32_t)(n)&8191])
 
+/* VL this seems to be a leftover without any purpose now 
+  (previously used in ugens3.c, loscilx.c, mp3in.c, fgens.c)
 #define LOFACT     1024
-
+*/
 #ifdef USE_DOUBLE
   extern int64_t MYNAN;
 #define SSTRCOD    (double)NAN

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -225,10 +225,6 @@ static const uint32_t PHMASK = (1U << 31) - 1U;
 #define OCTRES     8192
 #define CPSOCTL(n) ((MYFLT)(1<<((int32_t)(n)>>13))*csound->cpsocfrc[(int32_t)(n)&8191])
 
-/* VL this seems to be a leftover without any purpose now 
-  (previously used in ugens3.c, loscilx.c, mp3in.c, fgens.c)
-#define LOFACT     1024
-*/
 #ifdef USE_DOUBLE
   extern int64_t MYNAN;
 #define SSTRCOD    (double)NAN

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -204,9 +204,9 @@ extern "C" {
 #define CURTIME_inc (((double)csound->ksmps)/((double)csound->esr))
 
 #ifndef  SHORT_TABLE_LENGTH  // long max table length is the default
-static const uint32_t MAXLEN = 1U << 31;  
-static const double FMAXLEN = (double) (1U << 31);
-static const uint32_t PHMASK = (1U << 31) - 1U;
+static const uint32_t MAXLEN = 1U << 30;  
+static const double FMAXLEN = (double) (1U << 30);
+static const uint32_t PHMASK = (1U << 30) - 1U;
 #else   // this is the original max table length
 static const uint32_t MAXLEN =  1U << 24;  
 static const double FMAXLEN = (double) (1U << 24);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -203,11 +203,11 @@ extern "C" {
 #define CURTIME (((double)csound->icurTime)/((double)csound->esr))
 #define CURTIME_inc (((double)csound->ksmps)/((double)csound->esr))
 
-#ifdef  B64BIT
-#define MAXLEN     0x10000000
-#define FMAXLEN    ((MYFLT)(MAXLEN))
-#define PHMASK     0x0fffffff
-#else
+#ifndef  SHORT_TABLE_LENGTH  // long max table length is the default
+static const uint32_t MAXLEN = 1 << 31;  
+static const MYFLT FMAXLEN = (MYFLT) MAXLEN;
+static const uint32_t PHMASK = MAXLEN - 1;
+#else   // this is the original max table length
 #define MAXLEN     0x1000000L
 #define FMAXLEN    ((MYFLT)(MAXLEN))
 #define PHMASK     0x0FFFFFFL

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -208,11 +208,12 @@ static const uint32_t MAXLEN = 1U << 31;
 static const double FMAXLEN = (double) (1U << 31);
 static const uint32_t PHMASK = (1U << 31) - 1U;
 #else   // this is the original max table length
-#define MAXLEN     0x1000000L
-#define FMAXLEN    ((MYFLT)(MAXLEN))
-#define PHMASK     0x0FFFFFFL
+static const uint32_t MAXLEN =  1U << 24;  
+static const double FMAXLEN = (double) (1U << 24);
+static const double FMAXLEN = (1U << 24) - 1;
 #endif
 
+  
 #define MAX_STRING_CHANNEL_DATASIZE 16384
 
 #define PFRAC(x)   ((MYFLT)((x) & ftp->lomask) * ftp->lodiv)

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -204,9 +204,9 @@ extern "C" {
 #define CURTIME_inc (((double)csound->ksmps)/((double)csound->esr))
 
 #ifndef  SHORT_TABLE_LENGTH  // long max table length is the default
-static const uint32_t MAXLEN = 1 << 31;  
-static const MYFLT FMAXLEN = (MYFLT) MAXLEN;
-static const uint32_t PHMASK = MAXLEN - 1;
+static const uint32_t MAXLEN = 1U << 31;  
+static const double FMAXLEN = (double) (1U << 31);
+static const uint32_t PHMASK = (1U << 31) - 1U;
 #else   // this is the original max table length
 #define MAXLEN     0x1000000L
 #define FMAXLEN    ((MYFLT)(MAXLEN))
@@ -225,11 +225,7 @@ static const uint32_t PHMASK = MAXLEN - 1;
 #define OCTRES     8192
 #define CPSOCTL(n) ((MYFLT)(1<<((int32_t)(n)>>13))*csound->cpsocfrc[(int32_t)(n)&8191])
 
-#define LOBITS     10
 #define LOFACT     1024
-  /* LOSCAL is 1/LOFACT as MYFLT */
-#define LOSCAL     FL(0.0009765625)
-#define LOMASK     1023
 
 #ifdef USE_DOUBLE
   extern int64_t MYNAN;

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -24,12 +24,16 @@ if(BUILD_TESTS)
         server_test.cpp
     )
 
-    # Required because we're compiling the tests written in C as C++
-    if(NOT MSVC)
+   if(NOT MSVC)
         target_compile_options(unittests PRIVATE "-fpermissive" "-Wwrite-strings")
     endif()
 
     target_compile_features(unittests PUBLIC cxx_std_17)
+    if(APPLE)
+        target_compile_options(unittests PRIVATE "-fpermissive"
+    "-Wno-writable-strings" "-Wno-unused-variable")
+    endif()
+
 
     target_link_libraries(unittests
         PRIVATE

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -174,7 +174,7 @@ def runTest():
     ["test_plusname.csd", "test +Name for instr name"],
     ["testnewline.csd", "test newline in statements"],
     ["testmidichannels.csd", "test use of mapped multiport channels"],
-#    ["test_max_table_len.csd", "test max table length"],
+    ["test_max_table_len.csd", "test max table length"],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -235,7 +235,7 @@ def runTest():
             executable = (csoundExecutable == "") and "csound" or csoundExecutable
             if runtimeEnvironment:
                 executable = "%s %s" % (runtimeEnvironment, executable)
-            command = "%s %s %s %s/%s 2> %s"%(executable, parserType, runArgs, sourceDirectory, filename, tempfile)
+            command = "%s %s %s %s/%s "%(executable, parserType, runArgs, sourceDirectory, filename)
             print(command)
             retVal = os.system(command)
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -259,18 +259,18 @@ def runTest():
         output += "%s\n"%("=" * 80)
         output += "Test %i: %s (%s)\nReturn Code: %i\n"%(counter, desc, filename, retVal)
         output += "%s\n\n"%("=" * 80)
-        f = open(tempfile, "r")
+        #f = open(tempfile, "r")
 
         csOutput = ""
 
-        for line in f:
-            csOutput += line
+        #for line in f:
+         #   csOutput += line
 
-        output += csOutput
+        #output += csOutput
 
-        f.close()
+       # f.close()
 
-        retVals.append(t + [retVal, csOutput])
+        #retVals.append(t + [retVal, csOutput])
 
         output += "\n\n"
         counter += 1

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -174,7 +174,7 @@ def runTest():
     ["test_plusname.csd", "test +Name for instr name"],
     ["testnewline.csd", "test newline in statements"],
     ["testmidichannels.csd", "test use of mapped multiport channels"],
-    ["test_max_table_len.csd", "test max table length"],
+#    ["test_max_table_len.csd", "test max table length"],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],
@@ -235,7 +235,7 @@ def runTest():
             executable = (csoundExecutable == "") and "csound" or csoundExecutable
             if runtimeEnvironment:
                 executable = "%s %s" % (runtimeEnvironment, executable)
-            command = "%s %s %s %s/%s "%(executable, parserType, runArgs, sourceDirectory, filename)
+            command = "%s %s %s %s/%s 2> %s"%(executable, parserType, runArgs, sourceDirectory, filename, tempfile)
             print(command)
             retVal = os.system(command)
 
@@ -259,18 +259,18 @@ def runTest():
         output += "%s\n"%("=" * 80)
         output += "Test %i: %s (%s)\nReturn Code: %i\n"%(counter, desc, filename, retVal)
         output += "%s\n\n"%("=" * 80)
-        #f = open(tempfile, "r")
+        f = open(tempfile, "r")
 
         csOutput = ""
 
-        #for line in f:
-         #   csOutput += line
+        for line in f:
+            csOutput += line
 
-        #output += csOutput
+        output += csOutput
 
-       # f.close()
+        f.close()
 
-        #retVals.append(t + [retVal, csOutput])
+        retVals.append(t + [retVal, csOutput])
 
         output += "\n\n"
         counter += 1

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -174,6 +174,7 @@ def runTest():
     ["test_plusname.csd", "test +Name for instr name"],
     ["testnewline.csd", "test newline in statements"],
     ["testmidichannels.csd", "test use of mapped multiport channels"],
+    ["test_max_table_len.csd", "test max table length"],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test_max_table_len.csd
+++ b/tests/commandline/test_max_table_len.csd
@@ -5,7 +5,7 @@
 
 0dbfs = 1
 
-i1 ftgen 1, 0, 2^31, 2, 0, 2^31, 0 
+i1 ftgen 1, 0, 2^30, 2, 0, 2^30, 0 
 
 instr 1
 endin

--- a/tests/commandline/test_max_table_len.csd
+++ b/tests/commandline/test_max_table_len.csd
@@ -1,0 +1,17 @@
+<CsoundSynthesizer>
+<CsOptions>
+</CsOptions>
+<CsInstruments>
+
+0dbfs = 1
+
+i1 ftgen 1, 0, 2^31, 2, 0, 2^31, 0 
+
+instr 1
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This pushes the size to maximum possible without having to change the codebase to use 64bit ints for phase variables.