### PR TITLE
Misc fixes

### DIFF
--- a/OOps/schedule.c
+++ b/OOps/schedule.c
@@ -340,7 +340,7 @@ int32_t schedule(CSOUND *csound, SCHEDO *p)
     insno = instr_num(csound, ref->instr);
     p->argums[0] = &insno;
     res = insert_score_args_at_sample(csound, &evt, p->argums,
-                                      csound->icurTimeSamples);
+                                  csound->icurTimeSamples);
     p->argums[0] = (MYFLT *) ref;
     return res;
   } else if (GetTypeForArg(p->argums[0]) == &CS_VAR_TYPE_S) {
@@ -355,8 +355,12 @@ int32_t schedule(CSOUND *csound, SCHEDO *p)
     p->argums[0] = ref;
     return res;
   }
-  else return insert_score_args_at_sample(csound, &evt, p->argums,
+  else if (GetTypeForArg(p->argums[0]) == &CS_VAR_TYPE_I ||
+           GetTypeForArg(p->argums[0]) == &CS_VAR_TYPE_C ||
+           GetTypeForArg(p->argums[0]) == &CS_VAR_TYPE_P) 
+    return insert_score_args_at_sample(csound, &evt, p->argums,
                                       csound->icurTimeSamples);
+  else return csound->InitError(csound, "invalid instrument argument\n");
 }
 
 
@@ -392,8 +396,11 @@ int32_t schedule_N(CSOUND *csound, SCHED *p)
     char s[16384], sf[64];
     if (GetTypeForArg(p->which) == &CS_VAR_TYPE_INSTR) {
       INSTREF *ref = (INSTREF *) p->which;
-      insno = (MYFLT) instr_num(csound, ref->instr); 
-    }
+      insno = (MYFLT) instr_num(csound, ref->instr);
+    } else if (GetTypeForArg(p->which) != &CS_VAR_TYPE_I &&
+           GetTypeForArg(p->which) != &CS_VAR_TYPE_C &&
+           GetTypeForArg(p->which) != &CS_VAR_TYPE_P)
+      return csound->InitError(csound, "instrument argument invalid\n");
     
     snprintf(s, 16384, "i %f %f %f", insno, *p->when, *p->dur);
     for (i=4; i < argno ; i++) {

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -1024,7 +1024,8 @@ int32_t getcfg_opcode(CSOUND *csound, GETCFG_OP *p)
 #endif
     break;
   case 7:             /* is the channel I/O callback set ? (0: no, 1: yes) */
-    buf[0] = 0;
+    buf[0] = (csound->InputChannelCallback_ ||
+              csound->OutputChannelCallback_ ? '1' : '0');
     buf[1] = '\0';
     break;
   default:


### PR DESCRIPTION
#2216 : better error diagnostics on invalid instrument for `schedule` and `schedulek`

#2218 : added option 7 to return invalue/outvalue callback status
