### PR TITLE
Fixed memory access after free issue on instr redefinition fail

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1367,6 +1367,14 @@ void insert_instrtxt(CSOUND *csound, INSTRTXT *instrtxt, int32 instrNum,
                      ENGINE_STATE *engineState, int32_t merge) {
   int32_t i;
 
+  /* redefinition not allowed in the same compilation */
+  if(UNLIKELY(engineState->instrtxtp[instrNum] != NULL) &&
+     !merge) {
+      synterr(csound, Str("instr %d redefined in code:\n"
+                          "redefinition not allowed."), instrNum);
+      return;
+  }
+
   if (UNLIKELY(instrNum >= engineState->maxinsno)) {
     int32_t old_maxinsno = engineState->maxinsno;
 
@@ -1375,9 +1383,9 @@ void insert_instrtxt(CSOUND *csound, INSTRTXT *instrtxt, int32 instrNum,
       engineState->maxinsno += MAXINSNO;
     }
 
-    engineState->instrtxtp = (INSTRTXT **)csound->ReAlloc(
-                                                          csound, engineState->instrtxtp,
-                                                          (1 + engineState->maxinsno) * sizeof(INSTRTXT *));
+    engineState->instrtxtp = (INSTRTXT **)
+      csound->ReAlloc(csound, engineState->instrtxtp,
+                      (1 + engineState->maxinsno) * sizeof(INSTRTXT *));
 
     /* Array expected to be nulled so.... */
     for (i = old_maxinsno + 1; i <= engineState->maxinsno; i++) {
@@ -1389,9 +1397,6 @@ void insert_instrtxt(CSOUND *csound, INSTRTXT *instrtxt, int32 instrNum,
     instrtxt->isNew = 1;
 
     /* redefinition does not raise an error now, just a warning */
-    /* unless we are not merging */
-    if (!merge)
-      synterr(csound, Str("instr %d redefined\n"), instrNum);
     if (UNLIKELY(instrNum && csound->oparms->odebug))
       csound->Warning(csound, Str("instr %" PRIi32 " redefined, "
                                   "replacing previous definition"),

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -530,7 +530,6 @@ int32_t csoundCleanup(CSOUND *csound)
     }
 
     orcompact(csound);
-
     corfile_rm(csound, &csound->scstr);
 
     /* print stats only if musmon was actually run */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -121,6 +121,7 @@ def runTest():
 	["test46.csd", "if-then with expression in boolean comparison"],
 	["test47.csd", "until loop and t-variables"],
 	["test48.csd", "expected failure with variable used before defined", 1],
+    ["test_instr_redefinition.csd", "expected failure with instr redefinition", 1],
 	["test_instr0_labels.csd", "test labels in instr0 space"],
 	["test_string.csd", "test string assignment and printing"],
 	["test_sprintf.csd", "test string assignment and printing"],
@@ -140,6 +141,7 @@ def runTest():
              "test expected failure with negative dimension size and array", 1],
 
 	["test_audio_in.csd", "test the parsing of the 'in' operator as opcode"],
+    
 
 	["test_empty_conditional_branches.csd", "tests that empty branches do not cause compiler issues"],
 	["test_empty_instr.csd", "tests that empty instruments do not cause compiler issues"],

--- a/tests/commandline/test_instr_redefinition.csd
+++ b/tests/commandline/test_instr_redefinition.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+
+instr 1
+endin
+
+instr 2
+endin
+
+instr 3
+endin
+
+instr 4
+endin
+
+instr 4
+endin
+
+</CsInstruments>
+<CsScore>
+i4 0 2 
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Using address sanitizer, I picked up what looks like a longstanding issue where an instrument redefinition fail  was leading to access after free in `orcompact()`. This is fixed and a test has been added.