### PR TITLE
Globals redefinition

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1688,11 +1688,15 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
       csound->Free(csound, t);
     } else {
       // apply shadowing rule for implicit vars
+      // for backwards compatibility
       var = csoundFindVariableWithName(csound, typeTable->globalPool, varName);
       if(var == NULL)
 	var = csoundFindVariableWithName(csound, csound->engineState.varPool,
 	                                  varName);
-      if(var) {
+      // we are only concerned with opcoderef and instr vars
+      // added by the compiler as global read-only, internally
+      if(var && (var->varType == &CS_VAR_TYPE_OPCODEREF ||
+		 var->varType == &CS_VAR_TYPE_INSTR)) {
         if(csoundFindVariableWithName(csound, typeTable->localPool, varName)
 	      == NULL){
 	   argLetter[0] = *varName;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1145,7 +1145,6 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
      factor of 1/os, and xtratim also needs to be scaled by
      that factor
   */
-  printf("EXTRATIME %d \n", p->h.insdshead->xtratim);
   p->h.insdshead->xtratim *= os;
   CS_KCNT *= onedos;
   /* oversampling mode (s) */


### PR DESCRIPTION
An issue, reported by @rorywalsh, arose with the recently-introduced backwards compatibility code (#2261)  where any global variables starting with an implicit type letter would be redefined as an (implicit-type) local when assigned locally. This was because the new code was applying the rule to all, when it should have selected only the global readonly vars added by the compiler (opcode and instrument names). This PR fixes the problem. Implicit globals always start with 'g' and  none of the shadowing/redefinition rules are relevant in relation to them.


