### PR TITLE
pvsanal/pvsynth bug fix

### DIFF
--- a/OOps/pvsanal.c
+++ b/OOps/pvsanal.c
@@ -262,9 +262,7 @@ int32_t pvsanalset(CSOUND *csound, PVSANAL *p)
     p->fsig->framecount = 1;
     p->fsig->format = PVS_AMP_FREQ;      /* only this, for now */
     p->fsig->sliding = 0;
-
-    if (!(N & (N - 1))) /* if pow of two use this */
-     p->setup = csound->RealFFTSetup(csound,N,FFT_FWD);
+    p->setup = csound->RealFFTSetup(csound,N,FFT_FWD);
     return OK;
 }
 
@@ -747,9 +745,6 @@ int32_t pvsynthset(CSOUND *csound, PVSYNTH *p)
 
 
     synwinhalf = (MYFLT *) (p->synwinbuf.auxp) + halfwinsize;
-
-
-
     /* synthesis windows */
     if (M <= N) {
       if (UNLIKELY(PVS_CreateWindow(csound, synwinhalf, wintype, M) != OK))
@@ -835,9 +830,7 @@ int32_t pvsynthset(CSOUND *csound, PVSYNTH *p)
     p->outptr = 0;
     p->nextOut = (MYFLT *) (p->output.auxp);
     p->buflen = buflen;
-
-    if (!(N & (N - 1))) /* if pow of two use this */
-      p->setup = csound->RealFFTSetup(csound,N,FFT_INV);
+    p->setup = csound->RealFFTSetup(csound,N,FFT_INV);
     return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -121,6 +121,7 @@ def runTest():
 	["test46.csd", "if-then with expression in boolean comparison"],
 	["test47.csd", "until loop and t-variables"],
 	["test48.csd", "expected failure with variable used before defined", 1],
+    ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
     ["test_instr_redefinition.csd", "allow instr redefinition"],
 	["test_instr0_labels.csd", "test labels in instr0 space"],
 	["test_string.csd", "test string assignment and printing"],

--- a/tests/commandline/test_pvs_np2.csd
+++ b/tests/commandline/test_pvs_np2.csd
@@ -1,0 +1,13 @@
+<CsoundSynthesizer>
+<CsInstruments>
+instr 1
+ asig vco2 p4, p5
+ fs1 pvsanal asig,1000,250,1000,1
+ ahr pvsynth fs1
+ out ahr
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1 20000 440
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR fixes a segfault in pvsanal/pvsynth when using non-pow-two sizes (#2098) 