### PR TITLE
Replace OPDS by INSDS as variable context

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install cmake libgtest-dev libsndfile1-dev libasound2-dev libjack-dev portaudio19-dev libportmidi-dev libpulse-dev swig liblua5.1-0-dev default-jdk libfltk1.1-dev libfluidsynth-dev liblo-dev fluid ladspa-sdk libpng-dev dssi-dev libstk0-dev libgmm++-dev bison flex libportsmf-dev libeigen3-dev libcunit1-dev gettext libsamplerate0-dev
+          sudo apt-get install cmake libgtest-dev libsndfile1-dev libasound2-dev libjack-dev portaudio19-dev libportmidi-dev libpulse-dev swig liblua5.1-0-dev default-jdk liblo-dev fluid ladspa-sdk libpng-dev dssi-dev  bison flex libportsmf-dev libcunit1-dev gettext libsamplerate0-dev
 
       - name: Configure build
         run: |

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2189,7 +2189,7 @@ void initializeStructVar(CSOUND* csound, CS_VARIABLE* var, MYFLT* mem) {
   }
 }
 
-CS_VARIABLE* createStructVar(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createStructVar(void* cs, void* p, INSDS *ctx) {
   CSOUND* csound = (CSOUND*)cs;
   const CS_TYPE* type = (const CS_TYPE*)p;
 
@@ -2203,13 +2203,14 @@ CS_VARIABLE* createStructVar(void* cs, void* p, OPDS *ctx) {
   var->memBlockSize = sizeof(CS_STRUCT_VAR);
   var->initializeVariableMemory = initializeStructVar;
   var->varType = type;
+  var->ctx = ctx;
 
   //FIXME - implement
   return var;
 }
 
 void copyStructVar(CSOUND* csound, const CS_TYPE* structType, void* dest, const
-                   void* src, OPDS *p) {
+                   void* src, INSDS *p) {
   CS_STRUCT_VAR* varDest = (CS_STRUCT_VAR*)dest;
   CS_STRUCT_VAR* varSrc = (CS_STRUCT_VAR*)src;
   int32_t i, count;
@@ -2218,7 +2219,7 @@ void copyStructVar(CSOUND* csound, const CS_TYPE* structType, void* dest, const
   for (i = 0; i < count; i++) {
     CS_VAR_MEM* d = varDest->members[i];
     CS_VAR_MEM* s = varSrc->members[i];
-    d->varType->copyValue(csound, d->varType, &d->value, &s->value, NULL);
+    d->varType->copyValue(csound, d->varType, &d->value, &s->value, p);
   }
 }
 

--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -30,31 +30,31 @@
 /* MEMORY COPYING FUNCTIONS */
 
 void myflt_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                      const void* src, OPDS *ctx) {
+                      const void* src, INSDS *ctx) {
   MYFLT* f1 = (MYFLT*)dest;
   MYFLT* f2 = (MYFLT*)src;
   *f1 = *f2;
 }
 
 void asig_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                     const void* src, OPDS *ctx) {
-  int32_t ksmps = ctx ? ctx->insdshead->ksmps : csound->ksmps;
+                     const void* src, INSDS *ctx) {
+  int32_t ksmps = ctx ? ctx->ksmps : csound->ksmps;
   memcpy(dest, src, sizeof(MYFLT) * ksmps);
 }
 
 void complex_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                        const void* src, OPDS *ctx) {
+                        const void* src, INSDS *ctx) {
   memcpy(dest, src, sizeof(COMPLEXDAT));
 }
 
 void wsig_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                     const void* src, OPDS *ctx) {
+                     const void* src, INSDS *ctx) {
     memcpy(dest, src, sizeof(SPECDAT));
     //TODO - check if this needs to copy SPECDAT's DOWNDAT member and AUXCH
 }
 
 void fsig_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                     const void* src, OPDS *ctx) {
+                     const void* src, INSDS *ctx) {
     PVSDAT *fsigout = (PVSDAT*) dest;
     PVSDAT *fsigin = (PVSDAT*) src;
     int32_t N = fsigin->N;
@@ -68,7 +68,7 @@ void fsig_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
 
 
 void string_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                       const void* src, OPDS *p) {
+                       const void* src, INSDS *p) {
     STRINGDAT* sDest = (STRINGDAT*)dest;
     STRINGDAT* sSrc = (STRINGDAT*)src;
     CSOUND* cs = (CSOUND*)csound;
@@ -105,7 +105,7 @@ static size_t array_get_num_members(ARRAYDAT* aSrc) {
 }
 
 void array_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                      const void* src, OPDS *ctx) {
+                      const void* src, INSDS *ctx) {
     ARRAYDAT* aDest = (ARRAYDAT*)dest;
     ARRAYDAT* aSrc = (ARRAYDAT*)src;
     CSOUND* cs = (CSOUND*)csound;
@@ -152,7 +152,7 @@ void array_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
 }
 
 void instrRef_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                      const void* src, OPDS *ctx) {
+                      const void* src, INSDS *ctx) {
   INSTREF *p = (INSTREF *) dest;
   if(!p->readonly) {
    memcpy(dest, src, sizeof(INSTREF));
@@ -197,13 +197,13 @@ void varInitMemoryFsig(CSOUND *csound, CS_VARIABLE* var, MYFLT* memblock) {
 
 /* CREATE VAR FUNCTIONS */
 
-CS_VARIABLE* createAsig(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createAsig(void* cs, void* p, INSDS *ctx) {
     int32_t ksmps;
     CSOUND* csound = (CSOUND*)cs;
     IGN(p);
 
    if (ctx  != NULL) {
-      ksmps = ctx->insdshead->ksmps;
+      ksmps = ctx->ksmps;
    } else {
     ksmps = csound->ksmps;
     }
@@ -212,71 +212,79 @@ CS_VARIABLE* createAsig(void* cs, void* p, OPDS *ctx) {
     var->memBlockSize = CS_FLOAT_ALIGN(ksmps * sizeof (MYFLT));
     var->updateMemBlockSize = &updateAsigMemBlock;
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createMyflt(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createMyflt(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof (MYFLT));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createComplex(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createComplex(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(COMPLEXDAT));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createBool(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createBool(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof (MYFLT));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createWsig(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createWsig(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(SPECDAT));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createFsig(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createFsig(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(PVSDAT));
     var->initializeVariableMemory = &varInitMemoryFsig;
+    var->ctx = ctx;
     return var;
 }
 
 
-CS_VARIABLE* createString(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createString(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)cs;
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(STRINGDAT));
     var->initializeVariableMemory = &varInitMemoryString;
+    var->ctx = ctx;
     return var;
 }
 
-CS_VARIABLE* createArray(void* csnd, void* p, OPDS *ctx) {
+CS_VARIABLE* createArray(void* csnd, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*)csnd;
     ARRAY_VAR_INIT* state = (ARRAY_VAR_INIT*)p;
 
     CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(ARRAYDAT));
     var->initializeVariableMemory = &arrayInitMemory;
+    var->ctx = ctx;
 
     if (state) { // NB: this function is being called with p=NULL
       const CS_TYPE* type = state->type;
@@ -286,11 +294,12 @@ CS_VARIABLE* createArray(void* csnd, void* p, OPDS *ctx) {
     return var;
 }
 
-CS_VARIABLE* createInstrRef(void* csnd, void* p, OPDS *ctx) {
+CS_VARIABLE* createInstrRef(void* csnd, void* p, INSDS *ctx) {
    CSOUND* csound = (CSOUND*)csnd;
    CS_VARIABLE* var = csound->Calloc(csound, sizeof (CS_VARIABLE));
    var->memBlockSize = CS_FLOAT_ALIGN(sizeof(INSTREF));
    var->initializeVariableMemory = &varInitMemory;
+   var->ctx = ctx;
    return var;
 }
 
@@ -349,7 +358,7 @@ const CS_TYPE CS_VAR_TYPE_I = {
 };
 
 const CS_TYPE CS_VAR_TYPE_S = {
-    "S", "String var", CS_ARG_TYPE_BOTH, createString, string_copy_value, string_free_var_mem, NULL, 0
+  "S", "String var", CS_ARG_TYPE_BOTH, createString, string_copy_value, string_free_var_mem, NULL, 0
 };
 
 const CS_TYPE CS_VAR_TYPE_P = {

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -334,7 +334,7 @@ int32_t copyVarGeneric(CSOUND *csound, void *p) {
         typeR->varTypeName, typeA->varTypeName);
     }
 
-    typeR->copyValue(csound, typeR, assign->r, assign->a, &(assign->h));
+    typeR->copyValue(csound, typeR, assign->r, assign->a, assign->h.insdshead);
     return OK;
 }
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -418,7 +418,7 @@ int32_t xinset(CSOUND *csound, XIN *p)
     // check output kvars in case inputs are constants
     if (csoundGetTypeForArg(out) != &CS_VAR_TYPE_K &&
         csoundGetTypeForArg(out) != &CS_VAR_TYPE_A) {
-      current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+      current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
     }
     else if (csoundGetTypeForArg(out) == &CS_VAR_TYPE_A) {
       // initialise the converter
@@ -486,7 +486,7 @@ int32_t xoutset(CSOUND *csound, XOUT *p)
     // check output types in case of constants
     if (csoundGetTypeForArg(out) != &CS_VAR_TYPE_K &&
         csoundGetTypeForArg(out) != &CS_VAR_TYPE_A)
-      current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+      current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
     else if (csoundGetTypeForArg(out) == &CS_VAR_TYPE_A) {
       // initialise the converter
       if(CS_ESR != parent_sr) {
@@ -572,7 +572,7 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
           // This one checks if an array has a subtype of 'i'
           void* in = (void*)external_ptrs[i + inm->outchns];
           void* out = (void*)internal_ptrs[i + inm->outchns];
-          current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+          current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
         } else if (current->varType == &CS_VAR_TYPE_A) {
           MYFLT* in = (void*)external_ptrs[i + inm->outchns];
           MYFLT* out = (void*)internal_ptrs[i + inm->outchns];
@@ -676,7 +676,7 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
           // This one checks if an array has a subtype of 'i'
           void* in = (void*)external_ptrs[i + inm->outchns];
           void* out = (void*)internal_ptrs[i + inm->outchns];
-          current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+          current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
         } else if (current->varType == &CS_VAR_TYPE_A) {
           MYFLT* in = (void*)external_ptrs[i + inm->outchns];
           MYFLT* out = (void*)internal_ptrs[i + inm->outchns];
@@ -801,7 +801,7 @@ int32_t useropcd1(CSOUND *csound, UOPCODE *p)
           }
         }
       } else {
-        current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+        current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
       }
     }
     current = current->next;
@@ -861,7 +861,7 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
           } else {
             void* in = (void*)external_ptrs[i + inm->outchns];
             void* out = (void*)internal_ptrs[i + inm->outchns];
-            current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+            current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
           }
         } else { // oversampling
           void* in = (void*)external_ptrs[i + inm->outchns];
@@ -873,7 +873,7 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
 
           }
           else if(ocnt == 0) // only copy other variables once
-            current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+            current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
         }
       }
       current = current->next;
@@ -904,7 +904,7 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
           } else {
             void* in = (void*)internal_ptrs[i];
             void* out = (void*)external_ptrs[i];
-            current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+            current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
           }
         }
         else { // oversampling
@@ -915,7 +915,7 @@ int32_t useropcd2(CSOUND *csound, UOPCODE *p)
             // sample rate conversion
             src_convert(csound, p->cvt_out[cvt++], in, out);
           } else if(ocnt == 0) {// only copy other variables once
-            current->varType->copyValue(csound, current->varType, out, in, &(p->h));
+            current->varType->copyValue(csound, current->varType, out, in, p->h.insdshead);
           }
         }
       }

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -2335,7 +2335,7 @@ int32_t painit(CSOUND *csound, PAINIT *p)
   if (*p->end!=FL(0.0)) {
     if (k<pargs) pargs = k;
   }
-  tabinit(csound, p->inits, pargs-start+1, &(p->h));
+  tabinit(csound, p->inits, pargs-start+1, p->h.insdshead);
   for (n=0; n<=pargs-start; n++) {
     ((MYFLT*)p->inits->data)[n] = csound->init_event->p[n+start];
   }

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -859,7 +859,7 @@ int32_t chnget_array_opcode_init_i(CSOUND* csound, CHNGETARRAY* p)
     p->arraySize = arr->sizes[0];
     p->channels = (STRINGDAT*) arr->data;
 
-    tabinit(csound, p->arrayDat, p->arraySize, &(p->h));
+    tabinit(csound, p->arrayDat, p->arraySize, p->h.insdshead);
 
     int32_t err;
     MYFLT* fp;
@@ -906,7 +906,7 @@ int32_t chnget_array_opcode_init(CSOUND* csound, CHNGETARRAY* p)
     p->arraySize = arr->sizes[0];
     p->channels = (STRINGDAT*) arr->data;
     p->channelPtrs = (MYFLT **) csound->Malloc(csound, p->arraySize*sizeof(MYFLT*)); // VL: surely an array of pointers?
-    tabinit(csound, p->arrayDat, p->arraySize,  &(p->h));
+    tabinit(csound, p->arrayDat, p->arraySize,  p->h.insdshead);
 
     int32_t err;
     int32_t channelType;
@@ -2407,7 +2407,7 @@ int32_t chn_opcode_init_ARRAY(CSOUND *csound, CHN_OPCODE_ARRAY *p)
   
     adat->arrayType = (CS_TYPE *)
       csoundGetTypeWithVarTypeName(csound->typePool, p->type->data);
-    tabinit(csound, adat, siz, &(p->h));
+    tabinit(csound, adat, siz, p->h.insdshead);
     return OK;
 }
 

