### PR TITLE
added new csoundFindOpcode function

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -3223,7 +3223,7 @@ typedef struct {
   ARRAYDAT *tab, *tabin;
   STRINGDAT *str;
   int32_t    len;
-  OENTRY *opc;
+  const OENTRY *opc;
 } TABMAP;
 
 
@@ -3232,7 +3232,7 @@ static int32_t tabmap_set(CSOUND *csound, TABMAP *p)
 {
   MYFLT *data, *tabin = p->tabin->data;
   int32_t n, size;
-  OENTRY *opc  = NULL;
+  const OENTRY *opc  = NULL;
   AEVAL  eval;
 
   if (UNLIKELY(p->tabin->data == NULL)||p->tabin->dimensions!=1)
@@ -3247,7 +3247,7 @@ static int32_t tabmap_set(CSOUND *csound, TABMAP *p)
   data =  p->tab->data;
 
 
-  opc = csound->FindOpcode(csound, p->str->data, "i", "i");
+  opc = csound->FindOpcode(csound, 1, p->str->data, "i", "i");
   if (UNLIKELY(opc == NULL))
     return csound->InitError(csound,  Str("%s not found"), p->str->data);
   p->opc = opc;
@@ -3257,7 +3257,7 @@ static int32_t tabmap_set(CSOUND *csound, TABMAP *p)
     opc->init(csound, (void *) &eval);
   }
 
-  opc = csound->FindOpcode(csound, p->str->data, "k", "k");
+  opc = csound->FindOpcode(csound, 1, p->str->data, "k", "k");
   p->opc = opc;
   return OK;
 }
@@ -3267,7 +3267,8 @@ static int32_t tabmap_perf(CSOUND *csound, TABMAP *p)
   /* FIXME; eeds check */
   MYFLT *data =  p->tab->data, *tabin = p->tabin->data;
   int32_t n, size;
-  OENTRY *opc  = p->opc;
+
+  const OENTRY *opc  = p->opc;
   AEVAL  eval;
 
   if (UNLIKELY(p->tabin->data == NULL) || p->tabin->dimensions !=1)

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -371,6 +371,16 @@ const CSOUND_UTIL *csoundGetCsoundUtility(CSOUND *csound) {
   return &csound->csound_util;
 }
 
+/* 
+  exact selects the type of search 
+ */
+static const OENTRY* csoundFindOpcode(CSOUND *csound, int32_t exact,
+                                char* opname, char* outargs,
+                                char* inargs) {
+  if(exact) return find_opcode_exact(csound, opname, outargs, inargs);
+  else return find_opcode_new(csound, opname, outargs, inargs);
+}
+
 static const CSOUND cenviron_ = {
   /* attributes  */
   csoundGetNchnls,
@@ -562,7 +572,7 @@ static const CSOUND cenviron_ = {
   /* opcodes and instruments  */
   csoundAppendOpcode,
   csoundAppendOpcodes,
-  find_opcode_exact,
+  csoundFindOpcode,
   /* RT audio IO and callbacks */
   csoundSetPlayopenCallback,
   csoundSetRtplayCallback,

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1648,7 +1648,7 @@ static inline double PHMOD1(double p) {
                         int32_t (*perf)(CSOUND *, void *),
                         int32_t (*deinit)(CSOUND *, void *));
     int32_t (*AppendOpcodes)(CSOUND *, const OENTRY *opcodeList, int32_t n);
-    OENTRY* (*FindOpcode)(CSOUND*, char*, char* , char*);
+    const OENTRY* (*FindOpcode)(CSOUND*, int32_t exact, char*, char* , char*);
     /**@}*/
 
     /** @name RT audio IO module support */


### PR DESCRIPTION
Following the discussion in #2031, a new function is introduced to select either find_opcode_exact or find_opcode_new

```
const OENTRY* (*FindOpcode)(CSOUND*, int32_t exact, char*, char* , char*);
```
