### PR TITLE
MIDI sys realtime msgs input

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -1502,6 +1502,12 @@ OENTRY opcodlst_1[] = {
   { "db.i",     S(EVAL),0,        "i",    "i",     db                     },
   { "db.k",     S(EVAL),0,         "k",    "k",     NULL, db               },
   { "db.a",     S(EVAL),0,         "a",    "a",     NULL, dba        },
+  { "midiclockin",  S(MIDIKMB),0,     "k",    "",     NULL, midi_clock_in, NULL    },
+  { "midistart",  S(MIDIKMB),0,     "k",    "",     NULL, midi_start, NULL    },
+    { "midistop",  S(MIDIKMB),0,     "k",    "",     NULL, midi_stop, NULL    },
+    { "midicontinue",  S(MIDIKMB),0,     "k",    "",     NULL, midi_continue, NULL    },
+  { "midiclockfreq",  S(MIDIKMB),0,     "k",    "", NULL, midi_clock_freq, NULL    },
+  
   { "midichn",  S(MIDICHN),0,     "i",    "",      midichn, NULL, NULL    },
   { "pgmassign",S(PGMASSIGN),0,   "",     "iio",   pgmassign, NULL, NULL  },
   { "pgmassign.S",S(PGMASSIGN),0,  "",    "iSo",   pgmassign_S, NULL, NULL  },

--- a/H/midiops.h
+++ b/H/midiops.h
@@ -232,4 +232,9 @@ typedef struct {
 } PRINTPRESETS;
 
 int32_t event_type(CSOUND *csound, void *p);
+int32_t midi_clock_in(CSOUND *csound, void *p);
+int32_t midi_stop(CSOUND *csound, void *p);
+int32_t midi_start(CSOUND *csound, void *p);
+int32_t midi_continue(CSOUND *csound, void *p);
+int32_t midi_clock_freq(CSOUND *csound, void *p);
 #endif

--- a/InOut/midirecv.c
+++ b/InOut/midirecv.c
@@ -483,7 +483,12 @@ int32_t sens_midi(CSOUND *csound)
    const OPARMS  *O = csound->oparms;
     int32_t     n;
     int16   c, type;
-
+    // reset sys realtime msgs
+    csound->midi_clock_pulse = 0;
+    csound->midi_start = 0;
+    csound->midi_continue = 0;
+    csound->midi_stop = 0;
+    
  nxtchr:
     if (p->bufp >= p->endatp) {
       p->bufp = &(p->mbuf[0]);
@@ -513,9 +518,17 @@ int32_t sens_midi(CSOUND *csound)
         if (c & 0x08)                   /* sys_realtime:        */
           switch (lo3) {                /*   dispatch now       */
           case 0: /* m_clktim++; */     /* timing clock         */
+            csound->midi_clock_pulse = 1;
+            goto nxtchr;
           case 2:                       /* start                */
+            csound->midi_start = 1;
+            goto nxtchr;
           case 3:                       /* continue             */
+            csound->midi_continue = 1;
+            goto nxtchr;
           case 4:                       /* stop                 */
+           csound->midi_stop = 1;
+            goto nxtchr;
           case 6:                       /* active sensing       */
           case 7:                       /* system reset         */
             goto nxtchr;

--- a/OOps/midiops.c
+++ b/OOps/midiops.c
@@ -162,6 +162,48 @@ int32_t event_type(CSOUND *csound, void *p) {
   return OK;
 }
 
+int32_t midi_clock_in(CSOUND *csound, void *pp) {
+  MIDIKMB * p = ((MIDIKMB *)pp);
+  *p->r = csound->midi_clock_pulse;
+  return OK;
+}
+
+int32_t midi_start(CSOUND *csound, void *pp) {
+  MIDIKMB * p = ((MIDIKMB *)pp);
+  *p->r = csound->midi_start;
+  return OK;
+}
+
+int32_t midi_stop(CSOUND *csound, void *pp) {
+  MIDIKMB * p = ((MIDIKMB *)pp);
+  *p->r = csound->midi_clock_pulse;
+  return OK;
+}
+
+int32_t midi_continue(CSOUND *csound, void *pp) {
+  MIDIKMB * p = ((MIDIKMB *)pp);
+  *p->r = csound->midi_clock_pulse;
+  return OK;
+}
+
+
+int32_t midi_clock_freq(CSOUND *csound, void *pp) {
+   MIDIKMB * p = ((MIDIKMB *)pp);
+   if(csound->midi_clock_pulse) {
+     MYFLT per;
+     // cur time
+     p->scale = CS_KCNT*CS_ONEDKR;
+     // interclock period
+     per = (p->scale - p->prvbend);
+     // midiclock freq 
+     if(per) p->prvout = 1/per;
+     p->prvbend = p->scale;
+   }
+   *p->r = p->prvout;
+    return OK;
+}
+
+
 /* cpstmid by G.Maldonado */
 int32_t cpstmid(CSOUND *csound, CPSTABLE *p)
 {

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1200,7 +1200,8 @@ static const CSOUND cenviron_ = {
   getsndin
   },
     0, /* instance count */
-    300 /* genLabs */
+    300, /* genLabs */
+    0, 0, 0, 0 /* midi RT messages */
 };
 
 void csound_aops_init_tables(CSOUND *cs);

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1775,6 +1775,10 @@ struct CSOUND_ {
   CSOUND_UTIL csound_util;
   uint64_t instance_count;
   int32_t genlabs;
+  int32_t midi_clock_pulse;
+  int32_t midi_start;
+  int32_t midi_continue;
+  int32_t midi_stop;  
   /*struct CSOUND_ **self;*/
   /**@}*/
 #endif /* __BUILDING_LIBCSOUND */


### PR DESCRIPTION
This PR adds opcodes for MIDI sys RT output
https://github.com/csound/csound/issues/816

midiclockin
midistart
midistop
midicontinue
midiclockfreq

NB: the accuracy of these opcode depends on how RT audio IO is implemented - currently with synchronous IO in Csound backends there will be significant midiclock jitter. But if Csound IO is implemented in asynchronous callbacks by frontends, this should be improved.