--- a/OOps/compile_ops.c
+++ b/OOps/compile_ops.c
@@ -356,7 +356,7 @@ int32_t readOSC_perf(CSOUND *csound, ROSC *p) {
 #include "arrays.h"
 
 int32_t readOSCarray_init(CSOUND *csound, ROSCA *p) {
-  tabinit(csound, p->out, (int32_t) strlen(p->type->data), &(p->h));
+  tabinit(csound, p->out, (int32_t) strlen(p->type->data), p->h.insdshead);
   return OK;
 }
 

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -1628,7 +1628,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
       t->dimensions = 1;
       t->sizes = csound->Calloc(csound, sizeof(int32_t));
       t->sizes[0] = p->nChannels;
-      var  = t->arrayType->createVariable(csound, NULL, &(p->h));
+      var  = t->arrayType->createVariable(csound, NULL, p->h.insdshead);
       t->arrayMemberSize = var->memBlockSize;
       memSize = var->memBlockSize*(t->sizes[0]);
       t->data = csound->Calloc(csound, memSize);

--- a/OOps/lpred.c
+++ b/OOps/lpred.c
@@ -754,7 +754,7 @@ int32_t lpred_alloc(CSOUND *csound, LPREDA *p) {
     p->setup = csound->LPsetup(csound,N,p->M);
     if(p->buf.auxp == NULL || Nbytes > p->buf.size)
       csound->AuxAlloc(csound, Nbytes, &p->buf);
-    tabinit(csound,p->out,p->M, &(p->h));
+    tabinit(csound,p->out,p->M, p->h.insdshead);
     p->ft = ft;
     return OK;
   }
@@ -812,7 +812,7 @@ int32_t lpred_alloc2(CSOUND *csound, LPREDA2 *p) {
     csound->AuxAlloc(csound, Nbytes, &p->buf);
   if(p->cbuf.auxp == NULL || Nbytes > p->cbuf.size)
     csound->AuxAlloc(csound, Nbytes, &p->cbuf);
-  tabinit(csound,p->out,p->M, &(p->h));
+  tabinit(csound,p->out,p->M, p->h.insdshead);
   p->cp = 1;
   p->bp = 0;
   return OK;
@@ -1022,7 +1022,7 @@ int32_t pvscoefs_init(CSOUND *csound, PVSCFS *p) {
     csound->AuxAlloc(csound, Nbytes, &p->buf);
   if(p->coef.auxp == NULL || Mbytes > p->coef.size)
     csound->AuxAlloc(csound, Mbytes, &p->coef);
-  tabinit(csound,p->out,p->M, &(p->h));
+  tabinit(csound,p->out,p->M, p->h.insdshead);
   p->framecount = 0;
   p->mod = *p->imod;
   p->framecount = 0;
@@ -1061,7 +1061,7 @@ int32_t pvscoefs(CSOUND *csound, PVSCFS *p){
 int32_t coef2parm_init(CSOUND *csound, CF2P *p) {
   p->M = p->in->sizes[0];
   p->setup = csound->LPsetup(csound,0,p->M);
-  tabinit(csound,p->out,p->M, &(p->h));
+  tabinit(csound,p->out,p->M, p->h.insdshead);
   p->sum = 0.0;
   return OK;
 }

--- a/OOps/midiops.c
+++ b/OOps/midiops.c
@@ -811,7 +811,7 @@ int32_t savectrl_init(CSOUND *csound, SAVECTRL *p)
       if (ctlno < FL(0.0) || ctlno > FL(127.0))
         return csound->InitError(csound, Str("Value out of range [0,127]\n"));
     }
-    tabinit(csound, p->arr, 2+2*nargs, &(p->h));
+    tabinit(csound, p->arr, 2+2*nargs, p->h.insdshead);
     p->arr->data[0] = nargs;    /* length */
     p->arr->data[1] = chnl+1;   /* channel */
     for (i=0, j=2; i<nargs; i++, j+=2) {

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -184,7 +184,7 @@ int32_t strassign_k(CSOUND *csound, STRCPY_OP *p) {
   if(p->r != p->str) {
   if((uint64_t)p->str->timestamp == p->h.insdshead->kcounter) {
   CS_TYPE *strType = GetTypeForArg(p->str);    
-  strType->copyValue(csound, strType, p->r, p->str, &(p->h));
+  strType->copyValue(csound, strType, p->r, p->str, p->h.insdshead);
   //printf("copy \n");
   }
   }
@@ -194,7 +194,7 @@ int32_t strassign_k(CSOUND *csound, STRCPY_OP *p) {
 int32_t strcpy_opcode_S(CSOUND *csound, STRCPY_OP *p) {
   if(p->r != p->str) {
   CS_TYPE *strType = GetTypeForArg(p->str);
-  strType->copyValue(csound, strType, p->r, p->str,  &(p->h));
+  strType->copyValue(csound, strType, p->r, p->str,  p->h.insdshead);
   }
   return  OK;
 }

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1051,7 +1051,7 @@ static int32_t OSC_alist_init(CSOUND *csound, OSCLISTENA *p)
                                            strlen((char*) p->dest->data) + 1);
     strcpy(p->c.saved_path, (char*) p->dest->data);
     /* check for a valid argument list */
-    tabinit(csound, p->args, n= (int32_t)strlen((char*) p->type->data), &(p->h));
+    tabinit(csound, p->args, n= (int32_t)strlen((char*) p->type->data), p->h.insdshead);
     strcpy(p->c.saved_types, (char*) p->type->data);
     for (i = 0; i < n; i++) {
       switch (p->c.saved_types[i]) {

--- a/Opcodes/arrayops.cpp
+++ b/Opcodes/arrayops.cpp
@@ -55,7 +55,7 @@ template <MYFLT (*op)(MYFLT)> struct ArrayOp : csnd::Plugin<1, 1> {
   int32_t init() {
     csnd::myfltvec &out = outargs.myfltvec_data(0);
     csnd::myfltvec &in = inargs.myfltvec_data(0);
-    out.init(csound, in.len(), this);
+    out.init(csound, in.len(), this->insdshead);
     if (!is_perf()) process(out, in);
     return OK;
   }
@@ -82,7 +82,7 @@ template <MYFLT (*bop)(MYFLT, MYFLT)> struct ArrayOp2 : csnd::Plugin<1, 2> {
     csnd::myfltvec &in2 = inargs.myfltvec_data(1);
     if (UNLIKELY(in2.len() < in1.len()))
       return csound->init_error(Str_noop("second input array is too short\n"));
-    out.init(csound, in1.len(), this);
+    out.init(csound, in1.len(), this->insdshead);
     if (!is_perf()) process(out, in1, in2);
     return OK;
   }
@@ -106,7 +106,7 @@ template <MYFLT (*bop)(MYFLT, MYFLT)> struct ArrayOp3 : csnd::Plugin<1, 2> {
   int32_t init() {
     csnd::myfltvec &out = outargs.myfltvec_data(0);
     csnd::myfltvec &in = inargs.myfltvec_data(0);
-    out.init(csound, in.len(), this);
+    out.init(csound, in.len(), this->insdshead);
     if (!is_perf()) process(out, in, inargs[1]);
     return OK;
   }
@@ -132,7 +132,7 @@ struct ArrayOp4 : csnd::Plugin<1, 3> {
   int32_t init() {
     csnd::myfltvec &out = outargs.myfltvec_data(0);
     csnd::myfltvec &in = inargs.myfltvec_data(0);
-    out.init(csound, in.len(), this);
+    out.init(csound, in.len(), this->insdshead);
     if(!is_perf()) process(out, in, inargs[1], inargs[2]);
     return OK;
   }
@@ -156,7 +156,7 @@ template <typename T> struct ArraySort : csnd::Plugin<1, 1> {
   int32_t init() {
     csnd::myfltvec &out = outargs.myfltvec_data(0);
     csnd::myfltvec &in = inargs.myfltvec_data(0);
-    out.init(csound, in.len(), this);
+    out.init(csound, in.len(), this->insdshead);
     if (!is_perf()) process(out, in);
     return OK;
   }

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -130,7 +130,7 @@ static int32_t array_init(CSOUND *csound, ARRAYINIT *p)
   {
     CS_VARIABLE* var = arrayDat->arrayType->createVariable(csound, (void *)
                                                            arrayDat->arrayType,
-                                                           &(p->h));
+                                                           p->h.insdshead);
     char *mem;
     arrayDat->arrayMemberSize = var->memBlockSize;
     arrayDat->data = csound->Calloc(csound,
@@ -150,7 +150,7 @@ static int32_t tabfill(CSOUND *csound, TABFILL *p)
   int32_t i, size;
   size_t memMyfltSize;
   MYFLT  **valp = p->iargs;
-  tabinit(csound, p->ans, nargs, &(p->h));
+  tabinit(csound, p->ans, nargs, p->h.insdshead);
   /*     if (UNLIKELY(p->ans->dimensions > 2)) { */
   /*       return */
   /*         csound->InitError(csound, "%s", */
@@ -165,7 +165,7 @@ static int32_t tabfill(CSOUND *csound, TABFILL *p)
     p->ans->arrayType->copyValue(csound,
                                  p->ans->arrayType,
                                  p->ans->data + (i * memMyfltSize),
-                                 valp[i], &(p->h));
+                                 valp[i], p->h.insdshead);
   }
   return OK;
 }
@@ -219,7 +219,7 @@ static int32_t tabfillf(CSOUND* csound, TABFILLF* p)
     nextval(infile);
   } while (!feof(infile));
   flen--; // overshoots by 1
-  tabinit(csound, p->ans, flen, &(p->h));
+  tabinit(csound, p->ans, flen, p->h.insdshead);
   size = p->ans->sizes[0];
   for (i=1; i<p->ans->dimensions; i++) size *= p->ans->sizes[i];
   if (size<flen) flen = size;
@@ -276,7 +276,7 @@ static int32_t tabsfill(CSOUND *csound, TABFILLF *p)
     flen++;
   } while (*string!='\0');
   //flen--; // overshoots by 1
-  tabinit(csound, p->ans, flen, &(p->h));
+  tabinit(csound, p->ans, flen, p->h.insdshead);
   size = p->ans->sizes[0];
   for (i=1; i<p->ans->dimensions; i++) size *= p->ans->sizes[i];
   if (size<flen) flen = size;
@@ -336,7 +336,7 @@ static int32_t array_set(CSOUND* csound, ARRAY_SET *p)
   incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
   mem += incr;
   //memcpy(mem, p->value, dat->arrayMemberSize);
-  dat->arrayType->copyValue(csound, dat->arrayType, mem, p->value,  &(p->h));
+  dat->arrayType->copyValue(csound, dat->arrayType, mem, p->value,  p->h.insdshead);
   /* printf("array_set: mem = %p, incr = %d, value = %f\n", */
   /*         mem, incr, *((MYFLT*)p->value)); */
   return OK;
@@ -380,7 +380,7 @@ static int32_t array_get(CSOUND* csound, ARRAY_GET *p)
   mem += incr;
   //    memcpy(p->out, &mem[incr], dat->arrayMemberSize);
   dat->arrayType->copyValue(csound, dat->arrayType, (void*)p->out, (void*)mem,
-                            &(p->h));
+                            p->h.insdshead);
   return OK;
 }
 
@@ -2787,14 +2787,14 @@ static int32_t tabcopy(CSOUND *csound, TABCPY *p)
     int32_t index = (i * memMyfltSize);
     p->dst->arrayType->copyValue(csound, p->dst->arrayType,
                                  (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index), &(p->h));
+                                 (void*)(p->src->data + index), p->h.insdshead);
   }
 
   return OK;
 }
 
 static int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
-  tabinit(csound, p->dst, get_array_total_size(p->src), &(p->h));
+  tabinit(csound, p->dst, get_array_total_size(p->src), p->h.insdshead);
   return OK;
 }
 static int32_t tabcopyk(CSOUND *csound, TABCPY *p)
@@ -2838,7 +2838,7 @@ static int32_t tabcopyk(CSOUND *csound, TABCPY *p)
     int32_t index = (i * memMyfltSize);
     p->dst->arrayType->copyValue(csound, p->dst->arrayType,
                                  (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index), &(p->h));
+                                 (void*)(p->src->data + index), p->h.insdshead);
   }
 
   return OK;
