### PR TITLE
Generalising for loop

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1566,14 +1566,15 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
                            char* arrayArgType) {
 
-  CS_TYPE *iType = (CS_TYPE *)&CS_VAR_TYPE_I;
-  CS_TYPE *kType = (CS_TYPE *)&CS_VAR_TYPE_K;
-  CS_TYPE *aType = (CS_TYPE *)&CS_VAR_TYPE_A;
-  CS_TYPE *xType = (CS_TYPE *)&CS_VAR_TYPE_COMPLEX;
-  CS_TYPE *arrayType = (CS_TYPE *)
+  const CS_TYPE *iType = &CS_VAR_TYPE_I;
+  const CS_TYPE *kType = &CS_VAR_TYPE_K;
+  const CS_TYPE *aType = &CS_VAR_TYPE_A;
+  const CS_TYPE *xType = &CS_VAR_TYPE_COMPLEX;
+  const CS_TYPE *arrayType = 
     csoundGetTypeWithVarTypeName(csound->typePool, arrayArgType);
   int32_t isPerfRate = 0;
-  
+
+  // these array types generated perf-time loops
   if(arrayType == aType || arrayType == kType ||
      arrayType == xType) isPerfRate = 1;
   else isPerfRate = 0;
@@ -1602,6 +1603,10 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   arrayAssign->value = make_token(csound, "=");
   arrayAssign->type = T_ASSIGNMENT;
   arrayAssign->value->type = T_ASSIGNMENT;
+
+  // this array holds the data for each iteration
+  // the array type generally matches the loop var type
+  // with the exception of 'i' and 'k' which may be used interchangeably
   char *arrayName = create_synthetic_array_var_name(csound,csound->genlabs++,'x');
   TREE *arrayIdent = create_empty_token(csound);
   arrayIdent->value = make_token(csound, arrayName);

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -910,12 +910,18 @@ static char* create_synthetic_var_name(CSOUND* csound, int32 count, int32_t pref
   return name;
 }
 
+
+
 static char* create_synthetic_array_var_name(CSOUND* csound, int32 count, int32_t prefix)
 {
   char *name = (char *)csound->Calloc(csound, 36);
   snprintf(name, 36, "%c__synthetic_%"PRIi32"[]", prefix, count);
   return name;
 }
+
+
+
+
 
 static TREE *create_synthetic_ident(CSOUND *csound, int32 count)
 {
@@ -1562,14 +1568,15 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   CS_TYPE *iType = (CS_TYPE *)&CS_VAR_TYPE_I;
   CS_TYPE *kType = (CS_TYPE *)&CS_VAR_TYPE_K;
+  CS_TYPE *aType = (CS_TYPE *)&CS_VAR_TYPE_A;
+  CS_TYPE *xType = (CS_TYPE *)&CS_VAR_TYPE_COMPLEX;
+  CS_TYPE *arrayType = (CS_TYPE *)
+    csoundGetTypeWithVarTypeName(csound->typePool, arrayArgType);
   int32_t isPerfRate = 0;
-  if(arrayArgType[0] == 'k') isPerfRate = 1;
-  else if(arrayArgType[0] == 'i') isPerfRate = 0;
-  else {
-    synterr(csound, "only i- or k-type arrays allowed\n");
-    return NULL;
-  }
- 
+  
+  if(arrayType == aType || arrayType == kType ||
+     arrayType == xType) isPerfRate = 1;
+  else isPerfRate = 0;
 
   char* op = (char *)csound->Malloc(csound, 10);
   // create index counter
@@ -1595,13 +1602,12 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   arrayAssign->value = make_token(csound, "=");
   arrayAssign->type = T_ASSIGNMENT;
   arrayAssign->value->type = T_ASSIGNMENT;
-  char *arrayName = create_synthetic_array_var_name(csound,csound->genlabs++,
-                                                    isPerfRate ? 'k' : 'i');
+  char *arrayName = create_synthetic_array_var_name(csound,csound->genlabs++,'x');
   TREE *arrayIdent = create_empty_token(csound);
   arrayIdent->value = make_token(csound, arrayName);
   arrayIdent->type = T_ARRAY_IDENT;
   arrayIdent->value->type = T_ARRAY_IDENT;
-  add_array_arg(csound, arrayName, NULL, 1, typeTable);
+  add_array_arg(csound, arrayName, arrayArgType, 1, typeTable);
 
   arrayAssign->left = arrayIdent;
   arrayAssign->right = current->right->left;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2705,6 +2705,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
           1) if loop variable does not exist, it takes the type of the array
           2) if it exists, the loop type follows the variable type
       */
