### PR TITLE
String embedding added to the lexer

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -239,6 +239,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
                   PARM->xstrptr = 0; PARM->xstrmax = 128;
                   PARM->xstrbuff[PARM->xstrptr++] = '"';
                   PARM->xstrbuff[PARM->xstrptr] = '\0';
+                  PARM->xsubstr = 0;
                   BEGIN(xstr);
                 }
 
@@ -264,37 +265,61 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
 }
 
 <xstr>{
+  "\{\{" { 
+             PARM->xsubstr += 1; // substr start
+             if (PARM->xstrptr+3==PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+               csound->DebugMsg(csound,"Extending xstr buffer\n");
+             }
+             PARM->xstrbuff[PARM->xstrptr++] = '{';
+             PARM->xstrbuff[PARM->xstrptr++] = '{';
+             PARM->xstrbuff[PARM->xstrptr] = '\0';  
+         }
 
   "}}"   {
-                  BEGIN(INITIAL);
-                  PARM->xstrbuff[PARM->xstrptr++] = '"';
-                  PARM->xstrbuff[PARM->xstrptr] = '\0';
-                  /* printf("xstrbuff:>>%s<<\n", PARM->xstrbuff); */
-                  *lvalp = make_string(csound, PARM->xstrbuff);
-                  free(PARM->xstrbuff);
-                  return STRING_TOKEN;
-                }
-
-  "\n"     { /* The next two should be one case but I cannot get that to work */
-                  if (PARM->xstrptr+2==PARM->xstrmax) {
-                      PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+    if(PARM->xsubstr) {
+            PARM->xsubstr -= 1; // substr end
+           if (PARM->xstrptr+3==PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
-                      csound->DebugMsg(csound,"Extending xstr buffer\n");
-                  }
-                  //csound->DebugMsg(csound,"Adding newline (%.2x)\n", yytext[0]);
-                  PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
-                  PARM->xstrbuff[PARM->xstrptr] = '\0';
-                }
+               csound->DebugMsg(csound,"Extending xstr buffer\n");
+           }           
+           PARM->xstrbuff[PARM->xstrptr++] = '}';
+           PARM->xstrbuff[PARM->xstrptr++] = '}';
+           PARM->xstrbuff[PARM->xstrptr] = '\0';            
+    } else {
+           BEGIN(INITIAL);
+           PARM->xstrbuff[PARM->xstrptr++] = '"';
+           PARM->xstrbuff[PARM->xstrptr] = '\0';
+           /* printf("xstrbuff:>>%s<<\n", PARM->xstrbuff); */
+           *lvalp = make_string(csound, PARM->xstrbuff);
+            free(PARM->xstrbuff);
+            return STRING_TOKEN;
+          }
+  }
 
-  .         { if (PARM->xstrptr+2==PARM->xstrmax) {
-                      PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+  "\n"  { /* The next two should be one case but I cannot get that to work */
+           if (PARM->xstrptr+2==PARM->xstrmax) {
+               PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
-                      csound->DebugMsg(csound,"Extending xstr buffer\n");
-                  }
-                  //csound->DebugMsg(csound,"Adding (%.2x)\n", yytext[0]);
-                  PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
-                  PARM->xstrbuff[PARM->xstrptr] = '\0';
-                }
+               csound->DebugMsg(csound,"Extending xstr buffer\n");
+           }
+            //csound->DebugMsg(csound,"Adding newline (%.2x)\n", yytext[0]);
+               PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
+               PARM->xstrbuff[PARM->xstrptr] = '\0';
+           }
+
+  .        {
+            if (PARM->xstrptr+2==PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+                 csound->DebugMsg(csound,"Extending xstr buffer\n");
+               }
+              //csound->DebugMsg(csound,"Adding (%.2x)\n", yytext[0]);
+              PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
+              PARM->xstrbuff[PARM->xstrptr] = '\0';
+            }
 }
 
 {IDENT}:/[ \t\n]  { char *pp = yytext;

--- a/Engine/parse_param.h
+++ b/Engine/parse_param.h
@@ -58,6 +58,7 @@ typedef struct parse_parm_s {
     int             xstrptr,xstrmax;
     uint64_t        iline;      /* Line number for start of instrument */
     uint64_t        ilocn;      /* and location */
+    int             xsubstr;    /* count for substr */
 } PARSE_PARM;
 
 void    cs_init_math_constants_macros(CSOUND*);

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -178,6 +178,7 @@ def runTest():
     ["test_explicit_globals.csd", "test global declaration of explicit types"],
     ["test_fail_mismatched_types.csd", "syntax error on mismatched type declaration", 1],        
     ["test_declare.csd", "test declare keyword (CS7)"],
+    ["test_sub_str.csd", "test raw string embedded in raw string"],
     ["test_plusname.csd", "test +Name for instr name"],
     ["test_unary_expressions.csd", "various unary operators in various expressions"],
     ["test_opassign.csd", "test +=, ==, *= and /="],

--- a/tests/commandline/test_sub_str.csd
+++ b/tests/commandline/test_sub_str.csd
@@ -1,0 +1,20 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+
+instr 1
+ires compilestr {{
+prints {{test string
+}}
+}}
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+


### PR DESCRIPTION
This PR introduces the ability to embed multiline/raw strings inside raw strings, e.g.

```
instr 1
ires compilestr {{
prints {{
test string
}}
}}
endin
```

as per https://github.com/csound/csound/issues/2118