@@ -2887,7 +2887,7 @@ static int32_t tabcopy1(CSOUND *csound, TABCPY *p)
     p->dst->arrayType->copyValue(csound,
                                  p->dst->arrayType,
                                  (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index),  &(p->h));
+                                 (void*)(p->src->data + index),  p->h.insdshead);
   }
 
   return OK;
@@ -3066,9 +3066,9 @@ static int32_t tabgen(CSOUND *csound, TABGEN *p)
     return
       csound->InitError(csound, "%s",
                         Str("inconsistent start, end and increment parameters"));
-  tabinit(csound, p->tab, size, &(p->h));
+  tabinit(csound, p->tab, size, p->h.insdshead);
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, size, &(p->h));
+    tabinit(csound, p->tab, size, p->h.insdshead);
     p->tab->sizes[0] = size;
   }
   //else /* This is wrong if array exists only write to specified part */
@@ -3096,7 +3096,7 @@ static int32_t ftab2tabi(CSOUND *csound, TABCOPY *p)
     return csound->InitError(csound, "%s", Str("No table for copy2ftab"));
   fsize = ftp->flen;
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, fsize, &(p->h));
+    tabinit(csound, p->tab, fsize, p->h.insdshead);
     p->tab->sizes[0] = fsize;
   }
   tlen = p->tab->sizes[0];
