### PR TITLE
Type equality operator

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -122,7 +122,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
 "<"             { return S_LT; }
 "<="            { return S_LE; }
 "=="            { return S_EQ; }
-"==="           { return S_EQT; }
+"=t"            { return S_EQT; }
 "+="            { return S_ADDIN; }
 "-="            { return S_SUBIN; }
 "*="            { return S_MULIN; }

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -823,7 +823,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
     strNcpy(op, "==", 80);
     break;
   case S_EQT:
-    strNcpy(op, "===", 80);
+    strNcpy(op, "=t", 80);
     break;   
   case S_NEQ:
     strNcpy(op, "!=", 80);

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -162,7 +162,7 @@ char* get_boolean_expression_opcode_type(CSOUND* csound, TREE* tree) {
   case S_EQ:
     return "==";
   case S_EQT:
-    return "===";  
+    return "=t";  
   case S_NEQ:
     return "!=";
   case S_GE:

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -192,7 +192,7 @@ OENTRY opcodlst_1[] = {
   { "==",     S(RELAT),0,  /* 0,*/       "b",    "ii",   eq,     NULL              },
   { "==",     S(RELAT),0,  /* 0,*/       "b",    "ib",   eq,     NULL              },
   { "==",     S(RELAT),0,  /* 0,*/       "b",    "bi",   eq,     NULL              },
-  { "===",     S(RELAT),0,  /* 0,*/       "b",    "..",   check_type,     NULL     },
+  { "=t",     S(RELAT),0,  /* 0,*/       "b",    "..",   check_type,     NULL     },
   { "==.0",     S(RELAT),0,  /* 0,*/       "B",    "kk",   NULL,     eq              },
   { "!=",     S(RELAT),0,  /* 0,*/       "b",    "ii",   ne,     NULL              },
   { "!=.0",     S(RELAT),0,  /* 0,*/       "B",    "kk",  NULL,     ne              },

--- a/tests/commandline/test_type_eq.csd
+++ b/tests/commandline/test_type_eq.csd
@@ -8,7 +8,7 @@
 instr 1
 k:i init 0
 j:i init 0
-prints k === j ? "types match\n" : "types do not match\n" 
+prints k =t j ? "types match\n" : "types do not match\n" 
 endin
 
 


### PR DESCRIPTION
It was pointed out that `===` could be misinterpreted as both type and value equality, so this PR changes the operator
to `=t `

```
if var1 =t var2 then
```

I checked and this does not break any existing code.

Type equality can also be done with `typecheck(var1, var2)`
