### PR TITLE
Fix initial memcpy in strcat operator

### DIFF
--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -279,7 +279,7 @@ int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
 	csound->Calloc(csound, 2*size);
       p->r->size = 2*size;
     }
-    memcpy(p->r->data, p->str1->data, p->str1->size - 1);
+    memcpy(p->r->data, p->str1->data, p->str1->size);
     strcat(p->r->data, p->str2->data);
     return OK;
   }


### PR DESCRIPTION
We were doing a memcpy of the total allocated size minus 1, presumably because we knew that the string would be null terminated and we didn't want to copy the null.  However, strcat requires both of its arguments to be null terminated, so if we don't copy over the null terminator from str1, then we are only guaranteed that our first argument to strcat will be null terminated in the case where we re-Calloc'ed the buffer.  Otherwise, we might run into danger.

With this change, the attached code in github issue #2081  seems to run without errors.