### PR TITLE
Fixed bugs in foscil and foscili

### DIFF
--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -228,7 +228,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         fract = siz - FLOOR(siz);
         i = (int32_t)siz;
         v1 = ft[i++];
-        v2 = (i == ftlen) ? ft[0] : ft[i];
+        v2 = ft[i];
         ar[n] = (v1 + (v2 - v1) * fract) * amp;
         cphsf += cincf;
       }
@@ -263,7 +263,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         fract = siz - FLOOR(siz);
         int32_t i = (int32_t)siz;
         v1 = ft[i++];
-        v2 = (i == ftlen) ? ft[0] : ft[i];
+        v2 = ft[i];
         fmod = (v1 + (v2 - v1) * fract) * ndx;
         mphsf += mincf;
         cfreq = car + fmod;
@@ -273,7 +273,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         fract = siz - FLOOR(siz);
         i = (int32_t)siz;
         v1 = ft[i++];
-        v2 = (i == ftlen) ? ft[0] : ft[i];
+        v2 = ft[i];
         ar[n] = (v1 + (v2 - v1) * fract) * amp;
         cphsf += cincf;
       }

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -101,12 +101,12 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf -= FLOOR(mphsf);
+        mphsf = PHMOD1(mphsf);
         fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
         mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf -= FLOOR(cphsf);
+        cphsf = PHMOD1(cphsf);
         ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
         cphsf += cincf;
       }
@@ -131,12 +131,12 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         ar[n] = *(ftab + (cphs >>lobits)) * amp;
         cphs += cinc;
       } else {
-        mphsf -= FLOOR(mphsf);
+        mphsf = PHMOD1(mphsf);
         fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
         mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf -= FLOOR(cphsf);
+        cphsf = PHMOD1(cphsf);
         ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
         cphsf += cincf;
       }
@@ -213,9 +213,9 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf -= FLOOR(mphsf);
+        mphsf = PHMOD1(mphsf);
         MYFLT siz = mphsf*ftlen;
-        fract = siz - FLOOR(siz);
+        fract = PHMOD1(siz);
         int32_t i = (int32_t)siz;
         v1 = ft[i++];
         v2 = ft[i];
@@ -223,9 +223,9 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf -= FLOOR(cphsf);
+        cphsf = PHMOD1(cphsf);
         siz = cphsf*ftlen;
-        fract = siz - FLOOR(siz);
+        fract = PHMOD1(siz);
         i = (int32_t)siz;
         v1 = ft[i++];
         v2 = ft[i];
@@ -258,9 +258,9 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         ar[n] = (v1 + (*ftab - v1) * fract) * amp;
         cphs += cinc;
       } else {
-        mphsf -= FLOOR(mphsf);
+        mphsf = PHMOD1(mphsf);
         MYFLT siz = mphsf*ftlen;
-        fract = siz - FLOOR(siz);
+        fract = PHMOD1(siz);
         int32_t i = (int32_t)siz;
         v1 = ft[i++];
         v2 = ft[i];
@@ -268,9 +268,9 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf -= FLOOR(cphsf);
+        cphsf = PHMOD1(cphsf);
         siz = cphsf*ftlen;
-        fract = siz - FLOOR(siz);
+        fract = PHMOD1(siz);
         i = (int32_t)siz;
         v1 = ft[i++];
         v2 = ft[i];

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -218,7 +218,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         fract = siz - FLOOR(siz);
         int32_t i = (int32_t)siz;
         v1 = ft[i++];
-        v2 = (i == ftlen) ? ft[0] : ft[i];
+        v2 = ft[i];
         fmod = (v1 + (v2 - v1) * fract) * ndx;
         mphsf += mincf;
         cfreq = car + fmod;

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -46,22 +46,23 @@ int32_t foscset(CSOUND *csound, FOSC *p)
 
 int32_t foscil(CSOUND *csound, FOSC *p)
 {
-  FUNC    *ftp;
-  MYFLT   *ar, *ampp, *modp, cps, amp;
-  MYFLT   xcar, xmod, *carp, car, fmod, cfreq, mod, ndx, *ftab;
-  int32_t    mphs, cphs, minc, cinc, lobits, floatph = p->floatph;
+  FUNC     *ftp;
+  MYFLT    *ar, *ampp, *modp, cps, amp;
+  MYFLT    xcar, xmod, *carp, car, fmod, cfreq, mod, ndx, *ftab;
+  int32_t  ftlen, mphs, cphs, minc, cinc, lobits, floatph = p->floatph;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  MYFLT   mincf, cincf;
-  double cphsf, mphsf;
-  MYFLT   sicvt = CS_SICVT;
+  MYFLT    mincf, cincf;
+  double   cphsf, mphsf;
+  MYFLT    sicvt = CS_SICVT;
 
 
   ar = p->rslt;
   ftp = p->ftp;
   if (UNLIKELY(ftp == NULL)) goto err1;
   ftab = ftp->ftable;
+  ftlen = ftp->flen;
   lobits = ftp->lobits;
   mphs = p->mphs;
   cphs = p->cphs;
@@ -100,13 +101,13 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf = PHMOD1(mphsf);
-        fmod = *(ftab + (int32_t) mphsf) * ndx;
-        mphs += mincf;
+        mphsf -= FLOOR(mphsf);
+        fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
+        mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
-        ar[n] = *(ftab + (int32_t) cphsf) * amp;
+        cphsf -= FLOOR(cphsf);
+        ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
         cphsf += cincf;
       }
     }
