### PR TITLE
fixed k[] inarg with i[] var

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -807,6 +807,26 @@ int32_t check_array_arg(char* found, char* required) {
   return (*f == *r);
 }
 
+int32_t check_array_arg_in(char* found, char* required) {
+  char* f = found;
+  char* r = required;
+
+  while (*r == '[') r++;
+
+  if (*r == '.' || *r == '?' || *r == '*') {
+    return 1;
+  }
+
+  while (*f == '[') f++;
+
+  // special case: k args with i inputs
+  if(*r == 'k' && *f == 'i') return 1;
+  return (*f == *r);
+}
+
+
+
+
 int32_t check_in_arg(char* found, char* required) {
   char* t;
   int32_t i;
@@ -826,7 +846,7 @@ int32_t check_in_arg(char* found, char* required) {
     if (*found != *required) {
       return 0;
     }
-    return check_array_arg(found, required);
+    return check_array_arg_in(found, required);
   }
 
   t = (char*)POLY_IN_TYPES[0];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -213,6 +213,7 @@ def runTest():
         ["complex_array_test.csd", "testing complex array ops"],
         ["fft_array_test.csd", "testing complex fft array ops"],
         ["rfft_array_test.csd", "testing complex rfft array ops"],
+        ["test_k_i_array_args.csd", "testing k[] in-arg with i[] var"]
     ]
 
 

--- a/tests/commandline/test_k_i_array_args.csd
+++ b/tests/commandline/test_k_i_array_args.csd
@@ -1,0 +1,21 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+opcode cycle, i, ik[]
+  indx, kvals[] xin
+  ival = i(kvals, indx % lenarray(kvals))
+  xout ival
+endop
+
+instr 1
+ival = cycle(p4, [0,4,2,3,1])
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0.001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR fixes an issue where i[] could not be used with k[] in-args. 