### PR TITLE
Daisy Examples Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,9 @@ else()
     if(MSVC)
         message(FATAL_ERROR "Dirent.h not found, Csound will not be able to load dynamic plugins. Cannot continue with project generation")
     else()
+     if(NOT BARE_METAL)
         message(WARNING "Dirent.h not found, Csound will not be able to load dynamic plugins such as real-time audio")
+    endif()
     endif()
 endif()
 
@@ -1254,12 +1256,18 @@ if(APPLE)
     set(libcsound_SRCS "${libcsound_SRCS};${csheaders};${H_headers};${CMAKE_CURRENT_BINARY_DIR}/include/float-version.h;${CMAKE_CURRENT_BINARY_DIR}/include/version.h")
 endif()
 
+
 if(NOT IOS OR OSXCROSS_TARGET)
+if(NOT BARE_METAL)
     add_library(${CSOUNDLIB} SHARED ${libcsound_SRCS})
+else()
+   add_library(${CSOUNDLIB} STATIC ${libcsound_SRCS})
+endif()
     target_include_directories(${CSOUNDLIB} PRIVATE ${libcsound_private_include_dirs})
     target_include_directories(${CSOUNDLIB} PUBLIC ${libcsound_public_include_dirs})
     set_target_properties(${CSOUNDLIB} PROPERTIES SOVERSION ${APIVERSION})
 endif()
+
 
 if(APPLE)
     if(NOT IOS OR OSXCROSS_TARGET)

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.cpp
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.cpp
@@ -1,22 +1,46 @@
+/*
+  daisyCsoundGenerative.cpp:
 
+  Copyright (C) 2025 Aman Jagawni
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA
+*/
 
 #include "daisy_seed.h"
 #include "daisysp.h"
 #include <array>
 #include <stdio.h>
 #include "daisyCsoundGenerative.h"
-#include "csound.h"
-#include "plugin.h"
+#include <csound.h>
+#include <plugin.h>
 
 
 using namespace daisy;
 using namespace daisy::seed;
 
-
+/*
+// this function can be used to provide a message callback 
+// for csound
 static void DaisyCsoundMessageCallback(CSOUND     *csound,
                                        int         attr,
                                        const char *format,
                                        va_list     args);
+*/
 
 
 DaisySeed hw;
@@ -175,6 +199,7 @@ int main(void)
     System::Delay(5000);
 
     CSOUND *cs = csoundCreate(NULL, NULL);
+    // uncomment to set message callback
     // csoundSetMessageCallback(cs, DaisyCsoundMessageCallback);
     csoundSetHostData(cs, (void *)&hw);
     csoundSetHostAudioIO(cs);
@@ -195,10 +220,9 @@ int main(void)
         csound = cs;
         csoundSetOption(cs, "-n");
         csoundSetOption(cs, "--ksmps=512");
-        //   csoundSetOption(cs, "-M0");
         csoundSetOption(cs, "-dm0");
 
-        int ret = csoundCompileCSD(cs, csdText.c_str(), 1);
+        int ret = csoundCompileCSD(cs, csdText.c_str(), 1, 0);
 
         if(ret == 0)
         {
@@ -212,8 +236,6 @@ int main(void)
             digiHandler.initDigiPins();
             while(1)
             {
-                // hw.PrintLine("Hello from Daisy Csound\n");
-
                 for(int i = 0; i < numAdcChannels; i++)
                 {
                     adcVals[i] = hw.adc.GetFloat(i);
@@ -228,21 +250,17 @@ int main(void)
             }
             csoundReset(cs);
         }
-        else
-        {
-            // hw.PrintLine("Error: could not compile csd. \n");
-        }
     }
     else
     {
-        //  hw.PrintLine("Error: csoundCreate failed.\n");
-        return 1;
+        return CSOUND_ERROR;
     }
-    return 0;
+    return CSOUND_SUCCESS;
 }
 
+/*
+// message callback
 constexpr size_t kMessageBufferSize = 64;
-
 static void DaisyCsoundMessageCallback(CSOUND     *csound,
                                        int         attr,
                                        const char *format,
@@ -250,7 +268,6 @@ static void DaisyCsoundMessageCallback(CSOUND     *csound,
 {
     char messageBuffer[kMessageBufferSize];
     vsnprintf(messageBuffer, kMessageBufferSize, format, args);
-
-
     hw.PrintLine("%s", messageBuffer);
 }
+*/

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
@@ -20,7 +20,7 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
   02111-1307 USA
 */
-#ifn
+#if
 #ifndef DAISY_CSOUND_H
 #define DAISY_CSOUND_H
 

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
@@ -20,7 +20,6 @@
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
   02111-1307 USA
 */
