### PR TITLE
fixed csoundCreate with opcodedir override

### DIFF
--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -607,7 +607,12 @@ int32_t csoundLoadModules(CSOUND *csound)
 
   /* opcodedir GLOBAL override **experimental** */
   if (csound->opcodedir != NULL) {
-    dname = csound->opcodedir;
+    char *opcdir = cs_strdup(csound, csound->opcodedir);
+    // csound->opcodedir was strdup'd so we free it here now
+    // after we copied the data.
+    free(csound->opcodedir);
+    csound->opcodedir = opcdir;
+    dname = opcdir;
     csound->Message(csound, "OPCODEDIR overridden to %s \n", dname);
   }
   size_t pos = strlen(dname);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1419,14 +1419,12 @@ PUBLIC CSOUND *csoundCreate(void *hostdata, const char *opcodedir)
   if (init_done != 1) {
     if (csoundInitialize(0) < 0) return NULL;
   }
-
   csound = (CSOUND*) malloc(sizeof(CSOUND));
   if (UNLIKELY(csound == NULL)) return NULL;
   memcpy(csound, &cenviron_, sizeof(CSOUND));
   init_getstring(csound);
   csound->oparms = &(csound->oparms_);
   csound->hostdata = hostdata;
-  csound->opcodedir = cs_strdup(csound, (char *) opcodedir);
   p = (csInstance_t*) malloc(sizeof(csInstance_t));
   if (UNLIKELY(p == NULL)) {
     free(csound);
@@ -1437,6 +1435,10 @@ PUBLIC CSOUND *csoundCreate(void *hostdata, const char *opcodedir)
   p->nxt = (csInstance_t*) instance_list;
   instance_list = p;
   csoundUnLock();
+  // no cs_strdup yet so we use strdup and
+  // free it later.
+  if(opcodedir != NULL) 
+    csound->opcodedir = strdup(opcodedir);
   csoundReset(csound);
   csound->API_lock = csoundCreateMutex(1);
   allocate_message_queue(csound);


### PR DESCRIPTION
This PR fixes #2012, where`cs_strdup` was used before the memory alloc system had been started.

