### PR TITLE
Sample accurate mode fix for RT events

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install cmake libgtest-dev libsndfile1-dev libasound2-dev libjack-dev portaudio19-dev libportmidi-dev libpulse-dev swig liblua5.1-0-dev default-jdk libfltk1.1-dev libfluidsynth-dev liblo-dev fluid ladspa-sdk libpng-dev dssi-dev libstk0-dev libgmm++-dev bison flex libportsmf-dev libeigen3-dev libcunit1-dev gettext libsamplerate0-dev
+          sudo apt-get install cmake libgtest-dev libsndfile1-dev libasound2-dev libjack-dev portaudio19-dev libportmidi-dev libpulse-dev swig liblua5.1-0-dev default-jdk liblo-dev fluid ladspa-sdk libpng-dev dssi-dev  bison flex libportsmf-dev libcunit1-dev gettext libsamplerate0-dev
 
       - name: Configure build
         run: |

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -134,6 +134,9 @@ OENTRY opcodlst_1[] = {
   { "midglobal",S(MIDGLOBAL),0,   "",     "Sm", midglobal, NULL, NULL, NULL},
   { "ihold",  S(LINK),0,          "",     "",     ihold, NULL, NULL, NULL  },
   { "turnoff",S(LINK),0,           "",     "",     NULL,   turnoff, NULL, NULL },
+  { "offsetsmps", S(AOP), 0, "i", "", (SUBR) sa_offset, NULL, NULL},
+  { "offsetsmps", S(AOP), 0, "k", "", NULL,(SUBR) sa_offset, NULL},
+  { "earlysmps", S(AOP), 0, "k", "", NULL,(SUBR) sa_early, NULL},
   { "str", S(IREF_NUM) ,0,  "S", ":InstrDef;", (SUBR) get_instr_name},
   /* VL: 10.2.22 this was thread  but with parser3 we need to make string assignment on threads 1 & 2 */
   {  "=.S",   S(STRCPY_OP),0,     "S",    "S",

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -450,7 +450,7 @@ OENTRY opcodlst_1[] = {
   { "expsegb", S(EXXPSEG),0,       "k",    "iim",  xsgset_bkpt, kxpseg, NULL },
   { "expsegb.a", S(EXXPSEG),0,      "a",    "iim",  xsgset_bkpt, expseg },
   { "expsega",S(EXPSEG2),0,       "a",    "iim",  xsgset2, expseg2  },
-  { "exp=segba",S(EXPSEG2),0,       "a",    "iim",  xsgset2b, expseg2 },
+  { "expsegba",S(EXPSEG2),0,       "a",    "iim",  xsgset2b, expseg2 },
   { "expsegr",S(EXPSEG),0,        "k",    "iim",  xsgrset,kxpsegr,NULL },
   { "expsegr.a",S(EXPSEG),0,        "a",    "iim",  xsgrset,expsegr },
   { "linen",  S(LINEN),0,         "k",    "kiii", lnnset, klinen, NULL   },

--- a/Engine/entry1.c
+++ b/Engine/entry1.c
@@ -134,14 +134,11 @@ OENTRY opcodlst_1[] = {
   { "midglobal",S(MIDGLOBAL),0,   "",     "Sm", midglobal, NULL, NULL, NULL},
   { "ihold",  S(LINK),0,          "",     "",     ihold, NULL, NULL, NULL  },
   { "turnoff",S(LINK),0,           "",     "",     NULL,   turnoff, NULL, NULL },
-  { "offsetsmps", S(AOP), 0, "i", "", (SUBR) sa_offset, NULL, NULL},
   { "offsetsmps", S(AOP), 0, "k", "", NULL,(SUBR) sa_offset, NULL},
   { "earlysmps", S(AOP), 0, "k", "", NULL,(SUBR) sa_early, NULL},
   { "str", S(IREF_NUM) ,0,  "S", ":InstrDef;", (SUBR) get_instr_name},
-  /* VL: 10.2.22 this was thread  but with parser3 we need to make string assignment on threads 1 & 2 */
   {  "=.S",   S(STRCPY_OP),0,     "S",    "S",
      (SUBR) strcpy_opcode_S, (SUBR) strassign_k, (SUBR) NULL, NULL    },
-  /* VL: 11.2.22 this was thread   but with an update count, we need to be initialised */
   {  "#=.S",   S(STRCPY_OP),0,     "S",    "S",
      (SUBR) strcpy_opcode_S, (SUBR) strassign_k, (SUBR) NULL, NULL    },
   {  "=.T",   S(STRCPY_OP),0,     "S",    "i",
@@ -453,7 +450,7 @@ OENTRY opcodlst_1[] = {
   { "expsegb", S(EXXPSEG),0,       "k",    "iim",  xsgset_bkpt, kxpseg, NULL },
   { "expsegb.a", S(EXXPSEG),0,      "a",    "iim",  xsgset_bkpt, expseg },
   { "expsega",S(EXPSEG2),0,       "a",    "iim",  xsgset2, expseg2  },
-  { "expsegba",S(EXPSEG2),0,       "a",    "iim",  xsgset2b, expseg2 },
+  { "exp=segba",S(EXPSEG2),0,       "a",    "iim",  xsgset2b, expseg2 },
   { "expsegr",S(EXPSEG),0,        "k",    "iim",  xsgrset,kxpsegr,NULL },
   { "expsegr.a",S(EXPSEG),0,        "a",    "iim",  xsgrset,expsegr },
   { "linen",  S(LINEN),0,         "k",    "kiii", lnnset, klinen, NULL   },

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -523,17 +523,8 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp)
   ip->opcod_iobufs = NULL;
   ip->strarg       = newevtp->strarg;  /* copy strarg so it does not get lost */
 
-  // current event needs to be reset here
-  csound->init_event = newevtp;
-  error = init_pass(csound, ip);
-  if(error == 0)
-    ATOMIC_SET(ip->init_done, 1);
-  if (UNLIKELY(csound->inerrcnt || ip->p3.value == FL(0.0))) {
-    xturnoff_now(csound, ip);
-    return csound->inerrcnt;
-  }
-
   /* new code for sample-accurate timing, not for tied notes */
+  /* VL 18 Dec 24 - needs to be set before init pass to propagate to UDOS */
   if (O->sampleAccurate && !tie) {
     int64_t start_time_samps, start_time_kcycles;
     double duration_samps;
@@ -560,6 +551,16 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp)
     ip->ksmps_offset = 0;
     ip->ksmps_no_end = 0;
     ip->no_end = 0;
+  }
+  
+  // current event needs to be reset here
+  csound->init_event = newevtp;
+  error = init_pass(csound, ip);
+  if(error == 0)
+    ATOMIC_SET(ip->init_done, 1);
+  if (UNLIKELY(csound->inerrcnt || ip->p3.value == FL(0.0))) {
+    xturnoff_now(csound, ip);
+    return csound->inerrcnt;
   }
 
 #ifdef BETA

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -614,6 +614,25 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp)
   return 0;
 }
 
+/** offsetsmps
+ *  returns the sample accurate offset at i or k time
+ *
+ *  [i/k]offs offsetsmps
+*/    
+int32 sa_offset(CSOUND *csound, AOP *p){
+  *p->r = p->h.insdshead->ksmps_offset;
+  return OK;
+}
+
+/** earlysmps
+ *  returns the sample accurate early exit length at k time
+ *
+ *  kearly earlysmps
+*/    
+int32 sa_early(CSOUND *csound, AOP *p){
+  *p->r = p->h.insdshead->ksmps_no_end;
+  return OK;
+}
 
 /* insert a MIDI instr copy into active list */
 /*  then run an init pass                    */

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -1260,15 +1260,10 @@ static inline uint64_t time2kcnt(CSOUND *csound, double tval)
 {
   if (tval > 0.0) {
     tval *= (double) csound->ekr;
-#ifdef HAVE_C99
-    return (uint64_t) llrint(tval);
-#else
-    return (uint64_t) (tval + 0.5);
-#endif
+    return !csound->oparms->sampleAccurate ? MYFLT2UINT64(tval) : (uint64_t) FLOOR(tval);
   }
   return 0UL;
 }
-
 
 /* Schedule new score event to be played. 'time_ofs' is the amount of */
 /* time in seconds to add to evt->p[2] to get the actual start time   */

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -548,14 +548,13 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
   /* sample-accurate offset */
   ofs = offset;
 
-  /* clear offsets, since with CS_KSMPS=1
-     they don't apply to opcodes, but to the
-     calling code (ie. this code)
-  */
-  this_instr->ksmps_offset = 0;
-  this_instr->ksmps_no_end = 0;
-
   if (this_instr->ksmps == 1) {           /* special case for local kr == sr */
+    /* clear offsets, since with CS_KSMPS=1
+       they don't apply to opcodes, but to the
+       calling code (ie. this code)
+    */
+    this_instr->ksmps_offset = 0;
+    this_instr->ksmps_no_end = 0;
     do {
       this_instr->kcounter++; /*kcounter needs to be incremented BEFORE perf */
       /* copy inputs */
@@ -831,6 +830,9 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
   if (UNLIKELY(!done)) /* init not done, exit */
     return OK;
 
+  /* VL 18.12.24: ksmps_no_end is copied here as it
+     applies only to last kcycle */ 
+  p->ip->ksmps_no_end = p->h.insdshead->ksmps_no_end;
   p->ip->spin = p->parent_ip->spin;
   p->ip->spout = p->parent_ip->spout;
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -702,6 +702,9 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
         current = current->next;
       }
 
+      this_instr->ksmps_offset = 0; /* reset sample-accuracy offset for UDO */
+      this_instr->ksmps_no_end = 0;  /* reset end of loop samples for UDO */
+
       /*  run each opcode  */
       if ((opstart = (OPDS *) (this_instr->nxtp)) != NULL) {
         int32_t error = 0;
@@ -810,8 +813,6 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
   if (!p->ip)                                         /* loop to last opds */
     while (CS_PDS && CS_PDS->nxtp) CS_PDS = CS_PDS->nxtp;
 
-  this_instr->ksmps_offset = 0; /* reset sample-accuracy offset */
-  this_instr->ksmps_no_end = 0;  /* reset end of loop samples */
   return OK;
 }
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -810,6 +810,9 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
   /* check if instrument was deactivated (e.g. by perferror) */
   if (!p->ip)                                         /* loop to last opds */
     while (CS_PDS && CS_PDS->nxtp) CS_PDS = CS_PDS->nxtp;
+
+  this_instr->ksmps_offset = 0; /* reset sample-accuracy offset */
+  this_instr->ksmps_no_end = 0;  /* reset end of loop samples */
   return OK;
 }
 
@@ -930,6 +933,8 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
       CS_PDS = CS_PDS->nxtp;
     }
   }
