### PR TITLE
optional types for newstyle udos

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1536,6 +1536,25 @@ CS_VAR_POOL *find_global_annotation(char *varName, TYPE_TABLE* typeTable) {
   return pool;
 }
 
+// on new-type UDOS type-annotations can
+// be used for optional types
+// this checks and converts it to i or k type names
+char *check_optional_type(CSOUND *csound, char *name) {
+    if(is_in_optional_arg(name)) {
+      char *t = (char*)OPTIONAL_IN_TYPES[0];
+      char *o, str[2] =  {0};
+      for (int i = 0; t != NULL; i += 2) {
+        o = (char*)OPTIONAL_IN_TYPES[i + 1];
+        if (strcmp(t, name) == 0) {
+          str[0] = *o;        
+          return cs_strdup(csound, str);   
+        }
+        t = (char*)OPTIONAL_IN_TYPES[i + 2];
+      }
+    }
+    return cs_strdup(csound, name);
+}
+
 /* This function creates a new variable for a rhs argument
    if the variable is not found in any of the pools
    If the variable is found, a consistency check is made
@@ -1558,9 +1577,11 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
     if (annotation != NULL) {
       // check for global annotation in explicit-type rhs vars
       pool = find_global_annotation(varName, typeTable);
-      type = csoundGetTypeWithVarTypeName(csound->typePool, annotation);
+      // check to see if annotation is optional type
+      char *nm = check_optional_type(csound, annotation);
+      type = csoundGetTypeWithVarTypeName(csound->typePool,nm);
       typeArg = (void *) type;
-     
+      csound->Free(csound, nm);
     } else {
       // check for @global in implicit-type rhs vars
       // and if found, strip it and print warning
@@ -1593,12 +1614,8 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
       }
 
       argLetter[0] = (*t == 't') ? '[' : *t; /* Support legacy t-vars */
-      
-      
-
       type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
     }
-
     var = csoundCreateVariable(csound, csound->typePool,
                                type, varName, typeArg);
 
@@ -1606,13 +1623,16 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
   } else {
     //TODO - implement reference count increment
     if (annotation != NULL) {
-       // check if a variable is declared with same name
-       // and different type.
-       type = csoundGetTypeWithVarTypeName(csound->typePool, annotation);
-       if(type != var->varType) 
-         synterr(csound, "%s:%s type mismatch for variable %s:%s",
-                 varName, type->varTypeName, varName,
-                 var->varType->varTypeName);
+      // check for optional type 
+      char *t = check_optional_type(csound, annotation);
+      // check if a variable is declared with same name
+      // and different type.
+      type = csoundGetTypeWithVarTypeName(csound->typePool, t);
+      if(type && type != var->varType) 
+        synterr(csound, "%s:%s type mismatch for variable %s:%s",
+                varName, type->varTypeName, varName,
+                var->varType->varTypeName);
+      csound->Free(csound, t);
     }
   }
 

--- a/Engine/symbtab.c
+++ b/Engine/symbtab.c
@@ -46,7 +46,7 @@
 
 static char* map_udo_in_arg_type(char* in) {
     if(strlen(in) == 1) {
-      if (strchr("ijop", *in) != NULL) {
+      if (strchr("ijopqvh", *in) != NULL) {
           return "i";
       } else if (strchr("kKOJPV", *in) != NULL) {
           return "k";

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -130,7 +130,7 @@ def runTest():
     ["test_switch_statement.csd", "tests the new switch statement operator"],
 	["nested_strings.csd", "test nested strings works with schedule [issue #861]"],
 	["test_label_within_if_block.csd", "test label within if block"],
-
+    ["test_newstyle_udo_optargs.csd", "test newstyle UDO optional args"],
 	["test_arrays.csd", "test k-array with single dimension, assignment to expression value"],
 	["test_arrays2.csd", "test gk-array with single dimension, assignment to expression value"],
 	["test_arrays3.csd", "test k-array with single dimension, assignment with number"],

--- a/tests/commandline/test_newstyle_udo_optargs.csd
+++ b/tests/commandline/test_newstyle_udo_optargs.csd
@@ -1,0 +1,22 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+sr = 44100
+0dbfs=1
+nchnls = 2
+
+opcode myop(var1:i,var2:o,var3:p,var4:q,var5:v,var6:j,var7:h):void
+print var1,var2,var3,var4,var5,var6,var7
+endop
+
+instr 1
+myop(1)
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR adds optional types as per internal opcodes to newstyle UDOS:

```
opcode myop(var1:i,var2:o,var3:p,var4:q,var5:v,var6:j,var7:h):void
print var1,var2,var3,var4,var5,var6,var7
endop

instr 1
myop(1)
endin
```

prints

```
UDO myop:	var1 = 1.000	var2 = 0.000	var3 = 1.000	var4 = 10.000	var5 = 0.500	var6 = -1.000	var7 = 127.000
```