### PR TITLE
Makefile/README fixes for Windows

### DIFF
--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/Makefile
@@ -34,3 +34,4 @@ LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
+

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundGenerative/Makefile
@@ -24,10 +24,12 @@ LIBS += $(CSOUND_STATIC_LIB)
 LIBDIR  += -L$(CSOUND_LIB_DIR)
 
 # Use Bootloader v5.4
-BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+# BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+BOOT_BIN = ../dsy_bootloader_v5_4.bin
 
 # Use Custom Linker Script
-LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+# LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/Makefile
@@ -34,3 +34,4 @@ LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
+

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundMidi/Makefile
@@ -24,10 +24,12 @@ LIBS += $(CSOUND_STATIC_LIB)
 LIBDIR  += -L$(CSOUND_LIB_DIR)
 
 # Use Bootloader v5.4
-BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+# BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+BOOT_BIN = ../dsy_bootloader_v5_4.bin
 
 # Use Custom Linker Script
-LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+# LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundProcess/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundProcess/Makefile
@@ -34,3 +34,4 @@ LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
+

--- a/Daisy/DaisyCsoundExamples/DaisyCsoundProcess/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyCsoundProcess/Makefile
@@ -24,10 +24,12 @@ LIBS += $(CSOUND_STATIC_LIB)
 LIBDIR  += -L$(CSOUND_LIB_DIR)
 
 # Use Bootloader v5.4
-BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+# BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+BOOT_BIN = ../dsy_bootloader_v5_4.bin
 
 # Use Custom Linker Script
-LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+# LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/Daisy/DaisyCsoundExamples/DaisyPodSynth/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyPodSynth/Makefile
@@ -34,3 +34,4 @@ LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
+

--- a/Daisy/DaisyCsoundExamples/DaisyPodSynth/Makefile
+++ b/Daisy/DaisyCsoundExamples/DaisyPodSynth/Makefile
@@ -24,10 +24,12 @@ LIBS += $(CSOUND_STATIC_LIB)
 LIBDIR  += -L$(CSOUND_LIB_DIR)
 
 # Use Bootloader v5.4
-BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+# BOOT_BIN = $(shell pwd)/../dsy_bootloader_v5_4.bin
+BOOT_BIN = ../dsy_bootloader_v5_4.bin
 
 # Use Custom Linker Script
-LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+# LDSCRIPT = $(shell pwd)/../STM32H750IB_qspi_custom.lds
+LDSCRIPT = ../STM32H750IB_qspi_custom.lds
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/Daisy/DaisyCsoundExamples/README.md
+++ b/Daisy/DaisyCsoundExamples/README.md
@@ -30,5 +30,6 @@ Once the last step is complete, your Csound-based firmware should be running on 
 
 ## Additional Information
 
+- On Windows, you must use the Git Bash shell to build the examples.
 - A custom-modified linker script and the Daisy bootloader version 5.4 are included to ensure the Csound application uses SDRAM for its required heap allocation.
 - These examples can serve as templates or starting points for your own Daisy + Csound projects.


### PR DESCRIPTION
To build the Daisy examples on Windows, the Git Bash shell is required. Changed the paths for the bootloader and custom link script to simple relative paths to work in this environment, but ought to work on all supported systems.