### PR TITLE
Global var memory allocation

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1616,10 +1616,16 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
       argLetter[0] = (*t == 't') ? '[' : *t; /* Support legacy t-vars */
       type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
     }
-    var = csoundCreateVariable(csound, csound->typePool,
-                               type, varName, typeArg);
 
-    csoundAddVariable(csound, pool, var);
+    if(pool == typeTable->globalPool) { 
+      var = add_global_variable(csound, &csound->engineState,
+				(CS_TYPE *) type, varName, typeArg); 
+    }
+    else {
+      var = csoundCreateVariable(csound, csound->typePool,
+				 type, varName, typeArg);
+      csoundAddVariable(csound, pool, var);
+    }
   } else {
     //TODO - implement reference count increment
     if (annotation != NULL) {
@@ -1679,12 +1685,17 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
     varInit.dimensions = dimensions;
     varInit.type = varType;
     typeArg = &varInit;
-    var = csoundCreateVariable(csound, csound->typePool,
-                               &CS_VAR_TYPE_ARRAY,
-                               varName, typeArg);
 
-    
-    csoundAddVariable(csound, pool, var);
+    if(pool == typeTable->globalPool) { 
+      var = add_global_variable(csound, &csound->engineState,
+				(CS_TYPE *) &CS_VAR_TYPE_ARRAY, varName, typeArg); 
+    }
+    else {
+      var = csoundCreateVariable(csound, csound->typePool,
+				 &CS_VAR_TYPE_ARRAY,
+				 varName, typeArg);
+      csoundAddVariable(csound, pool, var);
+    }
   } else {
     //TODO - implement reference count increment
      if (annotation != NULL) {

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1616,16 +1616,9 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
       argLetter[0] = (*t == 't') ? '[' : *t; /* Support legacy t-vars */
       type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
     }
-
-    if(pool == typeTable->globalPool) { 
-      var = add_global_variable(csound, &csound->engineState,
-				(CS_TYPE *) type, varName, typeArg); 
-    }
-    else {
-      var = csoundCreateVariable(csound, csound->typePool,
+    var = csoundCreateVariable(csound, csound->typePool,
 				 type, varName, typeArg);
-      csoundAddVariable(csound, pool, var);
-    }
+    csoundAddVariable(csound, pool, var);
   } else {
     //TODO - implement reference count increment
     if (annotation != NULL) {
@@ -1685,17 +1678,10 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
     varInit.dimensions = dimensions;
     varInit.type = varType;
     typeArg = &varInit;
-
-    if(pool == typeTable->globalPool) { 
-      var = add_global_variable(csound, &csound->engineState,
-				(CS_TYPE *) &CS_VAR_TYPE_ARRAY, varName, typeArg); 
-    }
-    else {
-      var = csoundCreateVariable(csound, csound->typePool,
+    var = csoundCreateVariable(csound, csound->typePool,
 				 &CS_VAR_TYPE_ARRAY,
 				 varName, typeArg);
-      csoundAddVariable(csound, pool, var);
-    }
+    csoundAddVariable(csound, pool, var);
   } else {
     //TODO - implement reference count increment
      if (annotation != NULL) {

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -260,6 +260,7 @@ void csoundReallocateVarPoolMemory(CSOUND* csound, CS_VAR_POOL* pool) {
           varMem =
                (CS_VAR_MEM *)((CSOUND *)csound)->ReAlloc(csound,varMem,
                                              memSize);
+	  varMem->varType = current->varType;
           current->memBlock = varMem;
        }
        pool->poolSize += current->memBlockSize;


### PR DESCRIPTION
Global variables were not properly allocated causing their type info to be lost (#2236).
This PR fixes the problem. 