### PR TITLE
Fix for csoundCompileCSD 

### DIFF
--- a/Top/main.c
+++ b/Top/main.c
@@ -569,6 +569,9 @@ PUBLIC int32_t csoundCompile(CSOUND *csound, int32_t argc, const char **argv) {
   return csoundCompileArgs(csound, argc, argv);
 }
 
+// from threadsafe.c
+void csoundInputMessageAsync(CSOUND *csound, const char *message);
+
 static int32_t csoundCompileCSDText(CSOUND *csound, const char *csd_text, int32_t async) {
   int32_t res = read_unified_file4(csound, corfile_create_r(csound, csd_text));
   if (LIKELY(res)) {
@@ -590,7 +593,9 @@ static int32_t csoundCompileCSDText(CSOUND *csound, const char *csd_text, int32_
               csound->Message(
                   csound, Str("Real-time score events (engineStatus: %d).\n"),
                   csound->engineStatus);
-            csoundEventString(csound, (const char *) sc, async);
+            if(async)
+            csoundInputMessageAsync(csound, (const char *) sc);
+            else csound_input_message(csound, (const char *) sc);
           }
       } else {
         if (csound->scorestr == NULL) {

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -222,6 +222,34 @@ const char* event = R"(
     ASSERT_FALSE(result == 0);
 }
 
+TEST_F (OrcCompileTests, testReCompileCSD)
+{
+  const char* instrument = R"(
+<CsoundSynthesizer>
+<CsInstruments>
+
+instr 1
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 1000
+</CsScore>
+</CsoundSynthesizer>   
+     )";
+
+  int32_t result = csoundCompileCSD(csound,instrument,1,0);
+  ASSERT_TRUE(result == 0);
+  result = csoundStart(csound);
+  ASSERT_TRUE(result == 0);
+  result = csoundPerformKsmps(csound);
+  result = csoundCompileCSD(csound,instrument,1,0);
+  ASSERT_TRUE(result == 0);
+  result = csoundPerformKsmps(csound);
+  ASSERT_TRUE(result == 0);
+
+}
+
 TEST_F (OrcCompileTests, testSampleAccurate)
 {
   const char* instrument = R"(


### PR DESCRIPTION
csoundCompileCSD was using csoundEventString for realtime events. This caused a problem because the score was being sorted twice leading to a score reading error. This PR fixes the problem by replacing this function with the simple input message variants that do not try to sort the score.

A test for this was added and is passing.