### PR TITLE
Miscellaneous fixes

### DIFF
--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -45,7 +45,6 @@ void *csoundCreateCircularBuffer(CSOUND *csound, int32_t numelem, int32_t elemsi
       return NULL;
     }
     memset(p->buffer, 0, numelem*elemsize);
-    printf("numelem %d \n", numelem);
     return (void *)p;
 }
 

--- a/Lisp/csound-sbcl.lisp
+++ b/Lisp/csound-sbcl.lisp
@@ -75,8 +75,8 @@
 
 (in-package :csound)
 
-
-
+;; float traps disabled
+(sb-int:set-floating-point-modes :traps nil)
 (defvar *libcsound*
   (concatenate 'string (posix-getenv "HOME")
                "/Library/Frameworks/CsoundLib64.framework/CsoundLib64"))

--- a/include/csound.h
+++ b/include/csound.h
@@ -677,8 +677,8 @@ extern "C" {
   PUBLIC int32_t csoundStart(CSOUND *csound);
 
   /**
-   * Senses input events, and performs one control sample worth (ksmps) of
-   * audio output. csoundStart() must be called first.
+   * Senses input events, and performs one block of
+   * audio output containing ksmps frames. csoundStart() must be called first.
    * Returns false during performance, and true when performance is finished.
    * If called until it returns true, will perform an entire score.
    * Enables external software to control the execution of Csound,


### PR DESCRIPTION
Some miscellaneous fixes to code:
- traps suppressed in lisp interface
- tracing removed in circular buffer code
- improved comment in csound.h