### PR TITLE
Remove USE_DOUBLE override when MSVC is used

### DIFF
--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -101,11 +101,7 @@ typedef uint_least16_t uint16;
 #endif
 
 #if !defined(USE_DOUBLE)
-#if !defined(_MSC_VER)
 #include "float-version.h"
-#else
-#define USE_DOUBLE
-#endif
 #endif
 
 #ifdef USE_DOUBLE


### PR DESCRIPTION
When building with USE_DOUBLE=OFF and _MSC_VER defined the USE_DOUBLE is always defined. https://github.com/csound/csound/issues/2009