### PR TITLE
Retaining opcodedir under reset; free it in destroy

### DIFF
--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -607,12 +607,7 @@ int32_t csoundLoadModules(CSOUND *csound)
 
   /* opcodedir GLOBAL override **experimental** */
   if (csound->opcodedir != NULL) {
-    char *opcdir = cs_strdup(csound, csound->opcodedir);
-    // csound->opcodedir was strdup'd so we free it here now
-    // after we copied the data.
-    free(csound->opcodedir);
-    csound->opcodedir = opcdir;
-    dname = opcdir;
+    dname = csound->opcodedir;
     csound->Message(csound, "OPCODEDIR overridden to %s \n", dname);
   }
   size_t pos = strlen(dname);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1436,7 +1436,7 @@ PUBLIC CSOUND *csoundCreate(void *hostdata, const char *opcodedir)
   instance_list = p;
   csoundUnLock();
   // no cs_strdup yet so we use strdup and
-  // free it later.
+  // free it later in csoundDestroy
   if(opcodedir != NULL) 
     csound->opcodedir = strdup(opcodedir);
   csoundReset(csound);
@@ -1506,6 +1506,8 @@ PUBLIC void csoundDestroy(CSOUND *csound)
     //csoundLockMutex(csound->API_lock);
     csoundDestroyMutex(csound->API_lock);
   }
+  // free opcodedir
+  free(csound->opcodedir);
   /* clear the pointer */
   // *(csound->self) = NULL;
   free((void*) csound);
@@ -3422,6 +3424,7 @@ static void reset(CSOUND *csound)
   memcpy((void*) csound, (void*) saved_env, (size_t) length);
   csound->oparms = &(csound->oparms_);
   csound->hostdata = saved_env->hostdata;
+  csound->opcodedir = saved_env->opcodedir;
   p1 = (void*) &(csound->first_callback_);
   p2 = (void*) &(csound->last_callback_);
   length = (uintptr_t) p2 - (uintptr_t) p1;


### PR DESCRIPTION
This PR allows Csound to retain the opcodedir override under reset(); in Csound 6, this was not the case, but it makes sense to do this now, since we set it in csoundCreate(). We are freeing this in csoundDestroy, since it was strdup'ed.