@@ -130,13 +131,13 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         ar[n] = *(ftab + (cphs >>lobits)) * amp;
         cphs += cinc;
       } else {
-        mphsf = PHMOD1(mphsf);
-        fmod = *(ftab + (int32_t) mphsf) * ndx;
-        mphs += mincf;
+        mphsf -= FLOOR(mphsf);
+        fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
+        mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
-        ar[n] = *(ftab + (int32_t) cphsf) * amp;
+        cphsf -= FLOOR(cphsf);
+        ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
         cphsf += cincf;
       }
     }
@@ -154,22 +155,23 @@ int32_t foscil(CSOUND *csound, FOSC *p)
 
 int32_t foscili(CSOUND *csound, FOSC *p)
 {
-  FUNC   *ftp;
-  MYFLT  *ar, *ampp, amp, cps, fract, v1, car, fmod, cfreq, mod;
-  MYFLT  *carp, *modp, xcar, xmod, ndx, *ftab;
-  int32_t  mphs, cphs, minc, cinc, lobits, floatph = p->floatph;
+  FUNC     *ftp;
+  MYFLT    *ar, *ampp, amp, cps, fract, v1, v2, car, fmod, cfreq, mod;
+  MYFLT    *carp, *modp, xcar, xmod, ndx, *ftab;
+  int32_t  ftlen, mphs, cphs, minc, cinc, lobits, floatph = p->floatph;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  MYFLT  sicvt = CS_SICVT;
-  MYFLT  *ft, cincf, mincf;
-  double cphsf = p->cphsf, mphsf = p->mphsf;
+  MYFLT    *ft, sicvt = CS_SICVT;
+  MYFLT    cincf, mincf;
+  double   cphsf = p->cphsf, mphsf = p->mphsf;
 
 
   ar = p->rslt;
   ftp = p->ftp;
   if (UNLIKELY(ftp == NULL)) goto err1;        /* RWD fix */
   ft = ftp->ftable;
+  ftlen = ftp->flen;
   lobits = ftp->lobits;
   mphs = p->mphs;
   cphs = p->cphs;
@@ -211,19 +213,23 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf = PHMOD1(mphsf);
-        fract = mphsf - (int32_t) mphsf;
-        ftab = ft + (int32_t) mphsf;
-        v1 = *ftab++;
-        fmod = (v1 + (*ftab - v1) * fract) * ndx;
-        mphs += mincf;
+        mphsf -= FLOOR(mphsf);
+        MYFLT siz = mphsf*ftlen;
+        fract = siz - FLOOR(siz);
+        int32_t i = (int32_t)siz;
+        v1 = ft[i++];
+        v2 = (i == ftlen) ? ft[0] : ft[i];
+        fmod = (v1 + (v2 - v1) * fract) * ndx;
+        mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
-        fract = cphsf - (int32_t) cphsf;
-        ftab = ft + (int32_t) cphsf;
-        v1 = *ftab++;
-        ar[n] = (v1 + (*ftab - v1) * fract) * amp;
+        cphsf -= FLOOR(cphsf);
+        siz = cphsf*ftlen;
+        fract = siz - FLOOR(siz);
+        i = (int32_t)siz;
+        v1 = ft[i++];
+        v2 = (i == ftlen) ? ft[0] : ft[i];
+        ar[n] = (v1 + (v2 - v1) * fract) * amp;
         cphsf += cincf;
       }
     }
