### PR TITLE
Reducing warnings on Windows  

### DIFF
--- a/Engine/cs_new_dispatch.c
+++ b/Engine/cs_new_dispatch.c
@@ -351,7 +351,7 @@ taskID dag_get_task(CSOUND *csound, int32_t index, int32_t numThreads, taskID ne
 #ifndef WIN32        
         if (ATOMIC_CAS(&(task_status[i].s), current_task_status, INPROGRESS)) {
 #else
-if (ATOMIC_CAS(&(task_status[i].s), (long *)current_task_status, INPROGRESS)) {
+          if (ATOMIC_CAS((long *) &(task_status[i].s), current_task_status, INPROGRESS)) {
 #endif
           return (taskID)i;
         }

--- a/Engine/cs_new_dispatch.c
+++ b/Engine/cs_new_dispatch.c
@@ -348,7 +348,11 @@ taskID dag_get_task(CSOUND *csound, int32_t index, int32_t numThreads, taskID ne
       switch (current_task_status) {
       case AVAILABLE :
         // Need to CAS as the value may have changed
+#ifndef WIN32        
         if (ATOMIC_CAS(&(task_status[i].s), current_task_status, INPROGRESS)) {
+#else
+if (ATOMIC_CAS(&(task_status[i].s), (long *)current_task_status, INPROGRESS)) {
+#endif
           return (taskID)i;
         }
         break;

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -231,7 +231,7 @@ int32_t hfgens(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp, int32_t mode)
       ff.guardreq = ff.flen & 01;       /*  set guard request flg   */
       ff.flen &= -2L;                   /*  flen now w/o guardpt    */   
     }
-    if (ff.flen > MAXLEN)           
+    if (ff.flen >  MAXLEN)           
         return fterror(&ff, Str("illegal table length"));
     // now flen is set
     // test and set lobits

--- a/H/csGblMtx.h
+++ b/H/csGblMtx.h
@@ -47,7 +47,9 @@ void csoundUnLock() {
 #endif
 
 #elif defined(_WIN32) || defined (__WIN32__)
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
+#endif
 #include <windows.h>
 
 #ifdef __cplusplus
@@ -72,7 +74,7 @@ void csoundLock() {
     BOOL status;
     CRITICAL_SECTION* cs;
 
-    status = InitOnceExecuteOnce(&g_InitOnce, InitHandleFunction, NULL, &cs);
+    status = InitOnceExecuteOnce(&g_InitOnce, InitHandleFunction, NULL, (void **) &cs);
     if (status) {
       EnterCriticalSection(cs);
     }

--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -94,7 +94,9 @@ typedef uint32_t uintptr_t;
 #endif
 
 #ifdef WIN32
+#ifndef strcasecmp
 #define strcasecmp stricmp
+#endif
 #endif
 
 #ifndef M_PI

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -76,7 +76,7 @@ static inline void spout_interleave(CSOUND *csound, int32_t scal) {
   spoutrem -= (end-start)*nchnls;
   csound->libsndStatics.outbufrem -= (end-start)*nchnls;
   for(j=start; j<end; j++) {
-   for(i=0; i<nchnls;i++) {
+    for(i=0; i< (int32_t) nchnls;i++) {
      absamp = spinter[i*ksmps+j];
       // built inlimiter start ****
       // There is a rather awkward problem in reporting out of range not being

--- a/Opcodes/pinker.c
+++ b/Opcodes/pinker.c
@@ -57,10 +57,10 @@ static int32_t instance_cnt = 0;    /* Is tis thread-safe? */
 
 #define F(cf,m,shift)   (0.0625f*cf*(2*((m)>>shift&1)-1))
 
-#define FA(n)   F(1.190566,n,0)+F(0.162580,n,1)+F(0.002208,n,2)+ \
-                F(0.025475,n,3)+F(-0.001522,n,4)+F(0.007322,n,5)-PINK_BIAS
-#define FB(n)   F(0.001774,n,0)+F(0.004529,n,1)+F(-0.001561,n,2)+ \
-                F(0.000776,n,3)+F(-0.000486,n,4)+F(0.002017,n,5)
+#define FA(n)   ((float)(F(1.190566,n,0)+F(0.162580,n,1)+F(0.002208,n,2)+ \
+                         F(0.025475,n,3)+F(-0.001522,n,4)+F(0.007322,n,5)-PINK_BIAS))
+#define FB(n)   ((float)F(0.001774,n,0)+F(0.004529,n,1)+F(-0.001561,n,2)+ \
+                 F(0.000776,n,3)+F(-0.000486,n,4)+F(0.002017,n,5))
 
 #define FA8(n)  FA(n),FA(n+1),FA(n+2),FA(n+3),FA(n+4),FA(n+5),FA(n+6),FA(n+7)
 #define FB8(n)  FB(n),FB(n+1),FB(n+2),FB(n+3),FB(n+4),FB(n+5),FB(n+6),FB(n+7)

--- a/Opcodes/pinker.c
+++ b/Opcodes/pinker.c
@@ -59,8 +59,8 @@ static int32_t instance_cnt = 0;    /* Is tis thread-safe? */
 
 #define FA(n)   ((float)(F(1.190566,n,0)+F(0.162580,n,1)+F(0.002208,n,2)+ \
                          F(0.025475,n,3)+F(-0.001522,n,4)+F(0.007322,n,5)-PINK_BIAS))
-#define FB(n)   ((float)F(0.001774,n,0)+F(0.004529,n,1)+F(-0.001561,n,2)+ \
-                 F(0.000776,n,3)+F(-0.000486,n,4)+F(0.002017,n,5))
+#define FB(n)   ((float)(F(0.001774,n,0)+F(0.004529,n,1)+F(-0.001561,n,2)+ \
+                         F(0.000776,n,3)+F(-0.000486,n,4)+F(0.002017,n,5)))
 
 #define FA8(n)  FA(n),FA(n+1),FA(n+2),FA(n+3),FA(n+4),FA(n+5),FA(n+6),FA(n+7)
 #define FB8(n)  FB(n),FB(n+1),FB(n+2),FB(n+3),FB(n+4),FB(n+5),FB(n+6),FB(n+7)

--- a/Opcodes/sequencer.c
+++ b/Opcodes/sequencer.c
@@ -126,7 +126,7 @@ static int32_t sequencer(CSOUND *csound, SEQ *p)
     if (*p->verbos) printf("RESET!!\n");
     goto minus7;
   }
-  else if (p->time > CS_KSMPS) {         /* Not yet time to act */
+  else if (p->time > (int32_t) CS_KSMPS) {         /* Not yet time to act */
     //printf("**time= %d", p->time);
     p->time -= CS_KSMPS;
     *p->res = -FL(1.0);

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -525,7 +525,11 @@ static int32_t send_srecv(CSOUND *csound, SOCKRECVT *p)
     memset(q, '\0', k);
  again:
     errno = 0;
+#ifndef WIN32    
     n = (int32_t) recv(p->conn, q, k, 0);
+#else
+    n = (int32_t) recv(p->conn, (char *) q, k, 0);
+#endif    
     if (n==0) {      /* Connection broken */
       if (p->res) *p->res = -1;
       close(p->sock);

--- a/Opcodes/socksend.c
+++ b/Opcodes/socksend.c
@@ -422,8 +422,11 @@ static int32_t send_ssend(CSOUND *csound, SOCKSEND *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     int32_t n = sizeof(MYFLT) * (CS_KSMPS-offset-early);
-
+#ifndef WIN32
     if (UNLIKELY(n != send(p->sock, &p->asig[offset], n, 0))) {
+#else
+      if (UNLIKELY(n != send(p->sock, (const char *) (&p->asig[offset]), n, 0))) {
+#endif
       csound->Message(csound, Str("Expected %d got %d\n"),
                       (int32_t) (sizeof(MYFLT) * CS_KSMPS), n);
       return csound->PerfError(csound, &(p->h),

--- a/Opcodes/ugensa.h
+++ b/Opcodes/ugensa.h
@@ -31,7 +31,7 @@ typedef struct overlap {
   struct overlap *nxtact;
   struct overlap *nxtfree;
   int32          timrem, dectim, formphs, forminc;
-  uint32         risphs;
+  int32         risphs;
   int32          risinc, decphs, decinc;
   double         formphsf, formincf, risphsf, risincf, decphsf, decincf;
   MYFLT          curamp, expamp;

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -1109,7 +1109,7 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv)
         int32_t i = 1, n;
         s += 9;
         n = atoi(s);
-        while (i<=n && i< MAXLEN) i <<= 1;
+        while (i<=n && i < MAXLEN) i <<= 1;
         csound->sinelength = i;
         return 1;
       }

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1599,7 +1599,7 @@ inline void advanceINSDSPointer(INSDS ***start, int32_t num)
 
 inline static void mix_out(MYFLT *out, MYFLT *in,
                            uint32_t smps){
-  int32_t i;
+  uint32_t i;
   for(i=0; i < smps; i++) out[i] += in[i];
 }
 

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -208,13 +208,14 @@ extern "C" {
 #define CURTIME_inc (((double)csound->ksmps)/((double)csound->esr))
 
 #ifndef  SHORT_TABLE_LENGTH  // long max table length is the default
-static const uint32_t MAXLEN = 1U << 30;
-static const double FMAXLEN = (double) (1U << 30);
-static const uint32_t PHMASK = (1U << 30) - 1U;
+// MAXLEN is the largest positive 32bit signed pow of two  
+static const int32_t MAXLEN = 1 << 30;
+static const double FMAXLEN = (double) (1 << 30);
+static const uint32_t PHMASK = (1 << 30) - 1;
 #else   // this is the original max table length
-static const uint32_t MAXLEN =  1U << 24;
-static const double FMAXLEN = (double) (1U << 24);
-static const double FMAXLEN = (1U << 24) - 1;
+static const int32_t MAXLEN =  1 << 24;
+static const double FMAXLEN = (double) (1 << 24);
+static const uint32_t PHMASK = (1 << 24) - 1;
 #endif
 
 

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -108,7 +108,7 @@ int32_t key_callback_txt(void *userData, void *p, uint32_t type)
 
 TEST_F (IOTests, testKeyboardIO)
 {
-    int32_t ret, err, prev = 100;
+    int32_t ret, prev = 100;
 
     ret = csoundRegisterKeyboardCallback(csound, key_callback_evt, &prev, CSOUND_CALLBACK_KBD_EVENT);
     ASSERT_TRUE (ret == CSOUND_SUCCESS);


### PR DESCRIPTION
There seem to be over 50 warnings on Windows. This PR aims to either deal with all of these or at least reduce this number.

A lot of these had to do with unsigned/signed comparisons and the majority pointed at comparisons with MAXLEN. Since this sets the max table size, and table sizes are signed int32s, then it did not make sense to have MAXLEN as unsigned. It's actually the max power-of-two that can be represented as 32bit signed int positive value. I also spotted am typo in the definitions for short table sizes (PHMASK was not defined).

Some changes were also made to fix warnings in the mingw build.