### PR TITLE
bring in copyright update to readme template

### DIFF
--- a/README.md.in
+++ b/README.md.in
@@ -4,16 +4,24 @@ Version ${CS_VERSION}.${CS_SUBVER}.${CS_PATCHLEVEL} (beta)
 This is the the develop branch of the Csound main code repository. At
 the moment, we are developing the next main version (moving from 6.x
 to 7.0), and this branch reflects current work-in-progress. This is
-still undergoing changes and fixes until the first release, scheduled
-for September 2024. Anyone seeking the latest 6.x version please
-checkout the csound6 branch (or the master branch, containing the
-latest and final release of this version).
+still undergoing changes and fixes until the first release. The
+latest beta release installers for MacOS, iOS, and Windows can be
+downloaded from the relevant
+[github actions page](https://github.com/csound/csound/actions/workflows/csound_builds.yml).
+Selecting the latest develop build brings a page with the download
+artefacts at the bottom.
+
+
+Anyone seeking the latest 6.x version please checkout the csound6
+branch (or the master branch, containing the latest and final release
+of this version). Note that 6.x is EOL and no more releases of that
+version are planned.
 
 ![Build Status](https://github.com/csound/csound/actions/workflows/csound_builds.yml/badge.svg?branch=develop)
 <!--- ![Coverity Status](https://scan.coverity.com/projects/1822/badge.svg) --->
 A sound and music computing system.
 
-Csound is copyright (c) 1991-2020 The Csound Developers, see CONTRIBUTORS
+Csound is copyright (c) 1991-2024 The Csound Developers, see CONTRIBUTORS
 
 Csound is free software; you can redistribute them
 and/or modify them under the terms of the GNU Lesser General Public


### PR DESCRIPTION
I noticed that the cmake generation was causing a readme diff again, so I brought over the changes.