### PR TITLE
Fixing bug in callback setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of this version). Note that 6.x is EOL and no more releases of that
 version are planned.
 
 ![Build Status](https://github.com/csound/csound/actions/workflows/csound_builds.yml/badge.svg?branch=develop)
-
+<!--- ![Coverity Status](https://scan.coverity.com/projects/1822/badge.svg) --->
 A sound and music computing system.
 
 Csound is copyright (c) 1991-2024 The Csound Developers, see CONTRIBUTORS

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -316,14 +316,14 @@ PUBLIC void csoundSetSndfileCallbacks(CSOUND *csound, SNDFILE_CALLBACKS *p){
       p->sndfileWriteSamples : sndfileWriteSamples;
     csound->SndfileReadSamples = p->sndfileReadSamples ?
       p->sndfileReadSamples : sndfileReadSamples;
-    csound->SndfileSeek =  csound->SndfileSeek ?
-      csound->SndfileSeek : sndfileSeek;
-    csound->SndfileSetString = csound->SndfileSetString ?
-      csound->SndfileSetString : sndfileSetString;
-    csound->SndfileStrError = csound->SndfileStrError?
-      csound->SndfileStrError : sndfileStrError;
-    csound->SndfileCommand = csound->SndfileCommand?
-      csound->SndfileCommand :sndfileCommand;
+    csound->SndfileSeek =  p->sndfileSeek ?
+      p->sndfileSeek : sndfileSeek;
+    csound->SndfileSetString = p->sndfileSetString ?
+      p->sndfileSetString : sndfileSetString;
+    csound->SndfileStrError = p->sndfileStrError?
+      p->sndfileStrError : sndfileStrError;
+    csound->SndfileCommand = p->sndfileCommand?
+      p->sndfileCommand : sndfileCommand;
   }
 }
 

--- a/tests/c/csound_test_sndfile.cpp
+++ b/tests/c/csound_test_sndfile.cpp
@@ -46,12 +46,15 @@ public:
 void *sfile_open(CSOUND *csound, const char *path, int32_t mode,
                  SFLIB_INFO *sfinfo) {
   FILE *fp = fopen(path, mode == SFM_READ ? "rb" : "wb");
+  printf("soundfile opened %p\n", fp);
   if (fp != NULL) {
       sfile *file = (sfile *) csound->Calloc(csound, sizeof(sfile));
-      sfinfo->samplerate = (int32_t) csoundGetSr(csound);
-      sfinfo->channels = (int32_t) csoundGetNchnls(csound);
+      file->sfinfo = (SFLIB_INFO *) csound->Calloc(csound, sizeof(SFLIB_INFO));
+      sfinfo->samplerate =
+        file->sfinfo->samplerate = (int32_t) csoundGetSr(csound);
+      sfinfo->channels =
+      file->sfinfo->channels = (int32_t) csoundGetChannels(csound, 0);
       file->fp = fp;
-      file->sfinfo = sfinfo;
       return file;
    }
   else return NULL;
@@ -63,7 +66,11 @@ void *sfile_open_fd(CSOUND *csound, int32_t fd, int32_t mode, SFLIB_INFO *sfinfo
   if (fp != NULL) {
       sfile *file = (sfile *) csound->Calloc(csound, sizeof(sfile));
       file->fp = fp;
-      file->sfinfo = sfinfo;
+      file->sfinfo = (SFLIB_INFO *) csound->Calloc(csound, sizeof(SFLIB_INFO));
+      sfinfo->samplerate =
+        file->sfinfo->samplerate = (int32_t) csoundGetSr(csound);
+      sfinfo->channels =
+      file->sfinfo->channels = (int32_t) csoundGetChannels(csound, 0); 
       return file;
    }
   else return NULL;
@@ -73,12 +80,14 @@ void *sfile_open_fd(CSOUND *csound, int32_t fd, int32_t mode, SFLIB_INFO *sfinfo
 int32_t sfile_close(CSOUND *csound, void *p) {
     sfile *file = (sfile *) p;
     fclose(file->fp);
+    csound->Free(csound, file->sfinfo);
     csound->Free(csound, file);
     return CSOUND_SUCCESS;
 }
 
 int64_t sfile_write(CSOUND *csound, void *p, MYFLT *data, int64_t frames) {
   sfile *file = (sfile *) p;
+   printf("writing soundfile %p\n", p);
   return fwrite(data, sizeof(MYFLT)*file->sfinfo->channels, frames, file->fp);
 }
 
@@ -89,6 +98,7 @@ int64_t sfile_read(CSOUND *csound, void *p, MYFLT *data, int64_t frames) {
 
 int64_t sfile_write_samples(CSOUND *csound, void *p, MYFLT *data, int64_t samples) {
   sfile *file = (sfile *) p;
+  printf("writing soundfile %p\n", p);
   return fwrite(data, sizeof(MYFLT), samples, file->fp);
 }
 

--- a/tests/c/csound_test_sndfile.cpp
+++ b/tests/c/csound_test_sndfile.cpp
@@ -46,7 +46,6 @@ public:
 void *sfile_open(CSOUND *csound, const char *path, int32_t mode,
                  SFLIB_INFO *sfinfo) {
   FILE *fp = fopen(path, mode == SFM_READ ? "rb" : "wb");
-  printf("soundfile opened %p\n", fp);
   if (fp != NULL) {
       sfile *file = (sfile *) csound->Calloc(csound, sizeof(sfile));
       file->sfinfo = (SFLIB_INFO *) csound->Calloc(csound, sizeof(SFLIB_INFO));
@@ -87,7 +86,6 @@ int32_t sfile_close(CSOUND *csound, void *p) {
 
 int64_t sfile_write(CSOUND *csound, void *p, MYFLT *data, int64_t frames) {
   sfile *file = (sfile *) p;
-   printf("writing soundfile %p\n", p);
   return fwrite(data, sizeof(MYFLT)*file->sfinfo->channels, frames, file->fp);
 }
 
@@ -98,7 +96,6 @@ int64_t sfile_read(CSOUND *csound, void *p, MYFLT *data, int64_t frames) {
 
 int64_t sfile_write_samples(CSOUND *csound, void *p, MYFLT *data, int64_t samples) {
   sfile *file = (sfile *) p;
-  printf("writing soundfile %p\n", p);
   return fwrite(data, sizeof(MYFLT), samples, file->fp);
 }
 


### PR DESCRIPTION
This PR fixes a bug where some callbacks were not being set because of a typo in the code. This was leading to segfault in tests under Windows.