### PR TITLE
Fix handling when opcode shadows variable

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1790,20 +1790,6 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root, TYPE_TABLE* typeTa
   }
 
   if (root->value != NULL) {
-    /* xout exp(0) */
-    if (root->left != NULL &&
-        root->left->type == T_IDENT &&
-        find_opcode(csound, root->left->value->lexeme) != NULL) {
-      TREE* top = root->left;
-      root->left = NULL;
-      top->right = root;
-      top->next = root->next;
-      root->next = NULL;
-      top->type = T_OPCALL;
-      top->right->type = T_FUNCTION;
-      return top;
-    }
-
     /* Already processed T_OPCALL, return as-is */
     return root;
   }
@@ -1887,6 +1873,7 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root, TYPE_TABLE* typeTa
   if (leftCount == 1 && rightCount == 1) {
     TREE* newTop;
     if(root->right->type == T_IDENT &&
+       find_var_from_pools(csound, root->right->value->lexeme, root->right->value->lexeme, typeTable) == NULL &&
        find_opcode(csound, root->right->value->lexeme) != NULL) {
       newTop = root->right;
       newTop->type = T_OPCALL;

--- a/tests/commandline/test_ambiguous_opcall.csd
+++ b/tests/commandline/test_ambiguous_opcall.csd
@@ -10,6 +10,12 @@ nchnls = 2
 
 chn_k "bla",2
 
+opcode toStrArray, S[], S
+  StringIn xin
+  SArray[] fillarray StringIn
+  xout SArray
+endop
+
 instr 1
  // from github issue 1697
  // could be parsed as either of the following, but we want the first:
@@ -26,9 +32,17 @@ instr 2
  print fmax:i
 endin
 
+instr 3
+  // found while testing github issue 1964:
+  // variable shadowing udo that returns array - we can tell the difference
+  toStrArray:i init 1
+  String = toStrArray("Inline string-array get")[0]
+  prints "%s\n", String
+endin
 </CsInstruments>
 <CsScore>
 i 1 0 1
 i 2 0 1
+i 3 0 1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_ambiguous_opcall.csd
+++ b/tests/commandline/test_ambiguous_opcall.csd
@@ -18,8 +18,17 @@ instr 1
  chnset k(1), "bla"
 endin
 
+instr 2
+ // from github issue 1964
+ // make sure we can use a variable name which shadows an opcode
+ fmax:i init p4
+ print fmax
+ print fmax:i
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 1
+i 2 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Since the fix for differentiating between opcodes with a parenthesized first argument and function starts, there was a transformation in `convert_statement_to_opcall()` that was no longer getting called in its intended situation.  However, it was getting called and performing an invalid transformation on other trees.  It has been removed.

Also, in cases where we have a line of the form `ident1 ident2`, we were not checking whether ident2 was a variable and respecting that, but instead just checking whether it was an opcode.  There is now a check for looking through the variable pools.

Tests were added to the ambigous opcall csdtest to cover these cases.

This addresses the issue in #1964 as well as one other case found during testing.