### PR TITLE
Soundfile API

### DIFF
--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -1238,7 +1238,7 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int32_t type,
             /* the integer file descriptor is no longer needed */
             close(tmp_fd);
             p->fd = tmp_fd = -1;
-            sflib_command(p->sf, SFC_SET_VBR_ENCODING_QUALITY,
+            csound->FileCommand(csound,p->sf, SFC_SET_VBR_ENCODING_QUALITY,
                        &csound->oparms->quality, sizeof(double));
             goto doneSFOpen;
           }
@@ -1278,8 +1278,8 @@ void *csoundFileOpenWithType(CSOUND *csound, void *fd, int32_t type,
           goto err_return;
         }
       }
-      sflib_command(p->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
-      sflib_command(p->sf, SFC_SET_VBR_ENCODING_QUALITY,
+      csound->FileCommand(csound,p->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->FileCommand(csound,p->sf, SFC_SET_VBR_ENCODING_QUALITY,
                  &csound->oparms->quality, sizeof(double));
       *((SNDFILE**) fd) = p->sf;
       break;
@@ -1585,7 +1585,7 @@ int32_t csoundFSeekAsync(CSOUND *csound, void *handle, int32_t pos, int32_t when
       break;
     case CSFILE_SND_R:
     case CSFILE_SND_W:
-      ret = sflib_seek(p->sf,pos,whence);
+      ret = csound->SndfileSeek(csound,p->sf,pos,whence);
       //csoundMessage(csound, "seek set %d\n", pos);
       csound->FlushCircularBuffer(csound, p->cb);
       p->items = 0;
@@ -1613,7 +1613,7 @@ static int32_t read_files(CSOUND *csound){
           break;
         case CSFILE_SND_R:
           if (n == 0) {
-            n = sflib_read_MYFLT(current->sf, buf, items);
+            n = csound->SndfileReadSamples(csound, current->sf, buf, items);
             m = 0;
           }
           l = csound->WriteCircularBuffer(csound,current->cb,&buf[m],n);
@@ -1625,7 +1625,7 @@ static int32_t read_files(CSOUND *csound){
         case CSFILE_SND_W:
           items = csound->ReadCircularBuffer(csound, current->cb, buf, items);
           if (items == 0) { csoundSleep(10); break;}
-          sflib_write_MYFLT(current->sf, buf, items);
+          csound->SndfileWriteSamples(csound, current->sf, buf, items);
           break;
         }
       }

--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -1418,7 +1418,7 @@ int32_t csoundFileClose(CSOUND *csound, void *fd)
       case CSFILE_SND_R:
       case CSFILE_SND_W:
         if (p->sf)
-          retval = sflib_close(p->sf);
+          retval = csound->SndfileClose(csound,p->sf);
         p->sf = NULL;
         if (p->fd >= 0)
           retval |= close(p->fd);
@@ -1447,7 +1447,7 @@ int32_t csoundFileClose(CSOUND *csound, void *fd)
         break;
       case CSFILE_SND_R:
       case CSFILE_SND_W:
-        retval = sflib_close(p->sf);
+        retval = csound->SndfileClose(csound,p->sf);
         if (p->fd >= 0)
           retval |= close(p->fd);
         break;

--- a/Engine/envvar.c
+++ b/Engine/envvar.c
@@ -22,6 +22,7 @@
 */
 
 #include "csoundCore.h"
+#include "soundfile.h"
 #include "soundio.h"
 #include "envvar.h"
 #include <stdio.h>

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -26,6 +26,7 @@
 
 #include "csoundCore.h"         /*                      FGENS.C         */
 #include <ctype.h>
+#include "soundfile.h"
 #include "soundio.h"
 #include "cwindow.h"
 #include "cmath.h"
@@ -34,6 +35,7 @@
 #include "pvfileio.h"
 #include <stdlib.h>
 #include "fftlib.h"
+
 
 extern double besseli(double);
 static int32_t gen01raw(FGDATA *, FUNC *);

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -2566,7 +2566,7 @@ static int32_t gen01raw(FGDATA *ff, FUNC *ftp)
     ftp->cvtbas = LOFACT * p->sr * csound->onedsr;
     {
       SFLIB_INSTRUMENT lpd;
-      int32_t ans = sflib_command(fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));
+      int32_t ans = csound->FileCommand(csound,fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));
       if (ans) {
         double natcps;
 #ifdef BETA

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -2566,7 +2566,7 @@ static int32_t gen01raw(FGDATA *ff, FUNC *ftp)
     ftp->cvtbas = LOFACT * p->sr * csound->onedsr;
     {
       SFLIB_INSTRUMENT lpd;
-      int32_t ans = csound->FileCommand(csound,fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));
+      int32_t ans = csound->SndfileCommand(csound,fd, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT));
       if (ans) {
         double natcps;
 #ifdef BETA

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -23,6 +23,7 @@
 */
 
 #include "csoundCore.h"     /*                              MEMFILES.C      */
+#include "soundfile.h"
 #include "soundio.h"
 #include "pvfileio.h"
 #include "convolve.h"

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -620,7 +620,7 @@ SNDMEMFILE *csoundLoadSoundFile(CSOUND *csound, const char *fileName, void *sfi)
     if (UNLIKELY(fd == NULL)) {
       csound->ErrorMsg(csound,
                        Str("csoundLoadSoundFile(): failed to open '%s' %s"),
-                       fileName, Str(sflib_strerror(NULL)));
+                       fileName, Str(csound->SndfileStrError(csound,NULL)));
       return NULL;
     }
     p = (SNDMEMFILE*)
@@ -646,7 +646,7 @@ SNDMEMFILE *csoundLoadSoundFile(CSOUND *csound, const char *fileName, void *sfi)
     p->scaleFac = 1.0;
     {
       SFLIB_INSTRUMENT lpd;
-      if (csound->FileCommand(csound,sf, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT))
+      if (csound->SndfileCommand(csound,sf, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT))
           != 0) {
         if (lpd.loop_count > 0 && lpd.loops[0].mode != SF_LOOP_NONE) {
           /* set loop mode and loop points */

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -646,7 +646,7 @@ SNDMEMFILE *csoundLoadSoundFile(CSOUND *csound, const char *fileName, void *sfi)
     p->scaleFac = 1.0;
     {
       SFLIB_INSTRUMENT lpd;
-      if (sflib_command(sf, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT))
+      if (csound->FileCommand(csound,sf, SFC_GET_INSTRUMENT, &lpd, sizeof(SFLIB_INSTRUMENT))
           != 0) {
         if (lpd.loop_count > 0 && lpd.loops[0].mode != SF_LOOP_NONE) {
           /* set loop mode and loop points */
@@ -664,7 +664,7 @@ SNDMEMFILE *csoundLoadSoundFile(CSOUND *csound, const char *fileName, void *sfi)
         p->scaleFac = pow(10.0, (double) lpd.gain * 0.05);
       }
     }
-    if (UNLIKELY((size_t) sflib_readf_MYFLT(sf, &(p->data[0]), (sf_count_t) p->nFrames)
+    if (UNLIKELY((size_t) csound->SndfileRead(csound, sf, &(p->data[0]), (sf_count_t) p->nFrames)
                  != p->nFrames)) {
       csound->FileClose(csound, fd);
       csound->Free(csound, p->name);

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -24,6 +24,7 @@
 
 #include "csoundCore.h"         /*                         MUSMON.C     */
 #include "midiops.h"
+#include "soundfile.h"
 #include "soundio.h"
 #include "namedins.h"
 #include "oload.h"

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -232,4 +232,38 @@ int32_t csoundDeleteAllConfigurationVariables(CSOUND *);
 }
 #endif
 
+#ifdef  USE_DOUBLE
+#define sflib_write_MYFLT  sflib_write_double
+#define sflib_writef_MYFLT  sflib_writef_double
+#define sflib_read_MYFLT   sflib_read_double
+#define sflib_readf_MYFLT   sflib_readf_double
+#else
+#define sflib_write_MYFLT  sflib_write_float
+#define sflib_writef_MYFLT  sflib_writef_float
+#define sflib_read_MYFLT   sflib_read_float
+#define sflib_readf_MYFLT   sflib_readf_float
+#endif
+ 
+#ifdef __cplusplus
+extern "C" {
+#endif
+  int32_t sflib_command (void *handle, int32_t cmd, void *data, int32_t datasize);
+  void *sflib_open(const char *path, int32_t mode, SFLIB_INFO *sfinfo);
+  void *sflib_open_fd(int32_t fd, int32_t mode, SFLIB_INFO *sfinfo, int32_t close_desc);
+  int32_t sflib_close(void *sndfile);
+  long sflib_seek(void *handle, long frames, int32_t whence);
+  long sflib_read_float(void *sndfile, float *ptr, long items);
+  long sflib_readf_float(void *handle, float *ptr, long frames);
+  long sflib_read_double(void *sndfile, double *ptr, long items);
+  long sflib_readf_double(void *handle, double *ptr, long frames);
+  long sflib_write_float(void *sndfile, float *ptr, long items);
+  long sflib_writef_float(void *handle, float *ptr, long frames);
+  long sflib_write_double(void *handle, double *ptr, long items);
+  long sflib_writef_double(void *handle, double *ptr, long frames);
+  int32_t sflib_set_string(void *sndfile, int32_t str_type, const char* str);
+  const char *sflib_strerror(void *);  
+#ifdef __cplusplus
+}
+#endif
+
 #endif  /* __BUILDING_LIBCSOUND && !_CSOUND_PROTO_H */

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -73,7 +73,7 @@ int32_t     sfsampsize(int32_t sf_format);
 char    *type2string(int32_t type);
 int32_t     type2csfiletype(int32_t type, int32_t encoding);
 int32_t     sftype2csfiletype(int32_t type);
-void    rewriteheader(void *ofd);
+void    rewriteheader(CSOUND *csound, void *ofd);
 #if 0
 int32_t     readOptions_file(CSOUND *, FILE *, int32_t);
 #else

--- a/H/soundfile.h
+++ b/H/soundfile.h
@@ -30,7 +30,6 @@
 
 #define SFLIB_FALSE SF_FALSE
 #define SFLIB_TRUE SF_TRUE
-
 #define SFLIB_INSTRUMENT SF_INSTRUMENT
 
 #ifndef SNDFILE_MP3
@@ -247,22 +246,14 @@ typedef long sf_count_t;
 #define sflib_read_MYFLT   sflib_read_float
 #define sflib_readf_MYFLT   sflib_readf_float
 #endif
-  
-typedef struct sflib_info {
-  long  frames ;     
-  int32_t   samplerate ;
-  int32_t   channels ;
-  int32_t   format ;
-} SFLIB_INFO;
-
-
+ 
 #ifdef __cplusplus
 extern "C" {
 #endif
   int32_t sflib_command (void *handle, int32_t cmd, void *data, int32_t datasize);
   void *sflib_open(const char *path, int32_t mode, SFLIB_INFO *sfinfo);
   void *sflib_open_fd(int32_t fd, int32_t mode, SFLIB_INFO *sfinfo, int32_t close_desc);
-    int32_t sflib_close(void *sndfile);
+  int32_t sflib_close(void *sndfile);
   long sflib_seek(void *handle, long frames, int32_t whence);
   long sflib_read_float(void *sndfile, float *ptr, long items);
   long sflib_readf_float(void *handle, float *ptr, long frames);
@@ -272,7 +263,7 @@ extern "C" {
   long sflib_writef_float(void *handle, float *ptr, long frames);
   long sflib_write_double(void *handle, double *ptr, long items);
   long sflib_writef_double(void *handle, double *ptr, long frames);
-  int32_t  sflib_set_string(void *sndfile, int32_t str_type, const char* str);
+  int32_t sflib_set_string(void *sndfile, int32_t str_type, const char* str);
   const char *sflib_strerror(void *);  
 #ifdef __cplusplus
 }

--- a/InOut/cmidi.c
+++ b/InOut/cmidi.c
@@ -284,7 +284,7 @@ PUBLIC int32_t csoundModuleCreate(CSOUND *csound)
 PUBLIC int32_t csoundModuleInit(CSOUND *csound)
 {
     char    *drv;
-    csound->module_list_add(csound, "coremidi", "midi");
+    csound->ModuleListAdd(csound, "coremidi", "midi");
     drv = (char*) (csound->QueryGlobalVariable(csound, "_RTMIDI"));
     if (drv == NULL)
       return 0;

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -22,6 +22,7 @@
 */
 
 #include "csoundCore.h"                 /*             SNDLIB.C         */
+#include "soundfile.h"
 #include "soundio.h"
 #include <stdlib.h>
 #include <time.h>

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -914,7 +914,7 @@ void sfclosein(CSOUND *csound)
     }
     else if (STA(pipdevin) != 2) {
       if (STA(infile) != NULL)
-        sflib_close(STA(infile));
+        csound->SndfileClose(csound,STA(infile));
 #ifdef PIPES
       if (STA(pin) != NULL) {
         _pclose(STA(pin));
@@ -948,7 +948,7 @@ void sfcloseout(CSOUND *csound)
     if (STA(outfile) != NULL) {
       if (!STA(pipdevout) && O->outformat != AE_VORBIS)
         csound->SndfileCommand(csound,STA(outfile), SFC_UPDATE_HEADER_NOW, NULL, 0);
-      sflib_close(STA(outfile));
+      csound->SndfileClose(csound,STA(outfile));
       STA(outfile) = NULL;
     }
 #ifdef PIPES

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -159,12 +159,12 @@ static void writesf(CSOUND *csound, const MYFLT *outbuf, int32_t nbytes)
 
     if (UNLIKELY(STA(outfile) == NULL))
       return;
-    n = (int32_t) sflib_write_MYFLT(STA(outfile), (MYFLT*) outbuf,
+    n = (int32_t) csound->SndfileWriteSamples(csound, STA(outfile), (MYFLT*) outbuf,
                              nbytes / sizeof(MYFLT)) * (int32_t) sizeof(MYFLT);
     if (UNLIKELY(n < nbytes))
       sndwrterr(csound, n, nbytes);
     if (UNLIKELY(O->rewrt_hdr))
-      rewriteheader((void *)STA(outfile));
+      rewriteheader(csound,(void *)STA(outfile));
     switch (O->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME,
@@ -213,12 +213,12 @@ static void writesf_dither_16(CSOUND *csound, const MYFLT *outbuf, int32_t nbyte
       buf[n] += result;
     }
     STA(dither) = dith;
-    n = (int32_t) sflib_write_MYFLT(STA(outfile), (MYFLT*) outbuf,
+    n = (int32_t) csound->SndfileWriteSamples(csound, STA(outfile), (MYFLT*) outbuf,
                              nbytes / sizeof(MYFLT)) * (int32_t) sizeof(MYFLT);
     if (UNLIKELY(n < nbytes))
       sndwrterr(csound, n, nbytes);
     if (UNLIKELY(O->rewrt_hdr))
-      rewriteheader(STA(outfile));
+      rewriteheader(csound,STA(outfile));
     switch (O->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME,
@@ -267,12 +267,12 @@ static void writesf_dither_8(CSOUND *csound, const MYFLT *outbuf, int32_t nbytes
       buf[n] += result;
     }
     STA(dither) = dith;
-    n = (int32_t) sflib_write_MYFLT(STA(outfile), (MYFLT*) outbuf,
+    n = (int32_t) csound->SndfileWriteSamples(csound, STA(outfile), (MYFLT*) outbuf,
                              nbytes / sizeof(MYFLT)) * (int32_t) sizeof(MYFLT);
     if (UNLIKELY(n < nbytes))
       sndwrterr(csound, n, nbytes);
     if (UNLIKELY(O->rewrt_hdr))
-      rewriteheader(STA(outfile));
+      rewriteheader(csound,STA(outfile));
     switch (O->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME,
@@ -319,12 +319,12 @@ static void writesf_dither_u16(CSOUND *csound, const MYFLT *outbuf, int32_t nbyt
       buf[n] += result;
     }
     STA(dither) = dith;
-    n = (int32_t) sflib_write_MYFLT(STA(outfile), (MYFLT*) outbuf,
+    n = (int32_t) csound->SndfileWriteSamples(csound, STA(outfile), (MYFLT*) outbuf,
                              nbytes / sizeof(MYFLT)) * (int32_t) sizeof(MYFLT);
     if (UNLIKELY(n < nbytes))
       sndwrterr(csound, n, nbytes);
     if (UNLIKELY(O->rewrt_hdr))
-      rewriteheader(STA(outfile));
+      rewriteheader(csound,STA(outfile));
     switch (O->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME,
@@ -371,12 +371,13 @@ static void writesf_dither_u8(CSOUND *csound, const MYFLT *outbuf, int32_t nbyte
       buf[n] += result;
     }
     STA(dither) = dith;
-    n = (int32_t) sflib_write_MYFLT(STA(outfile), (MYFLT*) outbuf,
+    n = (int32_t)
+      csound->SndfileWriteSamples(csound, STA(outfile), (MYFLT*) outbuf,
                              nbytes / sizeof(MYFLT)) * (int32_t) sizeof(MYFLT);
     if (UNLIKELY(n < nbytes))
       sndwrterr(csound, n, nbytes);
     if (UNLIKELY(O->rewrt_hdr))
-      rewriteheader(STA(outfile));
+      rewriteheader(csound,STA(outfile));
     switch (O->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME,
@@ -409,7 +410,7 @@ static int32_t readsf(CSOUND *csound, MYFLT *inbuf, int32_t inbufsize)
 
     (void) csound;
     n = inbufsize / (int32_t) sizeof(MYFLT);
-    i = (int32_t) sflib_read_MYFLT(STA(infile), inbuf, n);
+    i = (int32_t)  csound->SndfileReadSamples(csound,STA(infile), inbuf, n);
     if (UNLIKELY(i < 0))
       return inbufsize;
     memset(&inbuf[i], 0, (n-i)*sizeof(MYFLT));
@@ -786,7 +787,7 @@ void sfopenout(CSOUND *csound)                  /* init for sound out       */
       if (UNLIKELY(STA(outfile) == NULL))
         csoundDie(csound, Str("sfinit: cannot open fd %d\n%s"), osfd,
                   Str(sflib_strerror(NULL)));
-      sflib_command(STA(outfile), SFC_SET_VBR_ENCODING_QUALITY,
+      csound->FileCommand(csound,STA(outfile), SFC_SET_VBR_ENCODING_QUALITY,
                  &O->quality, sizeof(double));
     }
     else {
@@ -798,7 +799,7 @@ void sfopenout(CSOUND *csound)                  /* init for sound out       */
       if (UNLIKELY(STA(outfile) == NULL))
         csoundDie(csound, Str("sfinit: cannot open %s\n%s"),
                   fullName, sflib_strerror (NULL));
-      sflib_command(STA(outfile), SFC_SET_VBR_ENCODING_QUALITY,
+      csound->FileCommand(csound,STA(outfile), SFC_SET_VBR_ENCODING_QUALITY,
                  &O->quality, sizeof(double));
       /* only notify the host if we opened a real file, not stdout or a pipe */
       csoundNotifyFileOpened(csound, fullName,
@@ -816,8 +817,8 @@ void sfopenout(CSOUND *csound)                  /* init for sound out       */
     
     /* IV - Feb 22 2005: clip integer formats */
     if (O->outformat != AE_FLOAT && O->outformat != AE_DOUBLE)
-      sflib_command(STA(outfile), SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
-    sflib_command(STA(outfile), SFC_SET_ADD_PEAK_CHUNK,
+      csound->FileCommand(csound,STA(outfile), SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+    csound->FileCommand(csound,STA(outfile), SFC_SET_ADD_PEAK_CHUNK,
                NULL, (csound->peakchunks ? SFLIB_TRUE : SFLIB_FALSE));
 #ifdef SOME_FINE_DAY
 #ifdef USE_LIBSNDFILE    
@@ -827,7 +828,7 @@ void sfopenout(CSOUND *csound)                  /* init for sound out       */
       ditherInfo.type  = SFD_TRIANGULAR_PDF | SFD_DEFAULT_LEVEL;
       ditherInfo.level = 1.0;
       ditherInfo.name  = (char*) NULL;
-      sflib_command(STA(outfile), SFC_SET_DITHER_ON_WRITE,
+      csound->FileCommand(csound,STA(outfile), SFC_SET_DITHER_ON_WRITE,
                  &ditherInfo, sizeof(SF_DITHER_INFO));   
     }
 #endif
@@ -946,7 +947,7 @@ void sfcloseout(CSOUND *csound)
       goto report;
     if (STA(outfile) != NULL) {
       if (!STA(pipdevout) && O->outformat != AE_VORBIS)
-        sflib_command(STA(outfile), SFC_UPDATE_HEADER_NOW, NULL, 0);
+        csound->FileCommand(csound,STA(outfile), SFC_UPDATE_HEADER_NOW, NULL, 0);
       sflib_close(STA(outfile));
       STA(outfile) = NULL;
     }

--- a/InOut/libsnd_u.c
+++ b/InOut/libsnd_u.c
@@ -22,6 +22,7 @@
 */
 
 #include "csoundCore.h"
+#include "soundfile.h"
 #include "soundio.h"
 
 void rewriteheader(CSOUND *csound, void *ofd)

--- a/InOut/libsnd_u.c
+++ b/InOut/libsnd_u.c
@@ -27,7 +27,7 @@
 void rewriteheader(CSOUND *csound, void *ofd)
 {
     if (LIKELY(ofd != NULL))
-      csound->FileCommand(csound,(SNDFILE *)ofd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+      csound->SndfileCommand(csound,(SNDFILE *)ofd, SFC_UPDATE_HEADER_NOW, NULL, 0);
 }
 
 /* Stand-Alone sndgetset() */
@@ -137,7 +137,7 @@ void *sndgetset(CSOUND *csound, void *p_)
                                      CSFTYPE_UNKNOWN_AUDIO, 0);
     if (UNLIKELY(p->fd == NULL)) {
       csound->ErrorMsg(csound, Str("soundin cannot open %s: %s"),
-                       sfname, sflib_strerror(NULL));
+                       sfname, csound->SndfileStrError(csound,NULL));
       goto err_return;
     }
     /* & record fullpath filnam */

--- a/InOut/libsnd_u.c
+++ b/InOut/libsnd_u.c
@@ -24,10 +24,10 @@
 #include "csoundCore.h"
 #include "soundio.h"
 
-void rewriteheader(void *ofd)
+void rewriteheader(CSOUND *csound, void *ofd)
 {
     if (LIKELY(ofd != NULL))
-      sflib_command((SNDFILE *)ofd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+      csound->FileCommand(csound,(SNDFILE *)ofd, SFC_UPDATE_HEADER_NOW, NULL, 0);
 }
 
 /* Stand-Alone sndgetset() */
@@ -95,7 +95,7 @@ static int32_t sreadin(CSOUND *csound, SNDFILE *infd, MYFLT *inbuf,
     /* return the number of samples read */
     int32_t   n, ntot = 0;
     do {
-      n = sflib_read_MYFLT(infd, inbuf + ntot, nsamples - ntot);
+      n = csound->SndfileReadSamples(csound, infd, inbuf + ntot, nsamples - ntot);
       if (UNLIKELY(n < 0))
         csound->Die(csound, Str("soundfile read error"));
     } while (n > 0 && (ntot += n) < nsamples);
@@ -229,7 +229,7 @@ void *sndgetset(CSOUND *csound, void *p_)
     }
     else {                                      /* for greater skiptime: */
       /* else seek to bndry */
-      if (UNLIKELY(sflib_seek(p->sinfd, (sf_count_t) skipframes, SEEK_SET) < 0)) {
+      if (UNLIKELY(csound->SndfileSeek(csound, p->sinfd, (sf_count_t) skipframes, SEEK_SET) < 0)) {
         csound->ErrorMsg(csound, Str("soundin seek error"));
         goto err_return;
       }

--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -537,7 +537,7 @@ PUBLIC int32_t csoundModuleCreate(CSOUND *csound)
 PUBLIC int32_t csoundModuleInit(CSOUND *csound)
 {
     char    *drv;
-    csound->module_list_add(csound, "portmidi", "midi");
+    csound->ModuleListAdd(csound, "portmidi", "midi");
     drv = (char*) (csound->QueryGlobalVariable(csound, "_RTMIDI"));
     if (drv == NULL)
       return 0;

--- a/InOut/rtalsa.c
+++ b/InOut/rtalsa.c
@@ -1903,10 +1903,10 @@ PUBLIC int32_t csoundModuleInit(CSOUND *csound)
     OPARMS oparms;
     csound->GetOParms(csound, &oparms);
 
-    csound->module_list_add(csound, "alsa", "audio");
-    csound->module_list_add(csound, "alsaraw", "midi");
-    csound->module_list_add(csound, "alsaseq", "midi");
-    csound->module_list_add(csound, "devfile", "midi");
+    csound->ModuleListAdd(csound, "alsa", "audio");
+    csound->ModuleListAdd(csound, "alsaraw", "midi");
+    csound->ModuleListAdd(csound, "alsaseq", "midi");
+    csound->ModuleListAdd(csound, "devfile", "midi");
 
     csCfgVariable_t *cfg;
     int32_t priority;

--- a/InOut/rtauhal.c
+++ b/InOut/rtauhal.c
@@ -879,7 +879,7 @@ int32_t csoundModuleInit(CSOUND *csound)
     char   *drv;
     OPARMS O;
     csound->GetOParms(csound, &O);
-    csound->module_list_add(csound, "auhal", "audio");
+    csound->ModuleListAdd(csound, "auhal", "audio");
     drv = (char *) csound->QueryGlobalVariable(csound, "_RTAUDIO");
     if (drv == NULL)
       return 0;

--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -1557,7 +1557,7 @@ PUBLIC int32_t csoundModuleInit(CSOUND *csound)
     char    *drv;
    OPARMS O;
     csound->GetOParms(csound, &O);
-    csound->module_list_add(csound,"jack", "audio");
+    csound->ModuleListAdd(csound,"jack", "audio");
     drv = (char*) csound->QueryGlobalVariable(csound, "_RTAUDIO");
     if (drv == NULL)
       return 0;

--- a/InOut/rtpa.c
+++ b/InOut/rtpa.c
@@ -892,8 +892,8 @@ PUBLIC int32_t csoundModuleInit(CSOUND *csound)
   char    drv[12];
   int32_t     i;
   memset(drv, '\0', 12);
-  csound->module_list_add(csound, "pa_bl", "audio");
-  csound->module_list_add(csound, "pa_cb", "audio");
+  csound->ModuleListAdd(csound, "pa_bl", "audio");
+  csound->ModuleListAdd(csound, "pa_cb", "audio");
   if ((s = (char*) csound->QueryGlobalVariable(csound, "_RTAUDIO")) == NULL)
     return 0;
   for (i = 0; s[i] != '\0' && i < 11; i++)
@@ -929,7 +929,7 @@ PUBLIC int32_t csoundModuleInit(CSOUND *csound)
       csound->SetAudioDeviceListCallback(csound, listDevices);
     }
 
-  csound->module_list_add(csound, s, "audio");
+  csound->ModuleListAdd(csound, s, "audio");
   return 0;
 }
 

--- a/InOut/rtpulse.c
+++ b/InOut/rtpulse.c
@@ -274,7 +274,7 @@ PUBLIC int32_t csoundModuleInit(CSOUND *csound)
     char    *s;
     int32_t     i;
     char    buf[9];
-    csound->module_list_add(csound, "pulse", "audio");
+    csound->ModuleListAdd(csound, "pulse", "audio");
     s = (char*) csound->QueryGlobalVariable(csound, "_RTAUDIO");
     i = 0;
     if (s != NULL) {

--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -20,7 +20,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-#include "csoundCore.h"  
+#include "csoundCore.h"
+#include "soundfile.h"
 
 #if USE_LIBSNDFILE
 const char *sflib_strerror(void *p){

--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -31,7 +31,7 @@ int32_t  sflib_set_string(void *sndfile, int32_t str_type, const char* str){
   return sf_set_string((SNDFILE *)sndfile, str_type, str) ;
 }
   
-int32_t sflib_command (void *handle, int32_t cmd, void *data, int32_t datasize)  {
+int32_t sflib_command(void *handle, int32_t cmd, void *data, int32_t datasize)  {
   return sf_command((SNDFILE*) handle, cmd, data, datasize) ;
 }
 
@@ -112,7 +112,7 @@ long sflib_writef_double(void *handle, double *ptr, long items) {
 }
 
 #else 
-int32_t sflib_command (void *handle, int32_t cmd, void *data, int32_t datasize)  {
+int32_t sflib_command(void *handle, int32_t cmd, void *data, int32_t datasize)  {
       return 0;
 }
 

--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -20,7 +20,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
     02110-1301 USA
 */
-#include <soundfile.h>
+#include "csoundCore.h"  
 
 #if USE_LIBSNDFILE
 const char *sflib_strerror(void *p){

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -342,7 +342,7 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
     if (UNLIKELY(fd == NULL)) {
       return csound->InitError(csound,
                                Str("diskin2: %s: failed to open file (%s)"),
-                               name, Str(sflib_strerror(NULL)));
+                               name, Str(csound->SndfileStrError(csound,NULL)));
     }
     /* record file handle so that it will be closed at note-off */
     memset(&(p->fdch), 0, sizeof(FDCH));
@@ -1092,13 +1092,13 @@ static int32_t sndo1set_(CSOUND *csound, void *pp, int32_t stringname)
     }
     sfname = csound->GetFileName(q->fd);
     if (format != AE_FLOAT)
-      csound->FileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->SndfileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     else
-      csound->FileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_FALSE);
+      csound->SndfileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_FALSE);
 #ifdef USE_DOUBLE
-    csound->FileCommand(csound,q->sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
+    csound->SndfileCommand(csound,q->sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
 #else
-    csound->FileCommand(csound,q->sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
+    csound->SndfileCommand(csound,q->sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
 #endif
     csound->Warning(csound, Str("%s: opening RAW outfile %s\n"),
                     opname, sfname);
@@ -1606,7 +1606,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
     if (UNLIKELY(fd == NULL)) {
       return csound->InitError(csound,
                                Str("diskin2: %s: failed to open file: %s"),
-                               name, Str(sflib_strerror(NULL)));
+                               name, Str(csound->SndfileStrError(csound,NULL)));
     }
     /* record file handle so that it will be closed at note-off */
     memset(&(p->fdch), 0, sizeof(FDCH));
@@ -2181,7 +2181,7 @@ static int32_t sndinset_(CSOUND *csound, SOUNDIN_ *p, int32_t stringname)
       if (csound->oparms->realtime==0)
         return csound->InitError(csound,
                                Str("soundin: %s: failed to open file: %s"),
-                                 name, Str(sflib_strerror(NULL)));
+                                 name, Str(csound->SndfileStrError(csound,NULL)));
       else
         return csound->InitError(csound,
                                  Str("soundin: %s: failed to open file"), name);

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -68,9 +68,9 @@ static CS_NOINLINE void diskin2_read_buffer(CSOUND *csound,
         if (nsmps > (int32_t) p->bufSize)
           nsmps = (int32_t) p->bufSize;
         nsmps *= (int32_t) p->nChannels;
-        sflib_seek(p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
+        csound->SndfileSeek(csound, p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
         /* convert sample count to mono samples and read file */
-        i = (int32_t)sflib_read_MYFLT(p->sf, p->buf, (sf_count_t) nsmps);
+        i = (int32_t) csound->SndfileReadSamples(csound, p->sf, p->buf, (sf_count_t) nsmps);
         if (UNLIKELY(i < 0))  /* error ? */
           i = 0;    /* clear entire buffer to zero */
       }
@@ -1019,7 +1019,7 @@ int32_t soundout_deinit(CSOUND *csound, void *pp)
       MYFLT *p0 = (MYFLT*) &(q->outbuf[0]);
       MYFLT *p1 = (MYFLT*) q->outbufp;
       if (p1 > p0) {
-        sflib_write_MYFLT(q->sf, p0, (sf_count_t) ((MYFLT*) p1 - (MYFLT*) p0));
+        csound->SndfileWriteSamples(csound, q->sf, p0, (sf_count_t) ((MYFLT*) p1 - (MYFLT*) p0));
         q->outbufp = (MYFLT*) &(q->outbuf[0]);
       }
       /* close file */
@@ -1092,13 +1092,13 @@ static int32_t sndo1set_(CSOUND *csound, void *pp, int32_t stringname)
     }
     sfname = csound->GetFileName(q->fd);
     if (format != AE_FLOAT)
-      sflib_command(q->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->FileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     else
-      sflib_command(q->sf, SFC_SET_CLIPPING, NULL, SFLIB_FALSE);
+      csound->FileCommand(csound,q->sf, SFC_SET_CLIPPING, NULL, SFLIB_FALSE);
 #ifdef USE_DOUBLE
-    sflib_command(q->sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
+    csound->FileCommand(csound,q->sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
 #else
-    sflib_command(q->sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
+    csound->FileCommand(csound,q->sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
 #endif
     csound->Warning(csound, Str("%s: opening RAW outfile %s\n"),
                     opname, sfname);
@@ -1130,7 +1130,7 @@ int32_t soundout(CSOUND *csound, SNDOUT *p)
     for (nn = offset; nn < nsmps; nn++) {
       if (UNLIKELY(p->c.outbufp >= p->c.bufend)) {
 
-        sflib_write_MYFLT(p->c.sf, p->c.outbuf, p->c.bufend - p->c.outbuf);
+        csound->SndfileWriteSamples(csound, p->c.sf, p->c.outbuf, p->c.bufend - p->c.outbuf);
         p->c.outbufp = p->c.outbuf;
       }
       *(p->c.outbufp++) = p->asig[nn];
@@ -1151,7 +1151,7 @@ int32_t soundouts(CSOUND *csound, SNDOUTS *p)
     if (UNLIKELY(early)) nsmps -= early;
     for (nn = offset; nn < nsmps; nn++) {
       if (UNLIKELY(p->c.outbufp >= p->c.bufend)) {
-        sflib_write_MYFLT(p->c.sf, p->c.outbuf, p->c.bufend - p->c.outbuf);
+        csound->SndfileWriteSamples(csound, p->c.sf, p->c.outbuf, p->c.bufend - p->c.outbuf);
         p->c.outbufp = p->c.outbuf;
       }
       *(p->c.outbufp++) = p->asig1[nn];
@@ -1196,9 +1196,9 @@ static CS_NOINLINE void diskin2_read_buffer_array(CSOUND *csound,
         if (nsmps > (int32_t) p->bufSize)
           nsmps = (int32_t) p->bufSize;
         nsmps *= (int32_t) p->nChannels;
-        sflib_seek(p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
+        csound->SndfileSeek(csound, p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
         /* convert sample count to mono samples and read file */
-        i = (int32_t)sflib_read_MYFLT(p->sf, p->buf, (sf_count_t) nsmps);
+        i = (int32_t) csound->SndfileReadSamples(csound, p->sf, p->buf, (sf_count_t) nsmps);
         if (UNLIKELY(i < 0))  /* error ? */
           i = 0;    /* clear entire buffer to zero */
       }
@@ -2083,8 +2083,8 @@ static void soundin_read_buffer(CSOUND *csound, SOUNDIN_ *p, int32_t bufReadPos)
         /* convert sample count to mono samples and read file */
         nsmps *= (int32_t) p->nChannels;
         if (csound->oparms->realtime==0){
-          sflib_seek(p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
-          i = (int32_t) sflib_read_MYFLT(p->sf, p->buf, (sf_count_t) nsmps);
+          csound->SndfileSeek(csound, p->sf, (sf_count_t) p->bufStartPos, SEEK_SET);
+          i = (int32_t) csound->SndfileReadSamples(csound, p->sf, p->buf, (sf_count_t) nsmps);
         }
         else
           i = (int32_t) csound->ReadAsync(csound, p->fdch.fd, p->buf,

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -22,6 +22,7 @@
 */
 
 #include "csoundCore.h"
+#include "soundfile.h"
 #include "soundio.h"
 #include "diskin2.h"
 #include <math.h>

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -275,11 +275,11 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
                                sfname, Str(sflib_strerror(NULL)));
     }
     if (channel <= 0) {
-      if (sflib_command(sf, SFC_GET_SIGNAL_MAX, &peakVal, sizeof(double))
+      if (csound->FileCommand(csound,sf, SFC_GET_SIGNAL_MAX, &peakVal, sizeof(double))
           == SFLIB_FALSE) {
         csound->Warning(csound, Str("%s: no PEAK chunk was found, scanning "
                                     "file for maximum amplitude"), sfname);
-        if (sflib_command(sf, SFC_CALC_NORM_SIGNAL_MAX,
+        if (csound->FileCommand(csound,sf, SFC_CALC_NORM_SIGNAL_MAX,
                        &peakVal, sizeof(double)) != 0)
           peakVal = -1.0;
       }
@@ -293,10 +293,10 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
                                 "of channels in file"));
       nBytes = sizeof(double)* sfinfo.channels;
       peaks = (double*)csound->Malloc(csound, nBytes);
-      if (sflib_command(sf, SFC_GET_MAX_ALL_CHANNELS, peaks, nBytes) == SFLIB_FALSE) {
+      if (csound->FileCommand(csound,sf, SFC_GET_MAX_ALL_CHANNELS, peaks, nBytes) == SFLIB_FALSE) {
         csound->Warning(csound, Str("%s: no PEAK chunk was found, scanning "
                                     "file for maximum amplitude"), sfname);
-        if (sflib_command(sf, SFC_CALC_NORM_MAX_ALL_CHANNELS, peaks, nBytes) == 0)
+        if (csound->FileCommand(csound,sf, SFC_CALC_NORM_MAX_ALL_CHANNELS, peaks, nBytes) == 0)
           peakVal = peaks[channel - 1];
       }
       csound->Free(csound, peaks);

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -67,7 +67,7 @@ static int32_t getsndinfo(CSOUND *csound, SNDINFO *p, SFLIB_INFO *hdr, int32_t s
     sfname = s;                         /* & record fullpath filnam */
     csFileType = CSFTYPE_UNKNOWN;
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
-    sf = sflib_open(sfname, SFM_READ, &sfinfo);
+    sf = csound->SndfileOpen(csound,sfname, SFM_READ, &sfinfo);
     if (sf == NULL) {
       /* open failed: maybe analysis or raw file ? */
       if (*(p->irawfiles) == FL(0.0)) {
@@ -121,7 +121,7 @@ static int32_t getsndinfo(CSOUND *csound, SNDINFO *p, SFLIB_INFO *hdr, int32_t s
         sfinfo.format = (int32_t)FORMAT2SF(csound->oparms->outformat)
                         | (int32_t)TYPE2SF(TYP_RAW);
         /* try again */
-        sf = sflib_open(sfname, SFM_READ, &sfinfo);
+        sf = csound->SndfileOpen(csound,sfname, SFM_READ, &sfinfo);
       }
     }
     if (UNLIKELY(sf == NULL && csFileType == CSFTYPE_UNKNOWN)) {
@@ -272,14 +272,14 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
     if (UNLIKELY(fd == NULL)) {
       /* RWD 5:2001 better to exit in this situation ! */
       return csound->InitError(csound, Str("diskinfo cannot open %s: %s"),
-                               sfname, Str(sflib_strerror(NULL)));
+                               sfname, Str(csound->SndfileStrError(csound,NULL)));
     }
     if (channel <= 0) {
-      if (csound->FileCommand(csound,sf, SFC_GET_SIGNAL_MAX, &peakVal, sizeof(double))
+      if (csound->SndfileCommand(csound,sf, SFC_GET_SIGNAL_MAX, &peakVal, sizeof(double))
           == SFLIB_FALSE) {
         csound->Warning(csound, Str("%s: no PEAK chunk was found, scanning "
                                     "file for maximum amplitude"), sfname);
-        if (csound->FileCommand(csound,sf, SFC_CALC_NORM_SIGNAL_MAX,
+        if (csound->SndfileCommand(csound,sf, SFC_CALC_NORM_SIGNAL_MAX,
                        &peakVal, sizeof(double)) != 0)
           peakVal = -1.0;
       }
@@ -293,10 +293,10 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
                                 "of channels in file"));
       nBytes = sizeof(double)* sfinfo.channels;
       peaks = (double*)csound->Malloc(csound, nBytes);
-      if (csound->FileCommand(csound,sf, SFC_GET_MAX_ALL_CHANNELS, peaks, nBytes) == SFLIB_FALSE) {
+      if (csound->SndfileCommand(csound,sf, SFC_GET_MAX_ALL_CHANNELS, peaks, nBytes) == SFLIB_FALSE) {
         csound->Warning(csound, Str("%s: no PEAK chunk was found, scanning "
                                     "file for maximum amplitude"), sfname);
-        if (csound->FileCommand(csound,sf, SFC_CALC_NORM_MAX_ALL_CHANNELS, peaks, nBytes) == 0)
+        if (csound->SndfileCommand(csound,sf, SFC_CALC_NORM_MAX_ALL_CHANNELS, peaks, nBytes) == 0)
           peakVal = peaks[channel - 1];
       }
       csound->Free(csound, peaks);

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -130,7 +130,7 @@ static int32_t getsndinfo(CSOUND *csound, SNDINFO *p, SFLIB_INFO *hdr, int32_t s
     if (sf != NULL) {
       csFileType = sftype2csfiletype(sfinfo.format);
       memcpy(hdr, &sfinfo, sizeof(SFLIB_INFO));
-      sflib_close(sf);
+      csound->SndfileClose(csound,sf);
     }
     /* FIXME: PVOC_OpenFile has already notified since it calls
        FileOpen(), even if the file was not a PVOC file. */

--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -26,6 +26,7 @@
              ugens to retrieve info about a sound file */
 
 #include "csoundCore.h"
+#include "soundfile.h"
 #include "soundio.h"
 #include "sndinfUG.h"
 #include "pvfileio.h"

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -280,7 +280,7 @@ static int32_t outfile(CSOUND *csound, OUTFILE *p)
     if (p->buf_pos >= p->guard_pos) {
       if (p->f.async==1)
         csound->WriteAsync(csound, p->f.fd, buf, p->buf_pos);
-      else //sflib_write_MYFLT(p->f.sf, buf, p->buf_pos);
+      else //csound->SndfileWriteSamples(csound, p->f.sf, buf, p->buf_pos);
         csound->SndfileWrite(csound, p->f.sf, buf, p->buf_pos/nargs); // in frames
       p->buf_pos = 0;
     }
@@ -318,7 +318,7 @@ static int32_t outfile_array(CSOUND *csound, OUTFILEA *p)
       if (p->f.async==1)
         csound->WriteAsync(csound, p->f.fd, buf, p->buf_pos);
       else
-        //sflib_write_MYFLT(p->f.sf, buf, p->buf_pos);
+        //csound->SndfileWriteSamples(csound, p->f.sf, buf, p->buf_pos);
         csound->SndfileWrite(csound, p->f.sf, (MYFLT *) buf, p->buf_pos/nargs); // in frames
       p->buf_pos = 0;
     }
@@ -368,7 +368,7 @@ static int32_t fout_flush_callback(CSOUND *csound, void *p_)
     if (p->f.async == 1)
       csound->WriteAsync(csound, p->f.fd, (MYFLT *) p->buf.auxp, p->buf_pos);
     else
-      // sflib_write_MYFLT(p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos);
+      // csound->SndfileWriteSamples(csound, p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos);
       csound->SndfileWrite(csound, p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos/p->nargs); // in frames
   }
   return fout_deinit(csound, &(p->f));
@@ -382,7 +382,7 @@ static int32_t fouta_flush_callback(CSOUND *csound, void *p_)
     if (p->f.async == 1)
       csound->WriteAsync(csound, p->f.fd, (MYFLT *) p->buf.auxp, p->buf_pos);
     else
-      // sflib_write_MYFLT(p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos);
+      // csound->SndfileWriteSamples(csound, p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos);
       csound->SndfileWrite(csound, p->f.sf, (MYFLT *) p->buf.auxp, p->buf_pos/p->tabin->sizes[0]); // in frames
   }
   return fout_deinit(csound, &(p->f));
@@ -501,7 +501,7 @@ static int32_t koutfile(CSOUND *csound, KOUTFILE *p)
   if (p->buf_pos >= p->guard_pos) {
     if (p->f.async==1)
       csound->WriteAsync(csound, p->f.fd, buf, p->buf_pos);
-    else //sflib_write_MYFLT(p->f.sf, buf, p->buf_pos);
+    else //csound->SndfileWriteSamples(csound, p->f.sf, buf, p->buf_pos);
       csound->SndfileWrite(csound, p->f.sf, (MYFLT *) buf, p->buf_pos/nargs); // in frames
     p->buf_pos = 0;
   }

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -218,9 +218,9 @@ static CS_NOINLINE FOUT_FILE *fout_open_file(CSOUND *csound, FOUT_FILE *p, void 
     }
     if (!do_scale) {
 #ifdef USE_DOUBLE
-      csound->FileCommand(csound,sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
+      csound->SndfileCommand(csound,sf, SFC_SET_NORM_DOUBLE, NULL, SFLIB_FALSE);
 #else
-      csound->FileCommand(csound,sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
+      csound->SndfileCommand(csound,sf, SFC_SET_NORM_FLOAT, NULL, SFLIB_FALSE);
 #endif
     }
     pp->file_opened[idx].file = sf;

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -39,6 +39,8 @@ static CS_NOINLINE int32_t fout_deinit(CSOUND *csound, FOUT_FILE *p)
     struct fileinTag  *pp;
     STDOPCOD_GLOBALS *ppp = (STDOPCOD_GLOBALS*) csound->QueryGlobalVariable(csound,
                                                                             "STDOPC_GLOBALS");
+    OPARMS oparms;
+    csound->GetOParms(csound, &oparms);
     p->sf = (SNDFILE*) NULL;
     p->f = (FILE*) NULL;
     if (p->idx) {
@@ -57,7 +59,7 @@ static CS_NOINLINE int32_t fout_deinit(CSOUND *csound, FOUT_FILE *p)
           pp->refCount = 0U;
 
           if (pp->fd != NULL) {
-            if ((ppp->oparms.msglevel & 7) == 7)
+            if ((oparms.msglevel & 7) == 7)
               csound->Message(csound, Str("Closing file '%s'...\n"),
                               csound->GetFileName(pp->fd));
             csound->FileClose(csound, pp->fd);
@@ -79,6 +81,8 @@ static CS_NOINLINE FOUT_FILE *fout_open_file(CSOUND *csound, FOUT_FILE *p, void 
     csound->QueryGlobalVariable(csound,"STDOPC_GLOBALS");
   char              *name;
   int32_t               idx, csFileType;
+  OPARMS oparms;
+  csound->GetOParms(csound, &oparms);
 
 
   if (p != (FOUT_FILE*) NULL) p->async = 0;
@@ -180,7 +184,7 @@ static CS_NOINLINE FOUT_FILE *fout_open_file(CSOUND *csound, FOUT_FILE *p, void 
     if (fileType == CSFILE_SND_W) {
       do_scale = ((SFLIB_INFO*) fileParams)->format;
       csFileType = csound->SndfileType2CsfileType(do_scale);
-      if (pp->oparms.realtime == 0 || forceSync == 1) {
+      if (oparms.realtime == 0 || forceSync == 1) {
         fd = csound->FileOpen(csound, &sf, fileType, name, fileParams,
                                "SFDIR", csFileType, 0);
         p->async = 0;
@@ -195,7 +199,7 @@ static CS_NOINLINE FOUT_FILE *fout_open_file(CSOUND *csound, FOUT_FILE *p, void 
       p->nchnls = ((SFLIB_INFO*) fileParams)->channels;
     }
     else {
-      if (pp->oparms.realtime == 0 || forceSync == 1) {
+      if (oparms.realtime == 0 || forceSync == 1) {
         fd = csound->FileOpen(csound, &sf, fileType, name, fileParams,
                                "SFDIR;SSDIR", CSFTYPE_UNKNOWN_AUDIO, 0);
         p->async = 0;
@@ -395,20 +399,22 @@ static int32_t outfile_set_S(CSOUND *csound, OUTFILE *p)
   int32_t istring = 1;
   STDOPCOD_GLOBALS *pp = (STDOPCOD_GLOBALS*) csound->QueryGlobalVariable(csound,
                                                                          "STDOPC_GLOBALS");
-
+  OPARMS oparms;
+  csound->GetOParms(csound, &oparms);
+  
   memset(&sfinfo, 0, sizeof(SFLIB_INFO));
   format_ = (int32_t) MYFLT2LRND(*p->iflag);
   if (format_ >= 51)
     sfinfo.format = AE_SHORT | TYP2SF(TYP_RAW);
   else if (format_ < 0) {
-    sfinfo.format = FORMAT2SF(pp->oparms.outformat);
-    sfinfo.format |= TYPE2SF(pp->oparms.filetyp);
+    sfinfo.format = FORMAT2SF(oparms.outformat);
+    sfinfo.format |= TYPE2SF(oparms.filetyp);
   }
   else sfinfo.format = fout_format_table[format_];
   if (!SF2FORMAT(sfinfo.format))
-    sfinfo.format |= FORMAT2SF(pp->oparms.outformat);
+    sfinfo.format |= FORMAT2SF(oparms.outformat);
   if (!SF2TYPE(sfinfo.format))
-    sfinfo.format |= TYPE2SF(pp->oparms.filetyp);
+    sfinfo.format |= TYPE2SF(oparms.filetyp);
   sfinfo.samplerate = (int32_t) MYFLT2LRND(CS_ESR);
   p->nargs = p->INOCOUNT - 2;
   p->buf_pos = 0;
@@ -445,21 +451,23 @@ static int32_t outfile_set_A(CSOUND *csound, OUTFILEA *p)
   int32_t len = p->tabin->sizes[0];
 
   STDOPCOD_GLOBALS *pp = (STDOPCOD_GLOBALS*) csound->QueryGlobalVariable(csound,
-                                                                         "STDOPC_GLOBALS");    
+                                                                         "STDOPC_GLOBALS");
+  OPARMS oparms;
+  csound->GetOParms(csound, &oparms);
   memset(&sfinfo, 0, sizeof(SFLIB_INFO));
   format_ = (int32_t) MYFLT2LRND(*p->iflag);
   if (format_ >=  51)
     sfinfo.format = AE_SHORT | TYP2SF(TYP_RAW);
   else if (format_ < 0) {
-    sfinfo.format = FORMAT2SF(pp->oparms.outformat);
-    sfinfo.format |= TYPE2SF(pp->oparms.filetyp);
+    sfinfo.format = FORMAT2SF(oparms.outformat);
+    sfinfo.format |= TYPE2SF(oparms.filetyp);
   }
   else
     sfinfo.format = fout_format_table[format_];
   if (!SF2FORMAT(sfinfo.format))
-    sfinfo.format |= FORMAT2SF(pp->oparms.outformat);
+    sfinfo.format |= FORMAT2SF(oparms.outformat);
   if (!SF2TYPE(sfinfo.format))
-    sfinfo.format |= TYPE2SF(pp->oparms.filetyp);
+    sfinfo.format |= TYPE2SF(oparms.filetyp);
   sfinfo.samplerate = (int32_t) MYFLT2LRND(CS_ESR);
   p->buf_pos = 0;
 

--- a/Opcodes/stdopcod.c
+++ b/Opcodes/stdopcod.c
@@ -50,7 +50,6 @@ int32_t stdopc_ModuleInit(CSOUND *csound)
     } else return CSOUND_SUCCESS;  // already initialised
     
     p->csound = csound;
-    csound->GetOParms(csound, &p->oparms);
     /* fout.c */
     p->file_opened = (struct fileinTag*) NULL;
     p->file_num = -1;

--- a/Opcodes/stdopcod.h
+++ b/Opcodes/stdopcod.h
@@ -74,7 +74,7 @@ typedef struct STDOPCOD_GLOBALS_ {
     MYFLT       *tb[16];       /* gab: updated */
     int32_t         tb_ixmode[16]; /* gab: added */
     int32       tb_size[16];   /* gab: added */
-    OPARMS  oparms;
+  //OPARMS  oparms;
 } STDOPCOD_GLOBALS;
 
 extern int32_t ambicode_init_(CSOUND *);

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -462,7 +462,6 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
   for (part = 0; part < p->numPartitions; part++) {
     int32_t start_chn = channel != ALLCHNLS ? channel-1 : 0;
     int64_t nframes;
-    MYFLT odbfs = csound->Get0dBFS(csound);
     /* get the block of input frames */ 
     if (UNLIKELY((nframes = csound->SndfileRead(csound, infd, inbuf,
                                                 p->Hlen)) <= 0))
@@ -476,7 +475,7 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
       fp1 = inbuf + i;
       fp2 = IRblock;
       for (j = 0; j < nframes/p->nchanls; j++) {
-        *fp2++ = (*fp1*odbfs) * scaleFac;
+        *fp2++ = *fp1 * scaleFac;
         fp1 += p->nchanls;
       }
 

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -460,7 +460,7 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
   
   /* form each partition and take its FFT */
   for (part = 0; part < p->numPartitions; part++) {
-    int32_t start_chn = channel != ALLCHNLS ? channel : 0;
+    int32_t start_chn = channel != ALLCHNLS ? channel-1 : 0;
     int64_t nframes;
     MYFLT odbfs = csound->Get0dBFS(csound);
     /* get the block of input frames */ 

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -383,59 +383,53 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
 {
   int32_t     channel = (*(p->channel) <= 0 ? ALLCHNLS : (int32_t) *(p->channel));
   SNDFILE *infd;
-  SOUNDIN IRfile;
+  SFLIB_INFO  IRinfo;
   MYFLT   *inbuf, *fp1,*fp2;
-  int32    i, j, read_in, part;
+  int32   i, j, part;
   MYFLT   *IRblock;
   MYFLT   ainput_dur, scaleFac;
   MYFLT   partitionSize;
   STDOPCOD_GLOBALS  *pp =  (STDOPCOD_GLOBALS*)
     csound->QueryGlobalVariable(csound,"STDOPC_GLOBALS");
+  char *sfname = NULL;
 
-
-  /* IV - 2005-04-06: fixed bug: was uninitialised */
-  memset(&IRfile, 0, sizeof(SOUNDIN));
-  /* open impulse response soundfile [code derived from SAsndgetset()] */
-  IRfile.skiptime = FL(0.0);
-
-  if (stringname==0){
+  if (stringname==0){ 
     if (IsStringCode(*p->ifilno))
-      strncpy(IRfile.sfname,csound->GetString(csound, *p->ifilno), 511);
-    else csound->StringArg2Name(csound, IRfile.sfname, p->ifilno, "soundin.",0);
+      sfname = csound->Strdup(csound, csound->GetString(csound, *p->ifilno));
+    else 
+      csound->StringArg2Name(csound, sfname, p->ifilno, "soundin.",0);
   }
-  else strncpy(IRfile.sfname, ((STRINGDAT *)p->ifilno)->data, 511);
+  else sfname = ((STRINGDAT *)p->ifilno)->data;
 
-  IRfile.sr = 0;
+
   if (UNLIKELY(channel < 1 || ((channel > 4) && (channel != ALLCHNLS)))) {
     return csound->InitError(csound, Str("channel request %d illegal"), channel);
   }
-  IRfile.channel = channel;
-  IRfile.analonly = 1;
-  if (UNLIKELY((infd = csound->SndInputOpen(csound, &IRfile)) == NULL)) {
+
+  if (UNLIKELY((infd = csound->SndfileOpen(csound, sfname, SFM_READ, &IRinfo)) == NULL)) {
     return csound->InitError(csound, "%s", Str("pconvolve: error while impulse file"));
   }
 
-  if (UNLIKELY(IRfile.framesrem < 0)) {
+  if (UNLIKELY(IRinfo.frames < 0)) {
     csound->Warning(csound, "%s", Str("undetermined file length, "
                                       "will attempt requested duration"));
     ainput_dur = FL(0.0);     /* This is probably wrong -- JPff */
   }
   else {
-    IRfile.getframes = IRfile.framesrem;
-    if (UNLIKELY(IRfile.sr==0)) return csound->InitError(csound, "%s", Str("SR zero"));
-    ainput_dur = (MYFLT) IRfile.getframes / IRfile.sr;
+    if (UNLIKELY(IRinfo.samplerate==0)) return csound->InitError(csound, "%s", Str("SR zero"));
+    ainput_dur = (MYFLT) IRinfo.frames / IRinfo.samplerate;
   }
 
   csound->Warning(csound, Str("analyzing %ld sample frames (%3.1f secs)\n"),
-                  (long) IRfile.getframes, ainput_dur);
+                  (long) IRinfo.frames, ainput_dur);
 
-  p->nchanls = (channel != ALLCHNLS ? 1 : IRfile.nchanls);
+  p->nchanls = (channel != ALLCHNLS ? 1 : IRinfo.channels);
   if (UNLIKELY(p->nchanls != (int32_t)p->OUTOCOUNT)) {
     return csound->InitError(csound, "%s", Str("PCONVOLVE: number of output channels "
                                                "not equal to input channels"));
   }
 
-  if (UNLIKELY(IRfile.sr != CS_ESR)) {
+  if (UNLIKELY(IRinfo.samplerate != (int32_t) CS_ESR)) {
     /* ## RWD suggests performing sr conversion here! */
     csound->Warning(csound, "%s", Str("IR srate != orch's srate"));
   }
@@ -453,32 +447,34 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
   p->Hlenpadded = 2*p->Hlen;
 
   /* determine the number of partitions */
-  p->numPartitions = CEIL((MYFLT)(IRfile.getframes) / (MYFLT)p->Hlen);
+  p->numPartitions = CEIL((MYFLT)(IRinfo.frames) / (MYFLT)p->Hlen);
 
   /* set up FFT tables */
   inbuf = (MYFLT *) csound->Malloc(csound,
-                                   p->Hlen * p->nchanls * sizeof(MYFLT));
+                                   p->Hlen * IRinfo.channels  * sizeof(MYFLT));
   csound->AuxAlloc(csound, p->numPartitions * (p->Hlenpadded + 2) *
                    sizeof(MYFLT) * p->nchanls, &p->H);
   IRblock = (MYFLT *)p->H.auxp;
   p->fwdsetup = csound->RealFFTSetup(csound,p->Hlenpadded, FFT_FWD);
   p->invsetup = csound->RealFFTSetup(csound,p->Hlenpadded, FFT_INV);
+  
   /* form each partition and take its FFT */
   for (part = 0; part < p->numPartitions; part++) {
-    /* get the block of input samples and normalize -- soundin code
-       handles finding the right channel */
-    if (UNLIKELY((read_in = csound->SndInputRead(csound, infd, inbuf,
-                                                 p->Hlen*p->nchanls, &IRfile)) <= 0))
+    int32_t start_chn = channel != ALLCHNLS ? channel : 0;
+    int64_t nframes;
+    /* get the block of input frames */ 
+    if (UNLIKELY((nframes = csound->SndfileRead(csound, infd, inbuf,
+                                                p->Hlen) <= 0)))
       return csound->InitError(csound,
                                "%s", Str("PCONVOLVE: less sound than expected!"));
 
     /* take FFT of each channel */
     scaleFac = CS_ONEDDBFS
       * csound->GetInverseRealFFTScale(csound, (int32_t) p->Hlenpadded);
-    for (i = 0; i < p->nchanls; i++) {
+    for (i = start_chn; i < p->nchanls; i++) {
       fp1 = inbuf + i;
       fp2 = IRblock;
-      for (j = 0; j < read_in/p->nchanls; j++) {
+      for (j = 0; j < nframes/p->nchanls; j++) {
         *fp2++ = *fp1 * scaleFac;
         fp1 += p->nchanls;
       }
@@ -491,7 +487,7 @@ static int32_t pconvset_(CSOUND *csound, PCONVOLVE *p, int32_t stringname)
   }
 
   csound->Free(csound, inbuf);
-  csound->FileClose(csound, IRfile.fd);
+  csound->SndfileClose(csound, infd);
 
   /* allocate the buffer saving recent input samples */
   csound->AuxAlloc(csound, p->Hlen * sizeof(MYFLT), &p->savedInput);

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -25,7 +25,9 @@
 #include <exception>
 
 #include "csound.hpp"
+#include "csound_files.h"
 #include "csPerfThread.hpp"
+#include "soundfile.h"
 #include "soundio.h"
 
 #include "csoundCore.h"
@@ -201,6 +203,7 @@ extern "C" {
   static uintptr_t recordThread_(void *recordData_)
   {
     recordData_t *recordData = (recordData_t *)recordData_;
+    CSOUND *csound = recordData->csound;
     int retval = 0;
     const int bufsize = 4096;
     MYFLT buf[bufsize];
@@ -212,13 +215,8 @@ extern "C" {
         do {
             sampsread = csoundReadCircularBuffer(NULL, recordData->cbuf,
                                                  buf, bufsize);
-#ifdef USE_DOUBLE
-            sflib_write_double((SNDFILE *) recordData->sfile,
+            csound->SndfileWriteSamples(csound, (SNDFILE *) recordData->sfile,
                             buf, sampsread);
-#else
-            sflib_write_float((SNDFILE *) recordData->sfile,
-                           buf, sampsread);
-#endif
         } while(sampsread != 0);
                 csoundUnlockMutex (recordData->mutex);
     }
@@ -245,6 +243,7 @@ public:
         if (!csound) {
             return;
         }
+        recordData->csound = csound;
         int bufsize = csoundGetOutputBufferSize(csound)
                 * csoundGetNchnls(csound) * numbufs;
         recordData->cbuf = csoundCreateCircularBuffer(csound,
@@ -274,7 +273,7 @@ public:
 
         sflib_info.format |= TYPE2SF(TYP_WAV);
 
-        recordData->sfile = (void *) sflib_open(filename.c_str(),
+        recordData->sfile = (void *) csound->SndfileOpen(csound,filename.c_str(),
                                                  SFM_WRITE,
                                                  &sflib_info);
         if (!recordData->sfile) {
@@ -303,7 +302,7 @@ public:
         CsoundPerformanceThreadMessage::lockRecord();
         recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
         if (recordData->sfile) {
-            sflib_close((SNDFILE *) recordData->sfile);
+            csound->SndfileClose(csound,(SNDFILE *) recordData->sfile);
             recordData->sfile = NULL;
         }
         CsoundPerformanceThreadMessage::unlockRecord();
@@ -323,16 +322,17 @@ public:
 
       CsoundPerformanceThreadMessage::lockRecord();
       recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
+      CSOUND *csound = recordData->csound;
       if (recordData->running) {
           recordData->running = false;
           csoundJoinThread(recordData->thread);
          /* VL: This appears to break the recording process
           needs to be investigated. I'm reverting the old code for now.
            */
-          sflib_close((SNDFILE *) recordData->sfile);
+          csound->SndfileClose(csound,(SNDFILE *) recordData->sfile);
           /*
           if (recordData->sfile) {
-            sflib_close((SNDFILE *) recordData->sfile);
+            csound->SndfileClose(csound,(SNDFILE *) recordData->sfile);
             recordData->sfile = NULL;
           }
           */

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -184,7 +184,7 @@ void print_csound_version(CSOUND* csound)
 void print_sndfile_version(CSOUND* csound) {
 #ifdef USE_LIBSNDFILE
   char buffer[128];
-  sflib_command(NULL, SFC_GET_LIB_VERSION, buffer, 128);
+  csound->FileCommand(csound, NULL, SFC_GET_LIB_VERSION, buffer, 128);
   csoundErrorMsg(csound, "%s\n", buffer);
 #else
   csoundErrorMsg(csound, "%s\n", "No soundfile IO");
@@ -246,9 +246,51 @@ static int32_t sndfileRead(CSOUND *csound, void *h, MYFLT *p, int32_t frames){
   return sflib_readf_MYFLT(h,p,frames); 
 }
 
+static int64_t sndfileWriteSamples(CSOUND *csound, void *h, MYFLT *p, int64_t samples){
+  IGN(csound);
+  return sflib_write_MYFLT(h,p,samples); 
+}
+
+static int64_t sndfileReadSamples(CSOUND *csound, void *h, MYFLT *p, int64_t samples){
+  IGN(csound);
+  return sflib_read_MYFLT(h,p,samples); 
+}
+
+
 static int32_t sndfileSeek(CSOUND *csound, void *h, int32_t frames, int32_t whence){
+  IGN(csound);
   return sflib_seek(h, frames, whence);
 }
+
+static void *sndfileOpen(CSOUND *csound, const char *path, int32_t mode,
+                         SFLIB_INFO *sfinfo){
+  IGN(csound);
+  return sflib_open(path, mode, sfinfo);
+}
+
+
+static void *sndfileOpenFd(CSOUND *csound,
+                          int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
+                           int32_t close_desc){
+  IGN(csound);
+  return sflib_open_fd(fd, mode, sfinfo, close_desc);
+}
+
+static void sndfileClose(CSOUND *csound, void *sndfile) {
+  IGN(csound);
+   sflib_close(sndfile);
+}
+
+static int32_t sndfileSetString(CSOUND *csound, void *sndfile, int32_t str_type, const char* str){
+  IGN(csound);
+  return sflib_set_string(sndfile, str_type, str);
+}
+
+static const char *sndfileStrError(CSOUND *csound, void *sndfile){
+  IGN(csound);
+  return sflib_strerror(sndfile);
+}
+
 
 #define MAX_MODULES 64
 
@@ -454,9 +496,16 @@ static const CSOUND cenviron_ = {
   csoundFileOpenWithType,
   csoundNotifyFileOpened,
   csoundFileClose,
+  sndfileOpen,
+  sndfileOpenFd,
+  sndfileClose,  
   sndfileWrite,
   sndfileRead,
+  sndfileWriteSamples,
+  sndfileReadSamples,
   sndfileSeek,
+  sndfileSetString,
+  sndfileStrError,
   csoundFileCommand,
   csoundFileError,    
   csoundFileOpenWithType_Async,

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -270,9 +270,9 @@ static void *sndfileOpenFd(CSOUND *csound,
   return sflib_open_fd(fd, mode, sfinfo, close_desc);
 }
 
-static void sndfileClose(CSOUND *csound, void *sndfile) {
+static int32_t sndfileClose(CSOUND *csound, void *sndfile) {
   IGN(csound);
-   sflib_close(sndfile);
+  return sflib_close(sndfile);
 }
 
 static int32_t sndfileSetString(CSOUND *csound, void *sndfile, int32_t str_type, const char* str){
@@ -291,6 +291,40 @@ static int32_t sndfileCommand(CSOUND *csound, void *handle,
 
 }
 
+PUBLIC void csoundSetSndfileCallbacks(CSOUND *csound, SNDFILE_CALLBACKS *p){
+  if(p == NULL) {
+    csound->SndfileOpen = sndfileOpen;
+    csound->SndfileOpenFd = sndfileOpenFd;   
+    csound->SndfileClose = sndfileClose; 
+    csound->SndfileWrite = sndfileWrite;
+    csound->SndfileRead = sndfileRead;
+    csound->SndfileWriteSamples = sndfileWriteSamples;
+    csound->SndfileReadSamples = sndfileReadSamples;
+    csound->SndfileSeek = sndfileSeek;
+    csound->SndfileSetString = sndfileSetString;
+    csound->SndfileStrError = sndfileStrError;
+    csound->SndfileCommand = sndfileCommand;
+  } else {
+    csound->SndfileOpen = p->sndfileOpen ? p->sndfileOpen : sndfileOpen;
+    csound->SndfileOpenFd = p->sndfileOpenFd ?
+      p->sndfileOpenFd :sndfileOpenFd;   
+    csound->SndfileClose = p->sndfileClose ? p->sndfileClose : sndfileClose; 
+    csound->SndfileWrite = p->sndfileWrite ? p->sndfileWrite : sndfileWrite;
+    csound->SndfileRead = p->sndfileRead ? p->sndfileRead : sndfileRead;
+    csound->SndfileWriteSamples = p->sndfileWriteSamples ?
+      p->sndfileWriteSamples : sndfileWriteSamples;
+    csound->SndfileReadSamples = p->sndfileReadSamples ?
+      p->sndfileReadSamples : sndfileReadSamples;
+    csound->SndfileSeek =  csound->SndfileSeek ?
+      csound->SndfileSeek : sndfileSeek;
+    csound->SndfileSetString = csound->SndfileSetString ?
+      csound->SndfileSetString : sndfileSetString;
+    csound->SndfileStrError = csound->SndfileStrError?
+      csound->SndfileStrError : sndfileStrError;
+    csound->SndfileCommand = csound->SndfileCommand?
+      csound->SndfileCommand :sndfileCommand;
+  }
+}
 
 #define MAX_MODULES 64
 

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -524,9 +524,6 @@ static const CSOUND cenviron_ = {
   /* File access */
   csoundFindInputFile,
   csoundFindOutputFile,
-  SAsndgetset,
-  sndgetset,
-  getsndin,
   csoundFileOpenWithType,
   csoundNotifyFileOpened,
   csoundFileClose,
@@ -604,6 +601,9 @@ static const CSOUND cenviron_ = {
   csoundGetUtilityDescription,
   set_util_sr,
   set_util_nchnls,
+  SAsndgetset,
+  sndgetset,
+  getsndin,
   /* displays & graphs */
   dispset,
   display,

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -380,7 +380,10 @@ PUBLIC const CS_TYPE *GetType(CSOUND *csound, const char *type) {
   return csoundGetTypeWithVarTypeName(csound->typePool, type);
 }
 
- 
+const CSOUND_UTIL *csoundGetCsoundUtility(CSOUND *csound) {
+  return &csound->csound_util;
+}
+
 static const CSOUND cenviron_ = {
   /* attributes  */
   csoundGetNchnls,
@@ -593,17 +596,6 @@ static const CSOUND cenviron_ = {
   csoundSetExternalMidiErrorStringCallback,
   csoundSetMIDIDeviceListCallback,
   module_list_add,
-  /* utilities */
-  csoundAddUtility,
-  csoundRunUtility,
-  csoundListUtilities,
-  csoundSetUtilityDescription,
-  csoundGetUtilityDescription,
-  set_util_sr,
-  set_util_nchnls,
-  SAsndgetset,
-  sndgetset,
-  getsndin,
   /* displays & graphs */
   dispset,
   display,
@@ -615,6 +607,7 @@ static const CSOUND cenviron_ = {
   csoundSetKillGraphCallback,
   csoundSetExitGraphCallback,
   /* miscellaneous */
+  csoundGetCsoundUtility,
   csoundPow2,
   csoundLocalizeString,
   cs_strtod,
@@ -1109,7 +1102,20 @@ static const CSOUND cenviron_ = {
   0,              /* mode */
   NULL,           /* opcodedir */
   NULL,           /* score_srt */
-  {NULL, NULL, NULL, 0, 0, NULL} /* osc_message_anchor */
+  {NULL, NULL, NULL, 0, 0, NULL}, /* osc_message_anchor */
+  SPINLOCK_INIT,
+  {                /* csound_util */
+   csoundAddUtility,
+  csoundRunUtility,
+  csoundListUtilities,
+  csoundSetUtilityDescription,
+  csoundGetUtilityDescription,
+  set_util_sr,
+  set_util_nchnls,
+  SAsndgetset,
+  sndgetset,
+  getsndin
+  }
 };
 
 void csound_aops_init_tables(CSOUND *cs);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -138,17 +138,11 @@ static const char *csoundFileError(CSOUND *csound, void *ff) {
   switch(f->type) {
   case CSFILE_SND_W:
   case CSFILE_SND_R: 
-    return sflib_strerror(ff);
+    return csound->SndfileStrError(csound, ff);
     break;
   default:
     return "";
   }
-}
-
-static int32_t csoundFileCommand(CSOUND *csound, void *handle,
-                                 int32_t cmd, void *data, int32_t datasize){
-  return sflib_command(handle, cmd, data, datasize);
-
 }
 
 void print_csound_version(CSOUND* csound)
@@ -184,7 +178,7 @@ void print_csound_version(CSOUND* csound)
 void print_sndfile_version(CSOUND* csound) {
 #ifdef USE_LIBSNDFILE
   char buffer[128];
-  csound->FileCommand(csound, NULL, SFC_GET_LIB_VERSION, buffer, 128);
+  csound->SndfileCommand(csound, NULL, SFC_GET_LIB_VERSION, buffer, 128);
   csoundErrorMsg(csound, "%s\n", buffer);
 #else
   csoundErrorMsg(csound, "%s\n", "No soundfile IO");
@@ -289,6 +283,12 @@ static int32_t sndfileSetString(CSOUND *csound, void *sndfile, int32_t str_type,
 static const char *sndfileStrError(CSOUND *csound, void *sndfile){
   IGN(csound);
   return sflib_strerror(sndfile);
+}
+
+static int32_t sndfileCommand(CSOUND *csound, void *handle,
+                                 int32_t cmd, void *data, int32_t datasize){
+  return sflib_command(handle, cmd, data, datasize);
+
 }
 
 
@@ -496,17 +496,6 @@ static const CSOUND cenviron_ = {
   csoundFileOpenWithType,
   csoundNotifyFileOpened,
   csoundFileClose,
-  sndfileOpen,
-  sndfileOpenFd,
-  sndfileClose,  
-  sndfileWrite,
-  sndfileRead,
-  sndfileWriteSamples,
-  sndfileReadSamples,
-  sndfileSeek,
-  sndfileSetString,
-  sndfileStrError,
-  csoundFileCommand,
   csoundFileError,    
   csoundFileOpenWithType_Async,
   csoundReadAsync,
@@ -524,6 +513,18 @@ static const CSOUND cenviron_ = {
   type2string,
   getstrformat,
   sfsampsize,
+  /* sndfile interface */
+  sndfileOpen,
+  sndfileOpenFd,
+  sndfileClose,  
+  sndfileWrite,
+  sndfileRead,
+  sndfileWriteSamples,
+  sndfileReadSamples,
+  sndfileSeek,
+  sndfileSetString,
+  sndfileStrError,
+  sndfileCommand,
   /* generic callbacks */
   csoundRegisterKeyboardCallback,
   csoundRemoveKeyboardCallback,

--- a/Top/main.c
+++ b/Top/main.c
@@ -21,7 +21,7 @@
 #include "soundio.h"
 #include "csmodule.h"
 #include "corfile.h"
-
+#include "soundfile.h"
 #include "csound_orc.h"
 
 #include "cs_par_base.h"

--- a/Top/utility.c
+++ b/Top/utility.c
@@ -118,12 +118,12 @@ PUBLIC int32_t csoundRunUtility(CSOUND *csound, const char *name,
     }
     else
       csound->ErrorMsg(csound, Str("Error: utility not found\n"));
-    lst = csound->ListUtilities(csound);
+    lst = csound->csound_util.ListUtilities(csound);
     if (lst != NULL && lst[0] != NULL) {
       int32_t i;
       csound->Message(csound, Str("The available utilities are:\n"));
       for (i = 0; lst[i] != NULL; i++) {
-        const char *desc = csound->GetUtilityDescription(csound, lst[i]);
+        const char *desc = csound->csound_util.GetUtilityDescription(csound, lst[i]);
         if (desc != NULL)
           csound->Message(csound, "    %s\t%s\n", lst[i], Str(desc));
         else

--- a/include/csPerfThread.hpp
+++ b/include/csPerfThread.hpp
@@ -106,6 +106,7 @@ typedef struct {
     bool running;
     void* condvar;
     void* mutex;
+    CSOUND *csound;
 } recordData_t;
 
 class PUBLIC CsoundPerformanceThread {

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -44,6 +44,12 @@
 #include <setjmp.h>
 #include "csound_type_system.h"
 #include "csound.h"
+#include "csound_files.h"
+#include "csound_graph_display.h"
+#include "csound_circular_buffer.h"
+#include "csound_threads.h"
+#include "csound_compiler.h"
+#include "csound_misc.h"
 #include "csound_server.h"
 #include "cscore.h"
 #include "csound_data_structures.h"
@@ -144,12 +150,7 @@ extern "C" {
   int32_t csoundScoreEvent(CSOUND *, char type, const MYFLT *pFields,
                         long numFields);
 
-#include "csound_files.h"
-#include "csound_graph_display.h"
-#include "csound_circular_buffer.h"
-#include "csound_threads.h"
-#include "csound_compiler.h"
-#include "csound_misc.h"
+
   
 #if defined(__MACH__) || defined(__FreeBSD__) || defined(__DragonFly__)
 #include <xlocale.h>
@@ -1642,7 +1643,7 @@ static inline double PHMOD1(double p) {
     void *(*SndfileOpenFd)(CSOUND *csound,
                           int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
                           int32_t close_desc);
-    void (*SndfileClose)(CSOUND *csound, void *);
+    int32_t (*SndfileClose)(CSOUND *csound, void *);
     int32_t (*SndfileWrite)(CSOUND *, void *, MYFLT *, int32_t);
     int32_t (*SndfileRead)(CSOUND *, void *, MYFLT *, int32_t);
     int64_t (*SndfileWriteSamples)(CSOUND *, void *, MYFLT *, int64_t);
@@ -1722,7 +1723,7 @@ static inline double PHMOD1(double p) {
                                                const char *(*func)(int32_t));
     void (*SetMIDIDeviceListCallback)(CSOUND *csound,
                                       int32_t (*audiodevlist__)(CSOUND *, CS_MIDIDEVICE *list, int32_t isOutput));
-    void (*module_list_add)(CSOUND *, char *, char *);
+    void (*ModuleListAdd)(CSOUND *, char *, char *);
     /**@}*/
 
     /** @name Utility module support */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -56,6 +56,7 @@
 #include "pools.h"
 #include "soundfile.h"
 
+
 #ifndef CSOUND_CSDL_H
 /* VL not sure if we need to check for SSE */
 #if defined(__SSE__) && !defined(EMSCRIPTEN)

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1614,9 +1614,19 @@ static inline double PHMOD1(double p) {
                       const char *, int32_t, int32_t); /* Rename FileOpen */
     void (*NotifyFileOpened)(CSOUND*, const char*, int32_t, int32_t, int32_t);
     int32_t (*FileClose)(CSOUND *, void *);
+    void *(*SndfileOpen)(CSOUND *csound, const char *path, int32_t mode,
+                        SFLIB_INFO *sfinfo);
+    void *(*SndfileOpenFd)(CSOUND *csound,
+                          int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
+                          int32_t close_desc);
+    void (*SndfileClose)(CSOUND *csound, void *);
     int32_t (*SndfileWrite)(CSOUND *, void *, MYFLT *, int32_t);
     int32_t (*SndfileRead)(CSOUND *, void *, MYFLT *, int32_t);
+    int64_t (*SndfileWriteSamples)(CSOUND *, void *, MYFLT *, int64_t);
+    int64_t (*SndfileReadSamples)(CSOUND *, void *, MYFLT *, int64_t);
     int32_t (*SndfileSeek)(CSOUND *, void *, int32_t, int32_t);
+    int32_t (*SndfileSetString)(CSOUND *csound, void *sndfile, int32_t str_type, const char* str);
+    const char *(*SndfileStrError)(CSOUND *csound, void *);
     int32_t (*FileCommand)(CSOUND *, void *, int32_t , void *, int32_t );
     const char *(*FileError)(CSOUND *, void *);
     void *(*FileOpenAsync)(CSOUND *, void *, int32_t, const char *, void *,
@@ -1624,7 +1634,7 @@ static inline double PHMOD1(double p) {
     uint32_t (*ReadAsync)(CSOUND *, void *, MYFLT *, int32_t);
     uint32_t (*WriteAsync)(CSOUND *, void *, MYFLT *, int32_t);
     int32_t  (*FSeekAsync)(CSOUND *, void *, int32_t, int32_t);
-    void (*RewriteHeader)(void *ofd);
+    void (*RewriteHeader)(CSOUND *csound, void *ofd);
     SNDMEMFILE *(*LoadSoundFile)(CSOUND *, const char *, void *);
     MEMFIL *(*LoadMemoryFile)(CSOUND *, const char *, int32_t,
                               int32_t (*callback)(CSOUND *, MEMFIL *));

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1608,10 +1608,6 @@ static inline double PHMOD1(double p) {
     char *(*FindInputFile)(CSOUND *, const char *filename, const char *envList);
     char *(*FindOutputFile)(CSOUND *,
                             const char *filename, const char *envList);
-    void *(*SndInputFileOpen)(CSOUND *,
-                              char *, void *, MYFLT *, MYFLT *, MYFLT *, int32_t);
-    void *(*SndInputOpen)(CSOUND *, void *);
-    int32_t (*SndInputRead)(CSOUND *, void *, MYFLT *, int32_t, void *);
     void *(*FileOpen)(CSOUND *, void *, int32_t, const char *, void *,
                       const char *, int32_t, int32_t); /* Rename FileOpen */
     void (*NotifyFileOpened)(CSOUND*, const char*, int32_t, int32_t, int32_t);
@@ -1738,6 +1734,10 @@ static inline double PHMOD1(double p) {
     const char *(*GetUtilityDescription)(CSOUND *, const char *utilName);
     void (*SetUtilSr)(CSOUND *, MYFLT);
     void (*SetUtilNchnls)(CSOUND *, int32_t);
+    void *(*SndinGetSetSA)(CSOUND *,
+                              char *, void *, MYFLT *, MYFLT *, MYFLT *, int32_t);
+    void *(*SndinGetSet)(CSOUND *, void *);
+    int32_t (*Sndin)(CSOUND *, void *, MYFLT *, int32_t, void *);
     /**@}*/
 
     /** @name Displays & graphs support */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1377,8 +1377,28 @@ static inline double PHMOD1(double p) {
     }
     return p;
   }
-  
 
+   /**
+   * Functions used in Csound utilities
+   * can be accessed via csound->GetUtility(csound);
+   */  
+  typedef struct _CSOUND_UTIL {
+    int32_t (*AddUtility)(CSOUND *, const char *name,
+                      int32_t (*UtilFunc)(CSOUND *, int32_t, char **));
+    int32_t (*RunUtility)(CSOUND *, const char *name, int32_t argc, char **argv);
+    char **(*ListUtilities)(CSOUND *);
+    int32_t (*SetUtilityDescription)(CSOUND *, const char *utilName,
+                                 const char *utilDesc);
+    const char *(*GetUtilityDescription)(CSOUND *, const char *utilName);
+    void (*SetUtilSr)(CSOUND *, MYFLT);
+    void (*SetUtilNchnls)(CSOUND *, int32_t);
+    void *(*SndinGetSetSA)(CSOUND *,
+                              char *, void *, MYFLT *, MYFLT *, MYFLT *, int32_t);
+    void *(*SndinGetSet)(CSOUND *, void *);
+    int32_t (*Sndin)(CSOUND *, void *, MYFLT *, int32_t, void *);
+  } CSOUND_UTIL;
+
+  
 
 #include "find_opcode.h"
 
@@ -1722,24 +1742,7 @@ static inline double PHMOD1(double p) {
                                       int32_t (*audiodevlist__)(CSOUND *, CS_MIDIDEVICE *list, int32_t isOutput));
     void (*ModuleListAdd)(CSOUND *, char *, char *);
     /**@}*/
-
-    /** @name Utility module support */
-    /**@{ */
-    int32_t (*AddUtility)(CSOUND *, const char *name,
-                      int32_t (*UtilFunc)(CSOUND *, int32_t, char **));
-    int32_t (*RunUtility)(CSOUND *, const char *name, int32_t argc, char **argv);
-    char **(*ListUtilities)(CSOUND *);
-    int32_t (*SetUtilityDescription)(CSOUND *, const char *utilName,
-                                 const char *utilDesc);
-    const char *(*GetUtilityDescription)(CSOUND *, const char *utilName);
-    void (*SetUtilSr)(CSOUND *, MYFLT);
-    void (*SetUtilNchnls)(CSOUND *, int32_t);
-    void *(*SndinGetSetSA)(CSOUND *,
-                              char *, void *, MYFLT *, MYFLT *, MYFLT *, int32_t);
-    void *(*SndinGetSet)(CSOUND *, void *);
-    int32_t (*Sndin)(CSOUND *, void *, MYFLT *, int32_t, void *);
-    /**@}*/
-
+    
     /** @name Displays & graphs support */
     /**@{ */
     void (*SetDisplay)(CSOUND *, WINDAT *, MYFLT *, int32, char *, int32_t, char *);
@@ -1759,6 +1762,8 @@ static inline double PHMOD1(double p) {
 
     /** @name Miscellaneous */
     /**@{ */
+    /* access functions used in csound utilities */
+    const CSOUND_UTIL *(*GetUtility)(CSOUND *csound);
     /* Fast power of two function from a precomputed table */
     MYFLT (*Pow2)(CSOUND *, MYFLT a);
 #if defined (__CUDACC__) || defined (__MACH__)
@@ -2197,6 +2202,7 @@ static inline double PHMOD1(double p) {
     char *score_srt;
     OSC_MESS osc_message_anchor;
     spin_lock_t osc_spinlock;
+    CSOUND_UTIL csound_util;
     /*struct CSOUND_ **self;*/
     /**@}*/
 #endif  /* __BUILDING_LIBCSOUND */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1614,20 +1614,6 @@ static inline double PHMOD1(double p) {
                       const char *, int32_t, int32_t); /* Rename FileOpen */
     void (*NotifyFileOpened)(CSOUND*, const char*, int32_t, int32_t, int32_t);
     int32_t (*FileClose)(CSOUND *, void *);
-    void *(*SndfileOpen)(CSOUND *csound, const char *path, int32_t mode,
-                        SFLIB_INFO *sfinfo);
-    void *(*SndfileOpenFd)(CSOUND *csound,
-                          int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
-                          int32_t close_desc);
-    void (*SndfileClose)(CSOUND *csound, void *);
-    int32_t (*SndfileWrite)(CSOUND *, void *, MYFLT *, int32_t);
-    int32_t (*SndfileRead)(CSOUND *, void *, MYFLT *, int32_t);
-    int64_t (*SndfileWriteSamples)(CSOUND *, void *, MYFLT *, int64_t);
-    int64_t (*SndfileReadSamples)(CSOUND *, void *, MYFLT *, int64_t);
-    int32_t (*SndfileSeek)(CSOUND *, void *, int32_t, int32_t);
-    int32_t (*SndfileSetString)(CSOUND *csound, void *sndfile, int32_t str_type, const char* str);
-    const char *(*SndfileStrError)(CSOUND *csound, void *);
-    int32_t (*FileCommand)(CSOUND *, void *, int32_t , void *, int32_t );
     const char *(*FileError)(CSOUND *, void *);
     void *(*FileOpenAsync)(CSOUND *, void *, int32_t, const char *, void *,
                            const char *, int32_t, int32_t, int32_t);
@@ -1648,6 +1634,24 @@ static inline double PHMOD1(double p) {
     char *(*GetStrFormat)(int32_t format);
     int32_t (*SndfileSampleSize)(int32_t format);
     /**@}*/
+
+     /** @name Soundfile interface */
+    /**@{ */   
+    void *(*SndfileOpen)(CSOUND *csound, const char *path, int32_t mode,
+                        SFLIB_INFO *sfinfo);
+    void *(*SndfileOpenFd)(CSOUND *csound,
+                          int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
+                          int32_t close_desc);
+    void (*SndfileClose)(CSOUND *csound, void *);
+    int32_t (*SndfileWrite)(CSOUND *, void *, MYFLT *, int32_t);
+    int32_t (*SndfileRead)(CSOUND *, void *, MYFLT *, int32_t);
+    int64_t (*SndfileWriteSamples)(CSOUND *, void *, MYFLT *, int64_t);
+    int64_t (*SndfileReadSamples)(CSOUND *, void *, MYFLT *, int64_t);
+    int32_t (*SndfileSeek)(CSOUND *, void *, int32_t, int32_t);
+    int32_t (*SndfileSetString)(CSOUND *csound, void *sndfile, int32_t str_type, const char* str);
+    const char *(*SndfileStrError)(CSOUND *csound, void *);
+    int32_t (*SndfileCommand)(CSOUND *, void *, int32_t , void *, int32_t );
+    /**@}*/    
 
     /** @name Generic callbacks */
     /**@{ */

--- a/include/csound_files.h
+++ b/include/csound_files.h
@@ -37,8 +37,7 @@ extern "C" {
     int32_t   channels ;
     int32_t   format ;
   } SFLIB_INFO;
-  
-
+ 
   /** 
    * Soundfile interface callbacks
    */

--- a/include/csound_files.h
+++ b/include/csound_files.h
@@ -28,6 +28,38 @@
 extern "C" {
 #endif
 
+  /**
+   * Soundfile interface data
+   */
+  typedef struct sflib_info {
+    long  frames ;     
+    int32_t   samplerate ;
+    int32_t   channels ;
+    int32_t   format ;
+  } SFLIB_INFO;
+  
+
+  /** 
+   * Soundfile interface callbacks
+   */
+  typedef struct sndfileCallbacks {
+    void *(*sndfileOpen)(CSOUND *csound, const char *path, int32_t mode,
+                        SFLIB_INFO *sfinfo);
+    void *(*sndfileOpenFd)(CSOUND *csound,
+                          int32_t fd, int32_t mode, SFLIB_INFO *sfinfo,
+                          int32_t close_desc);
+    int32_t (*sndfileClose)(CSOUND *csound, void *);
+    int32_t (*sndfileWrite)(CSOUND *, void *, MYFLT *, int32_t);
+    int32_t (*sndfileRead)(CSOUND *, void *, MYFLT *, int32_t);
+    int64_t (*sndfileWriteSamples)(CSOUND *, void *, MYFLT *, int64_t);
+    int64_t (*sndfileReadSamples)(CSOUND *, void *, MYFLT *, int64_t);
+    int32_t (*sndfileSeek)(CSOUND *, void *, int32_t, int32_t);
+    int32_t (*sndfileSetString)(CSOUND *csound, void *sndfile, int32_t str_type, const char* str);
+    const char *(*sndfileStrError)(CSOUND *csound, void *);
+    int32_t (*sndfileCommand)(CSOUND *, void *, int32_t , void *, int32_t );
+  } SNDFILE_CALLBACKS;
+  
+
 /**
    * The following constants are used with csound->FileOpen() and
    * csound->ldmemfile() to specify the format of a file that is being
@@ -176,6 +208,19 @@ extern "C" {
   PUBLIC void csoundSetFileOpenCallback(CSOUND *p,
                                         void (*func)(CSOUND*, const char*,
                                                      int32_t, int32_t, int32_t));
+
+  /** 
+   * Sets external callbacks for the soundfile interface
+   * replacing any default callbacks. These functions are used by
+   * Csound to perform soundfile IO throughout the system.
+   * These are set to sndfile.h functions if USE_LIBSNDFILE is defined
+   * otherwise they are set to non-op stubs.
+   * Callbacks are passed via the SNDFILE_CALLBACKS struct.
+   * Any NULL callback pointer will disable setting of the specific callback
+   * If p is NULL then all callbacks are reverted to default values.
+   **/
+  PUBLIC void csoundSetSndfileCallbacks(CSOUND *csound, SNDFILE_CALLBACKS *p);
+  
 #endif
 
 #ifdef __cplusplus

--- a/include/soundfile.h
+++ b/include/soundfile.h
@@ -232,40 +232,5 @@ typedef struct
 } SFLIB_INSTRUMENT ;
 
 typedef long sf_count_t;
-
-#endif // USE_LIBSNDFILE
-
-#ifdef  USE_DOUBLE
-#define sflib_write_MYFLT  sflib_write_double
-#define sflib_writef_MYFLT  sflib_writef_double
-#define sflib_read_MYFLT   sflib_read_double
-#define sflib_readf_MYFLT   sflib_readf_double
-#else
-#define sflib_write_MYFLT  sflib_write_float
-#define sflib_writef_MYFLT  sflib_writef_float
-#define sflib_read_MYFLT   sflib_read_float
-#define sflib_readf_MYFLT   sflib_readf_float
-#endif
- 
-#ifdef __cplusplus
-extern "C" {
-#endif
-  int32_t sflib_command (void *handle, int32_t cmd, void *data, int32_t datasize);
-  void *sflib_open(const char *path, int32_t mode, SFLIB_INFO *sfinfo);
-  void *sflib_open_fd(int32_t fd, int32_t mode, SFLIB_INFO *sfinfo, int32_t close_desc);
-  int32_t sflib_close(void *sndfile);
-  long sflib_seek(void *handle, long frames, int32_t whence);
-  long sflib_read_float(void *sndfile, float *ptr, long items);
-  long sflib_readf_float(void *handle, float *ptr, long frames);
-  long sflib_read_double(void *sndfile, double *ptr, long items);
-  long sflib_readf_double(void *handle, double *ptr, long frames);
-  long sflib_write_float(void *sndfile, float *ptr, long items);
-  long sflib_writef_float(void *handle, float *ptr, long frames);
-  long sflib_write_double(void *handle, double *ptr, long items);
-  long sflib_writef_double(void *handle, double *ptr, long frames);
-  int32_t sflib_set_string(void *sndfile, int32_t str_type, const char* str);
-  const char *sflib_strerror(void *);  
-#ifdef __cplusplus
-}
-#endif  
+#endif // USE_LIBSNDFILE  
 #endif /* _SOUNDFILE_H_ */

--- a/include/soundio.h
+++ b/include/soundio.h
@@ -24,7 +24,7 @@
 #ifndef CSOUND_SOUNDIO_H
 #define CSOUND_SOUNDIO_H
 
-#include "soundfile.h"
+#include "csoundCore.h"
 
 
 #ifdef WIN32

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -572,6 +572,4 @@ typedef int32_t spin_lock_t;
 #else
 # define ignore_value(x) ((void) (x))
 #endif
-
-
 #endif  /* CSOUND_SYSDEP_H */

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -7,7 +7,7 @@ set(stdutil_SRCS
     lpc_export.c    lpc_import.c    mixer.c     pvanal.c
     pv_export.c     pv_import.c     pvlook.c    scale.c
     sndinfo.c       srconv.c        std_util.c  xtrct.c
-    SDIF/sdif.c   ../InOut/soundfile.c)
+    SDIF/sdif.c )
 
 if(BUILD_UTILITIES)
    make_plugin(stdutil "${stdutil_SRCS}" ${MATH_LIBRARY} SndFile::sndfile)

--- a/util/atsa.c
+++ b/util/atsa.c
@@ -533,7 +533,7 @@ static int32_t main_anal(CSOUND *csound, char *soundfile, char *ats_outfile,
                           NULL, CSFTYPE_ATS, 0);
     if (UNLIKELY(fd == NULL)) {
       csound->Die(csound, Str("\nCould not open %s for writing, %s\nbye...\n"),
-                  ats_outfile, Str(sflib_strerror(NULL)));
+                  ats_outfile, Str(csound->SndfileStrError(csound,NULL)));
     }
     /* call tracker */
     sound = tracker(csound, anargs, soundfile, resfile);
@@ -1821,7 +1821,7 @@ static void compute_residual(CSOUND *csound, mus_sample_t **fil,
       csound->Die(csound, Str("\nERROR: cannot open file %s for writing\n"),
                   output_file);
     }
-    sflib_set_string(sf, SF_STR_SOFTWARE, "created by ATSA");
+    csound->SndfileSetString(csound,sf, SF_STR_SOFTWARE, "created by ATSA");
     /* allocate memory */
     obuf = (mus_sample_t **) csound->Malloc(csound, 2 * sizeof(mus_sample_t *));
     obuf[0] =
@@ -2016,7 +2016,7 @@ static ATS_SOUND *tracker(CSOUND *csound, ANARGS *anargs, char *soundfile,
                            "SFDIR;SSDIR", CSFTYPE_UNKNOWN_AUDIO, 0);
     if (UNLIKELY(fd == NULL)) {
       csound->ErrorMsg(csound, Str("atsa: cannot open input file '%s': %s"),
-                       soundfile, Str(sflib_strerror(NULL)));
+                       soundfile, Str(csound->SndfileStrError(csound,NULL)));
       return NULL;
     }
     /* warn about multi-channel sound files */

--- a/util/atsa.c
+++ b/util/atsa.c
@@ -2840,11 +2840,11 @@ static void free_sound(CSOUND *csound, ATS_SOUND *sound)
 
 int32_t atsa_init_(CSOUND *csound)
 {
-    int32_t     retval = csound->AddUtility(csound, "atsa", atsa_main);
+    int32_t     retval = (csound->GetUtility(csound))->AddUtility(csound, "atsa", atsa_main);
 
     if (!retval) {
       retval =
-          csound->SetUtilityDescription(csound, "atsa",
+          (csound->GetUtility(csound))->SetUtilityDescription(csound, "atsa",
                                         Str("Soundfile analysis for ATS opcodes"));
     }
     return retval;

--- a/util/atsa.c
+++ b/util/atsa.c
@@ -40,7 +40,7 @@
 #  endif
 #endif
 
-typedef float mus_sample_t;
+typedef MYFLT mus_sample_t;
 
 /*  window types */
 #define  BLACKMAN   0
@@ -950,7 +950,7 @@ static int32_t peak_smr_dec(void const *a, void const *b)
 }
 #endif
 
-static CS_NOINLINE void atsa_sound_read_noninterleaved(SNDFILE *sf,
+static CS_NOINLINE void atsa_sound_read_noninterleaved(CSOUND *csound, SNDFILE *sf,
                                                        mus_sample_t **bufs,
                                                        int32_t nChannels,
                                                        int32_t nFrames)
@@ -968,9 +968,7 @@ static CS_NOINLINE void atsa_sound_read_noninterleaved(SNDFILE *sf,
           k = m * nChannels;
         }
         if (sizeof(mus_sample_t) == sizeof(float))
-          n = (int) sflib_readf_float(sf, (void *) &(tmpBuf[0]), (sf_count_t) m);
-        else
-          n = (int) sflib_readf_double(sf, (void *) &(tmpBuf[0]), (sf_count_t) m);
+          n = (int) csound->SndfileRead(csound, sf, (void *) &(tmpBuf[0]), (sf_count_t) m);
         if (n < 0)
           n = 0;
         n *= nChannels;
@@ -983,7 +981,7 @@ static CS_NOINLINE void atsa_sound_read_noninterleaved(SNDFILE *sf,
     }
 }
 
-static CS_NOINLINE void atsa_sound_write_noninterleaved(SNDFILE *sf,
+static CS_NOINLINE void atsa_sound_write_noninterleaved(CSOUND *csound, SNDFILE *sf,
                                                         mus_sample_t **bufs,
                                                         int32_t nChannels,
                                                         int32_t nFrames)
@@ -1000,9 +998,7 @@ static CS_NOINLINE void atsa_sound_write_noninterleaved(SNDFILE *sf,
       if (j >= k || i == (nFrames - 1)) {
         n = j / nChannels;
         if (sizeof(mus_sample_t) == sizeof(float))
-          sflib_writef_float(sf, (void *) &(tmpBuf[0]), (sf_count_t) n);
-        else
-          sflib_writef_double(sf, (void *) &(tmpBuf[0]), (sf_count_t) n);
+          n = (int) csound->SndfileWrite(csound, sf, (void *) &(tmpBuf[0]), (sf_count_t) m);
         j = 0;
       }
     }
@@ -1525,7 +1521,7 @@ static void residual_analysis(CSOUND *csound, char *file, ATS_SOUND *sound)
     st_pt = N - M_2;
     filptr = M_2 * -1;
     /* read sound into memory */
-    atsa_sound_read_noninterleaved(sf, bufs, 2, sflen);
+    atsa_sound_read_noninterleaved(csound, sf, bufs, 2, sflen);
 
     for (frame_n = 0; frame_n < frames; frame_n++) {
       for (i = 0; i < (N + 2); i++) {
@@ -1885,7 +1881,7 @@ static void compute_residual(CSOUND *csound, mus_sample_t **fil,
         obuf[0][i] = (mus_sample_t) diff;
         obuf[1][i] = (mus_sample_t) synth;
       }
-      atsa_sound_write_noninterleaved(sf, obuf, 2, frm_samps);
+      atsa_sound_write_noninterleaved(csound, sf, obuf, 2, frm_samps);
     }
     csound->Free(csound, in_buff);
     csound->Free(csound, synth_buff);
@@ -2237,7 +2233,7 @@ static ATS_SOUND *tracker(CSOUND *csound, ANARGS *anargs, char *soundfile,
     /* half a window from first sample */
     filptr = anargs->first_smp - M_2;
     /* read sound into memory */
-    atsa_sound_read_noninterleaved(sf, bufs, 1, sflen);
+    atsa_sound_read_noninterleaved(csound, sf, bufs, 1, sflen);
 
     /* make our fft-struct */
     fft.size = anargs->fft_size;

--- a/util/cvanal.c
+++ b/util/cvanal.c
@@ -113,7 +113,7 @@ static int32_t cvanal(CSOUND *csound, int32_t argc, char **argv)
     infilnam = *argv++;
     outfilnam = *argv;
 
-    if (UNLIKELY((infd = csound->SndInputFileOpen(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       snprintf(err_msg, 512, Str("error while opening %s"), infilnam);
       return quit(csound, err_msg);
@@ -200,7 +200,7 @@ static int32_t takeFFT(CSOUND *csound, SOUNDIN *p, CVSTRUCT *cvh,
     nchanls = cvh->channel != ALLCHNLS ? 1 : cvh->src_chnls;
     j = (int32_t) (Hlen * nchanls);
     inbuf = fp1 = (MYFLT *) csound->Malloc(csound, j * sizeof(MYFLT));
-    if (UNLIKELY((read_in = csound->SndInputRead(csound, infd, inbuf, j, p)) < j)) {
+    if (UNLIKELY((read_in = csound->Sndin(csound, infd, inbuf, j, p)) < j)) {
       csound->Message(csound, "%s", Str("less sound than expected!\n"));
       return -1;
     }

--- a/util/cvanal.c
+++ b/util/cvanal.c
@@ -113,7 +113,7 @@ static int32_t cvanal(CSOUND *csound, int32_t argc, char **argv)
     infilnam = *argv++;
     outfilnam = *argv;
 
-    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = (csound->GetUtility(csound))->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       snprintf(err_msg, 512, Str("error while opening %s"), infilnam);
       return quit(csound, err_msg);
@@ -200,7 +200,7 @@ static int32_t takeFFT(CSOUND *csound, SOUNDIN *p, CVSTRUCT *cvh,
     nchanls = cvh->channel != ALLCHNLS ? 1 : cvh->src_chnls;
     j = (int32_t) (Hlen * nchanls);
     inbuf = fp1 = (MYFLT *) csound->Malloc(csound, j * sizeof(MYFLT));
-    if (UNLIKELY((read_in = csound->Sndin(csound, infd, inbuf, j, p)) < j)) {
+    if (UNLIKELY((read_in = (csound->GetUtility(csound))->Sndin(csound, infd, inbuf, j, p)) < j)) {
       csound->Message(csound, "%s", Str("less sound than expected!\n"));
       return -1;
     }
@@ -283,10 +283,10 @@ static int32_t CVAlloc(
 
 int32_t cvanal_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "cvanal", cvanal);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "cvanal", cvanal);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "cvanal",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "cvanal",
                                       Str("Soundfile analysis for convolve"));
     }
     return retval;

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -417,7 +417,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
                       Str("Must have an example noise file (-i name)\n"));
       return -1;
     }
-    if (UNLIKELY((inf = csound->SndInputFileOpen(csound, infile, &p, &beg_time,
+    if (UNLIKELY((inf = csound->SndinGetSetSA(csound, infile, &p, &beg_time,
                                             &input_dur, &sr, channel)) == NULL)) {
       csound->Message(csound, Str("error while opening %s"), infile);
       return -1;
@@ -480,7 +480,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
 
     /* read noise reference file */
 
-    if (UNLIKELY((fp = csound->SndInputFileOpen(csound, nfile, &pn, &beg_ntime,
+    if (UNLIKELY((fp = csound->SndinGetSetSA(csound, nfile, &pn, &beg_ntime,
                                            &input_ndur, &srn, channel)) == NULL)) {
       csound->Message(csound, "%s",
                       Str("dnoise: cannot open noise reference file\n"));
@@ -760,7 +760,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     while (nMin > (int64_t)ibuflen) {
       if (UNLIKELY(!csound->CheckEvents(csound)))
         csound->LongJmp(csound, 1);
-      nread = csound->SndInputRead(csound, fp, ibuf1, ibuflen, pn);
+      nread = csound->Sndin(csound, fp, ibuf1, ibuflen, pn);
       for(i=0; i < nread; i++)
         ibuf1[i] *= 1.0/csound->Get0dBFS(csound);
       if (UNLIKELY(nread < ibuflen)) {
@@ -771,7 +771,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(!csound->CheckEvents(csound)))
       csound->LongJmp(csound, 1);
     i = (int32_t) nMin;
-    nread = csound->SndInputRead(csound, fp, ibuf1, i, pn);
+    nread = csound->Sndin(csound, fp, ibuf1, i, pn);
     for(i=0; i < nread; i++)
         ibuf1[i] *= 1.0/csound->Get0dBFS(csound);
     if (UNLIKELY(nread < i)) {
@@ -783,7 +783,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
       if (UNLIKELY(!csound->CheckEvents(csound)))
         csound->LongJmp(csound, 1);
       lj += (int64_t) N;
-      nread = csound->SndInputRead(csound, fp, fbuf, N, pn);
+      nread = csound->Sndin(csound, fp, fbuf, N, pn);
       for(i=0; i < nread; i++)
         fbuf[i] *= 1.0/csound->Get0dBFS(csound);
       if (nread < N)
@@ -826,7 +826,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(!csound->CheckEvents(csound)))
       csound->LongJmp(csound, 1);
     /* fill ibuf2 to start */
-    nread = csound->SndInputRead(csound, inf, ibuf2, ibuflen, p);
+    nread = csound->Sndin(csound, inf, ibuf2, ibuflen, p);
 /*     nread = read(inf, ibuf2, ibuflen*sizeof(MYFLT)); */
 /*     nread /= sizeof(MYFLT); */
     for(i=0; i < nread; i++)
@@ -879,7 +879,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
           ib2 = ib0;
           ibs -= ibuflen;
           /* fill ib2 */
-          nread = csound->SndInputRead(csound, inf, ib2, ibuflen, p);
+          nread = csound->Sndin(csound, inf, ib2, ibuflen, p);
           for(i=0; i < nread; i++)
                ib2[i] *= 1.0/csound->Get0dBFS(csound);
           lnread += nread;

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -1197,7 +1197,7 @@ static int32_t writebuffer(CSOUND *csound, SNDFILE *outfd,
     if (UNLIKELY(outfd == NULL)) return 0;
     n = csound->SndfileWriteSamples(csound, outfd, outbuf, nsmps);
     if (UNLIKELY(n < nsmps)) {
-      sflib_close(outfd);
+      csound->SndfileClose(csound,outfd);
       sndwrterr(csound, n, nsmps);
       return -1;
     }

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -460,7 +460,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
       /* register file to be closed by csoundReset() */
       (void)csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W,
                                      O.outfilename);
-      sflib_command(outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->FileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
 
     csound->SetUtilSr(csound, (MYFLT)p->sr);
@@ -1195,14 +1195,14 @@ static int32_t writebuffer(CSOUND *csound, SNDFILE *outfd,
     int32_t n;
 
     if (UNLIKELY(outfd == NULL)) return 0;
-    n = sflib_write_MYFLT(outfd, outbuf, nsmps);
+    n = csound->SndfileWriteSamples(csound, outfd, outbuf, nsmps);
     if (UNLIKELY(n < nsmps)) {
       sflib_close(outfd);
       sndwrterr(csound, n, nsmps);
       return -1;
     }
     if (UNLIKELY(O->rewrt_hdr))
-      csound->RewriteHeader(outfd);
+      csound->RewriteHeader(csound, outfd);
 
     (*nrecs)++;                 /* JPff fix */
     switch (O->heartbeat) {

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -417,7 +417,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
                       Str("Must have an example noise file (-i name)\n"));
       return -1;
     }
-    if (UNLIKELY((inf = csound->SndinGetSetSA(csound, infile, &p, &beg_time,
+    if (UNLIKELY((inf = (csound->GetUtility(csound))->SndinGetSetSA(csound, infile, &p, &beg_time,
                                             &input_dur, &sr, channel)) == NULL)) {
       csound->Message(csound, Str("error while opening %s"), infile);
       return -1;
@@ -463,8 +463,8 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
       csound->SndfileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
 
-    csound->SetUtilSr(csound, (MYFLT)p->sr);
-    csound->SetUtilNchnls(csound, Chans = p->nchanls);
+    (csound->GetUtility(csound))->SetUtilSr(csound, (MYFLT)p->sr);
+    (csound->GetUtility(csound))->SetUtilNchnls(csound, Chans = p->nchanls);
 
     /* read header info */
     if (R < FL(0.0))
@@ -480,7 +480,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
 
     /* read noise reference file */
 
-    if (UNLIKELY((fp = csound->SndinGetSetSA(csound, nfile, &pn, &beg_ntime,
+    if (UNLIKELY((fp = (csound->GetUtility(csound))->SndinGetSetSA(csound, nfile, &pn, &beg_ntime,
                                            &input_ndur, &srn, channel)) == NULL)) {
       csound->Message(csound, "%s",
                       Str("dnoise: cannot open noise reference file\n"));
@@ -760,7 +760,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     while (nMin > (int64_t)ibuflen) {
       if (UNLIKELY(!csound->CheckEvents(csound)))
         csound->LongJmp(csound, 1);
-      nread = csound->Sndin(csound, fp, ibuf1, ibuflen, pn);
+      nread = (csound->GetUtility(csound))->Sndin(csound, fp, ibuf1, ibuflen, pn);
       for(i=0; i < nread; i++)
         ibuf1[i] *= 1.0/csound->Get0dBFS(csound);
       if (UNLIKELY(nread < ibuflen)) {
@@ -771,7 +771,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(!csound->CheckEvents(csound)))
       csound->LongJmp(csound, 1);
     i = (int32_t) nMin;
-    nread = csound->Sndin(csound, fp, ibuf1, i, pn);
+    nread = (csound->GetUtility(csound))->Sndin(csound, fp, ibuf1, i, pn);
     for(i=0; i < nread; i++)
         ibuf1[i] *= 1.0/csound->Get0dBFS(csound);
     if (UNLIKELY(nread < i)) {
@@ -783,7 +783,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
       if (UNLIKELY(!csound->CheckEvents(csound)))
         csound->LongJmp(csound, 1);
       lj += (int64_t) N;
-      nread = csound->Sndin(csound, fp, fbuf, N, pn);
+      nread = (csound->GetUtility(csound))->Sndin(csound, fp, fbuf, N, pn);
       for(i=0; i < nread; i++)
         fbuf[i] *= 1.0/csound->Get0dBFS(csound);
       if (nread < N)
@@ -826,7 +826,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(!csound->CheckEvents(csound)))
       csound->LongJmp(csound, 1);
     /* fill ibuf2 to start */
-    nread = csound->Sndin(csound, inf, ibuf2, ibuflen, p);
+    nread = (csound->GetUtility(csound))->Sndin(csound, inf, ibuf2, ibuflen, p);
 /*     nread = read(inf, ibuf2, ibuflen*sizeof(MYFLT)); */
 /*     nread /= sizeof(MYFLT); */
     for(i=0; i < nread; i++)
@@ -879,7 +879,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
           ib2 = ib0;
           ibs -= ibuflen;
           /* fill ib2 */
-          nread = csound->Sndin(csound, inf, ib2, ibuflen, p);
+          nread = (csound->GetUtility(csound))->Sndin(csound, inf, ib2, ibuflen, p);
           for(i=0; i < nread; i++)
                ib2[i] *= 1.0/csound->Get0dBFS(csound);
           lnread += nread;
@@ -1247,10 +1247,10 @@ static void hamming(MYFLT *win, int32_t winLen, int32_t even)
 
 int32_t dnoise_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "dnoise", dnoise);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "dnoise", dnoise);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "dnoise",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "dnoise",
                                       Str("Removes noise from a sound file"));
     }
     return retval;

--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -445,14 +445,14 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
           csound->Message(csound, Str("cannot open %s.\n"), O.outfilename);
           return -1;
         }
-        outfd = sflib_open(name, SFM_WRITE, &sfinfo);
+        outfd = csound->SndfileOpen(csound,name, SFM_WRITE, &sfinfo);
         if (outfd != NULL)
           csound->NotifyFileOpened(csound, name,
                       csound->Type2CsfileType(O.filetyp, O.outformat), 1, 0);
         csound->Free(csound, name);
       }
       else
-        outfd = sflib_open_fd(1, SFM_WRITE, &sfinfo, 1);
+        outfd = csound->SndfileOpenFd(csound,1, SFM_WRITE, &sfinfo, 1);
       if (UNLIKELY(outfd == NULL)) {
         csound->Message(csound, Str("cannot open %s."), O.outfilename);
         return -1;
@@ -460,7 +460,7 @@ static int32_t dnoise(CSOUND *csound, int32_t argc, char **argv)
       /* register file to be closed by csoundReset() */
       (void)csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W,
                                      O.outfilename);
-      csound->FileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->SndfileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
 
     csound->SetUtilSr(csound, (MYFLT)p->sr);

--- a/util/envext.c
+++ b/util/envext.c
@@ -121,7 +121,7 @@ SCsndgetset(CSOUND *csound, SOUNDIN **pp, char *inputfile)
     p->channel = ALLCHNLS;
     p->skiptime = FL(0.0);
     strNcpy(p->sfname, inputfile, MAXSNDNAME-1);
-    if ((infd = csound->SndInputOpen(csound, p)) == 0) /*open sndfil, do skiptime*/
+    if ((infd = csound->SndinGetSet(csound, p)) == 0) /*open sndfil, do skiptime*/
       return(0);
     p->getframes = p->framesrem;
     dur = (double) p->getframes / p->sr;
@@ -149,7 +149,7 @@ FindEnvelope(CSOUND *csound, SNDFILE *infd, SOUNDIN *p,
     buffer = (MYFLT*) malloc(bufferlen*sizeof(MYFLT));
     tpersample = 1.0/(double)p->sr;
     fprintf(outfile, "%.3f\t%.3f\n", 0.0, 0.0);
-    while ((read_in = csound->SndInputRead(csound,infd,buffer,bufferlen,p)) > 0) {
+    while ((read_in = csound->Sndin(csound,infd,buffer,bufferlen,p)) > 0) {
       max = 0.0;        mxpos = 0;
       min = 0.0;        minpos = 0;
       for (i=0; i<read_in; i++) {

--- a/util/envext.c
+++ b/util/envext.c
@@ -116,12 +116,12 @@ SCsndgetset(CSOUND *csound, SOUNDIN **pp, char *inputfile)
     double  dur;
     SOUNDIN *p;
 
-    csound->SetUtilSr(csound, FL(0.0));      /* set esr 0. with no orchestra   */
+    (csound->GetUtility(csound))->SetUtilSr(csound, FL(0.0));      /* set esr 0. with no orchestra   */
     *pp = p = (SOUNDIN *) csound->Calloc(csound, sizeof(SOUNDIN));
     p->channel = ALLCHNLS;
     p->skiptime = FL(0.0);
     strNcpy(p->sfname, inputfile, MAXSNDNAME-1);
-    if ((infd = csound->SndinGetSet(csound, p)) == 0) /*open sndfil, do skiptime*/
+    if ((infd = (csound->GetUtility(csound))->SndinGetSet(csound, p)) == 0) /*open sndfil, do skiptime*/
       return(0);
     p->getframes = p->framesrem;
     dur = (double) p->getframes / p->sr;
@@ -149,7 +149,7 @@ FindEnvelope(CSOUND *csound, SNDFILE *infd, SOUNDIN *p,
     buffer = (MYFLT*) malloc(bufferlen*sizeof(MYFLT));
     tpersample = 1.0/(double)p->sr;
     fprintf(outfile, "%.3f\t%.3f\n", 0.0, 0.0);
-    while ((read_in = csound->Sndin(csound,infd,buffer,bufferlen,p)) > 0) {
+    while ((read_in = (csound->GetUtility(csound))->Sndin(csound,infd,buffer,bufferlen,p)) > 0) {
       max = 0.0;        mxpos = 0;
       min = 0.0;        minpos = 0;
       for (i=0; i<read_in; i++) {
@@ -171,10 +171,10 @@ FindEnvelope(CSOUND *csound, SNDFILE *infd, SOUNDIN *p,
 
 int32_t envext_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "envext", envext);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "envext", envext);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "envext",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "envext",
                                       Str("Create a text file of envelope"));
     }
     return retval;

--- a/util/envext.c
+++ b/util/envext.c
@@ -163,7 +163,7 @@ FindEnvelope(CSOUND *csound, SNDFILE *infd, SOUNDIN *p,
               block*window+(double)mxpos*tpersample, max/SHORTMAX);
       block++;
     }
-    sflib_close(infd);
+    csound->SndfileClose(csound,infd);
     fclose(outfile);
 }
 

--- a/util/het_export.c
+++ b/util/het_export.c
@@ -78,10 +78,10 @@ static int32_t het_export(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t het_export_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "het_export", het_export);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "het_export", het_export);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "het_export",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "het_export",
                                       Str("translate hetro analysis file "
                                           "to text form"));
     }

--- a/util/het_import.c
+++ b/util/het_import.c
@@ -117,10 +117,10 @@ static int32_t het_import(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t het_import_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "het_import", het_import);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "het_import", het_import);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "het_import",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "het_import",
                                       Str("translate text form to "
                                           "hetro analysis file"));
     }

--- a/util/hetro.c
+++ b/util/hetro.c
@@ -256,7 +256,7 @@ static int32_t hetro(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY((t->input_dur < 0) || (t->beg_time < 0)))
       return quit(csound,Str("input and begin times cannot be less than zero"));
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, t->infilnam, &p,
+    if (UNLIKELY((infd = (csound->GetUtility(csound))->SndinGetSetSA(csound, t->infilnam, &p,
                                     &t->beg_time, &t->input_dur,
                                              &t->sr, channel)) == NULL)) {
       char errmsg[256];
@@ -268,7 +268,7 @@ static int32_t hetro(CSOUND *csound, int32_t argc, char **argv)
     t->auxp = (MYFLT*) csound->Malloc(csound, nsamps * sizeof(MYFLT));
     /* & read them in */
     if (UNLIKELY((t->smpsin =
-                  csound->Sndin(csound, infd,
+                  (csound->GetUtility(csound))->Sndin(csound, infd,
                                    t->auxp, nsamps, p)) <= 0)) {
       char errmsg[256];
       csound->Message(csound, "smpsin = %"PRId64"\n", (int64_t) t->smpsin);
@@ -940,9 +940,9 @@ static int32_t is_sdiffile(char *name)
 
 int32_t hetro_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "hetro", hetro);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "hetro", hetro);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "hetro",
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "hetro",
                                              Str("Soundfile analysis for adsyn"));
     }
     return retval;

--- a/util/hetro.c
+++ b/util/hetro.c
@@ -256,7 +256,7 @@ static int32_t hetro(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY((t->input_dur < 0) || (t->beg_time < 0)))
       return quit(csound,Str("input and begin times cannot be less than zero"));
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndInputFileOpen(csound, t->infilnam, &p,
+    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, t->infilnam, &p,
                                     &t->beg_time, &t->input_dur,
                                              &t->sr, channel)) == NULL)) {
       char errmsg[256];
@@ -268,7 +268,7 @@ static int32_t hetro(CSOUND *csound, int32_t argc, char **argv)
     t->auxp = (MYFLT*) csound->Malloc(csound, nsamps * sizeof(MYFLT));
     /* & read them in */
     if (UNLIKELY((t->smpsin =
-                  csound->SndInputRead(csound, infd,
+                  csound->Sndin(csound, infd,
                                    t->auxp, nsamps, p)) <= 0)) {
       char errmsg[256];
       csound->Message(csound, "smpsin = %"PRId64"\n", (int64_t) t->smpsin);

--- a/util/lpanal.c
+++ b/util/lpanal.c
@@ -545,7 +545,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
     lpg = (LPANAL_GLOBALS*) csound->Calloc(csound, sizeof(LPANAL_GLOBALS));
     lpg->firstcall = 1;
 
-    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = (csound->GetUtility(csound))->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       char errmsg[256];
       snprintf(errmsg,256,Str("error while opening %s"), infilnam);
@@ -598,7 +598,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
     sigbuf2 = sigbuf + slice;
 
     /* Try to read first frame in buffer */
-    if (UNLIKELY((n = csound->Sndin(csound, infd, sigbuf, lpc.WINDIN, p)) <
+    if (UNLIKELY((n = (csound->GetUtility(csound))->Sndin(csound, infd, sigbuf, lpc.WINDIN, p)) <
                  lpc.WINDIN))
       quit(csound,Str("soundfile read error, could not fill first frame"));
 
@@ -764,7 +764,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
       /*              *fp1++ = *fp2++;} */
 
       /* Get next sound frame */
-      if ((n = csound->Sndin(csound, infd, sigbuf2, slice, p)) == 0)
+      if ((n = (csound->GetUtility(csound))->Sndin(csound, infd, sigbuf2, slice, p)) == 0)
         break;          /* refill til EOF */
       if (UNLIKELY(!csound->CheckEvents(csound)))
         return -1;
@@ -1287,10 +1287,10 @@ static void ptable(CSOUND *csound,
 
 int32_t lpanal_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "lpanal", lpanal);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "lpanal", lpanal);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "lpanal",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "lpanal",
                                       Str("Linear predictive analysis for lpread"));
     }
     return retval;

--- a/util/lpanal.c
+++ b/util/lpanal.c
@@ -545,7 +545,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
     lpg = (LPANAL_GLOBALS*) csound->Calloc(csound, sizeof(LPANAL_GLOBALS));
     lpg->firstcall = 1;
 
-    if (UNLIKELY((infd = csound->SndInputFileOpen(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       char errmsg[256];
       snprintf(errmsg,256,Str("error while opening %s"), infilnam);
@@ -598,7 +598,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
     sigbuf2 = sigbuf + slice;
 
     /* Try to read first frame in buffer */
-    if (UNLIKELY((n = csound->SndInputRead(csound, infd, sigbuf, lpc.WINDIN, p)) <
+    if (UNLIKELY((n = csound->Sndin(csound, infd, sigbuf, lpc.WINDIN, p)) <
                  lpc.WINDIN))
       quit(csound,Str("soundfile read error, could not fill first frame"));
 
@@ -764,7 +764,7 @@ static int32_t lpanal(CSOUND *csound, int32_t argc, char **argv)
       /*              *fp1++ = *fp2++;} */
 
       /* Get next sound frame */
-      if ((n = csound->SndInputRead(csound, infd, sigbuf2, slice, p)) == 0)
+      if ((n = csound->Sndin(csound, infd, sigbuf2, slice, p)) == 0)
         break;          /* refill til EOF */
       if (UNLIKELY(!csound->CheckEvents(csound)))
         return -1;

--- a/util/lpc_export.c
+++ b/util/lpc_export.c
@@ -113,10 +113,10 @@ static int32_t lpc_export(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t lpc_export_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "lpc_export", lpc_export);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "lpc_export", lpc_export);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "lpc_export",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "lpc_export",
                                       Str("translate linear predictive "
                                           "coding file to text file"));
     }

--- a/util/lpc_import.c
+++ b/util/lpc_import.c
@@ -111,10 +111,10 @@ static int32_t lpc_import(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t lpc_import_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "lpc_import", lpc_import);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "lpc_import", lpc_import);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "lpc_import",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "lpc_import",
                                       Str("translate text file to "
                                           "linear predictive coding file"));
     }

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -386,7 +386,7 @@ static int32_t mixer_main(CSOUND *csound, int32_t argc, char **argv)
       else O.outfilename = "test";
     }
 #endif
-    csound->SetUtilSr(csound, (MYFLT)mixin[0].p->sr);
+    (csound->GetUtility(csound))->SetUtilSr(csound, (MYFLT)mixin[0].p->sr);
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
     //sfinfo.frames = 0/*was -1*/;
     sfinfo.samplerate = mixin[0].p->sr;
@@ -526,14 +526,14 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
     MYFLT   dur;
     SOUNDIN *p;
 
-    csound->SetUtilSr(csound, FL(0.0));         /* set esr 0. with no orchestra   */
+    (csound->GetUtility(csound))->SetUtilSr(csound, FL(0.0));         /* set esr 0. with no orchestra   */
     ddd->p = p = (SOUNDIN *) csound->Calloc(csound, sizeof(SOUNDIN));
     p->analonly = 1;
     p->channel = ALLCHNLS;
     p->skiptime = FL(0.0);
     strNcpy(p->sfname, ddd->name, MAXSNDNAME-1);
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndinGetSet(csound, p)) == NULL))
+    if (UNLIKELY((infd = (csound->GetUtility(csound))->SndinGetSet(csound, p)) == NULL))
       return NULL;
     p->getframes = p->framesrem;
     dur = (MYFLT) p->getframes / p->sr;
@@ -579,7 +579,7 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
       this_block = 0;
       for (i = 0; i<n; i++) {
         if (sample >= mixin[i].start) {
-          read_in = csound->Sndin(csound, mixin[i].fd, ibuffer,
+          read_in = (csound->GetUtility(csound))->Sndin(csound, mixin[i].fd, ibuffer,
                                      size*mixin[i].p->nchanls, mixin[i].p);
           if (csound->Get0dBFS(csound)!=FL(1.0)) { /* Optimisation? */
             MYFLT xx = 1.0/csound->Get0dBFS(csound);
@@ -671,12 +671,12 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
 int32_t mixer_init_(CSOUND *csound)
 {
     char    buf[128];
-    int32_t     retval = csound->AddUtility(csound, "mixer", mixer_main);
+    int32_t     retval = (csound->GetUtility(csound))->AddUtility(csound, "mixer", mixer_main);
 
     snprintf(buf, 128, Str("Mixes sound files (max. %d)"),
              (int32_t) NUMBER_OF_FILES);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "mixer", buf);
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "mixer", buf);
     }
     return retval;
 }

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -533,7 +533,7 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
     p->skiptime = FL(0.0);
     strNcpy(p->sfname, ddd->name, MAXSNDNAME-1);
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndInputOpen(csound, p)) == NULL))
+    if (UNLIKELY((infd = csound->SndinGetSet(csound, p)) == NULL))
       return NULL;
     p->getframes = p->framesrem;
     dur = (MYFLT) p->getframes / p->sr;
@@ -579,7 +579,7 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
       this_block = 0;
       for (i = 0; i<n; i++) {
         if (sample >= mixin[i].start) {
-          read_in = csound->SndInputRead(csound, mixin[i].fd, ibuffer,
+          read_in = csound->Sndin(csound, mixin[i].fd, ibuffer,
                                      size*mixin[i].p->nchanls, mixin[i].p);
           if (csound->Get0dBFS(csound)!=FL(1.0)) { /* Optimisation? */
             MYFLT xx = 1.0/csound->Get0dBFS(csound);

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -393,7 +393,7 @@ static int32_t mixer_main(CSOUND *csound, int32_t argc, char **argv)
     sfinfo.channels /*= csound->nchnls*/ = (int32_t) mixin[0].p->nchanls;
     sfinfo.format = TYPE2SF(O.filetyp) | FORMAT2SF(O.outformat);
     if (strcmp(O.outfilename, "stdout") == 0) {
-      outfd = sflib_open_fd(1, SFM_WRITE, &sfinfo, 0);
+      outfd = csound->SndfileOpenFd(csound,1, SFM_WRITE, &sfinfo, 0);
       if (outfd != NULL) {
         if (UNLIKELY(csound->CreateFileHandle(csound,
                                               &outfd, CSFILE_SND_W,
@@ -409,11 +409,11 @@ static int32_t mixer_main(CSOUND *csound, int32_t argc, char **argv)
       outfd = NULL;
     if (UNLIKELY(outfd == NULL)) {
       csound->ErrorMsg(csound, Str("mixer: error opening output file '%s': %s"),
-                       O.outfilename, Str(sflib_strerror(NULL)));
+                       O.outfilename, Str(csound->SndfileStrError(csound,NULL)));
       return -1;
     }
     if (UNLIKELY(O.rewrt_hdr))
-      csound->FileCommand(csound,outfd, SFC_SET_UPDATE_HEADER_AUTO, NULL, 0);
+      csound->SndfileCommand(csound,outfd, SFC_SET_UPDATE_HEADER_AUTO, NULL, 0);
     /* calc outbuf size & alloc bufspace */
     pp->outbufsiz = NUMBER_OF_SAMPLES * pp->outputs;
     pp->out_buf = csound->Malloc(csound, pp->outbufsiz * sizeof(MYFLT));

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -398,7 +398,7 @@ static int32_t mixer_main(CSOUND *csound, int32_t argc, char **argv)
         if (UNLIKELY(csound->CreateFileHandle(csound,
                                               &outfd, CSFILE_SND_W,
                                               "stdout") == NULL)) {
-          sflib_close(outfd);
+          csound->SndfileClose(csound,outfd);
           return -1;
         }
       }

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -413,7 +413,7 @@ static int32_t mixer_main(CSOUND *csound, int32_t argc, char **argv)
       return -1;
     }
     if (UNLIKELY(O.rewrt_hdr))
-      sflib_command(outfd, SFC_SET_UPDATE_HEADER_AUTO, NULL, 0);
+      csound->FileCommand(csound,outfd, SFC_SET_UPDATE_HEADER_AUTO, NULL, 0);
     /* calc outbuf size & alloc bufspace */
     pp->outbufsiz = NUMBER_OF_SAMPLES * pp->outputs;
     pp->out_buf = csound->Malloc(csound, pp->outbufsiz * sizeof(MYFLT));
@@ -624,7 +624,7 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
         if (buffer[j] > max) max = buffer[j], lmaxpos = sample+j, maxtimes=1;
         if (buffer[j] < min) min = buffer[j], lminpos = sample+j, mintimes=1;
       }
-      sflib_write_MYFLT(outfd, buffer, this_block * outputs);
+      csound->SndfileWriteSamples(csound, outfd, buffer, this_block * outputs);
       block++;
       //      bytes += O->sfsampsize * this_block * outputs;
       switch (O->heartbeat) {
@@ -647,7 +647,7 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
       }
       sample += size;
     }
-    csound->RewriteHeader((struct SNFDILE*)outfd);
+    csound->RewriteHeader(csound, outfd);
     min *= (DFLT_DBFS);
     max *= (DFLT_DBFS);
     csound->Message(csound, Str("Max val %d at index %ld (time %.4f, chan %d) "

--- a/util/pv_export.c
+++ b/util/pv_export.c
@@ -118,10 +118,10 @@ static int32_t pv_export(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t pv_export_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "pv_export", pv_export);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "pv_export", pv_export);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "pv_export",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "pv_export",
                                       Str("translate PVOC analysis file "
                                           "to text form"));
     }

--- a/util/pv_import.c
+++ b/util/pv_import.c
@@ -158,10 +158,10 @@ static int32_t pv_import(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t pv_import_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "pv_import", pv_import);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "pv_import", pv_import);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "pv_import",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "pv_import",
                                       Str("translate text form to "
                                           "PVOC analysis file"));
     }

--- a/util/pvanal.c
+++ b/util/pvanal.c
@@ -252,7 +252,7 @@ static int32_t pvanal(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(ovlp && frameIncr))
       return quit(csound, Str("pvanal cannot have both -w and -h"));
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = (csound->GetUtility(csound))->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       snprintf(err_msg, 512, Str("error while opening %s"), infilnam);
       return quit(csound, err_msg);
@@ -342,9 +342,9 @@ static int32_t quit(CSOUND *csound, char *msg)
 
 int32_t pvanal_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "pvanal", pvanal);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "pvanal", pvanal);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "pvanal",
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "pvanal",
                                              Str("Soundfile analysis for pvoc"));
     }
     return retval;
@@ -474,7 +474,7 @@ static int32_t pvxanal(CSOUND *csound, SOUNDIN *p, SNDFILE *fd, const char *fnam
                    (int32_t) (((int64_t) p->getframes * chans / overlap)
                           / DISPFRAMES));
 
-    while ((sampsread = csound->Sndin(csound,
+    while ((sampsread = (csound->GetUtility(csound))->Sndin(csound,
                                          fd, inbuf, buflen_samps, p)) > 0) {
       total_sampsread += sampsread;
       /* zeropad to full buflen */

--- a/util/pvanal.c
+++ b/util/pvanal.c
@@ -252,7 +252,7 @@ static int32_t pvanal(CSOUND *csound, int32_t argc, char **argv)
     if (UNLIKELY(ovlp && frameIncr))
       return quit(csound, Str("pvanal cannot have both -w and -h"));
     /* open sndfil, do skiptime */
-    if (UNLIKELY((infd = csound->SndInputFileOpen(csound, infilnam, &p, &beg_time,
+    if (UNLIKELY((infd = csound->SndinGetSetSA(csound, infilnam, &p, &beg_time,
                                              &input_dur, &sr, channel)) == NULL)) {
       snprintf(err_msg, 512, Str("error while opening %s"), infilnam);
       return quit(csound, err_msg);
@@ -474,7 +474,7 @@ static int32_t pvxanal(CSOUND *csound, SOUNDIN *p, SNDFILE *fd, const char *fnam
                    (int32_t) (((int64_t) p->getframes * chans / overlap)
                           / DISPFRAMES));
 
-    while ((sampsread = csound->SndInputRead(csound,
+    while ((sampsread = csound->Sndin(csound,
                                          fd, inbuf, buflen_samps, p)) > 0) {
       total_sampsread += sampsread;
       /* zeropad to full buflen */

--- a/util/pvlook.c
+++ b/util/pvlook.c
@@ -231,9 +231,9 @@ static int32_t pvlook(CSOUND *csound, int32_t argc, char *argv[])
 
 int32_t pvlook_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "pvlook", pvlook);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "pvlook", pvlook);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "pvlook",
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "pvlook",
                     "Prints information about PVOC analysis files");
     }
     return retval;

--- a/util/scale.c
+++ b/util/scale.c
@@ -268,8 +268,8 @@ static int32_t scale(CSOUND *csound, int32_t argc, char **argv)
         O.rewrt_hdr = 0;
       if (O.outfilename == NULL)
         O.outfilename = "test";
-      csound->SetUtilSr(csound, (MYFLT)sc.p->sr);
-      csound->SetUtilNchnls(csound, sc.p->nchanls);
+      (csound->GetUtility(csound))->SetUtilSr(csound, (MYFLT)sc.p->sr);
+      (csound->GetUtility(csound))->SetUtilNchnls(csound, sc.p->nchanls);
 
       memset(&sfinfo, 0, sizeof(SFLIB_INFO));
       //sfinfo.frames = 0/*was -1*/;
@@ -394,13 +394,13 @@ SCsndgetset(CSOUND *csound, SCALE *thissc, char *inputfile)
     double  dur;
     SOUNDIN *p;
 
-    csound->SetUtilSr(csound, FL(0.0));         /* set esr 0. with no orchestra */
+    (csound->GetUtility(csound))->SetUtilSr(csound, FL(0.0));         /* set esr 0. with no orchestra */
     thissc->p = p = (SOUNDIN *) csound->Calloc(csound, sizeof(SOUNDIN));
     p->channel = ALLCHNLS;
     p->skiptime = FL(0.0);
     p->analonly = 1;
     strNcpy(p->sfname, inputfile, MAXSNDNAME-1);//p->sfname[MAXSNDNAME-1]='\0';
-    if ((infile = csound->SndinGetSet(csound, p)) == 0) /*open sndfil, do skptim*/
+    if ((infile = (csound->GetUtility(csound))->SndinGetSet(csound, p)) == 0) /*open sndfil, do skptim*/
       return(0);
     p->getframes = p->framesrem;
     dur = (double) p->getframes / p->sr;
@@ -429,7 +429,7 @@ ScaleSound(CSOUND *csound, SCALE *thissc, SNDFILE *infile,
     tpersample = 1.0 / (double) thissc->p->sr;
     max = 0.0;  mxpos = 0; maxtimes = 0;
     min = 0.0;  minpos = 0; mintimes = 0;
-    while ((read_in = csound->Sndin(csound, infile, buffer,
+    while ((read_in = (csound->GetUtility(csound))->Sndin(csound, infile, buffer,
                                        bufferLenSamples, thissc->p)) > 0) {
       for (i = 0; i < read_in; i++) {
         j = (i / chans) + (bufferLenFrames * block);
@@ -478,7 +478,7 @@ static float FindAndReportMax(CSOUND *csound, SCALE *thissc,
     tpersample = 1.0 / (double) thissc->p->sr;
     max = 0.0;  mxpos = 0; maxtimes = 0;
     min = 0.0;  minpos = 0; mintimes = 0;
-    while ((read_in = csound->Sndin(csound, infile, buffer,
+    while ((read_in = (csound->GetUtility(csound))->Sndin(csound, infile, buffer,
                                        bufferLenSamples, thissc->p)) > 0) {
       for (i = 0; i < read_in; i++) {
         //j = (i / chans) + (bufferLenFrames * block);
@@ -512,10 +512,10 @@ static float FindAndReportMax(CSOUND *csound, SCALE *thissc,
 
 int32_t scale_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "scale", scale);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "scale", scale);
     if (retval)
       return retval;
     return
-      csound->SetUtilityDescription(csound, "scale",
+      (csound->GetUtility(csound))->SetUtilityDescription(csound, "scale",
                                     Str("Reports and/or adjusts maximum gain"));
 }

--- a/util/scale.c
+++ b/util/scale.c
@@ -400,7 +400,7 @@ SCsndgetset(CSOUND *csound, SCALE *thissc, char *inputfile)
     p->skiptime = FL(0.0);
     p->analonly = 1;
     strNcpy(p->sfname, inputfile, MAXSNDNAME-1);//p->sfname[MAXSNDNAME-1]='\0';
-    if ((infile = csound->SndInputOpen(csound, p)) == 0) /*open sndfil, do skptim*/
+    if ((infile = csound->SndinGetSet(csound, p)) == 0) /*open sndfil, do skptim*/
       return(0);
     p->getframes = p->framesrem;
     dur = (double) p->getframes / p->sr;
@@ -429,7 +429,7 @@ ScaleSound(CSOUND *csound, SCALE *thissc, SNDFILE *infile,
     tpersample = 1.0 / (double) thissc->p->sr;
     max = 0.0;  mxpos = 0; maxtimes = 0;
     min = 0.0;  minpos = 0; mintimes = 0;
-    while ((read_in = csound->SndInputRead(csound, infile, buffer,
+    while ((read_in = csound->Sndin(csound, infile, buffer,
                                        bufferLenSamples, thissc->p)) > 0) {
       for (i = 0; i < read_in; i++) {
         j = (i / chans) + (bufferLenFrames * block);
@@ -478,7 +478,7 @@ static float FindAndReportMax(CSOUND *csound, SCALE *thissc,
     tpersample = 1.0 / (double) thissc->p->sr;
     max = 0.0;  mxpos = 0; maxtimes = 0;
     min = 0.0;  minpos = 0; mintimes = 0;
-    while ((read_in = csound->SndInputRead(csound, infile, buffer,
+    while ((read_in = csound->Sndin(csound, infile, buffer,
                                        bufferLenSamples, thissc->p)) > 0) {
       for (i = 0; i < read_in; i++) {
         //j = (i / chans) + (bufferLenFrames * block);

--- a/util/scale.c
+++ b/util/scale.c
@@ -442,7 +442,7 @@ ScaleSound(CSOUND *csound, SCALE *thissc, SNDFILE *infile,
           min = buffer[i], minpos = i + bufferLenSamples * block, mintimes = 1;
         buffer[i] *= (1.0/csound->Get0dBFS(csound));
       }
-      sflib_write_MYFLT(outfd, buffer, read_in);
+      csound->SndfileWriteSamples(csound, outfd, buffer, read_in);
       block++;
       if (oparms->heartbeat) {
         csound->MessageS(csound, CSOUNDMSG_REALTIME, "%c\b", "|/-\\"[block&3]);

--- a/util/scale.c
+++ b/util/scale.c
@@ -285,7 +285,7 @@ static int32_t scale(CSOUND *csound, int32_t argc, char **argv)
           if (UNLIKELY((fd =
                         csound->CreateFileHandle(csound, &outfile,
                                                  CSFILE_SND_W, "stdout")) == NULL)) {
-            sflib_close(outfile);
+            csound->SndfileClose(csound,outfile);
             csound->Die(csound, "%s", Str("Memory allocation failure"));
           }
         }

--- a/util/scale.c
+++ b/util/scale.c
@@ -280,7 +280,7 @@ static int32_t scale(CSOUND *csound, int32_t argc, char **argv)
       fd = NULL;
       if (strcmp(O.outfilename, "stdout") == 0 ||
           strcmp(O.outfilename, "-") == 0) {
-        outfile = sflib_open_fd(1, SFM_WRITE, &sfinfo, 0);
+        outfile = csound->SndfileOpenFd(csound,1, SFM_WRITE, &sfinfo, 0);
         if (outfile != NULL) {
           if (UNLIKELY((fd =
                         csound->CreateFileHandle(csound, &outfile,
@@ -296,7 +296,7 @@ static int32_t scale(CSOUND *csound, int32_t argc, char **argv)
                        csound->Type2CsfileType(O.filetyp, O.outformat), 0);
       if (UNLIKELY(fd == NULL))
         csound->Die(csound, Str("Failed to open output file %s: %s"),
-                    O.outfilename, Str(sflib_strerror(NULL)));
+                    O.outfilename, Str(csound->SndfileStrError(csound,NULL)));
       outbufsiz = 1024 * O.sfsampsize;    /* calc outbuf size  */
       csound->Message(csound, Str("writing %d-byte blks of %s to %s %s\n"),
                               (int32_t) outbufsiz,

--- a/util/sndinfo.c
+++ b/util/sndinfo.c
@@ -179,10 +179,10 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
 
 int32_t sndinfo_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "sndinfo", sndinfo);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "sndinfo", sndinfo);
     if (!retval) {
       retval =
-        csound->SetUtilityDescription(csound, "sndinfo",
+        (csound->GetUtility(csound))->SetUtilityDescription(csound, "sndinfo",
                                       Str("Prints information about sound files"));
     }
     return retval;

--- a/util/sndinfo.c
+++ b/util/sndinfo.c
@@ -112,7 +112,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
           SFLIB_INSTRUMENT inst;
           int32_t     k;
 
-          if (sflib_command(hndl, SFC_GET_INSTRUMENT, &inst, sizeof (inst)) != 0) {
+          if (csound->FileCommand(csound,hndl, SFC_GET_INSTRUMENT, &inst, sizeof (inst)) != 0) {
             csound->Message(csound, Str("  Gain        : %d\n"),
                             inst.gain);
             csound->Message(csound, Str("  Base note   : %d\n"),
@@ -144,7 +144,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
           
           SF_BROADCAST_INFO bext;
 
-          if (sflib_command(hndl, SFC_GET_BROADCAST_INFO, &bext, sizeof (bext))
+          if (csound->FileCommand(csound,hndl, SFC_GET_BROADCAST_INFO, &bext, sizeof (bext))
               != 0) {
             csound->Message(csound, Str("Description      : %.*s\n"),
                             (int32_t) sizeof (bext.description), bext.description);

--- a/util/sndinfo.c
+++ b/util/sndinfo.c
@@ -67,7 +67,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
         continue;
       }
       memset(&sflib_info, 0, sizeof(SFLIB_INFO));
-      hndl = sflib_open(fname, SFM_READ, &sflib_info);
+      hndl = csound->SndfileOpen(csound,fname, SFM_READ, &sflib_info);
       if (UNLIKELY(hndl == NULL)) {
         csound->Message(csound, Str("%s: Not a sound file\n"), fname);
         csound->Free(csound, fname);
@@ -112,7 +112,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
           SFLIB_INSTRUMENT inst;
           int32_t     k;
 
-          if (csound->FileCommand(csound,hndl, SFC_GET_INSTRUMENT, &inst, sizeof (inst)) != 0) {
+          if (csound->SndfileCommand(csound,hndl, SFC_GET_INSTRUMENT, &inst, sizeof (inst)) != 0) {
             csound->Message(csound, Str("  Gain        : %d\n"),
                             inst.gain);
             csound->Message(csound, Str("  Base note   : %d\n"),
@@ -144,7 +144,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
           
           SF_BROADCAST_INFO bext;
 
-          if (csound->FileCommand(csound,hndl, SFC_GET_BROADCAST_INFO, &bext, sizeof (bext))
+          if (csound->SndfileCommand(csound,hndl, SFC_GET_BROADCAST_INFO, &bext, sizeof (bext))
               != 0) {
             csound->Message(csound, Str("Description      : %.*s\n"),
                             (int32_t) sizeof (bext.description), bext.description);

--- a/util/sndinfo.c
+++ b/util/sndinfo.c
@@ -168,7 +168,7 @@ static int32_t sndinfo(CSOUND *csound, int32_t argc, char **argv)
           }
         }
 #endif
-        sflib_close(hndl);
+        csound->SndfileClose(csound,hndl);
       }
     }
 

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -477,20 +477,20 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
           snprintf(err_msg, 256, Str("cannot open %s."), O.outfilename);
           goto err_rtn_msg;
         }
-        outfd = sflib_open(name, SFM_WRITE, &sfinfo);
+        outfd = csound->SndfileOpen(csound,name, SFM_WRITE, &sfinfo);
         if (outfd != NULL)
           csound->NotifyFileOpened(csound, name,
                                    csound->Type2CsfileType(O.filetyp,
                                                            O.outformat),
                                    1, 0);
         else {
-          snprintf(err_msg, 256, Str("libsndfile error: %s\n"), sflib_strerror(NULL));
+          snprintf(err_msg, 256, Str("libsndfile error: %s\n"), csound->SndfileStrError(csound,NULL));
           goto err_rtn_msg;
         }
         csound->Free(csound, name);
       }
       else
-        outfd = sflib_open_fd(1, SFM_WRITE, &sfinfo, 1);
+        outfd = csound->SndfileOpenFd(csound,1, SFM_WRITE, &sfinfo, 1);
       if (outfd == NULL) {
         snprintf(err_msg, 256, Str("cannot open %s."), O.outfilename);
         goto err_rtn_msg;
@@ -498,7 +498,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
       /* register file to be closed by csoundReset() */
       (void) csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W,
                                       O.outfilename);
-      csound->FileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->SndfileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
     csound->SetUtilSr(csound, (MYFLT)p->sr);
     csound->SetUtilNchnls(csound, Chans = p->nchanls);

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -351,7 +351,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
       usage(csound);
       return -1;
     }
-    if ((inf = csound->SndinGetSetSA(csound, infile, &p, &beg_time,
+    if ((inf = (csound->GetUtility(csound))->SndinGetSetSA(csound, infile, &p, &beg_time,
                                    &input_dur, &sr, channel)) == NULL) {
       csound->ErrorMsg(csound, Str("error while opening %s"), infile);
       return -1;
@@ -433,10 +433,10 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
     }
     /* This is not right *********  */
     if (P != FL(0.0)) {
-      csound->SetUtilSr(csound,Rin);
+      (csound->GetUtility(csound))->SetUtilSr(csound,Rin);
     }
     if (P == FL(0.0)) {
-      csound->SetUtilSr(csound,Rout);
+      (csound->GetUtility(csound))->SetUtilSr(csound,Rout);
     }
 
     if (O.outformat == 0)
@@ -500,8 +500,8 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
                                       O.outfilename);
       csound->SndfileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
-    csound->SetUtilSr(csound, (MYFLT)p->sr);
-    csound->SetUtilNchnls(csound, Chans = p->nchanls);
+    (csound->GetUtility(csound))->SetUtilSr(csound, (MYFLT)p->sr);
+    (csound->GetUtility(csound))->SetUtilNchnls(csound, Chans = p->nchanls);
 
     outbufsiz = OBUF * O.sfsampsize;                   /* calc outbuf size */
     csound->Message(csound, Str("writing %d-byte blks of %s to %s"),
@@ -587,7 +587,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
 
  /* initialization: */
 
-    nread = csound->Sndin(csound, inf, input, IBUF2, p);
+    nread = (csound->GetUtility(csound))->Sndin(csound, inf, input, IBUF2, p);
     for(i=0; i < nread; i++)
        input[i] *= 1.0/csound->Get0dBFS(csound);
     nMax = (long)(input_dur * p->sr);
@@ -644,7 +644,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
             mMax += IBUF2;
             if (nextIn >= (input + IBUF))
               nextIn = input;
-            nread = csound->Sndin(csound, inf, nextIn, IBUF2, p);
+            nread = (csound->GetUtility(csound))->Sndin(csound, inf, nextIn, IBUF2, p);
             for(i=0; i < nread; i++)
                input[i] *= 1.0/csound->Get0dBFS(csound);
             nextIn += nread;
@@ -704,7 +704,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
             mMax += IBUF2;
             if (nextIn >= (input + IBUF))
               nextIn = input;
-            nread = csound->Sndin(csound, inf, nextIn, IBUF2, p);
+            nread = (csound->GetUtility(csound))->Sndin(csound, inf, nextIn, IBUF2, p);
             for(i=0; i < nread; i++)
                input[i] *= 1.0/csound->Get0dBFS(csound);
             nextIn += nread;
@@ -863,9 +863,9 @@ static void kaiser(int32_t nf, float *w, int32_t n, int32_t ieo, double beta)
 
 int32_t srconv_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "srconv", srconv);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "srconv", srconv);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "srconv",
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "srconv",
                                              Str("Sample rate conversion"));
     }
     return retval;

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -69,10 +69,10 @@ static  void    usage(CSOUND *);
 static int32_t writebuffer(CSOUND *csound, MYFLT *out_buf, int32_t *block,
                        SNDFILE *outfd, int32_t length, OPARMS *oparms)
 {
-    sflib_write_MYFLT(outfd, out_buf, length);
+    csound->SndfileWriteSamples(csound, outfd, out_buf, length);
     (*block)++;
     if (oparms->rewrt_hdr)
-      csound->RewriteHeader((struct SNDFILE *)outfd);
+      csound->RewriteHeader(csound, SNDFILE *)outfd);
     switch (oparms->heartbeat) {
       case 1:
         csound->MessageS(csound, CSOUNDMSG_REALTIME, "%c\010",
@@ -498,7 +498,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
       /* register file to be closed by csoundReset() */
       (void) csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W,
                                       O.outfilename);
-      sflib_command(outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
+      csound->FileCommand(csound,outfd, SFC_SET_CLIPPING, NULL, SFLIB_TRUE);
     }
     csound->SetUtilSr(csound, (MYFLT)p->sr);
     csound->SetUtilNchnls(csound, Chans = p->nchanls);

--- a/util/srconv.c
+++ b/util/srconv.c
@@ -351,7 +351,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
       usage(csound);
       return -1;
     }
-    if ((inf = csound->SndInputFileOpen(csound, infile, &p, &beg_time,
+    if ((inf = csound->SndinGetSetSA(csound, infile, &p, &beg_time,
                                    &input_dur, &sr, channel)) == NULL) {
       csound->ErrorMsg(csound, Str("error while opening %s"), infile);
       return -1;
@@ -587,7 +587,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
 
  /* initialization: */
 
-    nread = csound->SndInputRead(csound, inf, input, IBUF2, p);
+    nread = csound->Sndin(csound, inf, input, IBUF2, p);
     for(i=0; i < nread; i++)
        input[i] *= 1.0/csound->Get0dBFS(csound);
     nMax = (long)(input_dur * p->sr);
@@ -644,7 +644,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
             mMax += IBUF2;
             if (nextIn >= (input + IBUF))
               nextIn = input;
-            nread = csound->SndInputRead(csound, inf, nextIn, IBUF2, p);
+            nread = csound->Sndin(csound, inf, nextIn, IBUF2, p);
             for(i=0; i < nread; i++)
                input[i] *= 1.0/csound->Get0dBFS(csound);
             nextIn += nread;
@@ -704,7 +704,7 @@ static int32_t srconv(CSOUND *csound, int32_t argc, char **argv)
             mMax += IBUF2;
             if (nextIn >= (input + IBUF))
               nextIn = input;
-            nread = csound->SndInputRead(csound, inf, nextIn, IBUF2, p);
+            nread = csound->Sndin(csound, inf, nextIn, IBUF2, p);
             for(i=0; i < nread; i++)
                input[i] *= 1.0/csound->Get0dBFS(csound);
             nextIn += nread;

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -296,7 +296,7 @@ static int32_t xtrct(CSOUND *csound, int32_t argc, char **argv)
       if (outfd != NULL) {
         fd = csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W, "stdout");
         if (UNLIKELY(fd == NULL)) {
-          sflib_close(outfd);
+          csound->SndfileClose(csound,outfd);
           csound->Die(csound, "%s", Str("Memory allocation failure"));
         }
       }

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -281,8 +281,8 @@ static int32_t xtrct(CSOUND *csound, int32_t argc, char **argv)
     if (O.outfilename == NULL)
       O.outfilename = "test";
 
-    csound->SetUtilSr(csound, (MYFLT)xtrc.p->sr);
-    csound->SetUtilNchnls(csound, xtrc.outputs);
+    (csound->GetUtility(csound))->SetUtilSr(csound, (MYFLT)xtrc.p->sr);
+    (csound->GetUtility(csound))->SetUtilNchnls(csound, xtrc.outputs);
     memset(&sfinfo, 0, sizeof(SFLIB_INFO));
     //sfinfo.frames = 0/*was -1*/;
     sfinfo.samplerate = (int32_t) ((MYFLT)xtrc.p->sr + FL(0.5));
@@ -320,12 +320,12 @@ EXsndgetset(CSOUND *csound, XTRC *x, char *name)
     SNDFILE*    infd;
     MYFLT       dur;
 
-    csound->SetUtilSr(csound,FL(0.0));      /* set esr 0. with no orchestra   */
+    (csound->GetUtility(csound))->SetUtilSr(csound,FL(0.0));      /* set esr 0. with no orchestra   */
     x->p = (SOUNDIN *) csound->Calloc(csound, sizeof(SOUNDIN));
     x->p->channel = ALLCHNLS;
     x->p->skiptime = FL(0.0);
     strNcpy(x->p->sfname, name,  MAXSNDNAME-1);
-    if ((infd = csound->SndinGetSet(csound, x->p)) == 0) /*open sndfil, do skiptime*/
+    if ((infd = (csound->GetUtility(csound))->SndinGetSet(csound, x->p)) == 0) /*open sndfil, do skiptime*/
         return(0);
     x->p->getframes = x->p->framesrem;
     dur = (MYFLT) x->p->getframes / x->p->sr;
@@ -369,9 +369,9 @@ ExtractSound(CSOUND *csound, XTRC *x, SNDFILE* infd, SNDFILE* outfd, OPARMS *opa
 
 int32_t xtrct_init_(CSOUND *csound)
 {
-    int32_t retval = csound->AddUtility(csound, "extractor", xtrct);
+    int32_t retval = (csound->GetUtility(csound))->AddUtility(csound, "extractor", xtrct);
     if (!retval) {
-      retval = csound->SetUtilityDescription(csound, "extractor",
+      retval = (csound->GetUtility(csound))->SetUtilityDescription(csound, "extractor",
                                              Str("Extract part of a sound file"));
     }
     return retval;

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -325,7 +325,7 @@ EXsndgetset(CSOUND *csound, XTRC *x, char *name)
     x->p->channel = ALLCHNLS;
     x->p->skiptime = FL(0.0);
     strNcpy(x->p->sfname, name,  MAXSNDNAME-1);
-    if ((infd = csound->SndInputOpen(csound, x->p)) == 0) /*open sndfil, do skiptime*/
+    if ((infd = csound->SndinGetSet(csound, x->p)) == 0) /*open sndfil, do skiptime*/
         return(0);
     x->p->getframes = x->p->framesrem;
     dur = (MYFLT) x->p->getframes / x->p->sr;

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -337,31 +337,31 @@ EXsndgetset(CSOUND *csound, XTRC *x, char *name)
 static void
 ExtractSound(CSOUND *csound, XTRC *x, SNDFILE* infd, SNDFILE* outfd, OPARMS *oparms)
 {
-    double buffer[NUMBER_OF_SAMPLES];
+    MYFLT buffer[NUMBER_OF_SAMPLES];
     long  read_in;
     //    long  frames = 0;
     int32_t   block = 0;
 
-    sflib_seek(infd, x->sample, SEEK_CUR);
+    csound->SndfileSeek(csound, infd, x->sample, SEEK_CUR);
     while (x->numsamps>0) {
       int32_t num = NUMBER_OF_SAMPLES / x->outputs;
       if (x->numsamps < num)
         num = x->numsamps;
       x->numsamps -= num;
-      read_in = sflib_readf_double(infd, buffer, num);
-      sflib_writef_double(outfd, buffer, read_in);
+      read_in = csound->SndfileRead(csound, infd, buffer, num);
+      csound->SndfileWrite(csound, outfd, buffer, read_in);
       block++;
       //frames += read_in;
       if (oparms->rewrt_hdr) {
-        sflib_command(outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
-        sflib_seek(outfd, 0L, SEEK_END); /* Place at end again */
+        csound->FileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+        csound->SndfileSeek(csound, outfd, 0L, SEEK_END); /* Place at end again */
       }
       if (oparms->heartbeat) {
         csound->MessageS(csound, CSOUNDMSG_REALTIME, "%c\b", "|/-\\"[block&3]);
       }
       if (read_in < num) break;
     }
-    sflib_command(outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+    csound->FileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
     return;
 }
 

--- a/util/xtrct.c
+++ b/util/xtrct.c
@@ -292,7 +292,7 @@ static int32_t xtrct(CSOUND *csound, int32_t argc, char **argv)
     fd = NULL;
     if (strcmp(O.outfilename, "stdout") == 0 ||
         strcmp(O.outfilename, "-") == 0) {
-      outfd = sflib_open_fd(1, SFM_WRITE, &sfinfo, 0);
+      outfd = csound->SndfileOpenFd(csound,1, SFM_WRITE, &sfinfo, 0);
       if (outfd != NULL) {
         fd = csound->CreateFileHandle(csound, &outfd, CSFILE_SND_W, "stdout");
         if (UNLIKELY(fd == NULL)) {
@@ -307,7 +307,7 @@ static int32_t xtrct(CSOUND *csound, int32_t argc, char **argv)
                        csound->Type2CsfileType(O.filetyp, O.outformat), 0);
     if (UNLIKELY(fd == NULL))
       csound->Die(csound, Str("Failed to open output file %s: %s"),
-                  O.outfilename, Str(sflib_strerror(NULL)));
+                  O.outfilename, Str(csound->SndfileStrError(csound,NULL)));
     ExtractSound(csound, &xtrc, infd, outfd, &O);
     if (O.ringbell)
       csound->MessageS(csound, CSOUNDMSG_REALTIME, "%c", '\007');
@@ -353,7 +353,7 @@ ExtractSound(CSOUND *csound, XTRC *x, SNDFILE* infd, SNDFILE* outfd, OPARMS *opa
       block++;
       //frames += read_in;
       if (oparms->rewrt_hdr) {
-        csound->FileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+        csound->SndfileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
         csound->SndfileSeek(csound, outfd, 0L, SEEK_END); /* Place at end again */
       }
       if (oparms->heartbeat) {
@@ -361,7 +361,7 @@ ExtractSound(CSOUND *csound, XTRC *x, SNDFILE* infd, SNDFILE* outfd, OPARMS *opa
       }
       if (read_in < num) break;
     }
-    csound->FileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
+    csound->SndfileCommand(csound,outfd, SFC_UPDATE_HEADER_NOW, NULL, 0);
     return;
 }
 


### PR DESCRIPTION
This PR does two things:

- Changes the code to open soundfiles using *only* the module API, as opposed to accessing `sflib_` functions directly.
- Adds a callback setting function so these soundfile operations can be implemented by hosts instead of the internal `sflib_` functions (which default to libsndfile if present or to non-op stubs otherwise).

This will enable among other things the access to soundfiles in platforms where libsndfile is not present.