### PR TITLE
Fixed schedule/event/etc for named instruments with instance annotation

### DIFF
--- a/Engine/linevent.c
+++ b/Engine/linevent.c
@@ -450,7 +450,7 @@ static void sensLine(CSOUND *csound, void *userData)
 }
 
 /* send a lineevent from the orchestra -matt 2001/12/07 */
-
+MYFLT named_instr_find(CSOUND *csound, char *s);
 static const char *errmsg_1 =
   Str_noop("event: param 1 must be \"a\", \"i\", \"q\", \"f\", \"d\", or \"e\"");
 static const char *errmsg_2 =
@@ -480,21 +480,20 @@ int32_t eventOpcode_(CSOUND *csound, LINEVENT *p, int32_t insname, char p1)
     /* IV - Oct 31 2002: allow string argument */
     if (evt.pcnt > 0) {
       if (insname) {
-        int32_t res;
+        MYFLT res;
         if (UNLIKELY(evt.opcod != 'i' && evt.opcod != 'q' && opcod != 'd'))
           return csound->PerfError(csound, &(p->h), "%s", Str(errmsg_2));
-        res = csound->StringArg2Insno(csound, ((STRINGDAT*) p->args[1])->data, 1);
-        if (UNLIKELY(res == NOT_AN_INSTRUMENT)) return NOTOK;
-        evt.p[1] = (MYFLT) res;
+        res = named_instr_find(csound, ((STRINGDAT *)p->args[1])->data);
+        if (UNLIKELY(res == FL(0.0))) return NOTOK;
+        evt.p[1] = res;
         evt.strarg = NULL; evt.scnt = 0;
       }
       else {
-        int32_t res;
+        MYFLT res;
         if (IsStringCode(*p->args[1])) {
-          res = csound->StringArg2Insno(csound,
-                                     get_arg_string(csound, *p->args[1]), 1);
-          if (UNLIKELY(res == NOT_AN_INSTRUMENT)) return NOTOK;
-          evt.p[1] = (MYFLT)res;
+          res = named_instr_find(csound, ((STRINGDAT *)p->args[1])->data);
+          if (UNLIKELY(res == FL(0.0))) return NOTOK;
+          evt.p[1] = res;
         } else {                  /* Should check for valid instr num here */
           MYFLT insno = FABS(*p->args[1]);
           evt.p[1] = *p->args[1];
@@ -565,12 +564,10 @@ int32_t eventOpcodeI_(CSOUND *csound, LINEVENT *p, int32_t insname, char p1)
     /* IV - Oct 31 2002: allow string argument */
     if (evt.pcnt > 0) {
       if (insname) {
-        int32_t res;
-        if (UNLIKELY(evt.opcod != 'i' && evt.opcod != 'q' && opcod != 'd'))
-          return csound->InitError(csound, "%s", Str(errmsg_2));
-        res = csound->StringArg2Insno(csound,((STRINGDAT *)p->args[1])->data, 1);
-        if (UNLIKELY(res == NOT_AN_INSTRUMENT)) return NOTOK;
-        evt.p[1] = (MYFLT)res;
+        MYFLT res;
+        res = named_instr_find(csound, ((STRINGDAT *)p->args[1])->data);
+        if (UNLIKELY(res == FL(0.0))) return NOTOK;
+        evt.p[1] = res;
         evt.strarg = NULL; evt.scnt = 0;
         for (i = 2; i <= evt.pcnt; i++)
            evt.p[i] = *p->args[i];
@@ -578,8 +575,7 @@ int32_t eventOpcodeI_(CSOUND *csound, LINEVENT *p, int32_t insname, char p1)
       else {
         evt.strarg = NULL; evt.scnt = 0;
         if (IsStringCode(*p->args[1])) {
-          int32_t res = csound->StringArg2Insno(csound,
-                                         get_arg_string(csound, *p->args[1]), 1);
+          MYFLT res = named_instr_find(csound, ((STRINGDAT *)p->args[1])->data);
           if (UNLIKELY(evt.p[1] == (MYFLT) NOT_AN_INSTRUMENT)) return NOTOK;
           evt.p[1] = (MYFLT)res;
         }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -176,6 +176,7 @@ def runTest():
     ["testmidichannels.csd", "test use of mapped multiport channels"],
     ["test_max_table_len.csd", "test max table length"],
     ["test_complex_numbers.csd", "testing complex number operations"],
+    ["test_schedule_named_instance.csd", "testing schedule with named instr instance"],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test_schedule_named_instance.csd
+++ b/tests/commandline/test_schedule_named_instance.csd
@@ -1,0 +1,22 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+opcode assert(inst1:i, inst2:i):void
+if inst1 != inst2 then
+ exitnow(-1)
+endif
+endop
+
+instr Test
+assert(p1, 1.01)
+endin
+schedule("Test.01", 0, 0)
+
+</CsInstruments>
+<CsScore>
+f0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR fixes issue https://github.com/csound/csound/issues/2018 where schedule (schedulek etc) and event_i (event) ignored the instance annotation on named instrument strings.