### PR TITLE
Update ioscross build image to use the correct secret

### DIFF
--- a/platform/ioscross/Dockerfile
+++ b/platform/ioscross/Dockerfile
@@ -25,7 +25,7 @@ ARG XCODE=Xcode_15.1.xip
 ARG DOWNLOAD_URL=http://172.17.0.1:8000/$XCODE.enc
 
 WORKDIR /
-RUN --mount=type=secret,id=secret curl $DOWNLOAD_URL | openssl aes-256-cbc -pbkdf2 -d -a -pass pass:$(cat /run/secrets/secret) > $XCODE
+RUN --mount=type=secret,id=IOSCROSS_PASSWORD curl $DOWNLOAD_URL | openssl aes-256-cbc -pbkdf2 -d -a -pass pass:$(cat /run/secrets/IOSCROSS_PASSWORD) > $XCODE
 
 ADD build_xar.sh .
 RUN ./build_xar.sh


### PR DESCRIPTION
This pr updates the ioscross build image Dockerfile to use the new id for the secret.