### PR TITLE
Shadowing of implicit types

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2104,9 +2104,13 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
   else {
     // if there is a discrepancy between out-types/annotation
     // print a warning and use out-types
-    if(leftArgString &&
+    // except for 'p' and 'i'
+    if(*leftArgString == 'p' && *root->value->optype == 'i')
+    oentry = resolve_opcode(csound, entries,
+                               root->value->optype, rightArgString);  
+    else if(leftArgString &&
        strcmp(leftArgString, root->value->optype)){
-      csound->Warning(csound, " output types %s "
+      csound->Warning(csound, " output type(s) %s "
                       "not matching annotation %s\n"
                       "ignoring annotation.",
                       leftArgString, root->value->optype) ;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1686,6 +1686,23 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
 				   type, lvarName, typeArg);
       csoundAddVariable(csound, pool, var); 	
       csound->Free(csound, t);
+    } else {
+      // apply shadowing rule for implicit vars
+      var = csoundFindVariableWithName(csound, typeTable->globalPool, varName);
+      if(var == NULL)
+	var = csoundFindVariableWithName(csound, csound->engineState.varPool,
+	                                  varName);
+      if(var) {
+        if(csoundFindVariableWithName(csound, typeTable->localPool, varName)
+	      == NULL){
+	   argLetter[0] = *varName;
+           type =
+	   csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
+           var = csoundCreateVariable(csound, csound->typePool,
+   	              type, varName, typeArg);
+           csoundAddVariable(csound, typeTable->localPool, var);
+        }
+      }
     }
   }
  end:

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -120,6 +120,7 @@ def runTest():
 	["test46.csd", "if-then with expression in boolean comparison"],
 	["test47.csd", "until loop and k[]"],
 	["test48.csd", "expected failure with variable used before defined", 1],
+    ["test_shadowing_implicit.csd", "test local shadowing of global vars for implicit types"],
     ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
     ["test_oversample.csd", "test oversampling in new-style UDO"],
     ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],

--- a/tests/commandline/test_shadowing_implicit.csd
+++ b/tests/commandline/test_shadowing_implicit.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+instr 1
+imag = 1
+imag *= 2
+atone = 0
+atone *= 2
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR implements shadowing of implicit types, resolving any backwards incompatibility arising from the introduction of global constants for OpcodeDef and InstrDef types. Test added.