### PR TITLE
Fixing message buffer test which did not pass address sanitizer

### DIFF
--- a/tests/c/csound_message_buffer_test.cpp
+++ b/tests/c/csound_message_buffer_test.cpp
@@ -62,7 +62,7 @@ TEST_F (MessageBufferTests, testBufferRun)
     while (csoundGetMessageCnt(csound)) {
         const char * msg = csoundGetFirstMessage(csound);
         ASSERT_TRUE (msg != NULL);
-        csoundPopFirstMessage(csound);
         printf("CSOUND MESSAGE: %s", msg);
+        csoundPopFirstMessage(csound);
     }
 }


### PR DESCRIPTION
Using address sanitizer I picked up an error in one of the tests, where the message buffer was being popped out before it was used and a use-after-free error ensued. This fixes the test and all tests are passing now.