### PR TITLE
Add methods to the PerformanceThread to access more functionality of the API 

### DIFF
--- a/include/csPerfThread.h
+++ b/include/csPerfThread.h
@@ -134,6 +134,25 @@ extern "C" {
     double timeVal);
   
   /**
+     Compiles the given orchestra code
+  */  
+  PUBLIC void csoundPerformanceThreadCompileOrc(CS_PERF_THREAD* pt, 
+    const char* code);
+    
+  /**
+     Evaluates the given code, calls the `returncb` callback with the 
+     value passed to the `return` opcode in global space. 
+  */
+  PUBLIC void csoundPerformanceThreadEvalCode(CS_PERF_THREAD* pt, 
+    const char *code, void (*returncb)(MYFLT));
+    
+  /**
+     Calls the given callback within the context of the callback thread
+  */
+  PUBLIC void csoundPerformanceThreadRequestCallback(CS_PERF_THREAD *pt,
+    void (*func)(void *));
+    
+  /**
      Waits until the performance is finished or fails.
      Returns a positive value if the end of score was reached or
      stop() was called, and a negative value if an error occured.

--- a/include/csPerfThread.hpp
+++ b/include/csPerfThread.hpp
@@ -214,6 +214,23 @@ class PUBLIC CsoundPerformanceThread {
      * and a negative value if an error occured. Also releases any resources
      * associated with the performance thread object.
      */
+     
+    void CompileOrc(const char *code);
+    /**
+     * Compiles the given orchestra code
+     */
+    
+    void EvalCode(const char *code, void (*returncb)(MYFLT));
+    /**
+     * Evaluates the given code, calls the `returncb` callback with the 
+     * value passed to the `return` opcode in global space. 
+     */
+     
+    void RequestCallback(void (*func)(CsoundPerformanceThread *));
+    /**
+     * Calls the given callback within the context of the performance thread
+     */
+    
     int32_t Join();
     /**
      * Waits until all pending messages (pause, send score event, etc.)


### PR DESCRIPTION
This PR adds three methods to the CsoundPerformanceThread to give access to the API:

* CompileOrc: schedules a compilation action
* EvalCode: calls csoundEvalCode within the performance thread, calls a given callback with the result of the evaluation
* RequestCallback: calls a callback from the performance thread, allowing to have access to the API within the context of the performance thread

Exposes all these methods to the API as csoundPerformanceThreadCompileOrc, csoundPerformanceThreadEvalCode and csoundPerformanceThreadRequestCallback

These methods were tested within the context of multithreaded c++, resulting in better and more consistent latency when sending code to the API. Additional tests were done in python code accessing the csound API via libcsound. This resulted in better performance and latency than directly accessing the API (csoundCompileOrc, csoundEvalCode, etc.) or using the process callback within the performance thread. 
