### PR TITLE
feat(wasm): make mode optional ts-type and more methods

### DIFF
--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -266,9 +266,9 @@ declare interface CsoundObj {
    */
   start: () => Promise<number>;
   /**
-   * Compiles a Csound input file but does not perform it.
+   * Compiles a Csound input file but does not perform it. Mode = 0 for file, 1 for text.
    */
-  compileCsd: (path: string, mode:number) => Promise<number>;
+  compileCSD: (path: string, mode?: number) => Promise<number>;
   /**
    * Pauses a performance if it's running
    */
@@ -425,6 +425,34 @@ declare interface CsoundObj {
    * Terminates an instances and all its workers, making disabling any futher uses of a given instance.
    */
   terminateInstance: () => Promise<void>;
+  /**
+   * Enable audio input functionality
+   */
+  enableAudioInput: () => Promise<void>;
+  /**
+   * Get MIDI device list
+   */
+  getMIDIDevList: () => Promise<any>;
+  /**
+   * Get MIDI output filename
+   */
+  getMidiOutFileName: () => Promise<string>;
+  /**
+   * Get real-time MIDI name
+   */
+  getRtMidiName: () => Promise<string>;
+  /**
+   * Set MIDI callbacks
+   */
+  setMidiCallbacks: (callbacks: any) => Promise<void>;
+  /**
+   * Append environment variable
+   */
+  appendEnv: (name: string, value: string) => Promise<void>;
+  /**
+   * Instance name identifier
+   */
+  name: string;
 }
 
 /**

--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta1",
+  "version": "7.0.0-beta2",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",

--- a/wasm/browser/yarn.lock
+++ b/wasm/browser/yarn.lock
@@ -263,10 +263,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@csound/wasm-bin@7.0.0-alpha2":
-  version "7.0.0-alpha2"
-  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-alpha2.tgz#3cf85820ade7883b65d9c2f8a9b37fb5409584e3"
-  integrity sha512-xSn+xSQ6FVWLkvh9UI5tbXn2xvIykjg5hP/dltXZnP3HGWpEOxaloSDAwcRsiUj3H2pR/es2116vUhGtfcxqyg==
+"@csound/wasm-bin@7.0.0-beta1":
+  version "7.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-beta1.tgz#1de371e5dc72c86cbfa7d6604f70437d21d5ed00"
+  integrity sha512-SmIczZU3PAYub0+RbZ1c7Zq64yKZZP35vCyNLYhpXEqAyYWm5ZbDAslnukUnCIeOgrl8sFCs1Nw+5FD8h7GlNQ==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"


### PR DESCRIPTION
those methods I'm adding are mostly for internal use but since they exist I feel they should be declared too