@@ -3137,7 +3137,7 @@ typedef struct {
 static int32_t trim_i(CSOUND *csound, TRIM *p)
 {
   int32_t size = (int)(*p->size);
-  tabinit(csound, p->tab, size, &(p->h));
+  tabinit(csound, p->tab, size, p->h.insdshead);
   p->tab->sizes[0] = size;
   return OK;
 }
@@ -3180,12 +3180,12 @@ static int32_t tabslice(CSOUND *csound, TABSLICE *p) {
   if (UNLIKELY(inc<=0))
     return csound->InitError(csound, "%s",
                              Str("slice increment must be positive"));
-  tabinit(csound, p->tab, size, &(p->h));
+  tabinit(csound, p->tab, size, p->h.insdshead);
 
   for (i = start, destIndex = 0; i < end + 1; i+=inc, destIndex++) {
     p->tab->arrayType->copyValue(csound, p->tab->arrayType,
                                  p->tab->data + (destIndex * memMyfltSize),
-                                 tabin + (memMyfltSize * i),  &(p->h));
+                                 tabin + (memMyfltSize * i),  p->h.insdshead);
   }
 
   return OK;
@@ -3240,7 +3240,7 @@ static int32_t tabmap_set(CSOUND *csound, TABMAP *p)
 
   size = p->tabin->sizes[0];
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, size, &(p->h));
+    tabinit(csound, p->tab, size, p->h.insdshead);
     p->tab->sizes[0] = size;
   }
   else size = size < p->tab->sizes[0] ? size : p->tab->sizes[0];
@@ -3413,7 +3413,7 @@ int32_t init_autocorr(CSOUND *csound, AUTOCORR *p) {
     csound->AuxAlloc(csound, fn*sizeof(MYFLT), &p->mem);
   p->N = N;
   p->FN = fn;
-  tabinit(csound, p->out,N, &(p->h));
+  tabinit(csound, p->out,N, p->h.insdshead);
   return OK;
 }
 
@@ -3447,7 +3447,7 @@ int32_t init_rfft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("rfft: only one-dimensional arrays allowed"));
-  tabinit(csound, p->out,N, &(p->h));
+  tabinit(csound, p->out,N, p->h.insdshead);
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
   return OK;
 }
