### PR TITLE
Remove unused semantic transformation

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1790,20 +1790,6 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root, TYPE_TABLE* typeTa
   }
 
   if (root->value != NULL) {
-    /* xout exp(0) */
-    if (root->left != NULL &&
-        root->left->type == T_IDENT &&
-        find_opcode(csound, root->left->value->lexeme) != NULL) {
-      TREE* top = root->left;
-      root->left = NULL;
-      top->right = root;
-      top->next = root->next;
-      root->next = NULL;
-      top->type = T_OPCALL;
-      top->right->type = T_FUNCTION;
-      return top;
-    }
-
     /* Already processed T_OPCALL, return as-is */
     return root;
   }

--- a/tests/commandline/test_ambiguous_opcall.csd
+++ b/tests/commandline/test_ambiguous_opcall.csd
@@ -18,8 +18,15 @@ instr 1
  chnset k(1), "bla"
 endin
 
+instr 2
+ // from github issue 1964
+ // make sure we can assign to a variable that has the same name as an opcode
+ fmax:i init p4
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 1
+i 2 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
In the branch that tried to process an already processed T_OPCALL, there was a transformation that we tried to do if the first identifer on the line was recognized as an opcode.  However, this seems to now be unused after the fix for recognizing opcodes with a parentisized first argument vs a function start.  Simply removing this transformation, all tests still passed.

I've added a test to ensure that the original report is now fixed, and that we can assign to a variable with the same name as an opcode using the non-functional syntax.