### PR TITLE
A-var multiple assignment

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -152,6 +152,7 @@ OENTRY opcodlst_1[] = {
   { "=.k",    S(ASSIGNM),0,        "zzzzzzzzzzzzzzzzzzzzzzzz", "z",
     NULL, minit, NULL, NULL },
   { "=.a",    S(ASSIGN),0,         "a",    "a",    NULL, gaassign, NULL },
+  { "=.y",    S(ASSIGNM),0,         "mmmmmmmmmmmmmmmmmmmmmmmm",    "y",    NULL, (SUBR) mainit2, NULL },
   { "=.l",    S(ASSIGN),0,         "a",    "a",    NULL,   laassign, NULL },
   { "=.up",   S(UPSAMP),0,         "a",    "k",  NULL, (SUBR)upsamp, NULL },
   { "=.down",   S(DOWNSAMP),0,    "k",    "ao",   (SUBR)downset,(SUBR)downsamp },

--- a/H/aops.h
+++ b/H/aops.h
@@ -246,3 +246,4 @@ int32_t bassign(CSOUND *csound, RELAT *p);
 int32_t b2s(CSOUND *csound, ASSIGN *p);
 int32_t b2b(CSOUND *csound, ASSIGN *p);
 int32_t binit(CSOUND *csound, ASSIGNM *p);
+int32_t mainit2(CSOUND *csound, ASSIGNM *p);

--- a/H/opcode.h
+++ b/H/opcode.h
@@ -34,6 +34,7 @@ typedef struct _opinfo {
 typedef struct _oprun {
   OPDS h;
   MYFLT *args[VARGMAX];
+  AUXCH mem;
 } OPRUN;
 
 typedef struct _oparray {

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -231,6 +231,29 @@ int32_t mainit(CSOUND *csound, ASSIGNM *p)
   return OK;
 }
 
+int32_t mainit2(CSOUND *csound, ASSIGNM *p)
+{
+  uint32_t nargs = p->INOCOUNT;
+  uint32_t nouts = p->OUTOCOUNT;
+  uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t early  = p->h.insdshead->ksmps_no_end;
+  uint32_t i, n, nsmps = CS_KSMPS;
+  MYFLT *aa;
+  early = nsmps - early;      /* Bit at end to ignore */
+  if (UNLIKELY(nargs != nouts))
+    return csound->InitError(csound,
+                             Str("Out and in numbers not matching in "
+                                 "assignment (%d,%d)"),nouts, nargs);
+  for (i=0; i<nargs; i++) {
+    aa = p->a[i];
+    MYFLT *r =p->r[i];
+    for (n = 0; n < nsmps; n++)
+      r[n] = (n < offset || n > early ? FL(0.0) : aa[n]);
+  }
+
+  return OK;
+}
+
 
 int32_t signum(CSOUND *csound, ASSIGN *p)
 {

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -1261,6 +1261,9 @@ int32_t osckki(CSOUND *csound, OSC   *p){
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
 
+  if(!(IS_ASIG_ARG(p->sr)))
+     csound->PerfError(csound, &p->h, "output is not a-type\n");
+
   if (UNLIKELY((ftp = p->ftp)==NULL)) goto err1;
   lobits = ftp->lobits;
   phs = p->lphs;

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -1253,8 +1253,7 @@ int32_t koscli(CSOUND *csound, OSC   *p)
                            Str("oscili(krate): not initialised"));
 }
 
-int32_t osckki(CSOUND *csound, OSC   *p)
-{
+int32_t osckki(CSOUND *csound, OSC   *p){
   FUNC    *ftp;
   MYFLT   fract, v1, amp, *ar, *ft, *ftab;
   int32_t   phs, inc, lobits;
@@ -1262,31 +1261,27 @@ int32_t osckki(CSOUND *csound, OSC   *p)
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
 
-  if(!IS_ASIG_ARG(p->sr))
-    return csound->PerfError(csound, &(p->h), "output is not asig\n") ;
-
-
-    if (UNLIKELY((ftp = p->ftp)==NULL)) goto err1;
-    lobits = ftp->lobits;
-    phs = p->lphs;
-    inc = MYFLT2LONG(*p->xcps * CS_SICVT);
-    amp = *p->xamp;
-    ar = p->sr;
-    if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
-    }
-    ft = ftp->ftable;
-    for (n=offset; n<nsmps; n++) {
-      fract = PFRAC(phs);
-      ftab = ft + (phs >> lobits);
-      v1 = ftab[0];
-      ar[n] = (v1 + (ftab[1] - v1) * fract) * amp;
-      phs = (phs+inc) & PHMASK;
-    }
-    p->lphs = phs;
-    return OK;
+  if (UNLIKELY((ftp = p->ftp)==NULL)) goto err1;
+  lobits = ftp->lobits;
+  phs = p->lphs;
+  inc = MYFLT2LONG(*p->xcps * CS_SICVT);
+  amp = *p->xamp;
+  ar = p->sr;
+  if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
+  if (UNLIKELY(early)) {
+    nsmps -= early;
+    memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
+  }
+  ft = ftp->ftable;
+  for (n=offset; n<nsmps; n++) {
+    fract = PFRAC(phs);
+    ftab = ft + (phs >> lobits);
+    v1 = ftab[0];
+    ar[n] = (v1 + (ftab[1] - v1) * fract) * amp;
+    phs = (phs+inc) & PHMASK;
+  }
+  p->lphs = phs;
+  return OK;
  err1:
   return csound->PerfError(csound, &(p->h),
                            Str("oscili: not initialised"));

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -1497,7 +1497,7 @@ int32_t opcode_array_perf(CSOUND *csound, OPRUN *p) {
   AUXCH *mem = (AUXCH *) p->mem.auxp;
   CS_VAR_MEM *argmem = NULL;
   for(i = 0; i < n; i++) {
-         size_t size;  
+   size_t size;  
   // copy array args data in
   for(j = p->OUTOCOUNT + 1; j < argn; j++) {
     if(csoundGetTypeForArg(p->args[j]) == &CS_VAR_TYPE_ARRAY) {
@@ -1513,10 +1513,9 @@ int32_t opcode_array_perf(CSOUND *csound, OPRUN *p) {
   if(obj[i].dataspace->perf != NULL)
     obj[i].dataspace->perf(csound, obj[i].dataspace);
   
-        // copy array args data out
+   // copy array args data out
    for(j = 0; j < p->OUTOCOUNT; j++) {
      if(csoundGetTypeForArg(p->args[j]) == &CS_VAR_TYPE_ARRAY) {
-
        array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
        size = array->arrayMemberSize;
        char *data = (char *) array->data; // copy loc pointer to args

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -1402,9 +1402,13 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
   CS_TYPE *types[VARGMAX] = {0};
   ARRAYDAT  *array;
   OPCODEOBJ *obj;
+  CS_VAR_MEM *argmem = NULL;
+  AUXCH *mem;
   array = (ARRAYDAT *) p->args[p->OUTOCOUNT];
   obj = (OPCODEOBJ *) array->data;
   n = array->sizes[0];
+  csound->AuxAlloc(csound, sizeof(AUXCH)*n*VARGMAX, &p->mem);
+  mem = (AUXCH *) p->mem.auxp;
   // check all array args are 1-dim arrays of at least same size as obj[]
   for(i = 0; i < (int32_t) (p->INOCOUNT + p->OUTOCOUNT); i++)
     if(csoundGetTypeForArg(p->args[i]) == &CS_VAR_TYPE_ARRAY) {
@@ -1415,6 +1419,7 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
         tabinit(csound, array, n, p->h.insdshead);
   }    
   for(i = 0; i < n; i++) {
+    size_t size;
     set_line_num_and_loc(&obj[i], p);
     if(context_check(csound, &obj[i], p->h.insdshead) != OK)
       return csound->InitError(csound, "incompatible context, "
@@ -1423,11 +1428,16 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
     for(j = 0; j < (int32_t) p->OUTOCOUNT; j++) {
       if((types[j] = csoundGetTypeForArg(p->args[j]))
           == &CS_VAR_TYPE_ARRAY) {
-      array = (ARRAYDAT *)  p->args[j]; // each outarg is an array
-      char *data = (char *) array->data;
+        // arrays need to be treated separately
+        // data needs to be placed into typed variable memory
+        // unfortunately we need to copy in order to have this correct
+      array = (ARRAYDAT *)  p->args[j]; // each outarg is an array  
+      size = array->arrayMemberSize;
+      csound->AuxAlloc(csound, sizeof(CS_TYPE *) + size, &mem[i+j]);
+      argmem = (CS_VAR_MEM *) mem[i+j].auxp;
       types[j] = (CS_TYPE *) array->arrayType; // set type
-      args[j] = (MYFLT *)(data + i*array->arrayMemberSize); // set pointer
-      
+      argmem->varType = types[j];
+      args[j] = &argmem->value; // set pointer
       } else // single var
          args[j] = p->args[j];
     }
@@ -1436,18 +1446,36 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
       m = j + p->OUTOCOUNT + 1;
       if((types[m] = csoundGetTypeForArg(p->args[m]))
          == &CS_VAR_TYPE_ARRAY) {
+      array = (ARRAYDAT *)  p->args[m]; // each inarg is an array  
+      size = array->arrayMemberSize;
+      csound->AuxAlloc(csound, sizeof(CS_TYPE *) + size, &mem[i+m]);
+      argmem = (CS_VAR_MEM *) mem[i+m].auxp;        
       array = (ARRAYDAT *)  p->args[m]; // each inarg is an array
       char *data = (char *) array->data; // copy loc pointer to args
       types[m] = (CS_TYPE *) array->arrayType;
-      args[m] = (MYFLT *)(data + i*array->arrayMemberSize);
+      argmem->varType = types[m];
+      args[m] = &argmem->value; 
+      // copy array args data in
+      memcpy(&argmem->value, data+i*size, size);  
       } else // single var
         args[m] = p->args[m];
     }
     // call setup_args with array flag checked, passing assigned args
     if(setup_args(csound, &obj[i], &(p->h), args, types,
-                             p->OUTOCOUNT, p->INOCOUNT - 1) == OK) {
-      if(obj[i].dataspace->init != NULL) 
+                  p->OUTOCOUNT, p->INOCOUNT - 1) == OK) {
+      if(obj[i].dataspace->init != NULL) {
         obj[i].dataspace->init(csound, obj[i].dataspace);
+        // copy array args data out
+        for(j = 0; j < p->OUTOCOUNT; j++) {
+          if(csoundGetTypeForArg(p->args[j]) == &CS_VAR_TYPE_ARRAY) {
+            array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
+            size = array->arrayMemberSize;
+            char *data = (char *) array->data; // copy loc pointer to args
+            argmem = (CS_VAR_MEM *) mem[i+j].auxp; 
+            memcpy(data+i*size, &argmem->value, size); 
+          }
+        }  
+      }
     } else return csound->InitError(csound, "mismatching arguments\n"
                                     "for opcode obj %s\t"
                                     "outypes: %s\tintypes: %s",
@@ -1464,12 +1492,38 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
  */
 int32_t opcode_array_perf(CSOUND *csound, OPRUN *p) {
   ARRAYDAT  *array = (ARRAYDAT *) p->args[p->OUTOCOUNT];
-  int32_t   n = array->sizes[0], i;
+  int32_t   n = array->sizes[0], i, j, argn = p->OUTOCOUNT + p->INOCOUNT;
   OPCODEOBJ *obj = (OPCODEOBJ *) array->data;
+  AUXCH *mem = (AUXCH *) p->mem.auxp;
+  CS_VAR_MEM *argmem = NULL;
   for(i = 0; i < n; i++) {
+         size_t size;  
+  // copy array args data in
+  for(j = p->OUTOCOUNT + 1; j < argn; j++) {
+    if(csoundGetTypeForArg(p->args[j]) == &CS_VAR_TYPE_ARRAY) {
+      array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
+      size = array->arrayMemberSize;
+      char *data = (char *) array->data; // copy loc pointer to args
+      argmem = (CS_VAR_MEM *) mem[i+j].auxp;
+      memcpy(&argmem->value, data+i*size, size);
+    }
+  }
+
   set_line_num_and_loc(&obj[i], p);
   if(obj[i].dataspace->perf != NULL)
     obj[i].dataspace->perf(csound, obj[i].dataspace);
+  
+        // copy array args data out
+   for(j = 0; j < p->OUTOCOUNT; j++) {
+     if(csoundGetTypeForArg(p->args[j]) == &CS_VAR_TYPE_ARRAY) {
+
+       array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
+       size = array->arrayMemberSize;
+       char *data = (char *) array->data; // copy loc pointer to args
+       argmem = (CS_VAR_MEM *) mem[i+j].auxp; 
+       memcpy(data+i*size, &argmem->value, size);
+     }
+  }
   }
   return OK;
 }

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -1455,8 +1455,10 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
       types[m] = (CS_TYPE *) array->arrayType;
       argmem->varType = types[m];
       args[m] = &argmem->value; 
-      // copy array args data in
-      memcpy(&argmem->value, data+i*size, size);  
+      // copy array args data in - but not k or a vars
+      if(types[m] != &CS_VAR_TYPE_K ||
+         types[m] != &CS_VAR_TYPE_A)
+         memcpy(&argmem->value, data+i*size, size);  
       } else // single var
         args[m] = p->args[m];
     }
@@ -1471,7 +1473,10 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
             array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
             size = array->arrayMemberSize;
             char *data = (char *) array->data; // copy loc pointer to args
-            argmem = (CS_VAR_MEM *) mem[i+j].auxp; 
+            argmem = (CS_VAR_MEM *) mem[i+j].auxp;
+            // copy array args data out - but not k or a vars
+           if(types[m] != &CS_VAR_TYPE_K ||
+             types[m] != &CS_VAR_TYPE_A)
             memcpy(data+i*size, &argmem->value, size); 
           }
         }  
@@ -1505,7 +1510,9 @@ int32_t opcode_array_perf(CSOUND *csound, OPRUN *p) {
       size = array->arrayMemberSize;
       char *data = (char *) array->data; // copy loc pointer to args
       argmem = (CS_VAR_MEM *) mem[i+j].auxp;
-      memcpy(&argmem->value, data+i*size, size);
+      // only perf-time data
+      if(array->arrayType != &CS_VAR_TYPE_I)
+       memcpy(&argmem->value, data+i*size, size);
     }
   }
 
@@ -1519,8 +1526,10 @@ int32_t opcode_array_perf(CSOUND *csound, OPRUN *p) {
        array = (ARRAYDAT *)  p->args[j]; // each inarg is an array
        size = array->arrayMemberSize;
        char *data = (char *) array->data; // copy loc pointer to args
-       argmem = (CS_VAR_MEM *) mem[i+j].auxp; 
-       memcpy(data+i*size, &argmem->value, size);
+       argmem = (CS_VAR_MEM *) mem[i+j].auxp;
+       // only perf-time data
+       if(array->arrayType != &CS_VAR_TYPE_I)
+        memcpy(data+i*size, &argmem->value, size);
      }
   }
   }

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -397,6 +397,7 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
                    CS_TYPE **cstypes, int32_t no, int32_t ni){
   TEXT *t = &(obj->dataspace->optext->t);
   OENTRY *ep = t->oentry;
+  char *opname = ep->opname;
   char *types;
   CS_TYPE *argtype;
   int32_t n = 0, opt = 0;
@@ -433,8 +434,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
           argtype = check_arg_type(args[n], cstypes, n);
           // if output arg exists, try to connect it
           if(argtype != &CS_VAR_TYPE_A) {
-            csound->Message(csound, "Output arg %d, expected type: "
-                            "%s, got: %s\n", i+1,CS_VAR_TYPE_A.varTypeName,
+            csound->Message(csound, "%s outarg %d, expected type: "
+                            "%s, got: %s\n", opname, i+1,CS_VAR_TYPE_A.varTypeName,
                             argtype->varTypeName);
             return NOTOK;
           }
@@ -451,8 +452,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
         if(n < no) {
           argtype = check_arg_type(args[n], cstypes, n);
           if(argtype != &CS_VAR_TYPE_K){
-            csound->Message(csound, "Output arg %d, expected type: "
-                            "%s, got: %s\n", i+1, CS_VAR_TYPE_K.varTypeName,
+            csound->Message(csound, "%s outarg %d, expected type: "
+                            "%s, got: %s\n", opname, i+1, CS_VAR_TYPE_K.varTypeName,
                             argtype->varTypeName);
             return NOTOK;
           }
@@ -467,8 +468,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
         if(n < no) {
           argtype = check_arg_type(args[n], cstypes, n);
           if(argtype != &CS_VAR_TYPE_I){
-            csound->Message(csound, "Output arg %d, expected type: "
-                            "%s, got: %s\n",i+1, CS_VAR_TYPE_I.varTypeName,
+            csound->Message(csound, "%s outarg %d, expected type: "
+                            "%s, got: %s\n",opname, i+1, CS_VAR_TYPE_I.varTypeName,
                             argtype->varTypeName);
             return NOTOK;
           }
@@ -485,9 +486,9 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
           if(argtype != &CS_VAR_TYPE_A && argtype != &CS_VAR_TYPE_K &&
              argtype != &CS_VAR_TYPE_I ){
             csound->Message(csound,
-                            "Output arg %d, expected types: "
+                            "%s outarg %d, expected types: "
                             "%s, %s, or %s, got: %s\n",
-                            i+1, CS_VAR_TYPE_A.varTypeName,
+                            opname, i+1, CS_VAR_TYPE_A.varTypeName,
                             CS_VAR_TYPE_K.varTypeName,
                             CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
             return NOTOK;
@@ -505,9 +506,9 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
           if(argtype != &CS_VAR_TYPE_A && argtype != &CS_VAR_TYPE_K &&
              argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_S){
             csound->Message(csound,
-                            "Output arg %d, expected types: "
+                            "%s outarg %d, expected types: "
                             "%s, %s, %s, or %s, got: %s\n",
-                            i+1, CS_VAR_TYPE_A.varTypeName,
+                            opname, i+1, CS_VAR_TYPE_A.varTypeName,
                             CS_VAR_TYPE_K.varTypeName,
                             CS_VAR_TYPE_I.varTypeName,
                             CS_VAR_TYPE_S.varTypeName, argtype->varTypeName);
@@ -525,8 +526,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
         if(n < no) {
           argtype = check_arg_type(args[n], cstypes, n);  
           if(argtype != &CS_VAR_TYPE_F) {
-            csound->Message(csound, "Output arg %d, expected type: "
-                            "%s, got: %s\n", i+1, CS_VAR_TYPE_F.varTypeName,
+            csound->Message(csound, "%s outarg %d, expected type: "
+                            "%s, got: %s\n", opname, i+1, CS_VAR_TYPE_F.varTypeName,
                             argtype->varTypeName);
             return NOTOK;
           }
@@ -545,24 +546,24 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
       argtype = check_arg_type(args[n], cstypes, n);
       if(*(types+end+1) != '[' && strncmp(argtype->varTypeName,
                                           typeName, end) != 0) {
-        csound->Message(csound, "Output arg %d, expect type: "
-                        "%s, got %s\n", i+1, typeName,
+        csound->Message(csound, "%s outarg %d, expect type: "
+                        "%s, got %s\n", opname, i+1, typeName,
                         argtype->varTypeName);
         return NOTOK;
       }
       if(*(types+end+1) == '[' &&
          argtype != &CS_VAR_TYPE_ARRAY){
-        csound->Message(csound, "Output arg %d, expect array, got %s\n",
-                        i+1, typeName);
+        csound->Message(csound, "%s outarg %d, expect array, got %s\n",
+                        opname, i+1, typeName);
         return NOTOK;
       }
       if(*(types+1) == '[') {
         ARRAYDAT *arg = (ARRAYDAT *) args[n];
         const CS_TYPE *atyp = arg->arrayType;
         if(strncmp(atyp->varTypeName, argtype->varTypeName, 1) != 0) {
-          csound->Message(csound, "Output arg %d, mismatching array subtype"
+          csound->Message(csound, "%s outarg %d, mismatching array subtype"
                           " expected %s, got %s\n",
-                          i+1, argtype->varTypeName, atyp->varTypeName);
+                          opname, i+1, argtype->varTypeName, atyp->varTypeName);
           return NOTOK;
         }
       }
@@ -575,23 +576,23 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     argtype = check_arg_type(args[n], cstypes, n);
     if(*(types+1) != '[' &&
        strncmp(argtype->varTypeName, types, 1) != 0) {
-      csound->Message(csound, "Output arg %d, expect type: "
-                      "%c, got %s\n", i+1, *types, argtype->varTypeName);
+      csound->Message(csound, "%s outarg %d, expect type: "
+                      "%c, got %s\n", opname, i+1, *types, argtype->varTypeName);
       return NOTOK;
     }
     if(*(types+1) == '[' &&
        argtype != &CS_VAR_TYPE_ARRAY){
-      csound->Message(csound, "Output arg %d, expect array, got %c\n",
-                      i+1, *types);
+      csound->Message(csound, "%s outarg %d, expect array, got %c\n",
+                      opname, i+1, *types);
       return NOTOK;
     }
     if(*(types+1) == '[') {
       ARRAYDAT *arg = (ARRAYDAT *) args[n];
       const CS_TYPE *atyp = arg->arrayType;
       if(strncmp(atyp->varTypeName, types, 1) != 0) {
-        csound->Message(csound, "Output arg %d, mismatching array subtype"
+        csound->Message(csound, "%s outarg %d, mismatching array subtype"
                         " expected %c, got %s\n",
-                        i+1, *types, atyp->varTypeName);
+                        opname, i+1, *types, atyp->varTypeName);
         return NOTOK;
       }
     }
@@ -605,8 +606,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
   // n is the outarg count
   if(n != no) {
     // arg number mismatch?
-    csound->Message(csound, "Output arg number mismatch, " 
-                            "expected %d, got %d\n", no, n);
+    csound->Message(csound, "%s outarg number mismatch, " 
+                    "expected %d, got %d\n", opname, no, n);
     return NOTOK;
   }
      
@@ -628,6 +629,10 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
       // connect all remaining args
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         inargs[i] = args[n];
       }
       break; // no further inputs expected
@@ -636,12 +641,16 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'M') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+         if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }           
         if(argtype != &CS_VAR_TYPE_A && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P){
-          csound->Message(csound, "Input arg %d, expected types: "
+          csound->Message(csound, "%s inarg %d, expected types: "
                           "%s, %s, or %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_A.varTypeName,
+                          opname, i+1,CS_VAR_TYPE_A.varTypeName,
                           CS_VAR_TYPE_K.varTypeName,
                           CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
           return NOTOK;
@@ -653,13 +662,17 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'N') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(argtype != &CS_VAR_TYPE_A && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_S &&
            argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P){
           csound->Message(csound,
-                          "Input arg %d, expected types: "
+                          "%s inarg %d, expected types: "
                           "%s, %s, %s, or %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_A.varTypeName,
+                          opname, i+1,CS_VAR_TYPE_A.varTypeName,
                           CS_VAR_TYPE_K.varTypeName,
                           CS_VAR_TYPE_I.varTypeName, CS_VAR_TYPE_S.varTypeName,
                           argtype->varTypeName);
@@ -672,10 +685,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'm') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P){
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i] = args[n];
@@ -685,9 +702,13 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'y') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(argtype != &CS_VAR_TYPE_A){
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_A.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_A.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i] = args[n];
@@ -697,10 +718,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'z') { 
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(argtype != &CS_VAR_TYPE_K && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P && argtype != &CS_VAR_TYPE_I){
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_K.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_K.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i] = args[n];
@@ -710,9 +735,13 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'W') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(argtype != &CS_VAR_TYPE_S){
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_S.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_S.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i] = args[n];
@@ -722,17 +751,21 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'Z') {
       for(; i < ni; n++, i++) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }            
         if(n%2 && argtype != &CS_VAR_TYPE_A) {
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1, CS_VAR_TYPE_A.varTypeName,
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1, CS_VAR_TYPE_A.varTypeName,
                           argtype->varTypeName);
           return NOTOK;
         }
         if(n%2 == 0 && argtype != &CS_VAR_TYPE_K && argtype != &CS_VAR_TYPE_I
            && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected type: %s, got: %s\n",
-                          i+1, CS_VAR_TYPE_K.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s, got: %s\n",
+                          opname, i+1, CS_VAR_TYPE_K.varTypeName, argtype->varTypeName);
 
           return NOTOK;
         }
@@ -742,12 +775,16 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     }
     else if(*types == 'x') {
       argtype = check_arg_type(args[n], cstypes, n);
+      if(argtype == NULL) {
+        csound->Message(csound, "missing %s inarg %d", opname, n - no);
+        return NOTOK;
+      }
       if(argtype != &CS_VAR_TYPE_A && argtype != &CS_VAR_TYPE_K &&
          argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_C &&
          argtype != &CS_VAR_TYPE_P){
-        csound->Message(csound, "Input arg %d, expected types: "
+        csound->Message(csound, "%s inarg %d, expected types: "
                         "%s, %s, or %s, got: %s\n",
-                        i+1, CS_VAR_TYPE_A.varTypeName,
+                        opname, i+1, CS_VAR_TYPE_A.varTypeName,
                         CS_VAR_TYPE_K.varTypeName,CS_VAR_TYPE_I.varTypeName,
                         argtype->varTypeName);
         return NOTOK;
@@ -757,11 +794,15 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     }
     else if(*types == 'T') {
       argtype = check_arg_type(args[n], cstypes, n);
+      if(argtype == NULL) {
+        csound->Message(csound, "missing %s inarg %d", opname, n - no);
+        return NOTOK;
+      }
       if(argtype != &CS_VAR_TYPE_S && argtype != &CS_VAR_TYPE_I
          && argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P){
-        csound->Message(csound, "Input arg %d, expected types: "
+        csound->Message(csound, "%s inarg %d, expected types: "
                         "%s or %s, got: %s\n",
-                        i+1, CS_VAR_TYPE_I.varTypeName,
+                        opname, i+1, CS_VAR_TYPE_I.varTypeName,
                         CS_VAR_TYPE_S.varTypeName,argtype->varTypeName);
         return NOTOK;
       }
@@ -770,12 +811,16 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     }
     else if(*types == 'U') {
       argtype = check_arg_type(args[n], cstypes, n);
+      if(argtype == NULL) {
+        csound->Message(csound, "missing %s inarg %d", opname, n - no);
+        return NOTOK;
+      }
       if(argtype != &CS_VAR_TYPE_S && argtype != &CS_VAR_TYPE_I &&
          argtype != &CS_VAR_TYPE_K && argtype != &CS_VAR_TYPE_C &&
          argtype != &CS_VAR_TYPE_P){
-        csound->Message(csound, "Input arg %d, expected types: "
+        csound->Message(csound, "%s inarg %d, expected types: "
                         "%s, %s, or %s, got: %s\n",
-                        i+1, CS_VAR_TYPE_K.varTypeName,
+                        opname, i+1, CS_VAR_TYPE_K.varTypeName,
                         CS_VAR_TYPE_I.varTypeName,CS_VAR_TYPE_S.varTypeName,
                         argtype->varTypeName);
         return NOTOK;
@@ -802,11 +847,15 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'o' || *types == 'O') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+         csound->Message(csound, "missing %s inarg %d", opname, n - no);
+         return NOTOK;
+        }        
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected types: "
+          csound->Message(csound, "%s inarg %d, expected types: "
                           "%s or %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_I.varTypeName,
+                          opname, i+1,CS_VAR_TYPE_I.varTypeName,
                           CS_VAR_TYPE_K.varTypeName,argtype->varTypeName);
           return NOTOK;
         }
@@ -821,11 +870,15 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'p' || *types == 'P') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }        
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected types: "
+          csound->Message(csound, "%s inarg %d, expected types: "
                           "%s or %s, got: %s\n",
-                          i+1,CS_VAR_TYPE_I.varTypeName,
+                          opname, i+1,CS_VAR_TYPE_I.varTypeName,
                           CS_VAR_TYPE_K.varTypeName,argtype->varTypeName);
           return NOTOK;
         }
@@ -840,10 +893,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'q') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected types: %s got: %s\n",
-                          i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected types: %s got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i++] = args[n++];
@@ -857,10 +914,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'v' || *types == 'V') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }        
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected types: "
-                          "%s or %s, got: %s\n", i+1,
+          csound->Message(csound, "%s inarg %d, expected types: "
+                          "%s or %s, got: %s\n", opname, i+1,
                           CS_VAR_TYPE_I.varTypeName, CS_VAR_TYPE_K.varTypeName,
                           argtype->varTypeName);
           return NOTOK;
@@ -876,10 +937,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'j' || *types == 'J') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_K &&
            argtype != &CS_VAR_TYPE_C && argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected types: "
-                          "%s or %s, got: %s\n",i+1,
+          csound->Message(csound, "%s inarg %d, expected types: "
+                          "%s or %s, got: %s\n",opname, i+1,
                           CS_VAR_TYPE_I.varTypeName, CS_VAR_TYPE_K.varTypeName,
                           argtype->varTypeName);
           return NOTOK;
@@ -895,10 +960,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     else if(*types == 'h') {
       if(args[n] != NULL) {
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }        
         if(argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_C &&
            argtype != &CS_VAR_TYPE_P) {
-          csound->Message(csound, "Input arg %d, expected type: %s got: %s\n",
-                          i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expected type: %s got: %s\n",
+                          opname, i+1,CS_VAR_TYPE_I.varTypeName, argtype->varTypeName);
           return NOTOK;
         }
         inargs[i++] = args[n++];
@@ -911,10 +980,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     }
     else if(*types == 'k' && *(types+1) !=  '[') {
       argtype = check_arg_type(args[n], cstypes, n);
+      if(argtype == NULL) {
+        csound->Message(csound, "missing %s inarg %d", opname, n - no);
+        return NOTOK;
+      }    
       if(argtype != &CS_VAR_TYPE_P && argtype != &CS_VAR_TYPE_C
          && argtype != &CS_VAR_TYPE_I && argtype != &CS_VAR_TYPE_K) {
-        csound->Message(csound, "Input arg %d, expected type: k got: %s\n",
-                        i+1,argtype->varTypeName);
+        csound->Message(csound, "%s inarg %d, expected type: k got: %s\n",
+                        opname, i+1,argtype->varTypeName);
         return NOTOK;
       }
       inargs[i++] = args[n++];
@@ -922,10 +995,14 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
     }
     else if(*types == 'i' && *(types+1) !=  '[') {
       argtype = check_arg_type(args[n], cstypes, n);
+      if(argtype == NULL) {
+        csound->Message(csound, "missing %s inarg %d", opname, n - no);
+        return NOTOK;
+      }      
       if(argtype != &CS_VAR_TYPE_P && argtype != &CS_VAR_TYPE_C
          && argtype != &CS_VAR_TYPE_I) {
-        csound->Message(csound, "Input arg %d, expected type: i got: %s\n",
-                        i+1,argtype->varTypeName);
+        csound->Message(csound, "%s inarg %d, expected type: i got: %s\n",
+                        opname, i+1,argtype->varTypeName);
         return NOTOK;
       }
       inargs[i++] = args[n++];
@@ -940,26 +1017,34 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
         size_t end = types - strchr(types, ';');
         memcpy(typeName, types, end);
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+          csound->Message(csound, "missing %s inarg %d", opname, n - no);
+          return NOTOK;
+        }        
         if(*(types+end+1) != '[' && strncmp(argtype->varTypeName,
                                             typeName, end) != 0) {
-          csound->Message(csound, "Input arg %d, expect type: "
-                          "%s, got %s\n", i+1, typeName,
+          csound->Message(csound, "%s inarg %d, expect type: "
+                          "%s, got %s\n", opname, i+1, typeName,
                           argtype->varTypeName);
           return NOTOK;
         }
         if(*(types+end+1) == '[' &&
            argtype != &CS_VAR_TYPE_ARRAY){
-          csound->Message(csound, "Input arg %d, expect array, got %s\n",
-                          i+1, typeName);
+          csound->Message(csound, "%s inarg %d, expect array, got %s\n",
+                          opname, i+1, typeName);
           return NOTOK;
         }
         if(*(types+end+1) == '[') {
           ARRAYDAT *arg = (ARRAYDAT *) args[n];
+          if(arg == NULL) {
+           csound->Message(csound, "missing %s inarg %d", opname, n - no);
+           return NOTOK;
+          }          
           const CS_TYPE *atyp = arg->arrayType;
           if(strncmp(atyp->varTypeName, argtype->varTypeName, 1) != 0) {
-            csound->Message(csound, "Input arg %d, mismatching array subtype"
+            csound->Message(csound, "%s inarg %d, mismatching array subtype"
                             " expected %s, got %s\n",
-                            i+1, argtype->varTypeName, atyp->varTypeName);
+                            opname, i+1, argtype->varTypeName, atyp->varTypeName);
             return NOTOK;
           }
         }
@@ -970,25 +1055,33 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
       } else {
         // single-char types
         argtype = check_arg_type(args[n], cstypes, n);
+        if(argtype == NULL) {
+         csound->Message(csound, "missing %s inarg %d", opname, n - no);
+         return NOTOK;
+        }        
         if(*(types+1) != '[' &&
            strncmp(argtype->varTypeName, types, 1) != 0) {
-          csound->Message(csound, "Input arg %d, expect type: "
-                          "%c, got %s\n", i+1, *types, argtype->varTypeName);
+          csound->Message(csound, "%s inarg %d, expect type: "
+                          "%c, got %s\n", opname, i+1, *types, argtype->varTypeName);
           return NOTOK;
         }
         if(*(types+1) == '[' &&
            argtype != &CS_VAR_TYPE_ARRAY){
-          csound->Message(csound, "Input arg %d, expect array, got %c\n",
-                          i+1, *types);
+          csound->Message(csound, "%s inarg %d, expect array, got %c\n",
+                          opname, i+1, *types);
           return NOTOK;
         }
         if(*(types+1) == '[') {
           ARRAYDAT *arg = (ARRAYDAT *) args[n];
+          if(arg == NULL) {
+           csound->Message(csound, "missing %s inarg %d", opname, n - no);
+           return NOTOK;
+          }             
           const CS_TYPE *atyp = arg->arrayType;
           if(strncmp(atyp->varTypeName, types, 1) != 0) {
-            csound->Message(csound, "Input arg %d, mismatching array subtype"
+            csound->Message(csound, "%s inarg %d, mismatching array subtype"
                             " expected %c, got %s\n",
-                            i+1, *types, atyp->varTypeName);
+                            opname, i+1, *types, atyp->varTypeName);
             return NOTOK;
           }
         }
@@ -1002,8 +1095,8 @@ int32_t setup_args(CSOUND *csound, OPCODEOBJ *obj, OPDS *h, MYFLT *args[],
   }
   // check that input args match. 
   if(ni != i - opt) {
-    csound->Message(csound, "Input arg number mismatch, expected %d, got %d\n",
-                    ni, i - opt);    
+    csound->Message(csound, "%s inarg number mismatch, expected %d, got %d\n",
+                    opname, ni, i - opt);    
     return NOTOK;
   }
 

--- a/tests/commandline/test3.csd
+++ b/tests/commandline/test3.csd
@@ -11,9 +11,9 @@ nchnls=2
 
 iamp,ifreq = 10000,440
 
-aout	vco2 iamp, ifreq
+aout1,aout2 = vco2(iamp, ifreq), vco2(iamp,ifreq)
 
-	outs aout, aout
+	outs aout1, aout2
 	endin
 
 


### PR DESCRIPTION
Unlike i and k types, multi assignment had not been implemented for a-types. This PR now adds the missing code. Test3 has been expanded to account for this.