### PR TITLE
Shorthand for genarray

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -113,6 +113,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
                                        yyscanner);
                 }
 "->"            { return S_ELIPSIS; }
+"..."           { return S_ELIPSIS2; }
 
 "!="            { return S_NEQ; }
 "&&"            { return S_AND; }

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -97,6 +97,7 @@
 
 
 %token S_ELIPSIS
+%token S_ELIPSIS2
 %token T_ARRAY
 %token T_ARRAY_IDENT
 %token T_DECLARE
@@ -572,14 +573,23 @@ expr    : function_call
         | number
         | string
         | array_expr
+        | gen_array
         | static_array
         | struct_expr
         ;
 
-static_array : '[' expr_list ']' {
+gen_array:  '[' expr S_ELIPSIS2 expr_list  ']' {
+            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "genarray"));
+            $$->right = $2;
+            append_to_tree(csound, $$->right, $4);
+             }
+
+static_array :
+           '[' expr_list ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "fillarray"));
             $$->right = $2;
           }
+          
 
 /* TODO: Investigate whether this should allow for expressions as base before brackets to make more generic
 */

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -578,14 +578,13 @@ expr    : function_call
         | struct_expr
         ;
 
-gen_array:  '[' expr S_ELIPSIS2 expr_list  ']' {
+gen_array : '[' expr S_ELIPSIS2 expr_list  ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "genarray"));
             $$->right = $2;
             append_to_tree(csound, $$->right, $4);
              }
 
-static_array :
-           '[' expr_list ']' {
+static_array : '[' expr_list ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "fillarray"));
             $$->right = $2;
           }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -213,7 +213,8 @@ def runTest():
         ["complex_array_test.csd", "testing complex array ops"],
         ["fft_array_test.csd", "testing complex fft array ops"],
         ["rfft_array_test.csd", "testing complex rfft array ops"],
-        ["test_k_i_array_args.csd", "testing k[] in-arg with i[] var"]
+        ["test_k_i_array_args.csd", "testing k[] in-arg with i[] var"],
+        ["test_gen_array.csd", "testing genarray shorthand"],
     ]
 
 

--- a/tests/commandline/test_gen_array.csd
+++ b/tests/commandline/test_gen_array.csd
@@ -1,0 +1,22 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+
+instr 1
+for j in [1 ... 10] do
+ print j
+od
+endin
+
+
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
To complement the shorthand for `fillarray()` (eg `[1,2,3]`). I have added a short hand for `genarray`:

```
arr:i = [start ... end, incr]
```
for `genarray(start,end,incr)`
 
For example,

```
for j in [1 ... 10] do
 print j
od
```