@@ -3471,7 +3471,7 @@ int32_t init_rifft(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "%s",
                              Str("rifft: only one-dimensional arrays allowed"));
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
-  tabinit(csound, p->out, N, &(p->h));
+  tabinit(csound, p->out, N, p->h.insdshead);
   return OK;
 }
 
@@ -3493,7 +3493,7 @@ int32_t init_rfftmult(CSOUND *csound, FFT *p) {
   if (UNLIKELY(N != p->in2->sizes[0]))
     return csound->InitError(csound, "%s", Str("array sizes do not match\n"));
   /*if (isPowerOfTwo(N))*/
-  tabinit(csound, p->out, N, &(p->h));
+  tabinit(csound, p->out, N, p->h.insdshead);
   /* else
      return
      csound->InitError(csound, "%s",
@@ -3512,7 +3512,7 @@ int32_t initialise_fft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("fft: only one-dimensional arrays allowed"));
-  tabinit(csound,p->out,N2, &(p->h));
+  tabinit(csound,p->out,N2, p->h.insdshead);
   return OK;
 }
 
@@ -3535,7 +3535,7 @@ int32_t init_ifft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("fftinv: only one-dimensional arrays allowed"));
-  tabinit(csound, p->out, N2, &(p->h));
+  tabinit(csound, p->out, N2, p->h.insdshead);
   return OK;
 }
 
@@ -3554,7 +3554,7 @@ int32_t ifft_i(CSOUND *csound, FFT *p) {
 
 int32_t init_recttopol(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N, &(p->h));
+  tabinit(csound, p->out, N, p->h.insdshead);
   return OK;
 }
 
@@ -3589,7 +3589,7 @@ int32_t perf_poltorect(CSOUND *csound, FFT *p) {
 int32_t init_poltorect2(CSOUND *csound, FFT *p) {
   if (LIKELY(p->in2->sizes[0] == p->in->sizes[0])) {
     int32_t   N = p->in2->sizes[0];
-    tabinit(csound, p->out, N*2 - 2, &(p->h));
+    tabinit(csound, p->out, N*2 - 2, p->h.insdshead);
     return OK;
   } else return csound->InitError(csound,
                                   Str("in array sizes do not match: %d and %d\n"),
@@ -3616,7 +3616,7 @@ int32_t perf_poltorect2(CSOUND *csound, FFT *p) {
 
 int32_t init_mags(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N/2+1, &(p->h));
+  tabinit(csound, p->out, N/2+1, p->h.insdshead);
   return OK;
 }
 
@@ -3645,7 +3645,7 @@ int32_t perf_phs(CSOUND *csound, FFT *p) {
 }
 
 int32_t init_logarray(CSOUND *csound, FFT *p) {
-  tabinit(csound, p->out, p->in->sizes[0], &(p->h));
+  tabinit(csound, p->out, p->in->sizes[0], p->h.insdshead);
   if (LIKELY(*((MYFLT *)p->in2)))
     p->b = 1/log(*((MYFLT *)p->in2));
   else
@@ -3671,7 +3671,7 @@ int32_t perf_logarray(CSOUND *csound, FFT *p) {
 
 int32_t init_rtoc(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N*2, &(p->h));
+  tabinit(csound, p->out, N*2, p->h.insdshead);
   return OK;
 }
 
@@ -3696,7 +3696,7 @@ int32_t rtoc_i(CSOUND *csound, FFT *p) {
 
 int32_t init_ctor(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N/2, &(p->h));
+  tabinit(csound, p->out, N/2, p->h.insdshead);
   return OK;
 }
 
@@ -3723,7 +3723,7 @@ int32_t init_window(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
   int32_t   i,type = (int32_t) *p->f;
   MYFLT *w;
-  tabinit(csound, p->out, N, &(p->h));
+  tabinit(csound, p->out, N, p->h.insdshead);
   if (p->mem.auxp == 0 || p->mem.size < N*sizeof(MYFLT))
     csound->AuxAlloc(csound, N*sizeof(MYFLT), &p->mem);
   w = (MYFLT *) p->mem.auxp;
@@ -3770,7 +3770,7 @@ int32_t pvsceps_init(CSOUND *csound, PVSCEPS *p) {
   int32_t N = p->fin->N;
   if (LIKELY(isPowerOfTwo(N))) {
     p->setup = csound->RealFFTSetup(csound, N/2, FFT_FWD);
-    tabinit(csound, p->out, N/2+1, &(p->h));
+    tabinit(csound, p->out, N/2+1, p->h.insdshead);
   }
   else
     return csound->InitError(csound, "%s",
@@ -3810,7 +3810,7 @@ int32_t init_ceps(CSOUND *csound, FFT *p) {
                              Str("FFT size too small (min 64 samples)\n"));
   if (LIKELY(isPowerOfTwo(N))) {
     p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
-    tabinit(csound, p->out, N+1, &(p->h));
+    tabinit(csound, p->out, N+1, p->h.insdshead);
   }
   else
     return csound->InitError(csound, "%s",
@@ -3842,7 +3842,7 @@ int32_t init_iceps(CSOUND *csound, FFT *p) {
   int32_t N = p->in->sizes[0]-1;
   if (LIKELY(isPowerOfTwo(N))) {
     p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
-    tabinit(csound, p->out, N+1, &(p->h));
+    tabinit(csound, p->out, N+1, p->h.insdshead);
   }
   else
     return csound->InitError(csound, "%s",
@@ -3869,7 +3869,7 @@ int32_t perf_iceps(CSOUND *csound, FFT *p) {
 int32_t rows_init(CSOUND *csound, FFT *p) {
   if (p->in->dimensions == 2) {
     int32_t siz = p->in->sizes[1];
-    tabinit(csound, p->out, siz, &(p->h));
+    tabinit(csound, p->out, siz, p->h.insdshead);
     return OK;
   }
   else
@@ -3904,7 +3904,7 @@ int32_t rows_perf_S(CSOUND *csound, FFT *p)
     //incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
     //printf("*** mem = %p dst = %p\n", mem, dest);
     for (i = 0; i<p->in->sizes[1]; i++) {
-      dat->arrayType->copyValue(csound, dat->arrayType, (void*)dest, (void*)mem, &(p->h));
+      dat->arrayType->copyValue(csound, dat->arrayType, (void*)dest, (void*)mem, p->h.insdshead);
       //printf("*** copies i=%d: %s -> %s\n", i,(char*)(mem->data),(char*)(dest->data));
       dest +=1;
       mem += 1;
@@ -3929,7 +3929,7 @@ int32_t set_rows_perf_S(CSOUND *csound, FFT *p)
     //incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
     //printf("*** mem = %p dst = %p\n", mem, dest);
     for (i = 0; i<p->in->sizes[1]; i++) {
-      dat->arrayType->copyValue(csound, dat->arrayType, (void*)mem, (void*)dest,  &(p->h));
+      dat->arrayType->copyValue(csound, dat->arrayType, (void*)mem, (void*)dest,  p->h.insdshead);
       //printf("*** copies i=%d: %s -> %s\n", i,(char*)(mem->data),(char*)(dest->data));
       dest+= 1;
       mem += 1;
@@ -3959,7 +3959,7 @@ int32_t rows_i(CSOUND *csound, FFT *p) {
 
 static inline void tabensure2D(CSOUND *csound, ARRAYDAT *p,
                                int32_t rows, int32_t columns,
-                               OPDS *ctx)
+                               INSDS *ctx)
 {
   if (p->data==NULL || p->dimensions == 0 ||
       (p->dimensions==2 && (p->sizes[0] < rows || p->sizes[1] < columns))) {
@@ -3983,7 +3983,7 @@ static inline void tabensure2D(CSOUND *csound, ARRAYDAT *p,
 int32_t set_rows_init(CSOUND *csound, FFT *p) {
   int32_t sizs = p->in->sizes[0];
   int32_t row = *((MYFLT *)p->in2);
-  tabensure2D(csound, p->out, row+1, sizs, &(p->h));
+  tabensure2D(csound, p->out, row+1, sizs, p->h.insdshead);
   return OK;
 }
 
@@ -4003,7 +4003,7 @@ int32_t rows_init_S(CSOUND *csound, FFT *p) {
 int32_t cols_init(CSOUND *csound, FFT *p) {
   if (LIKELY(p->in->dimensions == 2)) {
     int32_t siz = p->in->sizes[0];
-    tabinit(csound, p->out, siz, &(p->h));
+    tabinit(csound, p->out, siz, p->h.insdshead);
     return OK;
   }
   else
@@ -4056,7 +4056,7 @@ int32_t cols_perf_S(CSOUND *csound, FFT *p) {
     //printf("*** mem = %p dst = %p\n", mem, dest);
     for (i = 0; i<p->in->sizes[0]; i++) {
       dat->arrayType->copyValue(csound, dat->arrayType, (void*)dest, (void*)mem,
-                                &(p->h));
+                                p->h.insdshead);
       //printf("*** copies i=%d: %s -> %s\n", i,(char*)(dest->data),(char*)(mem->data));
       dest+= 1;
       mem += p->in->sizes[1];
@@ -4094,7 +4094,7 @@ int32_t set_rows_i(CSOUND *csound, FFT *p) {
 int32_t set_cols_init(CSOUND *csound, FFT *p) {
   int32_t siz = p->in->sizes[0];
   int32_t col = *((MYFLT *)p->in2);
-  tabensure2D(csound, p->out, siz, col+1, &(p->h));
+  tabensure2D(csound, p->out, siz, col+1, p->h.insdshead);
   return OK;
 }
 
@@ -4145,7 +4145,7 @@ int32_t set_cols_perf_S(CSOUND *csound, FFT *p) {
     //printf("*** mem = %p dst = %p\n", mem, dest);
     for (i = 0; i<p->in->sizes[0]; i++) {
       dat->arrayType->copyValue(csound, dat->arrayType, (void*)mem, (void*)dest,
-                                &(p->h));
+                                p->h.insdshead);
       //printf("*** copies i=%d: %s -> %s\n", i,(char*)(mem->data),(char*)(dest->data));
       dest += p->in->sizes[1];
       mem  += 1;
@@ -4171,7 +4171,7 @@ int32_t cols_init_S(CSOUND *csound, FFT *p) {
 int32_t shiftin_init(CSOUND *csound, FFT *p) {
   int32_t sizs = CS_KSMPS;
   if(p->out->sizes[0] < sizs)
-    tabinit(csound, p->out, sizs, &(p->h));
+    tabinit(csound, p->out, sizs, p->h.insdshead);
   p->n = 0;
   return OK;
 }
@@ -4271,7 +4271,7 @@ int32_t init_dct(CSOUND *csound, FFT *p) {
     if (UNLIKELY(p->in->dimensions > 1))
       return csound->InitError(csound, "%s",
                                Str("dct: only one-dimensional arrays allowed"));
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
     p->setup =  csound->DCTSetup(csound,N,FFT_FWD);
     return OK;
   }
@@ -4301,7 +4301,7 @@ int32_t init_dctinv(CSOUND *csound, FFT *p) {
     if (UNLIKELY(p->in->dimensions > 1))
       return csound->InitError(csound, "%s",
                                Str("dctinv: only one-dimensional arrays allowed"));
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
     p->setup =  csound->DCTSetup(csound,N,FFT_INV);
     return OK;
   }
@@ -4354,7 +4354,7 @@ int32_t mfb_init(CSOUND *csound, MFB *p) {
   int32_t   L = *p->len;
   int32_t N = p->in->sizes[0];
   if (LIKELY(L < N)) {
-    tabinit(csound, p->out, L, &(p->h));
+    tabinit(csound, p->out, L, p->h.insdshead);
   }
   else
     return csound->InitError(csound, "%s",
@@ -4469,7 +4469,7 @@ int32_t interleave_i (CSOUND *csound, INTERL *p) {
      p->c->dimensions == 1 &&
      p->b->sizes[0] == p->c->sizes[0]) {
     int32_t len = p->b->sizes[0], i,j;
-    tabinit(csound, p->a, len*2, &(p->h));
+    tabinit(csound, p->a, len*2, p->h.insdshead);
     for(i = 0, j = 0; i < len; i++,j+=2) {
       p->a->data[j] =  p->b->data[i];
       p->a->data[j+1] = p->c->data[i];
@@ -4492,8 +4492,8 @@ int32_t interleave_perf (CSOUND *csound, INTERL *p) {
 int32_t deinterleave_i (CSOUND *csound, INTERL *p) {
   if(p->c->dimensions == 1) {
     int32_t len = p->c->sizes[0]/2, i,j;
-    tabinit(csound, p->a, len, &(p->h));
-    tabinit(csound, p->b, len, &(p->h));
+    tabinit(csound, p->a, len, p->h.insdshead);
+    tabinit(csound, p->b, len, p->h.insdshead);
     for(i = 0, j = 0; i < len; i++,j+=2) {
       p->a->data[i] =  p->c->data[j];
       p->b->data[i] = p->c->data[j+1];

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -108,7 +108,7 @@ typedef struct {
 
 static int32_t linlinarr1_init(CSOUND *csound, LINLINARR1 *p) {
     int32_t numitems = p->xs->sizes[0];
-    tabinit(csound, p->ys, numitems, &(p->h));
+    tabinit(csound, p->ys, numitems, p->h.insdshead);
     CHECKARR1D(p->xs);
     CHECKARR1D(p->ys);
     return OK;
@@ -159,7 +159,7 @@ blendarray_init(CSOUND *csound, BLENDARRAY *p) {
     int32_t numitemsA = p->A->sizes[0];
     int32_t numitemsB = p->B->sizes[0];
     int32_t numitems = numitemsA < numitemsB ? numitemsA : numitemsB;
-    tabinit(csound, p->out, numitems, &(p->h));
+    tabinit(csound, p->out, numitems, p->h.insdshead);
     p->numitems = numitems;
     return OK;
 }
@@ -385,7 +385,7 @@ static int32_t
 ftom_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     p->freqA4 = csound->GetA4(csound);
     p->rnd = (int)*p->irnd;
-    tabinit(csound, p->outarr, p->inarr->sizes[0], &(p->h));
+    tabinit(csound, p->outarr, p->inarr->sizes[0], p->h.insdshead);
     p->skip = 0;
     ftom_arr(csound, p);
     p->skip = 1;
@@ -416,7 +416,7 @@ mtof_arr(CSOUND *csound, PITCHCONV_ARR *p) {
 static int32_t
 mtof_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     p->freqA4 = csound->GetA4(csound);
-    tabinit(csound, p->outarr, p->inarr->sizes[0], &(p->h));
+    tabinit(csound, p->outarr, p->inarr->sizes[0], p->h.insdshead);
     p->skip = 0;
     mtof_arr(csound, p);
     p->skip = 1;
@@ -887,7 +887,7 @@ typedef struct {
 
 
 static int32_t bpf_K_Km_init(CSOUND *csound, BPF_K_Km *p) {
-  tabinit(csound, p->out, p->in->sizes[0], &(p->h));
+  tabinit(csound, p->out, p->in->sizes[0], p->h.insdshead);
     p->lastidx = -1;
     int32_t datalen = p->INOCOUNT - 1;
     if(datalen % 2)
@@ -897,7 +897,7 @@ static int32_t bpf_K_Km_init(CSOUND *csound, BPF_K_Km *p) {
     if(datalen >= BPF_MAXPOINTS)
         return INITERR(Str("bpf: too many pargs (max=256)"));
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
     return OK;
 }
 
@@ -1366,7 +1366,7 @@ cmp_init(CSOUND *csound, Cmp *p) {
 static int32_t
 cmparray1_init(CSOUND *csound, Cmp_array1 *p) {
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
     int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
@@ -1384,7 +1384,7 @@ cmparray2_init(CSOUND *csound, Cmp_array2 *p) {
 
     // make sure that we can put the result in `out`,
     // grow the array if necessary
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
     int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
@@ -1397,7 +1397,7 @@ cmparray2_init(CSOUND *csound, Cmp_array2 *p) {
 static int32_t
 cmp2array1_init(CSOUND *csound, Cmp2_array1 *p) {
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, &(p->h));
+    tabinit(csound, p->out, N, p->h.insdshead);
 
     char *op1 = (char*)p->op1->data;
     int64_t op1size = p->op1->size - 1;
@@ -1866,7 +1866,7 @@ tab2array_init(CSOUND *csound, TAB2ARRAY *p) {
     if(numitems < 0) {
         return PERFERR(Str("tab2array: cannot copy a negative number of items"));
     }
-    tabinit(csound, p->out, numitems, &(p->h));
+    tabinit(csound, p->out, numitems, p->h.insdshead);
     p->numitems = numitems;
     return OK;
 }
@@ -2433,7 +2433,7 @@ array_binop_init(CSOUND *csound, BINOP_AAA *p) {
     for(i=0; i<p->in1->dimensions; i++) {
         numitems *= p->in1->sizes[i];
     }
-    tabinit(csound, p->out, numitems, &(p->h));
+    tabinit(csound, p->out, numitems, p->h.insdshead);
     p->numitems = numitems;
     return OK;
 }

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -920,7 +920,7 @@ static int32_t infile_set_A(CSOUND *csound, INFILEA *p)
   if (p->f.async == 1)
     csound->FSeekAsync(csound,p->f.fd, p->currpos*p->f.nchnls, SEEK_SET);
 
-  tabinit(csound, p->tabout, p->chn, &(p->h));
+  tabinit(csound, p->tabout, p->chn, p->h.insdshead);
   return OK;
 }
 

--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -260,7 +260,8 @@ int32_t Framebuffer_initialise(CSOUND *csound, Framebuffer *self)
         array->sizes[0] = self->elementCount;
         array->dimensions = 1;
         CS_VARIABLE *var = array->arrayType->createVariable(csound,
-                                                            NULL, &(self->h));
+                                                            NULL,
+                                                            self->h.insdshead);
         array->arrayMemberSize = var->memBlockSize;
         array->data = csound->Calloc(csound,
                                      var->memBlockSize * self->elementCount);

--- a/Opcodes/ftsamplebank.cpp
+++ b/Opcodes/ftsamplebank.cpp
@@ -210,33 +210,6 @@ std::vector<std::string> searchDir(CSOUND *csound, char *directory,
                                    char *extension);
 
 #include "arrays.h"
-#if 0
-/* from Opcodes/arrays.c */
-static inline void tabensure(CSOUND *csound, ARRAYDAT *p, int32_t size) {
-    if (p->data==NULL || p->dimensions == 0 ||
-        (p->dimensions==1 && p->sizes[0] < size)) {
-      size_t ss;
-      if (p->data == NULL) {
-        CS_VARIABLE* var = p->arrayType->createVariable(csound, NULL);
-        p->arrayMemberSize = var->memBlockSize;
-      }
-      ss = p->arrayMemberSize*size;
-      if (p->data==NULL) {
-        p->data = (MYFLT*)csound->Calloc(csound, ss);
-        p->allocated = ss;
-      }
-      else if (ss > p->allocated) {
-        p->data = (MYFLT*) csound->ReAlloc(csound, p->data, ss);
-        p->allocated = ss;
-      }
-      if (p->dimensions==0) {
-        p->dimensions = 1;
-        p->sizes = (int32_t*)csound->Malloc(csound, sizeof(int32_t));
-      }
-    }
-    p->sizes[0] = size;
-}
-#endif
 
 static int32_t directory(CSOUND *csound, DIR_STRUCT *p) {
   int32_t inArgCount = p->INOCOUNT;
@@ -263,7 +236,7 @@ static int32_t directory(CSOUND *csound, DIR_STRUCT *p) {
   }
 
   int32_t numberOfFiles = (int32_t) fileNames.size();
-  tabinit(csound, p->outArr, numberOfFiles, &(p->h));
+  tabinit(csound, p->outArr, numberOfFiles, p->h.insdshead);
   STRINGDAT *strings = (STRINGDAT *)p->outArr->data;
 
   for (int32_t i = 0; i < numberOfFiles; i++) {

--- a/Opcodes/loscilx.c
+++ b/Opcodes/loscilx.c
@@ -390,7 +390,7 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
       sf->loopEnd = tmp;
     }
     p->nChannels = sf->nChannels;
-    tabinit(csound, p->arr, p->nChannels, &(p->h));
+    tabinit(csound, p->arr, p->nChannels, p->h.insdshead);
     dataPtr = (void*) &(sf->data[0]);
     p->curPos = loscilx_convert_phase(sf->startOffs);
     p->curLoopMode = sf->loopMode - 1;
@@ -417,7 +417,7 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
     if (ftp == NULL)
       return NOTOK;
     p->nChannels = ftp->nchanls;
-    tabinit(csound, p->arr, p->nChannels, &(p->h));
+    tabinit(csound, p->arr, p->nChannels, p->h.insdshead);
     dataPtr = (void*) &(ftp->ftable[0]);
     p->curPos = (int_least64_t) 0;
     switch ((int32_t) ftp->loopmode1) {

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -87,7 +87,7 @@ struct PVTrace2 : csnd::FPlugin<2, 5> {
     csnd::Fsig &fout = outargs.fsig_data(0);
     fout.init(csound, inargs.fsig_data(0));
 
-    bins.init(csound, inargs.fsig_data(0).nbins(), this);
+    bins.init(csound, inargs.fsig_data(0).nbins(), this->insdshead);
 
     framecount = 0;
     return OK;

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -786,8 +786,8 @@ static int32_t scsnmapV_init(CSOUND *csound, PSCSNMAPV *p)
     /* Get corresponding update */
     p->p = listget(csound, (int32_t)*p->i_id);
     if (p->p == NULL) return NOTOK;
-    tabinit(csound, p->k_pos,(p->p)->len, &(p->h));
-    tabinit(csound, p->k_vel,(p->p)->len, &(p->h));
+    tabinit(csound, p->k_pos,(p->p)->len, p->h.insdshead);
+    tabinit(csound, p->k_vel,(p->p)->len, p->h.insdshead);
     return OK;
 }
 

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -622,7 +622,7 @@ static int32_t init_raw_osc(CSOUND *csound, RAWOSC *p)
       memset(buf, 0, MTU);
     }
     if(p->sout->data == NULL)
-      tabinit(csound, p->sout, 2, &(p->h));
+      tabinit(csound, p->sout, 2, p->h.insdshead);
 
   return OK;
 }

--- a/Opcodes/vbap.c
+++ b/Opcodes/vbap.c
@@ -1917,7 +1917,7 @@ int32_t vbap_init_a(CSOUND *csound, VBAPA *p)
                              "%s", Str("vbap system NOT configured.\nMissing"
                                        " vbaplsinit opcode in orchestra?"));
   //printf("**** size = %d\n", p->q.ls_set_am);