+  p->ip->ksmps_offset = 0; /* reset sample-accuracy offset */
+  p->ip->ksmps_no_end = 0;  /* reset end of loop samples */
   return OK;
 }
 

--- a/H/insert.h
+++ b/H/insert.h
@@ -26,6 +26,7 @@
 
 #include "csoundCore.h"
 #include "udo.h"
+#include "aops.h"
 
 typedef struct {                        /*       INSERT.H                */
     OPDS    h;
@@ -61,6 +62,9 @@ typedef struct {
 } KILLOP;
 
 
+int32 sa_early(CSOUND *csound, AOP *p);
+int32 sa_offset(CSOUND *csound, AOP *p);
+  
 /* the number of optional outputs defined in entry.c */
 #define SUBINSTNUMOUTS  8
 

--- a/Opcodes/vaops.c
+++ b/Opcodes/vaops.c
@@ -57,11 +57,16 @@ static int32_t vaget(CSOUND *csound, VA_GET *p)
     int32 ndx = (int32) MYFLOOR((double)*p->kindx);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
+    if(LIKELY(ndx >= 0 && ndx < CS_KSMPS)) {
     if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaget (%d)"), ndx);
+      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+                      ndx, offset, CS_KSMPS-early);
     *p->kout = p->avar[ndx];
     return OK;
+    } else
+      return csound->PerfError(csound, &(p->h),
+                               Str("Out of range in vaget.k (%d)"), ndx);
+
 }
 
 static int32_t vaset(CSOUND *csound, VA_SET *p)
