### PR TITLE
Fixed longstanding access-after-free bug

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -988,8 +988,7 @@ void deleteVarPoolMemory(void *csound, CS_VAR_POOL *pool);
 void free_instrtxt(CSOUND *csound, INSTRTXT *instrtxt) {
   INSTRTXT *ip = instrtxt;
   INSDS *active = ip->instance;
-  /* remove instance memory */
-   while (active != NULL) { 
+  while (active != NULL) { /* remove instance memory */
     INSDS *nxt = active->nxtinstance;
     if (active->fdchp != NULL)
       fdchclose(csound, active);
@@ -1000,7 +999,7 @@ void free_instrtxt(CSOUND *csound, INSTRTXT *instrtxt) {
       csound->Free(csound, active->opcod_iobufs);
     csound->Free(csound, active);
     active = nxt;
-    } 
+  }
   OPTXT *t = ip->nxtop;
   while (t) {
     OPTXT *s = t->nxtop;
@@ -1160,7 +1159,11 @@ int32_t named_instr_alloc(CSOUND *csound, char *s, INSTRTXT *ip, int32 insno,
         csound->Message(csound, Str("no active instances\n"));
       free_instrtxt(csound, engineState->instrtxtp[inm->instno]);
       engineState->instrtxtp[inm->instno] = NULL;
-     }
+    }
+    else {
+      inm->ip->instance = inm->ip->act_instance =
+        inm->ip->lst_instance = NULL;
+    }
     }
   }
 cont:

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -988,7 +988,8 @@ void deleteVarPoolMemory(void *csound, CS_VAR_POOL *pool);
 void free_instrtxt(CSOUND *csound, INSTRTXT *instrtxt) {
   INSTRTXT *ip = instrtxt;
   INSDS *active = ip->instance;
-  while (active != NULL) { /* remove instance memory */
+  /* remove instance memory */
+   while (active != NULL) { 
     INSDS *nxt = active->nxtinstance;
     if (active->fdchp != NULL)
       fdchclose(csound, active);
@@ -999,7 +1000,7 @@ void free_instrtxt(CSOUND *csound, INSTRTXT *instrtxt) {
       csound->Free(csound, active->opcod_iobufs);
     csound->Free(csound, active);
     active = nxt;
-  }
+    } 
   OPTXT *t = ip->nxtop;
   while (t) {
     OPTXT *s = t->nxtop;
@@ -1159,8 +1160,7 @@ int32_t named_instr_alloc(CSOUND *csound, char *s, INSTRTXT *ip, int32 insno,
         csound->Message(csound, Str("no active instances\n"));
       free_instrtxt(csound, engineState->instrtxtp[inm->instno]);
       engineState->instrtxtp[inm->instno] = NULL;
-    }
-    inm->ip->instance = inm->ip->act_instance = inm->ip->lst_instance = NULL;
+     }
     }
   }
 cont:

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1234,7 +1234,7 @@ void orcompact(CSOUND *csound)          /* free all inactive instr spaces */
         if (!ip->actflg) {
           cnt++;
           if (ip->opcod_iobufs && ip->insno > csound->engineState.maxinsno)
-            csound->Free(csound, ip->opcod_iobufs);   /* IV - Nov 10 2002 */
+            csound->Free(csound, ip->opcod_iobufs);   
           if (ip->fdchp != NULL)
             fdchclose(csound, ip);
           if (ip->auxchp != NULL)


### PR DESCRIPTION
With the use of address sanitizer we have identified a longstanding access after free issue in the allocation of named instruments, present in the code since 6.x (and verified). Code tried to set three pointers to NULL, but the memory for these pointers had already been freed a few lines before (csound_orc_compile.c:1161). The solution was to use an `else` branch to avoid trying to set the pointers if the memory had been freed.