-  tabinit(csound,  p->tabout, p->q.ls_set_am, &(p->h));
+  tabinit(csound,  p->tabout, p->q.ls_set_am, p->h.insdshead);
   cnt = p->q.number = p->tabout->sizes[0];
   csound->AuxAlloc(csound, p->q.ls_set_am * sizeof(LS_SET), &p->q.aux);
   if (UNLIKELY(p->q.aux.auxp == NULL)) {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSOUND
 Version 7.0.0 (beta)
 
-This is the the develop branch of the Csound main code repository. At
+This is the develop branch of the Csound main code repository. At
 the moment, we are developing the next main version (moving from 6.x
 to 7.0), and this branch reflects current work-in-progress. This is
 still undergoing changes and fixes until the first release. The

--- a/examples/types/tuple.c
+++ b/examples/types/tuple.c
@@ -13,17 +13,18 @@ static void varInitMemory(CSOUND *csound, CS_VARIABLE* var, MYFLT* memblock) {
 }
 
 static void tupleCopyValue(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                        const void* src, OPDS *ctx) {
+                        const void* src, INSDS *ctx) {
   memcpy(dest, src, sizeof(TUPLE));
 }
 
-static CS_VARIABLE* createTuple(void* cs, void* p, OPDS *ctx) {
+static CS_VARIABLE* createTuple(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*) cs;
     CS_VARIABLE* var = (CS_VARIABLE *)
       csound->Calloc(csound, sizeof(CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(TUPLE));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -29,7 +29,7 @@ typedef struct {
     MYFLT   *r, *a;
 } AEVAL;
 
-static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *ctx)
+static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx)
 {
     size_t ss;
     if (p->dimensions==0) {
@@ -48,7 +48,6 @@ static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *ctx)
         p->allocated = ss;
     }
     if (p->dimensions==1) p->sizes[0] = size;
-    //p->dimensions = 1;
 }
 
 static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
