### PR TITLE
arm baremetal build improvement

### DIFF
--- a/Daisy/crosscompile.cmake
+++ b/Daisy/crosscompile.cmake
@@ -5,6 +5,8 @@ SET(CMAKE_SYSTEM_PROCESSOR ARM)
 SET(CMAKE_SYSTEM_VERSION 1)
 
 # specify the cross compiler
+SET(COMPILER_PREFIX "arm-none-eabi")
+
 SET(CMAKE_C_COMPILER   arm-none-eabi-gcc)
 SET(CMAKE_CXX_COMPILER arm-none-eabi-g++)
 

--- a/Zynq/crosscompile.cmake
+++ b/Zynq/crosscompile.cmake
@@ -3,6 +3,8 @@ SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_PROCESSOR ARM)
 
 # Specify the cross compiler
+SET(COMPILER_PREFIX "arm-none-eabi")
+
 SET(CMAKE_C_COMPILER arm-none-eabi-gcc)
 SET(CMAKE_CXX_COMPILER arm-none-eabi-g++)
 


### PR DESCRIPTION
The CMake cross-compile file for arm-none-abi did not correctly set the ar/ranlib tools path, leading to library build issues on non-ARM platforms (e.g x86_64). This PR fixes this issue.