### PR TITLE
restoring strsets and strsmax access

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -129,7 +129,7 @@ static const char *csoundGetStrsets(CSOUND *csound, int32_t n) {
   else return csound->strsets[n];
 }
 
-static int csoundGetStrsetsMax(CSOUND *csound) {
+static int32_t csoundGetStrsetsMax(CSOUND *csound) {
   return csound->strsmax;
 }
 

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -124,6 +124,16 @@ extern OENTRY opcodlst_1[];
 #define STRING_HASH(arg) STRSH(arg)
 #define STRSH(arg) #arg
 
+static const char *csoundGetStrsets(CSOUND *csound, int32_t n) {
+  if(csound->strsets == NULL) return NULL;
+  else return csound->strsets[n];
+}
+
+static int csoundGetStrsetsMax(CSOUND *csound) {
+  return csound->strsmax;
+}
+
+
 static const char *csoundFileError(CSOUND *csound, void *ff) {
   CSFILE *f = (CSFILE *) ff;
   switch(f->type) {
@@ -380,6 +390,8 @@ static const CSOUND cenviron_ = {
   csoundGetTieFlag,
   csoundGetReinitFlag,
   csoundGetInstrumentList,
+  csoundGetStrsetsMax,
+  csoundGetStrsets,
   csoundGetHostData,
   csoundGetCurrentTimeSamples,
   csoundGetInputBufferSize,

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1378,6 +1378,10 @@ static inline double PHMOD1(double p) {
     int32_t (*GetReinitFlag)(CSOUND *);
     /** Get current compiled instrument list */
     INSTRTXT **(*GetInstrumentList)(CSOUND *);
+    /** Get the max number of strsets */
+    int (*GetStrsetsMax)(CSOUND *);
+    /** Get a string from Strsets */
+    const char *(*GetStrsets)(CSOUND *, int32_t);    
 
     void *(*GetHostData)(CSOUND *);
     int64_t (*GetCurrentTimeSamples)(CSOUND *);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1379,7 +1379,7 @@ static inline double PHMOD1(double p) {
     /** Get current compiled instrument list */
     INSTRTXT **(*GetInstrumentList)(CSOUND *);
     /** Get the max number of strsets */
-    int (*GetStrsetsMax)(CSOUND *);
+    int32_t (*GetStrsetsMax)(CSOUND *);
     /** Get a string from Strsets */
     const char *(*GetStrsets)(CSOUND *, int32_t);    
 


### PR DESCRIPTION
This PR adds two functions to the module API

```
    /** Get the max number of strsets */
    int32_t (*GetStrsetsMax)(CSOUND *);
    /** Get a string from Strsets */
    const char *(*GetStrsets)(CSOUND *, int32_t);    
```