+
       char* arrayArgType = get_arg_type2(csound, current->right->left,
                                          typeTable);
       CS_VARIABLE* var = find_var_from_pools(csound,
@@ -2713,24 +2714,46 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
                                              typeTable);
       if (*arrayArgType != '[') {
         if(current->right->left->value != NULL) 
-        synterr(csound,Str("Line: %d invalid argument in for statement: "
+        synterr(csound,Str("line:%d invalid argument in for statement: "
                            "found '%s', which is not an array\n"),
           current->line,current->right->left->value->lexeme);
-        else synterr(csound,Str("Line: %d expected an array variable in for statement."),
+        else synterr(csound,Str("line:%d expected an array variable in for statement."),
                      current->line);
         return 0;
       }    
-      
+
+      char* atype = cs_strdup(csound, arrayArgType+1);
+      char * typ;
+      atype[strlen(atype)-1] = '\0';
       if(var == NULL) {
-      char  atype[2] = { arrayArgType[1], '\0' };
-      // now create the arg based on the array type
-       add_arg(csound, current->left->value->lexeme, atype,
+       typ = remove_type_quoting(csound, atype);
+       // now create the arg based on the array type
+       add_arg(csound, current->left->value->lexeme, typ,
               typeTable);
-       arrayArgType++;
       } else {
-        arrayArgType = var->varType->varTypeName;
+        // now we need to check that the array matches the
+        // var type
+        const CS_TYPE *iType = &CS_VAR_TYPE_I;
+        const CS_TYPE *kType = &CS_VAR_TYPE_K;
+        const CS_TYPE *avartyp = csoundGetTypeWithVarTypeName(csound->typePool, atype);
+        if(var->varType != avartyp) {
+          if((avartyp == iType && var->varType == kType) ||
+             (avartyp == kType && var->varType == iType)) {
+            if(csound->GetDebug(csound))
+              csound->Message(csound, "%s-type loop\n", var->varType->varTypeName);
+          }
+          else {
+            synterr(csound,Str("line %d loop variable type mismatch in for statement,\n"
+                               "%s for array type %s"),
+                    current->line, var->varType->varTypeName, atype);
+            return 0;
+          }
+        }
+        typ = cs_strdup(csound, var->varType->varTypeName);
       }
-      current = expand_for_statement(csound, current, typeTable, arrayArgType);
+      current = expand_for_statement(csound, current, typeTable, typ);
+      csound->Free(csound, atype);
+      csound->Free(csound, typ);
       if (previous != NULL) {
         previous->next = current;
       }

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2703,7 +2703,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
     case FOR_TOKEN: {
       /** for-loop typing:
           1) if loop variable does not exist, it takes the type of the array
-          2) if it exists, the loop type follows the variable type
+          2) if it exists, the loop type follows the variable type when conversion is possible
       */
 
       char* arrayArgType = get_arg_type2(csound, current->right->left,
@@ -2722,9 +2722,9 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
         return 0;
       }    
 
-      char* atype = cs_strdup(csound, arrayArgType+1);
-      char * typ;
-      atype[strlen(atype)-1] = '\0';
+      char* atype = cs_strdup(csound, arrayArgType+1); // skip '['
+      char* typ;
+      atype[strlen(atype)-1] = '\0'; // remove ']'
       if(var == NULL) {
        typ = remove_type_quoting(csound, atype);
        // now create the arg based on the array type
@@ -2732,7 +2732,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
               typeTable);
       } else {
         // now we need to check that the array matches the
-        // var type
+        // var type - automatic conversion possible for i and k
         const CS_TYPE *iType = &CS_VAR_TYPE_I;
         const CS_TYPE *kType = &CS_VAR_TYPE_K;
         const CS_TYPE *avartyp = csoundGetTypeWithVarTypeName(csound->typePool, atype);
@@ -2740,7 +2740,8 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
           if((avartyp == iType && var->varType == kType) ||
              (avartyp == kType && var->varType == iType)) {
             if(csound->GetDebug(csound))
-              csound->Message(csound, "%s-type loop\n", var->varType->varTypeName);
+              csound->Message(csound, "%s-type loop with %s-type array\n",
+                              var->varType->varTypeName, atype);
           }
           else {
             synterr(csound,Str("line %d loop variable type mismatch in for statement,\n"

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -870,7 +870,7 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
         csound->advanceCnt = kCnt;
         csound->ErrorMsg(csound,
                         Str("time advanced %5.3f beats by score request\n"),
-                        evt->p3orig);
+                         kCnt*csound->onedkr);
       }
     }
     break;

--- a/tests/commandline/test_for_in.csd
+++ b/tests/commandline/test_for_in.csd
@@ -26,6 +26,7 @@ endin
 /* case 2
    loop var is declared
    loop type follows var type
+   if a conversion is possible (e.g. k and i)
    regardless of array type
 */
 instr 2
@@ -36,11 +37,21 @@ od
 turnoff
 endin
 
+/* Loops of other array types are
+   also possible 
+*/
+instr 3
+for j in ["hello\n","world\n","!!!\n"] do
+ prints j
+od
+endin
+
 
 </CsInstruments>
 <CsScore>
 i1 0 0
 i2 0 0.001
+i3 0 0
 </CsScore>
 </CsoundSynthesizer>
 

--- a/tests/commandline/test_for_in2.csd
+++ b/tests/commandline/test_for_in2.csd
@@ -21,9 +21,18 @@ instr 2
   turnoff
 endin
 
+instr 3
+for S, i in ["hello ","world ","!!! "] do
+ prints S
+ prints "\n"
+ print i
+od
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 0
 i 2 .001 .01
+i3 0 0
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
This PR addresses  #2225 by generalising for-loops so they can handle any other types of arrays (beyond i and k). The rules are

- if a loop variable exists, it needs to match the loop array type, except for i and k types which may be converted automatically (and the loop type matches the loop variable type)
- k, a, and Complex arrays generate perf-time loops, all other types generate init-time loops.
- loop index variable if given will be either i or k depending on the type of loop.