@@ -236,7 +242,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
     minc = (int32_t)(mod * sicvt);
     mincf = mod * CS_ONEDSR;
     for (n=offset;n<nsmps;n++) {
-      if(floatph) {
+      if(!floatph) {
         mphs &= PHMASK;
         fract = PFRAC(mphs);
         ftab = ft + (mphs >>lobits);
@@ -252,19 +258,23 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         ar[n] = (v1 + (*ftab - v1) * fract) * amp;
         cphs += cinc;
       } else {
-        mphsf = PHMOD1(mphsf);
-        fract = mphsf - (int32_t) mphsf;
-        ftab = ft + (int32_t) mphsf;
-        v1 = *ftab++;
-        fmod = (v1 + (*ftab - v1) * fract) * ndx;
-        mphs += mincf;
+        mphsf -= FLOOR(mphsf);
+        MYFLT siz = mphsf*ftlen;
+        fract = siz - FLOOR(siz);
+        int32_t i = (int32_t)siz;
+        v1 = ft[i++];
+        v2 = (i == ftlen) ? ft[0] : ft[i];
+        fmod = (v1 + (v2 - v1) * fract) * ndx;
+        mphsf += mincf;
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
-        fract = cphsf - (int32_t) cphsf;
-        ftab = ft + (int32_t) cphsf;
-        v1 = *ftab++;
-        ar[n] = (v1 + (*ftab - v1) * fract) * amp;
+        cphsf -= FLOOR(cphsf);
+        siz = cphsf*ftlen;
+        fract = siz - FLOOR(siz);
+        i = (int32_t)siz;
+        v1 = ft[i++];
+        v2 = (i == ftlen) ? ft[0] : ft[i];
+        ar[n] = (v1 + (v2 - v1) * fract) * amp;
         cphsf += cincf;
       }
     }

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -748,8 +748,8 @@ typedef struct _FFT_SETUP {
 /**
  * Phase modulo-1 for oscillators
  */
-static inline double PHMOD1(double p) {
-  return p < 0 ? -(1. - FLOOR(p)) : p - (uint64_t)p;
+static inline MYFLT PHMOD1(MYFLT p) {
+  return p < 0 ? p - (int64_t) (p-1) : p - (uint64_t)p;
 }
 
 /**


### PR DESCRIPTION
This PR fixes several bugs in foscil and foscili:
1) line 239, the condition has to be inverted for correct branching: if (!floatph) instead of (floatph)
2) when the ftable length is not a power of two:
    a) lines 103, 135, 219 and 260 : mphsf += mincf instead of mphs += mincf; needed for modulation!
    b) lines 104, 109, 134, 139 mpĥsf and cphsf have to be multiplied by the ftable length for correct indexing.
    c) In foscili, I refactored the linear interpolation to avoid segfault (we don't have a guard point in ftables with length not a power of two).

The following csd, when run before the PR shows the different bugs. After the application of the PR, everything runs OK.

<CsoundSynthesizer>
<CsOptions>
-odac -d
</CsOptions>
<CsInstruments>
0dbfs  = 1

sine2@global:i = ftgen(1, 0, 16384, 10, 1)
sine3@global:i = ftgen(2, 0, 20000, 10, 1)

instr 1
  prints("foscil: power of two table length, no a-time args\n")
  env:k = linen(0.7, 0.05, p3, 0.2)
  out(foscil(env, 440, 1, 1.5, 1.5, sine2))
endin

instr 2
  prints("foscil: power of two table length, a-time arg\n")
  env:a = linen(0.7, 0.05, p3, 0.2)
  out(foscil(env, 660, 1, 1.5, 1.5, sine2))
endin

instr 3
  prints("foscil: non power of two table length, no a-time args\n")
  env:k = linen(0.7, 0.05, p3, 0.2)
  out(foscil(env, 440, 1, 1.5, 1.5, sine3))
endin

instr 4
  prints("foscil: non power of two table length, a-time arg\n")
  env:a = linen(0.7, 0.05, p3, 0.2)
  out(foscil(env, 660, 1, 1.5, 1.5, sine3))
endin

instr 5
  prints("foscili: power of two table length, no a-time args\n")
  env:k = linen(0.7, 0.05, p3, 0.2)
  out(foscili(env, 440, 1, 1.5, 1.5, sine2))
endin

instr 6
  prints("foscili: power of two table length, a-time arg\n")
  env:a = linen(0.7, 0.05, p3, 0.2)
  out(foscili(env, 660, 1, 1.5, 1.5, sine2))
endin

instr 7
  prints("foscili: non power of two table length, no a-time args\n")
  env:k = linen(0.7, 0.05, p3, 0.2)
  out(foscili(env, 440, 1, 1.5, 1.5, sine3))
endin

instr 8
  prints("foscili: non power of two table length, a-time arg\n")
  env:a = linen(0.7, 0.05, p3, 0.2)
  out(foscili(env, 660, 1, 1.5, 1.5, sine3))
endin
</CsInstruments>
<CsScore>
i1 0 1
i2 1 1
i3 2 1
i4 3 1
s
i5 0 1
i6 1 1
i7 2 1
i8 3 1
</CsScore>
</CsoundSynthesizer>

