### PR TITLE
Update build images to use gh container registry

### DIFF
--- a/.github/workflows/csound_build_images.yml
+++ b/.github/workflows/csound_build_images.yml
@@ -6,6 +6,9 @@ on:
 #      - develop
   workflow_dispatch:
 
+permissions:
+  packages: write
+
 jobs:
   build-and-push-android-image:
     name: Android
@@ -24,23 +27,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        run: |
-          docker build -t csound-android:${{ env.VERSION }} platform/android
-          docker save csound-android:${{ env.VERSION }} > csound-android-${{ env.VERSION }}.tar
-
-      - name: Upload image
-        uses: actions/upload-artifact@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: csound-android-${{ env.VERSION }}
-          path: csound-android-${{ env.VERSION }}.tar
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update workflow_run_id
-        if: ${{ success() }}
-        run: |
-          gh variable set ANDROID_WORKFLOW_RUN_ID --body ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: platform/android
+          push: true
+          tags: ghcr.io/csound/csound-android:${{ env.VERSION }},ghcr.io/csound/csound-android:latest
 
   build-and-push-ioscross-image:
     name: ioscross
@@ -59,24 +58,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        run: |
-          echo $IOSCROSS_PASSWORD > secret
-          docker build --build-arg="DOWNLOAD_URL=$IOSCROSS_DOWNLOAD_URL" --secret id=secret,src=secret -t csound-ioscross:${{ env.VERSION }} platform/ioscross
-          docker save csound-ioscross:${{ env.VERSION }} > csound-ioscross-${{ env.VERSION }}.tar
-        env:
-          IOSCROSS_PASSWORD: ${{ secrets.IOSCROSS_PASSWORD }}
-          IOSCROSS_DOWNLOAD_URL: ${{ vars.IOSCROSS_DOWNLOAD_URL }}
-
-      - name: Upload image
-        uses: actions/upload-artifact@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          name: csound-ioscross-${{ env.VERSION }}
-          path: csound-ioscross-${{ env.VERSION }}.tar
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update workflow_run_id
-        if: ${{ success() }}
-        run: |
-          gh variable set IOSCROSS_WORKFLOW_RUN_ID --body ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: platform/ioscross
+          push: true
+          tags: ghcr.io/csound/csound-ioscross:${{ env.VERSION }},ghcr.io/csound/csound-ioscross:latest
+          build-args: |
+            DOWNLOAD_URL=${{ vars.IOSCROSS_DOWNLOAD_URL }}
+          secrets: |
+            IOSCROSS_PASSWORD=${{ secrets.IOSCROSS_PASSWORD }}


### PR DESCRIPTION
Github artifacts expire after some period of time.

This pr updates build images to use gh container registry to store docker images instead of artifacts.