@@ -91,39 +90,9 @@ static inline int32_t tabcheck(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *
         Str("Array too small (allocated %zu < needed %zu), but cannot "
             "allocate during performance pass. Allocate a bigger array at init time"),
         p->allocated, s);
-      return NOTOK;
     }
     p->sizes[0] = size;
     return OK;
 }
-
-#if 0
-static inline void tabensure(CSOUND *csound, ARRAYDAT *p, int32_t size)
-{
-    if (p->data==NULL || p->dimensions == 0 ||
-        (p->dimensions==1 && p->sizes[0] < size)) {
-      size_t ss;
-      if (p->data == NULL) {
-        CS_VARIABLE* var = p->arrayType->createVariable(csound, NULL);
-        p->arrayMemberSize = var->memBlockSize;
-      }
-      ss = p->arrayMemberSize*size;
-      if (p->data==NULL) {
-        p->data = (MYFLT*)csound->Calloc(csound, ss);
-        p->allocated = ss;
-      }
-      else if (ss > p->allocated) {
-        p->data = (MYFLT*) csound->ReAlloc(csound, p->data, ss);
-        p->allocated = ss;
-      }
-      if (p->dimensions==0) {
-        p->dimensions = 1;
-        p->sizes = (int32_t*)csound->Malloc(csound, sizeof(int32_t));
-      }
-      p->sizes[0] = size;
-    }
-    //p->sizes[0] = size;
-}
-#endif
 
 #endif /* end of include guard: __ARRAY_H__ */

