### PR TITLE
fixed bug in string channel allocation

### DIFF
--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -424,8 +424,8 @@ static CS_NOINLINE CHNENTRY *alloc_channel(CSOUND *csound,
             break;
         case CSOUND_STRING_CHANNEL:
             dsize = sizeof(STRINGDAT);
-            break;
             varType = &CS_VAR_TYPE_S;
+            break;
         case CSOUND_PVS_CHANNEL:
             dsize = sizeof(PVSDAT);
             varType = &CS_VAR_TYPE_F;


### PR DESCRIPTION
As the title says, the code had a bug in the order of execution and string channels never got the ir varType set. Thanks @rorywalsh for reporting the issue.