@@ -69,11 +74,15 @@ static int32_t vaset(CSOUND *csound, VA_SET *p)
     int32 ndx = (int32) MYFLOOR((double)*p->kindx);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
+    if(LIKELY(ndx >= 0 && ndx < CS_KSMPS)) {
     if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaset (%d)"), ndx);
-    p->avar[ndx] = *p->kval;
-    return OK;
+      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+                      ndx, offset, CS_KSMPS-early);
+     p->avar[ndx] = *p->kval;
+     return OK;
+    }
+    else return csound->PerfError(csound, &(p->h),
+                               Str("Out of range in vaset.k (%d)"), ndx);
 }
 
 
@@ -82,11 +91,15 @@ static int32_t vasigget(CSOUND *csound, VASIG_GET *p)
     int32 ndx = (int32) MYFLOOR((double)*p->kindx);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
+    if(LIKELY(ndx >= 0 && ndx < CS_KSMPS)) {
     if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaget (%d)"), ndx);
+      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+                      ndx, offset, CS_KSMPS-early);
     *p->kout = p->avar[ndx];
     return OK;
+    } else
+      return csound->PerfError(csound, &(p->h),
+                               Str("Out of range in vasigget.k (%d)"), ndx);
 }
 
 static int32_t vasigset(CSOUND *csound, VASIG_SET *p)
