### PR TITLE
Adjusting version printing and help message

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -471,7 +471,7 @@ int32_t csoundCleanup(CSOUND *csound)
     /* print stats only if musmon was actually run */
     /* NOT SURE HOW   ************************** */
     // if(csound->oparms->msglevel)
-    {
+    if(!csound->info_message_request){
       csound->ErrorMsg(csound, Str("\t\t   overall amps:"));
       corfile_rm(csound, &csound->expanded_sco);
       for (n = 0; n < csound->nchnls; n++) {

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -343,7 +343,7 @@ static const char *longUsageList[] = {
     Str_noop("--limiter[=num]         include clipping in audio output"),
     Str_noop("--vbr                   set MPEG encoding to variable bitrate"),
     Str_noop("--suppress-version      do not print version details"),
-    Str_noop("--print-version         print version and exit"),
+    Str_noop("--print-version         always print version details"),
     Str_noop("--run-unit-tests        enable assertion opcodes and report test failures"),
     Str_noop("                          (assertions are ignored by default)"),
     Str_noop("--help                  long help"),
@@ -890,9 +890,7 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
     csound->print_version = 0;
     return 1;
   } else if (!(strcmp(s, "print-version"))) {
-     print_csound_version(csound);
-     csound->print_version = 0;
-     csound->info_message_request = 1;
+     csound->print_version = 1;
      csound->LongJmp(csound, 0);
      return 1;
   } else if (!(strncmp(s, "logfile=", 8))) {
@@ -1083,6 +1081,7 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
     return 1;
   } else if (!(strcmp(s, "version"))) {
     print_csound_version(csound);
+    csound->info_message_request = 1;
     csound->LongJmp(csound, 0);
   } else if (!(strcmp(s, "help"))) {
     longusage(csound);

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -342,8 +342,9 @@ static const char *longUsageList[] = {
         "--aft-zero              set aftertouch to zero, not 127 (default)"),
     Str_noop("--limiter[=num]         include clipping in audio output"),
     Str_noop("--vbr                   set MPEG encoding to variable bitrate"),
-    Str_noop("--suppress-version      do not print version details")
-    Str_noop("--run-unit-tests         enable assertion opcodes and report test failures"),
+    Str_noop("--suppress-version      do not print version details"),
+    Str_noop("--print-version         print version and exit"),
+    Str_noop("--run-unit-tests        enable assertion opcodes and report test failures"),
     Str_noop("                          (assertions are ignored by default)"),
     Str_noop("--help                  long help"),
     NULL};
@@ -888,6 +889,12 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
   } else if (!(strcmp(s, "suppress-version"))) {
     csound->print_version = 0;
     return 1;
+  } else if (!(strcmp(s, "print-version"))) {
+     print_csound_version(csound);
+     csound->print_version = 0;
+     csound->info_message_request = 1;
+     csound->LongJmp(csound, 0);
+     return 1;
   } else if (!(strncmp(s, "logfile=", 8))) {
     s += 8;
     if (UNLIKELY(*s == '\0'))

--- a/Top/main.c
+++ b/Top/main.c
@@ -248,6 +248,10 @@ int32_t csoundCompileArgs(CSOUND *csound, int32_t argc, const char **argv) {
   /* this assumes that argdecode is safe to run multiple times */
   csound->orcname_mode = 1;      /* ignore orc/sco name */
   argdecode(csound, argc, argv); /* should not fail this time */
+  if(csound->print_version == 1) {
+     print_csound_version(csound);
+  }
+  
   /* some error checking */
   if (UNLIKELY(csound->stdin_assign_flg &&
                (csound->stdin_assign_flg & (csound->stdin_assign_flg - 1)) !=
@@ -408,6 +412,7 @@ int32_t csoundCompileArgs(CSOUND *csound, int32_t argc, const char **argv) {
       return CSOUND_EXITJMP_SUCCESS;
     return CSOUND_ERROR;
   }
+  csound->print_version = 0;
   return CSOUND_SUCCESS;
 }
 
@@ -434,9 +439,11 @@ PUBLIC int32_t csoundStart(CSOUND *csound) // DEBUG
   int32_t n;
 
   // Always print version, unless this was supressed
+  // or already printed
   // (print_version is set to 1 by default)
   if(csound->print_version == 1) {
     print_csound_version(csound);
+    csound->print_version = 0;
   }
 
   /* if a CSD was not used and options were not checked, check options */


### PR DESCRIPTION
This PR adjusts the order of version printing, reinstates `--print-version` and documents it in the help message.