### PR TITLE
Slicearray shorthand

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -576,6 +576,7 @@ expr    : function_call
         | array_expr
         | gen_array
         | static_array
+        | slice_array
         | struct_expr
         ;
 
@@ -584,6 +585,13 @@ gen_array : '[' expr S_ELIPSIS2 expr_list  ']' {
             $$->right = $2;
             append_to_tree(csound, $$->right, $4);
              }
+
+slice_array : identifier '[' expr ':' expr_list  ']' {
+            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray"));
+            $$->right = $1;
+            $$->right = append_to_tree(csound, $$->right, $3);
+            append_to_tree(csound, $$->right, $5);
+           }
 
 static_array : '[' expr_list ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "fillarray"));

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -217,6 +217,7 @@ def runTest():
         ["rfft_array_test.csd", "testing complex rfft array ops"],
         ["test_k_i_array_args.csd", "testing k[] in-arg with i[] var"],
         ["test_gen_array.csd", "testing genarray shorthand"],
+        ["test_slice_array.csd", "testing slice shorthand"],
     ]
 
 

--- a/tests/commandline/test_slice_array.csd
+++ b/tests/commandline/test_slice_array.csd
@@ -1,0 +1,19 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n 
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+
+instr 1
+arr:i[] = [1,2,3,4,5,6,7]
+sl:i[] = arr[0 : 4, 2]
+printarray(sl)
+endin
+</CsInstruments>
+<CsScore>
+i1 0 0.001
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
In addition to the existing array op shortand, this PR adds

```
arr[start : end, stride]
```

for 

```
slicearray(arr, start, end [, stride])
```