@@ -94,11 +107,16 @@ static int32_t vasigset(CSOUND *csound, VASIG_SET *p)
     int32 ndx = (int32) MYFLOOR((double)*p->kindx);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
+    if(LIKELY(ndx >= 0 && ndx < CS_KSMPS)) {
     if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaset (%d)"), ndx);
-    p->avar[ndx] = *p->kval;
-    return OK;
+      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+                      ndx, offset, CS_KSMPS-early);
+     p->avar[ndx] = *p->kval;
+     return OK;
+    }
+    else return csound->PerfError(csound, &(p->h),
+                               Str("Out of range in vasigset.k (%d)"), ndx);
+    
 }
 
 #define S(x)    sizeof(x)

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -416,6 +416,12 @@ static inline int64 MYFLT2LRND64(double fval)
 #  endif
 #endif
 
+#ifdef HAVE_C99
+#define MYFLT2UINT64(x) ((uint64_t) llrint(x))
+#else
+#define MYFLT2UINT64(x) ((uint64_t) (tval + 0.5)) 
+#endif
+
 /* inline functions and macros for clamping denormals to zero */
 
 #if defined(__i386__) || defined(MSVC)

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -29,7 +29,7 @@ public:
     virtual void SetUp ()
     {
         csound = csoundCreate (NULL,NULL);
-        csoundCreateMessageBuffer (csound, 0);
+        //csoundCreateMessageBuffer (csound, 0);
         csoundSetOption (csound, "-odac --logfile=null");
     }
 
@@ -193,5 +193,30 @@ const char* event = R"(
    }
    else
     ASSERT_FALSE(result == 0);
