### PR TITLE
Fix for isstrcod()

### DIFF
--- a/include/coreDefs.h
+++ b/include/coreDefs.h
@@ -84,10 +84,10 @@ static const uint32_t PHMASK = (1 << 24) - 1;
 #define CPSOCTL(n) ((MYFLT)(1<<((int32_t)(n)>>13))*csound->cpsocfrc[(int32_t)(n)&8191])
 #ifdef USE_DOUBLE
   extern int64_t MYNAN;
-#define SSTRCOD    (double)NAN
+#define SSTRCOD    (double) NAN
 #else
   extern int32 MYNAN;
-#define SSTRCOD    (float)NAN
+#define SSTRCOD    (float) NAN
 #endif
 #define SSTRSIZ    1024
 #define ALLCHNLS   0x7fff

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -796,7 +796,7 @@ static inline int32_t byte_order(void) {
       int32_t i[2];
     } z;
     z.d = xx;
-    return ((z.i[sel]&0x7f800000)==0x7f800000); // was 0x7ff00000 - failing on clang 17!
+    return ((z.i[sel]&0x7ff80000)==0x7ff80000); // was 0x7ff00000 - failing on clang 17!
 #else
   union {
     float f;

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -796,7 +796,7 @@ static inline int32_t byte_order(void) {
       int32_t i[2];
     } z;
     z.d = xx;
-    return ((z.i[sel]&0x7ff00000)==0x7ff00000);
+    return ((z.i[sel]&0x7f800000)==0x7f800000); // was 0x7ff00000 - failing on clang 17!
 #else
   union {
     float f;


### PR DESCRIPTION
Starting with clang 17, the code for isstrcod() is failing to detect score strings on Release builds. 

This seems to be due to some change in the compiler, which is also bringing some extraneous warnings about macro NANs (-Wnan-infinity-disable) also on Release builds. Since NANs are used here as constants, I don't think these warnings apply. They can be silenced with -Wno-nan-infinity-disable.

NB: according to https://en.wikipedia.org/wiki/Double-precision_floating-point_format the double NaN encoding is 0x7ff8 0000 (upper 4 bytes)
and 0x7ff0 0000 is for a quiet NaN. Looks like on Debug builds, it doesn't matter, both NaN and qNaN work - but when it is optmised, only checking for NaN works. So that looks like the answer.