--- a/include/csound_type_system.h
+++ b/include/csound_type_system.h
@@ -38,15 +38,15 @@ extern "C" {
 
   struct csvariable;
   struct cstype;
-  struct opds;
+  struct insds;
     
   typedef struct cstype {
     char* varTypeName;
     char* varDescription;
     int32_t argtype; // used to denote if allowed as in-arg, out-arg, or both
-    struct csvariable* (*createVariable)(void *cs, void *p, struct opds *ctx);
+    struct csvariable* (*createVariable)(void *cs, void *p, struct insds *ctx);
     void (*copyValue)(CSOUND* csound, const struct cstype* cstype, void* dest, const
-                      void* src, struct opds *ctx);
+                      void* src, struct insds *ctx);
     void (*freeVariableMemory)(void* csound, void* varMem);
     CONS_CELL* members;
     int32_t userDefinedType;
@@ -77,6 +77,7 @@ extern "C" {
     void (*updateMemBlockSize)(CSOUND*, struct csvariable*);
     void (*initializeVariableMemory)(CSOUND*, struct csvariable*, MYFLT*);
     CS_VAR_MEM *memBlock;
+    struct insds *ctx;
   } CS_VARIABLE;
 
   typedef struct cstypeitem {

--- a/include/csound_type_system.h
+++ b/include/csound_type_system.h
@@ -76,8 +76,8 @@ extern "C" {
     const CS_TYPE* subType;
     void (*updateMemBlockSize)(CSOUND*, struct csvariable*);
     void (*initializeVariableMemory)(CSOUND*, struct csvariable*, MYFLT*);
-    CS_VAR_MEM *memBlock;
     struct insds *ctx;
+    CS_VAR_MEM *memBlock;
   } CS_VARIABLE;
 
   typedef struct cstypeitem {

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -371,7 +371,7 @@ template <typename T> class Vector : ARRAYDAT {
 public:
   /** Initialise the container
    */
-  void init(Csound *csound, int32_t size, OPDS *ctx) {
+  void init(Csound *csound, int32_t size, INSDS *ctx) {
     tabinit(csound, this, size, ctx);
   }
 

--- a/tests/c/test_new_type.cpp
+++ b/tests/c/test_new_type.cpp
@@ -47,24 +47,25 @@ void varInitMemory(CSOUND *csound, CS_VARIABLE* var, MYFLT* memblock) {
 }
 
 void tupleCopyValue(CSOUND* csound, const CS_TYPE* cstype, void* dest,
-                        const void* src, OPDS *ctx) {
+                        const void* src, INSDS *ctx) {
   memcpy(dest, src, sizeof(Tuple));
 }
 
-CS_VARIABLE* createTuple(void* cs, void* p, OPDS *ctx) {
+CS_VARIABLE* createTuple(void* cs, void* p, INSDS *ctx) {
     CSOUND* csound = (CSOUND*) cs;
     CS_VARIABLE* var = (CS_VARIABLE *)
       csound->Calloc(csound, sizeof(CS_VARIABLE));
     IGN(p);
     var->memBlockSize = CS_FLOAT_ALIGN(sizeof(Tuple));
     var->initializeVariableMemory = &varInitMemory;
+    var->ctx = ctx;
     return var;
 }
 
 CS_TYPE CS_VAR_TYPE_TUPLE = {
    (char *) "Tuple", (char *) "Tuple", CS_ARG_TYPE_BOTH,
     createTuple, tupleCopyValue,
-    NULL, NULL, 0
+   NULL, NULL, 0
 };
 
 


### PR DESCRIPTION
This PR replaces OPDS * by INSDS * as the context for variables as it makes more sense. It also saves the context to the variable data structure.