+}
+
+TEST_F (OrcCompileTests, testSampleAccurate)
+{
+  const char* instrument = R"(
+instr 1
+a1 oscili 1, 440, -1, 0.25
+out a1
+endin
+schedule(1,6/sr,0.5)
+     )";
+
+    
+  int32_t result = csoundSetOption(csound, "--sample-accurate");
+  ASSERT_TRUE(result == 0);
+  result = csoundCompileOrc(csound, instrument);
+  ASSERT_TRUE(result == 0);
+  result = csoundStart(csound);
+  ASSERT_TRUE(result == 0);
+  result = csoundPerformKsmps(csound);
+  const MYFLT *spout = csoundGetSpout(csound);
+  ASSERT_TRUE(spout[5] == 0.0);
+  ASSERT_TRUE(spout[6] == 1.0);
+ 
+
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -184,6 +184,7 @@ def runTest():
     ["test_schedule_named_instance.csd", "testing schedule with named instr instance"],
     ["test_instr_type_var_new_compilation.csd", "testing schedule of named instr in new compilations"],
     ["test_ambiguous_opcall.csd", "test ambiguous opcall examples"],
+    ["test_sa.csd", "test sample accurate mode"],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test_sa.csd
+++ b/tests/commandline/test_sa.csd
@@ -1,0 +1,34 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n --sample-accurate
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+ksmps = 10
+
+opcode Test,0,i
+ i1 xin
+ ioffs offsetsmps
+ if ioffs != i1 then
+  exitnow(-1)
+ else
+  print ioffs
+ endif
+endop
+
+instr 1
+ ioffs offsetsmps
+ if ioffs == 0 then
+  exitnow(-1)
+ else
+  print ioffs
+endif
+Test ioffs
+endin
+
+schedule(1,6/sr,0.5)
+</CsInstruments>
+<CsScore>
+f 0 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_sa.csd
+++ b/tests/commandline/test_sa.csd
@@ -6,13 +6,19 @@
 0dbfs = 1
 ksmps = 10
 
-opcode Test,0,i
- i1 xin
+opcode Test,0,ik
+ i1,k1 xin
  ioffs offsetsmps
  if ioffs != i1 then
   exitnow(-1)
  else
   print ioffs
+ endif
+ kearly earlysmps
+ if kearly != k1 then
+  schedulek(2,0,0)
+ else
+  printk2 kearly
  endif
 endop
 
@@ -22,8 +28,23 @@ instr 1
   exitnow(-1)
  else
   print ioffs
+ endif
+
+kearly earlysmps
+Test ioffs,kearly
+
+if release() != 0 then
+ if kearly == 0 then
+  schedulek(2,0,0)
+ else
+  printk2 kearly
+ endif
 endif
-Test ioffs
+
+endin
+
+instr 2
+exitnow(-1)
 endin
 
 schedule(1,6/sr,0.5)
@@ -32,3 +53,4 @@ schedule(1,6/sr,0.5)
 f 0 1
 </CsScore>
 </CsoundSynthesizer>
+

--- a/tests/commandline/test_sa.csd
+++ b/tests/commandline/test_sa.csd
@@ -6,13 +6,13 @@
 0dbfs = 1
 ksmps = 10
 
-opcode Test,0,ik
- i1,k1 xin
- ioffs offsetsmps
- if ioffs != i1 then
-  exitnow(-1)
+opcode Test,0,kk
+ k2,k1 xin
+ koffs offsetsmps
+ if koffs != k2 then
+  schedulek(2,0,0)
  else
-  print ioffs
+  printk2 koffs
  endif
  kearly earlysmps
  if kearly != k1 then
@@ -23,15 +23,17 @@ opcode Test,0,ik
 endop
 
 instr 1
- ioffs offsetsmps
- if ioffs == 0 then
-  exitnow(-1)
- else
-  print ioffs
- endif
+kflag init 1
+koffs offsetsmps
+if koffs == 0 && kflag == 1 then
+  schedulek(2,0,0)
+else
+ kflag = 0
+ printk2 koffs
+endif
 
 kearly earlysmps
-Test ioffs,kearly
+Test koffs,kearly
 
 if release() != 0 then
  if kearly == 0 then


### PR DESCRIPTION
While testing the sample accurate mode, I discovered that realtime events were not always correctly handled. A bug was found where events were sometimes shifted one kcycle forward because rounding instead of floor() was used (only for RT events). That was fixed and I added a test to check for correct insertion of sample-accurate event.