### PR TITLE
Remove support for legacy t-var

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -725,10 +725,6 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
     if (*s == '#') s++;
     if (*s == 'g') s++;
 
-    if (*s == 't') { /* Support legacy t-vars by mapping to k-array */
-      return cs_strdup(csound, "[k]");
-    }
-
     t = s;
 
     int32_t len = 1;
@@ -1625,7 +1621,7 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
       if (*t == 'g') pool = typeTable->globalPool;
       if (*t == 'g') t++;
       
-      if (*t == '[' || *t == 't') { /* Support legacy t-vars */
+      if (*t == '[') { 
         int32_t dimensions = 1;
         const CS_TYPE* varType;
         char* b = t + 1;
@@ -1634,7 +1630,7 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
           b++;
           dimensions++;
         }
-        argLetter[0] = (*b == 't') ? 'k' : *b; /* Support legacy t-vars */
+        argLetter[0] = *b;
 
         varType = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
 
@@ -1643,7 +1639,7 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
         typeArg = &varInit;
       }
 
-      argLetter[0] = (*t == 't') ? '[' : *t; /* Support legacy t-vars */
+      argLetter[0] = *t; 
       type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
     }
     var = csoundCreateVariable(csound, csound->typePool,
@@ -1730,7 +1726,7 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
       if (*t == 'g') pool = typeTable->globalPool;
       if (*t == 'g') t++;
 
-      argLetter[0] = (*t == 't') ? 'k' : *t; /* Support legacy t-vars */
+      argLetter[0] = *t; 
 
       varType =
         csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
@@ -1795,13 +1791,8 @@ int32_t add_args(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
         // skip reserved vars, these are handled elsewhere
         break;
       }
-
-      if (*varName == 't' && current->value->optype == NULL) { /* Support legacy t-vars */
-        add_array_arg(csound, varName, "k", 1, typeTable);
-      } else {
-        add_arg(csound, varName, current->value->optype, typeTable, current);
-      }
-
+      add_arg(csound, varName, current->value->optype, typeTable, current);
+  
       break;
 
     case T_ARRAY:

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -118,7 +118,7 @@ def runTest():
 	["test44.csd", "expected failure with in-arg given to in opcode", 1],
 	["test45.csd", "if-goto with expression in boolean comparison"],
 	["test46.csd", "if-then with expression in boolean comparison"],
-	["test47.csd", "until loop and t-variables"],
+	["test47.csd", "until loop and k[]"],
 	["test48.csd", "expected failure with variable used before defined", 1],
     ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
     ["test_oversample.csd", "test oversampling in new-style UDO"],

--- a/tests/commandline/test47.csd
+++ b/tests/commandline/test47.csd
@@ -8,7 +8,7 @@ ksmps  = 300
 nchnls = 1
 
 instr 1
- t1 init 10
+ t1:k[] init 10
  k1 init 0
  
  until k1 >= 10 do


### PR DESCRIPTION
For a brief period in the final versions of 5.x we had a t-type that implemented a k-rate array. These were quickly replaced by generic arrays in 6.0, but support for them was maintained in the semantic analysis. 

However, continuing this support with explicit types has become difficult because it is leading to syntax errors when variables are named with t as a starting letter. Because they are translated into k-rate arrays internally, that is seen as redefinition of an array-type variable by a non-array variable - which is not allowed. Supporting this legacy type with the new semantics is driving us into tight corners and I foresee the time when it will put all sorts of limitations.

For this reason, I am proposing to remove the support. I do not think this type was used beyond our early tests and experiments with arrays, so I think it will not be a major backwards compatibility issue.