### PR TITLE
for loop 

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -534,7 +534,7 @@ for_in : FOR_TOKEN identifier in expr DO_TOKEN statement_list OD_TOKEN
           $3->right = $6;
           $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $2, $3);
         }
-        | FOR_TOKEN identifier ',' identifier in expr DO_TOKEN statement_list OD_TOKEN
+      | FOR_TOKEN identifier ',' identifier in expr DO_TOKEN statement_list OD_TOKEN
         {
           $2->next = $4;
           $5->left = $6;

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -40,7 +40,6 @@ static TREE *create_boolean_expression(CSOUND*, TREE*, int32_t,  uint64_t,
 static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
                                TYPE_TABLE*);
 static TREE *create_synthetic_label(CSOUND *csound, int32 count);
-static int32_t genlabs = 300;
 
 TREE* tree_tail(TREE* node) {
   TREE* t = node;
@@ -309,7 +308,7 @@ static TREE *create_cond_expression(CSOUND *csound,
                                     TYPE_TABLE* typeTable)
 {
   TREE *last = NULL;
-  int32 ln1 = genlabs++, ln2 = genlabs++;
+  int32 ln1 = csound->genlabs++, ln2 = csound->genlabs++;
   TREE *L1 = create_synthetic_label(csound, ln1);
   TREE *L2 = create_synthetic_label(csound, ln2);
   TREE *b = create_boolean_expression(csound, root->left, line, locn,
@@ -1179,7 +1178,7 @@ TREE* expand_if_statement(CSOUND* csound,
     if (UNLIKELY(PARSER_DEBUG))
       csound->Message(csound, "Found if-then\n");
     if (right->next != NULL) {
-      endLabelCounter = genlabs++;
+      endLabelCounter = csound->genlabs++;
     }
 
     while (ifBlockCurrent != NULL) {
@@ -1206,8 +1205,8 @@ TREE* expand_if_statement(CSOUND* csound,
         int32_t gotoType;
 
         statements = tempRight->right;
-        label = create_synthetic_ident(csound, genlabs);
-        labelEnd = create_synthetic_label(csound, genlabs++);
+        label = create_synthetic_ident(csound, csound->genlabs);
+        labelEnd = create_synthetic_label(csound, csound->genlabs++);
         tempRight->right = label;
 
         typeTable->labelList =
@@ -1325,7 +1324,7 @@ TREE* expand_switch_statement(
   TREE* switchExpression = current->left;
 
   TREE* endGoto = create_goto_node(csound, isPerfRate);
-  TREE* endLabel = create_synthetic_label(csound, genlabs++);
+  TREE* endLabel = create_synthetic_label(csound, csound->genlabs++);
   typeTable->labelList = cs_cons(
     csound,
     cs_strdup(csound, endLabel->value->lexeme),
@@ -1349,7 +1348,7 @@ TREE* expand_switch_statement(
 
   while (caseNode) {
     if (caseNode->type == CASE_TOKEN) {
-        caseLabel = create_synthetic_label(csound, genlabs++);
+        caseLabel = create_synthetic_label(csound, csound->genlabs++);
         typeTable->labelList = cs_cons(
           csound,
           cs_strdup(csound, caseLabel->value->lexeme),
@@ -1401,7 +1400,7 @@ TREE* expand_switch_statement(
         }
     } else if (caseNode->type == DEFAULT_TOKEN && gotoChainHeadDefaultCase == NULL) {
       gotoChainHeadDefaultCase = create_goto_node(csound, isPerfRate);
-      defaultCaseLabel = create_synthetic_label(csound, genlabs++);
+      defaultCaseLabel = create_synthetic_label(csound, csound->genlabs++);
       typeTable->labelList = cs_cons(
         csound,
         cs_strdup(csound, defaultCaseLabel->value->lexeme),
@@ -1475,8 +1474,8 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 
   TREE* gotoToken;
 
-  int32 topLabelCounter = genlabs++;
-  int32 endLabelCounter = genlabs++;
+  int32 topLabelCounter = csound->genlabs++;
+  int32 endLabelCounter = csound->genlabs++;
   TREE* tempRight = current->right;
   TREE* last = NULL;
   TREE* labelEnd;
@@ -1547,19 +1546,23 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   CS_TYPE *iType = (CS_TYPE *)&CS_VAR_TYPE_I;
   CS_TYPE *kType = (CS_TYPE *)&CS_VAR_TYPE_K;
+  int32_t isPerfRate = 0;
+  if(arrayArgType[0] == 'k') isPerfRate = 1;
+  else if(arrayArgType[0] == 'i') isPerfRate = 0;
+  else {
+    synterr(csound, "only i- or k-type arrays allowed\n");
+    return NULL;
+  }
+ 
 
-  int32_t isPerfRate = arrayArgType[1] == 'k';
   char* op = (char *)csound->Malloc(csound, 10);
   // create index counter
   TREE *indexAssign = create_empty_token(csound);
   indexAssign->value = make_token(csound, "=");
   indexAssign->type = T_ASSIGNMENT;
   indexAssign->value->type = T_ASSIGNMENT;
-  char *indexName = create_synthetic_var_name(
-    csound,
-    genlabs++,
-    isPerfRate ? 'k' : 'i'
-  );
+  char *indexName = create_synthetic_var_name(csound,csound->genlabs++,
+                                              isPerfRate ? 'k' : 'i');
   TREE *indexIdent = create_empty_token(csound);
   indexIdent->value = make_token(csound, indexName);
   indexIdent->type = T_IDENT;
@@ -1576,11 +1579,8 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   arrayAssign->value = make_token(csound, "=");
   arrayAssign->type = T_ASSIGNMENT;
   arrayAssign->value->type = T_ASSIGNMENT;
-  char *arrayName = create_synthetic_array_var_name(
-    csound,
-    genlabs++,
-    isPerfRate ? 'k' : 'i'
-  );
+  char *arrayName = create_synthetic_array_var_name(csound,csound->genlabs++,
+                                                    isPerfRate ? 'k' : 'i');
   TREE *arrayIdent = create_empty_token(csound);
   arrayIdent->value = make_token(csound, arrayName);
   arrayIdent->type = T_ARRAY_IDENT;
@@ -1595,11 +1595,8 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   arrayLength->value = make_token(csound, "=");
   arrayLength->type = T_ASSIGNMENT;
   arrayLength->value->type = T_ASSIGNMENT;
-  char *arrayLengthName = create_synthetic_var_name(
-    csound,
-    genlabs++,
-    isPerfRate ? 'k' : 'i'
-  );
+  char *arrayLengthName = create_synthetic_var_name(csound,csound->genlabs++,
+                                                    isPerfRate ? 'k' : 'i');
   TREE *arrayLengthIdent = create_empty_token(csound);
   arrayLengthIdent->value = make_token(csound, arrayLengthName);
   arrayLengthIdent->type = T_IDENT;
@@ -1613,18 +1610,17 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   arrayLengthFn->right = arrayLengthArrayIdent;
   arrayLength->right = arrayLengthFn;
   arrayAssign->next = arrayLength;
-
-
-  TREE* loopLabel = create_synthetic_label(csound, genlabs++);
+  
+  TREE* loopLabel = create_synthetic_label(csound, csound->genlabs++);
   loopLabel->type = LABEL_TOKEN;
   loopLabel->value->type = LABEL_TOKEN;
-  CS_VARIABLE *loopLabelVar = csoundCreateVariable(
-      csound, csound->typePool, isPerfRate ? kType : iType, loopLabel->value->lexeme, NULL);
+  CS_VARIABLE *loopLabelVar =
+    csoundCreateVariable(csound, csound->typePool, isPerfRate ? kType : iType,
+                         loopLabel->value->lexeme, NULL);
   csoundAddVariable(csound, typeTable->localPool, loopLabelVar);
-  typeTable->labelList = cs_cons(csound,
-                                 cs_strdup(csound, loopLabel->value->lexeme),
+  typeTable->labelList =
+    cs_cons(csound, cs_strdup(csound, loopLabel->value->lexeme),
                                  typeTable->labelList);
-
   arrayLength->next = loopLabel;
 
   // handle case where user provided an index identifier
@@ -1643,6 +1639,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   TREE* arrayGetStatement = create_opcode_token(csound, "##array_get");
   arrayGetStatement->left = current->left;
+  
   arrayGetStatement->right = copy_node(csound, arrayIdent);
   arrayGetStatement->right->next = copy_node(csound, indexIdent);
   if (hasOptionalIndex) {
@@ -1660,6 +1657,8 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   TREE* indexArgToken = copy_node(csound, indexIdent);
   loopLtStatement->right = indexArgToken;
+  // VL: need to set the next statement after loop
+  loopLtStatement->next = current->next;
 
   // loop less-than arg1: increment by 1
   TREE *oneToken = create_empty_token(csound);

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1932,6 +1932,7 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
   if (!check_args_exist(csound, root->right, typeTable)) {
     return 0;
   }
+  
   add_args(csound, root->left, typeTable);
 
   opcodeName = root->value->lexeme;
@@ -2571,7 +2572,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       }
 
       current = expand_if_statement(csound, current, typeTable);
-
+ 
       if (previous != NULL) {
         previous->next = current;
       }
@@ -2606,8 +2607,13 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
     continue;
 
     case FOR_TOKEN: {
+      /** for-loop typing:
+          1) if loop variable does not exist, it takes the type of the array
+          2) if it exists, the loop type follows the variable type
+      */
       char* arrayArgType = get_arg_type2(csound, current->right->left, typeTable);
-      
+      CS_VARIABLE* var = find_var_from_pools(csound, current->left->value->lexeme,
+                                        current->left->value->lexeme, typeTable);
       if (*arrayArgType != '[') {
         if(current->right->left->value != NULL) 
         synterr(csound,Str("Line: %d invalid argument in for statement: "
@@ -2616,15 +2622,25 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
         else synterr(csound,Str("Line: %d expected an array variable in for statement."),
                      current->line);
         return 0;
+      }    
+      
+      if(var == NULL) {
+      char  atype[2] = { arrayArgType[1], '\0' };
+      // now create the arg based on the array type
+      add_arg(csound, current->left->value->lexeme, atype,
+              typeTable);
+       arrayArgType++;
+      } else {
+        arrayArgType = var->varType->varTypeName;
+        printf("%s \n", arrayArgType);
       }
-
       current = expand_for_statement(csound, current, typeTable, arrayArgType);
-
       if (previous != NULL) {
         previous->next = current;
       }
     }
-      continue;
+    continue;
+    
     case LABEL_TOKEN:
       break;
 

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -285,8 +285,8 @@ OENTRY opcodlst_1[] = {
   { "init.a", sizeof(ARRAYINIT), 0, "a[]", "m", (SUBR)array_init },
   { "init.S", sizeof(ARRAYINIT), 0, "S[]", "m", (SUBR)array_init },
   { "init.0", sizeof(ARRAYINIT), 0, ".[]", "m", (SUBR)array_init },
-  { "fillarray.k", sizeof(TABFILL), 0, "k[]", "m", (SUBR)tabfill },
   { "fillarray.i", sizeof(TABFILL), 0, "i[]", "m", (SUBR)tabfill },
+  { "fillarray.k", sizeof(TABFILL), 0, "k[]", "m", (SUBR)tabfill },
   { "fillarray.s", sizeof(TABFILL), 0, "S[]", "W", (SUBR)tabfill },
   { "fillarray.K", sizeof(TABFILL), 0, "k[]", "z", NULL, (SUBR)tabfill },
   { "fillarray.f", sizeof(TABFILLF), 0, "k[]", "S", (SUBR)tabfillf },
@@ -587,7 +587,7 @@ OENTRY opcodlst_1[] = {
   { "lentab.i", sizeof(TABQUERY1), _QQ, "i", "k[]p", (SUBR) tablength },
   { "lentab.k", sizeof(TABQUERY1), _QQ, "k", "k[]p", NULL, (SUBR) tablength },
   { "lenarray.ix", sizeof(TABQUERY1), 0, "i", ".[]p", (SUBR) tablength },
-  { "lenarray.kx", sizeof(TABQUERY1), 0, "k", ".[]p", NULL, (SUBR)tablength },
+  { "lenarray.kx", sizeof(TABQUERY1), 0, "k", ".[]p", (SUBR)tablength, (SUBR)tablength },
   /* complex arrays */
   {"##add.Complex[]Complex[]", sizeof(COPS1), 0, ":Complex;[]",
    ":Complex;[]:Complex;[]",

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1198,7 +1198,8 @@ static const CSOUND cenviron_ = {
   sndgetset,
   getsndin
   },
-  0 /* instance count */    
+    0, /* instance count */
+    300 /* genLabs */
 };
 
 void csound_aops_init_tables(CSOUND *cs);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1773,6 +1773,7 @@ struct CSOUND_ {
   spin_lock_t osc_spinlock;
   CSOUND_UTIL csound_util;
   uint64_t instance_count;
+  int32_t genlabs;
   /*struct CSOUND_ **self;*/
   /**@}*/
 #endif /* __BUILDING_LIBCSOUND */

--- a/tests/commandline/test_for_in.csd
+++ b/tests/commandline/test_for_in.csd
@@ -8,9 +8,10 @@
 instr 1
 j:i init 0
 arr:i[] fillarray 1,2,3
-for iin in arr do
- print iin
+for j in arr do
+ print j
 od
+printarray arr
 endin
 
 instr 2
@@ -19,6 +20,7 @@ arr:k[] fillarray 1,2,3
 for j in arr do
  printk2 j
 od
+turnoff
 endin
 
 

--- a/tests/commandline/test_for_in.csd
+++ b/tests/commandline/test_for_in.csd
@@ -1,23 +1,36 @@
 <CsoundSynthesizer>
 <CsOptions>
--odac
+-n
 </CsOptions>
 <CsInstruments>
 0dbfs = 1
 
+/* for-in loop
+   for var in array do
+   ...
+   od
+   running either at i or k (perf) time
+*/
+
+/* case 1
+   loop var is not declared
+   loop type follows array type
+   (i-type in this case)
+*/
 instr 1
-j:i init 0
-arr:i[] fillarray 1,2,3
-for j in arr do
+for j in [1,2,3] do
  print j
 od
-printarray arr
 endin
 
+/* case 2
+   loop var is declared
+   loop type follows var type
+   regardless of array type
+*/
 instr 2
 j:k init 0
-arr:k[] fillarray 1,2,3
-for j in arr do
+for j in [1,2,3] do
  printk2 j
 od
 turnoff


### PR DESCRIPTION
This PR fixes the for-in-loop introduced earlier on in the new parser so that it can work with explicit types (as well as implicit types); a bug preventing the remainder of the code after the loop from executing was also fixed.

This was not documented at all - I have now added a commented example and can write a man page when this PR is merged.

Basically the for-in loop has the following syntax

```
for var in array do
 ...
od
```

where `var` and `array` can be either of i or k-types. The type of the loop (init or perf) is determined as follows

1) if `var` does not exist, it is created to match the type of the array variable. The loop type is determined by the array variable.
2) if `var` exists, it determines the type of the loop, regardless of the array type.

For example

```
/* case 1
   loop var is not declared
   loop type follows array type
   (i-type in this case)
*/
instr 1
for j in [1,2,3] do
 print j
od
endin
```

and

```
/* case 2
   loop var is declared
   loop type follows var type
   regardless of array type
*/
instr 2
j:k init 0
for j in [1,2,3] do
 printk2 j
od
endin
```

The converse case - an i-type loop var and a k-type array also runs only at i-time.