-#if
 #ifndef DAISY_CSOUND_H
 #define DAISY_CSOUND_H
 

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/daisyCsoundGenerative.h
@@ -1,3 +1,26 @@
+/*
+  daisyCsoundGenerative.h
+
+  Copyright (C) 2025 Aman Jagawni
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA
+*/
+#ifn
 #ifndef DAISY_CSOUND_H
 #define DAISY_CSOUND_H
 

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.cpp
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.cpp
@@ -18,6 +18,8 @@ static int32_t ReadMidiData(CSOUND        *csound,
                             void          *userData,
                             unsigned char *mbuf,
                             int32_t        nbytes);
+/*
+// MIDI output - needs to be implemented
 static int32_t
 OpenMidiOutDevice(CSOUND *csound, void **userData, const char *dev);
 static int32_t CloseMidiOutDevice(CSOUND *csound, void *userData);
@@ -25,11 +27,14 @@ static int32_t WriteMidiData(CSOUND              *csound,
                              void                *userData,
                              const unsigned char *mbuf,
                              int                  nbytes);
+*/
+/*
+// use this for Csound message callbacks
 static void    DaisyCsoundMessageCallback(CSOUND     *csound,
                                           int         attr,
                                           const char *format,
                                           va_list     args);
-
+*/
 
 DaisySeed      hw;
 MidiUsbHandler midi;
@@ -217,7 +222,7 @@ int main(void)
         csoundSetOption(cs, "-M0");
         csoundSetOption(cs, "-dm0");
 
-        int ret = csoundCompileCSD(cs, csdText.c_str(), 1);
+        int ret = csoundCompileCSD(cs, csdText.c_str(), 1, 0);
 
         if(ret == 0)
         {
@@ -298,9 +303,9 @@ int32_t ReadMidiData(CSOUND        *csound,
     return 0;
 }
 
-
+/*
+// use this for Csound message callbacks
 constexpr size_t kMessageBufferSize = 64;
-
 static void DaisyCsoundMessageCallback(CSOUND     *csound,
                                        int         attr,
                                        const char *format,
@@ -312,3 +317,4 @@ static void DaisyCsoundMessageCallback(CSOUND     *csound,
 
     hw.PrintLine("%s", messageBuffer);
 }
+*/

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.cpp
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.cpp
@@ -1,11 +1,34 @@
+/*
+  daisyCsoundMidi.cpp:
+
+  Copyright (C) 2025 Aman Jagawni
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA
+*/
+
 #include "daisy_seed.h"
 #include "daisysp.h"
 #include <array>
 #include <stdio.h>
 #include "daisyCsoundMidi.h"
 #include "midiBuffer.h"
-#include "csound.h"
-#include "plugin.h"
+#include <csound.h>
+#include <plugin.h>
 
 using namespace daisy;
 using namespace daisy::seed;

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.h
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/daisyCsoundMidi.h
@@ -1,3 +1,25 @@
+/*
+  daisyCsoundMidi.h
+
+  Copyright (C) 2025 Aman Jagawni
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA
+*/
 #ifndef DAISY_CSOUND_H
 #define DAISY_CSOUND_H
 

--- a/Daisy/DaisyCsoundExamples/README.md
+++ b/Daisy/DaisyCsoundExamples/README.md
@@ -10,8 +10,8 @@ Both examples showcase the use of DaisyCsound's analog and digital interfaces.
 
 ## Instructions
 
-1. Place this folder inside your `DaisyExamples` directory (assuming you've already cloned the [DaisyExamples GitHub repository](https://github.com/electro-smith/DaisyExamples)).  
-2. Open a terminal and navigate (`cd`) to one of the example folders.  
+1. Place this folder inside your `DaisyExamples` directory (assuming
+you've already downloaded and installed the Daisy tools from Electrosmith)
 3. Open the included `Makefile` and update the following variables to match your system’s Csound installation:
    - `CSOUND_INCLUDE_DIR`  
    - `CSOUND_LIB_DIR`  

--- a/include/coreDefs.h
+++ b/include/coreDefs.h
@@ -107,12 +107,18 @@ static const uint32_t PHMASK = (1 << 24) - 1;
 
 #ifndef PI
 #define PI      (3.141592653589793238462643383279502884197)
-#endif /* pi */
+#endif /* pi */ 
 #define TWOPI   (6.283185307179586476925286766559005768394)
 #define HALFPI  (1.570796326794896619231321691639751442099)
+#ifndef PI_F  
 #define PI_F    ((MYFLT) PI)
+#endif
+#ifndef TWOPI_F    
 #define TWOPI_F ((MYFLT) TWOPI)
+#endif
+#ifndef HALFPI_F  
 #define HALFPI_F ((MYFLT) HALFPI)
+#endif  
 #define INF     (2147483647.0)
 #define ROOT2   (1.414213562373095048801688724209698078569)
 /* CONSTANTS FOR USE IN MSGLEVEL */


### PR DESCRIPTION
This PR implements a few changes to Baremetal/Daisy

- fixed Daisy examples for changes in the `csoundCompileCSD()` signature
- fixed cmake warnings for baremetal build
- fixed build warnings for Daisy examples
- improved instructions
