### PR TITLE
Bug fix: array expressions inlined in opcall

### DIFF
--- a/Engine/auxfd.c
+++ b/Engine/auxfd.c
@@ -31,56 +31,56 @@ static CS_NOINLINE void fdchprint(CSOUND *, INSDS *);
 
 void auxalloc(CSOUND *csound, size_t nbytes, AUXCH *auxchp)
 {
-    if (auxchp->auxp != NULL) {
-      /* if allocd with same size, just clear to zero */
-      if (nbytes == (size_t)auxchp->size) {
-        memset(auxchp->auxp, 0, nbytes);
-        return;
-      }
-      else {
-        void  *tmp = auxchp->auxp;
-        /* if size change only, free the old space and re-allocate */
-        auxchp->auxp = NULL;
-        csound->Free(csound, tmp);
-      }
+  if (auxchp->auxp != NULL) {
+    /* if allocd with same size, just clear to zero */
+    if (nbytes == (size_t)auxchp->size) {
+      memset(auxchp->auxp, 0, nbytes);
+      return;
     }
-    else {                                  /* else link in new auxch blk */
-      auxchp->nxtchp = csound->curip->auxchp;
-      csound->curip->auxchp = auxchp;
+    else {
+      void  *tmp = auxchp->auxp;
+      /* if size change only, free the old space and re-allocate */
+      auxchp->auxp = NULL;
+      csound->Free(csound, tmp);
     }
-    /* now alloc the space and update the internal data */
-    auxchp->size = nbytes;
-    auxchp->auxp = csound->Calloc(csound, nbytes);
-    auxchp->endp = (char*)auxchp->auxp + nbytes;
-    if (UNLIKELY(csound->oparms->odebug))
-      auxchprint(csound, csound->curip);
+  }
+  else {                                  /* else link in new auxch blk */
+    auxchp->nxtchp = csound->curip->auxchp;
+    csound->curip->auxchp = auxchp;
+  }
+  /* now alloc the space and update the internal data */
+  auxchp->size = nbytes;
+  auxchp->auxp = csound->Calloc(csound, nbytes);
+  auxchp->endp = (char*)auxchp->auxp + nbytes;
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    auxchprint(csound, csound->curip);
 }
 
 
 static uintptr_t alloc_thread(void *p) {
-    AUXASYNC *pp = (AUXASYNC *) p;
-    CSOUND *csound = pp->csound;
-    AUXCH newm;
-    char *ptr;
-    if (pp->auxchp->auxp == NULL) {
-      /* Allocate new memory */
-      newm.size = pp->nbytes;
-      newm.auxp = csound->Calloc(csound, pp->nbytes);
-      newm.endp = (char*) newm.auxp + pp->nbytes;
-      ptr = (char *) newm.auxp;
-      newm  = *(pp->notify(csound, pp->userData, &newm));
-      /* check that the returned pointer is not
-         NULL and that is not the memory we have
-         just allocated in case the old memory was
-         never swapped back.
-      */
-      if (newm.auxp != NULL && newm.auxp != ptr)
-        csound->Free(csound, newm.auxp);
-    } else {
-      auxalloc(csound,pp->nbytes,pp->auxchp);
-      pp->notify(csound, pp->userData, pp->auxchp);
-    }
-    return 0;
+  AUXASYNC *pp = (AUXASYNC *) p;
+  CSOUND *csound = pp->csound;
+  AUXCH newm;
+  char *ptr;
+  if (pp->auxchp->auxp == NULL) {
+    /* Allocate new memory */
+    newm.size = pp->nbytes;
+    newm.auxp = csound->Calloc(csound, pp->nbytes);
+    newm.endp = (char*) newm.auxp + pp->nbytes;
+    ptr = (char *) newm.auxp;
+    newm  = *(pp->notify(csound, pp->userData, &newm));
+    /* check that the returned pointer is not
+       NULL and that is not the memory we have
+       just allocated in case the old memory was
+       never swapped back.
+    */
+    if (newm.auxp != NULL && newm.auxp != ptr)
+      csound->Free(csound, newm.auxp);
+  } else {
+    auxalloc(csound,pp->nbytes,pp->auxchp);
+    pp->notify(csound, pp->userData, pp->auxchp);
+  }
+  return 0;
 }
 
 
@@ -90,16 +90,16 @@ static uintptr_t alloc_thread(void *p) {
    callback, where it can be swapped if necessary.
 */
 int32_t auxalloc_async(CSOUND *csound, size_t nbytes, AUXCH *auxchp,
-                        AUXASYNC *as, aux_cb cb, void *userData) {
-    as->csound = csound;
-    as->nbytes = nbytes;
-    as->auxchp = auxchp;
-    as->notify = cb;
-    as->userData = userData;
-    if (UNLIKELY(csoundCreateThread(alloc_thread, as) == NULL))
-      return CSOUND_ERROR;
-    else
-      return CSOUND_SUCCESS;
+		       AUXASYNC *as, aux_cb cb, void *userData) {
+  as->csound = csound;
+  as->nbytes = nbytes;
+  as->auxchp = auxchp;
+  as->notify = cb;
+  as->userData = userData;
+  if (UNLIKELY(csoundCreateThread(alloc_thread, as) == NULL))
+    return CSOUND_ERROR;
+  else
+    return CSOUND_SUCCESS;
 }
 
 
@@ -108,39 +108,39 @@ int32_t auxalloc_async(CSOUND *csound, size_t nbytes, AUXCH *auxchp,
 
 void fdrecord(CSOUND *csound, FDCH *fdchp)
 {
-    fdchp->nxtchp = csound->curip->fdchp;
-    csound->curip->fdchp = fdchp;
-    if (UNLIKELY(csound->oparms->odebug))
-      fdchprint(csound, csound->curip);
+  fdchp->nxtchp = csound->curip->fdchp;
+  csound->curip->fdchp = fdchp;
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    fdchprint(csound, csound->curip);
 }
 
 /* close a file and remove from fd chain */
 /*  call only from inits, after fdrecord */
 void csound_fd_close(CSOUND *csound, FDCH *fdchp)
 {
-    FDCH    *prvchp = NULL, *nxtchp;
+  FDCH    *prvchp = NULL, *nxtchp;
 
-    nxtchp = csound->curip->fdchp;              /* from current insds,  */
-    while (LIKELY(nxtchp != NULL)) {            /* chain through fdlocs */
-      if (UNLIKELY(nxtchp == fdchp)) {          /*   till find this one */
-        void  *fd = fdchp->fd;
-        if (LIKELY(fd)) {
-          fdchp->fd = NULL;                     /* then delete the fd   */
-          csoundFileClose(csound, fd);          /*   close the file &   */
-        }
-        if (prvchp)
-          prvchp->nxtchp = fdchp->nxtchp;       /* unlnk from fdchain   */
-        else
-          csound->curip->fdchp = fdchp->nxtchp;
-        if (UNLIKELY(csound->oparms->odebug))
-          fdchprint(csound, csound->curip);
-        return;
+  nxtchp = csound->curip->fdchp;              /* from current insds,  */
+  while (LIKELY(nxtchp != NULL)) {            /* chain through fdlocs */
+    if (UNLIKELY(nxtchp == fdchp)) {          /*   till find this one */
+      void  *fd = fdchp->fd;
+      if (LIKELY(fd)) {
+	fdchp->fd = NULL;                     /* then delete the fd   */
+	csoundFileClose(csound, fd);          /*   close the file &   */
       }
-      prvchp = nxtchp;
-      nxtchp = nxtchp->nxtchp;
+      if (prvchp)
+	prvchp->nxtchp = fdchp->nxtchp;       /* unlnk from fdchain   */
+      else
+	csound->curip->fdchp = fdchp->nxtchp;
+      if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+	fdchprint(csound, csound->curip);
+      return;
     }
-    fdchprint(csound, csound->curip);
-    csound->Die(csound, Str("csound_fd_close: no record of fd %p"), fdchp->fd);
+    prvchp = nxtchp;
+    nxtchp = nxtchp->nxtchp;
+  }
+  fdchprint(csound, csound->curip);
+  csound->Die(csound, Str("csound_fd_close: no record of fd %p"), fdchp->fd);
 }
 
 /* release all xds in instr auxp chain */
@@ -148,17 +148,17 @@ void csound_fd_close(CSOUND *csound, FDCH *fdchp)
 
 void auxchfree(CSOUND *csound, INSDS *ip)
 {
-    if (UNLIKELY(csound->oparms->odebug))
-      auxchprint(csound, ip);
-    while (LIKELY(ip->auxchp != NULL)) {        /* for all auxp's in chain: */
-      void  *auxp = (void*) ip->auxchp->auxp;
-      AUXCH *nxt = ip->auxchp->nxtchp;
-      memset((void*) ip->auxchp, 0, sizeof(AUXCH)); /*  delete the pntr     */
-      csound->Free(csound, auxp);                   /*  & free the space    */
-      ip->auxchp = nxt;
-    }
-    if (UNLIKELY(csound->oparms->odebug))
-      auxchprint(csound, ip);
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    auxchprint(csound, ip);
+  while (LIKELY(ip->auxchp != NULL)) {        /* for all auxp's in chain: */
+    void  *auxp = (void*) ip->auxchp->auxp;
+    AUXCH *nxt = ip->auxchp->nxtchp;
+    memset((void*) ip->auxchp, 0, sizeof(AUXCH)); /*  delete the pntr     */
+    csound->Free(csound, auxp);                   /*  & free the space    */
+    ip->auxchp = nxt;
+  }
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    auxchprint(csound, ip);
 }
 
 /* close all files in instr fd chain        */
@@ -167,54 +167,54 @@ void auxchfree(CSOUND *csound, INSDS *ip)
 
 void fdchclose(CSOUND *csound, INSDS *ip)
 {
-    if (UNLIKELY(csound->oparms->odebug))
-      fdchprint(csound, ip);
-    /* for all fd's in chain: */
-    for ( ; ip->fdchp != NULL; ip->fdchp = ip->fdchp->nxtchp) {
-      void  *fd = ip->fdchp->fd;
-      if (LIKELY(fd)) {
-        ip->fdchp->fd = NULL;           /*    delete the fd     */
-        csoundFileClose(csound, fd);    /*    & close the file  */
-      }
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    fdchprint(csound, ip);
+  /* for all fd's in chain: */
+  for ( ; ip->fdchp != NULL; ip->fdchp = ip->fdchp->nxtchp) {
+    void  *fd = ip->fdchp->fd;
+    if (LIKELY(fd)) {
+      ip->fdchp->fd = NULL;           /*    delete the fd     */
+      csoundFileClose(csound, fd);    /*    & close the file  */
     }
-    if (UNLIKELY(csound->oparms->odebug))
-      fdchprint(csound, ip);
+  }
+  if (UNLIKELY(csoundGetDebug(csound) & 0x01))
+    fdchprint(csound, ip);
 }
 
 /* print the xp chain for this insds blk */
 
 static CS_NOINLINE void auxchprint(CSOUND *csound, INSDS *ip)
 {
-    AUXCH *curchp;
-    char *name = csound->engineState.instrtxtp[ip->insno]->insname;
+  AUXCH *curchp;
+  char *name = csound->engineState.instrtxtp[ip->insno]->insname;
 
-    if (name)
-      csoundMessage(csound, Str("auxlist for instr %s [%d] (%p):\n"),
-                      name, ip->insno, ip);
-    else
-      csoundMessage(csound, Str("auxlist for instr %d (%p):\n"),
-                      ip->insno, ip);
-    /* chain through auxlocs */
-    for (curchp = ip->auxchp; curchp != NULL; curchp = curchp->nxtchp)
-      csoundMessage(csound,
-                      Str("\tauxch at %p: size %zu, auxp %p, endp %p\n"),
-                      curchp, curchp->size, curchp->auxp, curchp->endp);
+  if (name)
+    csoundMessage(csound, Str("auxlist for instr %s [%d] (%p):\n"),
+		  name, ip->insno, ip);
+  else
+    csoundMessage(csound, Str("auxlist for instr %d (%p):\n"),
+		  ip->insno, ip);
+  /* chain through auxlocs */
+  for (curchp = ip->auxchp; curchp != NULL; curchp = curchp->nxtchp)
+    csoundMessage(csound,
+		  Str("\tauxch at %p: size %zu, auxp %p, endp %p\n"),
+		  curchp, curchp->size, curchp->auxp, curchp->endp);
 }
 
 /* print the fd chain for this insds blk */
 
 static CS_NOINLINE void fdchprint(CSOUND *csound, INSDS *ip)
 {
-    FDCH *curchp;
-    char *name = csound->engineState.instrtxtp[ip->insno]->insname;
+  FDCH *curchp;
+  char *name = csound->engineState.instrtxtp[ip->insno]->insname;
 
-    if (name)
-      csoundMessage(csound, Str("fdlist for instr %s [%d] (%p):"),
-                      name, ip->insno, ip);
-    else
-      csoundMessage(csound, Str("fdlist for instr %d (%p):"), ip->insno, ip);
-    /* chain through fdlocs */
-    for (curchp = ip->fdchp; curchp != NULL; curchp = curchp->nxtchp)
-      csoundMessage(csound, Str("  fd %p in %p"), curchp->fd, curchp);
-    csoundMessage(csound, "\n");
+  if (name)
+    csoundMessage(csound, Str("fdlist for instr %s [%d] (%p):"),
+		  name, ip->insno, ip);
+  else
+    csoundMessage(csound, Str("fdlist for instr %d (%p):"), ip->insno, ip);
+  /* chain through fdlocs */
+  for (curchp = ip->fdchp; curchp != NULL; curchp = curchp->nxtchp)
+    csoundMessage(csound, Str("  fd %p in %p"), curchp->fd, curchp);
+  csoundMessage(csound, "\n");
 }

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2037,7 +2037,7 @@ static void print_instr(CSOUND *csound, INSTRTXT *tp, ENGINE_STATE *e) {
   if(tp != e->instxtanchor.nxtinstxt)
     csoundMessage(csound, "instr %s\n ", tp->insname ? tp->insname : "");
   else if(optxt->nxtop != NULL)
-    csoundMessage(csound, "\n");
+    csoundMessage(csound, "\n ");
   
   while ((optxt = optxt->nxtop) != NULL) { /* for each op in instr */
     TEXT *ttp = &optxt->t;

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2032,12 +2032,19 @@ static void print_instr(CSOUND *csound, INSTRTXT *tp, ENGINE_STATE *e) {
   char **argp;
   int32_t n;
   ARGLST *outlist, *inlist;
+
+  // find number
+  for(n = 0; n < e->maxinsno; n++)
+    if(e->instrtxtp[n] == tp) break;
   
   optxt = (OPTXT *)tp;
-  if(tp != e->instxtanchor.nxtinstxt)
-    csoundMessage(csound, "instr %s\n ", tp->insname ? tp->insname : "");
+  if(tp != e->instxtanchor.nxtinstxt) {
+    tp->insname ?
+      csoundMessage(csound,"instr %s\n",tp->insname) :
+      csoundMessage(csound, "instr %d\n", n);
+  }
   else if(optxt->nxtop != NULL)
-    csoundMessage(csound, "\n ");
+    csoundMessage(csound, "\n");
   
   while ((optxt = optxt->nxtop) != NULL) { /* for each op in instr */
     TEXT *ttp = &optxt->t;
@@ -2053,7 +2060,8 @@ static void print_instr(CSOUND *csound, INSTRTXT *tp, ENGINE_STATE *e) {
       csound->Message(csound, "%s: \n", ep->opname);
       continue;
     }
-    
+
+    csoundMessage(csound, " ");
     if ((outlist = ttp->outlist) == NULL || !outlist->count)
       ttp->outArgs = NULL;
     else {
@@ -2077,7 +2085,7 @@ static void print_instr(CSOUND *csound, INSTRTXT *tp, ENGINE_STATE *e) {
 	else
 	 csound->Message(csound, "%s ",*argp++);
     }
-    csound->Message(csound, "\n ");
+    csound->Message(csound, "\n");
   }
   csound->Message(csound, "\n");
 }

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1305,6 +1305,23 @@ char* convert_external_to_internal(CSOUND* csound, char* arg) {
 }
 
 
+static int is_external(const char *s) {
+  int res = 0;
+  if(*s != '[') {
+    s++;
+    while(*s != '\0') {
+      if(*s == '[') {
+	res = 1;
+	break;
+      }
+      s++;
+    }
+  }
+  return res;
+
+}
+
+
 char* get_arg_string_from_tree(CSOUND* csound, TREE* tree,
                                TYPE_TABLE* typeTable) {
 
@@ -1327,9 +1344,15 @@ char* get_arg_string_from_tree(CSOUND* csound, TREE* tree,
       // if we failed to find argType, exit from parser
       csound->Die(csound, "Could not parse type for argument");
     } else {
-      argType = convert_internal_to_external(csound, argType);
-      argsLen += strlen(argType);
-      argTypes[index++] = argType;
+      if(is_external(argType)) {
+	// catch type[] in expressions to opcall - no conversion
+        argsLen += strlen(argType);
+        argTypes[index++] = argType;
+      } else {	
+         argType = convert_internal_to_external(csound, argType);
+         argsLen += strlen(argType);
+         argTypes[index++] = argType;
+       }
     }
 
     current = current->next;
@@ -1350,6 +1373,7 @@ char* get_arg_string_from_tree(CSOUND* csound, TREE* tree,
   csound->Free(csound, argTypes);
   return argString;
 }
+
 
 
 /* Used by new UDO syntax, expects tree's with value->lexeme as type names */

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2080,6 +2080,14 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root,
   return NULL;
 }
 
+char *strip_extension(CSOUND *csound, const char *s) {
+  char *s1 = cs_strdup(csound, s);
+  char *dot = strchr(s1, '.');
+  if(dot != NULL)
+      *dot = '\0';
+  return s1;
+}
+
 /*
  * Verifies:
  *    -number of args correct
@@ -2161,18 +2169,22 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
 
   if (UNLIKELY(oentry == NULL)) {
     int32_t i;
+    char *name = strip_extension(csound, opcodeName);
     synterr(csound, Str("Unable to find opcode entry for \'%s\' "
-                        "with matching argument types:\n"),
-            opcodeName);
+                        "with matching argument types:\n"), name);
+    csound->Free(csound, name);
+    name = strip_extension(csound, root->value->lexeme);
     csoundMessage(csound, Str("Found:\n  %s %s %s\n"),
-                  leftArgString, root->value->lexeme, rightArgString);
-
+                  leftArgString, name, rightArgString);
+    csound->Free(csound, name);
     csoundMessage(csound, Str("\nCandidates:\n"));
 
     for (i = 0; i < entries->count; i++) {
       OENTRY *entry = entries->entries[i];
-      csoundMessage(csound, "  %s %s %s\n", entry->outypes, entry->opname,
+      name = strip_extension(csound, entry->opname);
+      csoundMessage(csound, "  %s %s %s\n", entry->outypes, name,
                     entry->intypes);
+      csound->Free(csound, name);
     }
 
     csoundMessage(csound, Str("\nLine: %d\n"),
@@ -3017,7 +3029,7 @@ void do_baktrace(CSOUND *csound, uint64_t files)
   while (files) {
     uint32_t ff = files&0xff;
     files = files >>8;
-    csound->ErrorMsg(csound, Str(" from file %s (%d)\n"),
+    csound->ErrorMsg(csound, Str("from file %s (%d)\n"),
                     csound->filedir[ff], ff);
   }
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1306,25 +1306,16 @@ char* convert_external_to_internal(CSOUND* csound, char* arg) {
 
 
 static int is_external(const char *s) {
-  int res = 0;
   if(*s != '[') {
-    s++;
-    while(*s != '\0') {
-      if(*s == '[') {
-	res = 1;
-	break;
-      }
-      s++;
-    }
+    if(strchr(s+1, '[') != NULL)
+        return 1;
   }
-  return res;
-
+  return 0;
 }
 
 
 char* get_arg_string_from_tree(CSOUND* csound, TREE* tree,
                                TYPE_TABLE* typeTable) {
-
   int32_t len = tree_arg_list_count(tree);
   int32_t i;
 
@@ -1344,15 +1335,12 @@ char* get_arg_string_from_tree(CSOUND* csound, TREE* tree,
       // if we failed to find argType, exit from parser
       csound->Die(csound, "Could not parse type for argument");
     } else {
-      if(is_external(argType)) {
-	// catch type[] in expressions to opcall - no conversion
-        argsLen += strlen(argType);
-        argTypes[index++] = argType;
-      } else {	
+      	// catch type[] in expressions to opcall - no conversion
+      if(!is_external(argType)) 
          argType = convert_internal_to_external(csound, argType);
-         argsLen += strlen(argType);
-         argTypes[index++] = argType;
-       }
+      argsLen += strlen(argType);
+      argTypes[index++] = argType;
+
     }
 
     current = current->next;

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -325,13 +325,15 @@ int32_t copy_var_generic(CSOUND *csound, void *p) {
     if(typeR != typeA) {
       if(assign->h.perf != copy_var_no_op)
         return csound->PerfError(csound,&(assign->h),
-        Str("Opcode given variables "
-            "with two different types: %s : %s"), 
-        typeR->varTypeName, typeA->varTypeName);
+        Str("\ncannot handle "
+            "different types (%s, %s)"),
+         *typeR->varTypeName == '[' ? "array" : typeR->varTypeName,
+	 *typeA->varTypeName == '[' ? "array" : typeA->varTypeName);
        else return csound->InitError(csound,
-        Str("Opcode given variables "
-            "with two different types: %s : %s"),
-        typeR->varTypeName, typeA->varTypeName);
+        Str("\ncannot handle "
+            "different types (%s, %s)"),
+         *typeR->varTypeName == '[' ? "array" : typeR->varTypeName,
+	 *typeA->varTypeName == '[' ? "array" : typeA->varTypeName);
     }
 
     typeR->copyValue(csound, typeR, assign->r, assign->a, assign->h.insdshead);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -266,16 +266,33 @@ int32_t init0(CSOUND *csound)
   return csound->inerrcnt;                        /*   return errcnt      */
 }
 
-static void putop(CSOUND *csound, TEXT *tp)
+static void print_opcall(CSOUND *csound, TEXT *tp)
 {
   int32_t n, nn;
   char *name;
+  ARG *arg;
   
   if ((n = tp->outlist->count) != 0) {
     nn = 0;
-    while (n-- > 1)
-      csound->Message(csound, "%s,", tp->outlist->arg[nn++]);
-    csound->Message(csound, "%s ", tp->outlist->arg[nn++]);
+    arg = tp->outArgs;
+    CS_VARIABLE *var = (CS_VARIABLE *) arg->argPtr;
+    char *type = var->varType->varTypeName; 
+    char  arrtype[64]; 
+    while (n-- > 1) {
+      if(*type == '[') {
+        snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
+         type = arrtype;
+      }  
+      csound->Message(csound, "%s:%s,", tp->outlist->arg[nn++], type);
+      arg = arg->next;
+      var = (CS_VARIABLE *) arg->argPtr;
+      type = var->varType->varTypeName;
+    }
+    if(*type == '[') {
+        snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
+         type = arrtype;
+    }    
+    csound->Message(csound, "%s:%s ", tp->outlist->arg[nn++], type);
   }
   else
     csound->Message(csound, " ");
@@ -283,9 +300,25 @@ static void putop(CSOUND *csound, TEXT *tp)
   csound->Message(csound, "%s ", name);
   if ((n = tp->inlist->count) != 0) {
     nn = 0;
-    while (n-- > 1)
-      csound->Message(csound, "%s,", tp->inlist->arg[nn++]);
-    csound->Message(csound, "%s", tp->inlist->arg[nn++]);
+    arg = tp->inArgs;
+    CS_VARIABLE *var = (CS_VARIABLE *) arg->argPtr;
+    char *type = var->varType->varTypeName;
+    char  arrtype[64]; 
+    while (n-- > 1) {
+      if(*type == '[') {
+        snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
+         type = arrtype;
+      }        
+      csound->Message(csound, "%s:%s,", tp->inlist->arg[nn++], type);
+      arg = arg->next;
+      var = (CS_VARIABLE *) arg->argPtr;
+      type = var->varType->varTypeName;
+    }
+    if(*type == '[') {
+        snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
+         type = arrtype;
+    }      
+    csound->Message(csound, "%s:%s", tp->inlist->arg[nn++], type);
   }
   csound->Message(csound, "\n");
 }
@@ -1319,7 +1352,7 @@ int32_t csoundInitError(CSOUND *csound, const char *s, ...)
   csoundErrMsgV(csound, buf, s, args);
   va_end(args);
   do_baktrace(csound, csound->ids->optext->t.locn);
-  putop(csound, &(csound->ids->optext->t));
+  print_opcall(csound, &(csound->ids->optext->t));
   return ++(csound->inerrcnt);
 }
 
@@ -1356,7 +1389,7 @@ int32_t csoundPerfError(CSOUND *csound, OPDS *h, const char *s, ...)
   csoundErrMsgV(csound, buf, s, args);
   va_end(args);
   if (ip->pds)
-    putop(csound, &(ip->pds->optext->t));
+    print_opcall(csound, &(ip->pds->optext->t));
   csoundErrorMsg(csound, "%s",  Str("   note aborted\n"));
   csound->perferrcnt++;
   xturnoff_now((CSOUND*) csound, ip);       /* rm ins fr actlist */

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -269,19 +269,23 @@ int32_t init0(CSOUND *csound)
 static void putop(CSOUND *csound, TEXT *tp)
 {
   int32_t n, nn;
-
+  char *name;
+  
   if ((n = tp->outlist->count) != 0) {
     nn = 0;
-    while (n--)
-      csound->Message(csound, "%s\t", tp->outlist->arg[nn++]);
+    while (n-- > 1)
+      csound->Message(csound, "%s,", tp->outlist->arg[nn++]);
+    csound->Message(csound, "%s ", tp->outlist->arg[nn++]);
   }
   else
-    csound->Message(csound, "\t");
-  csound->Message(csound, "%s\t", tp->opcod);
+    csound->Message(csound, " ");
+  name = strip_extension(csound, tp->opcod);
+  csound->Message(csound, "%s ", name);
   if ((n = tp->inlist->count) != 0) {
     nn = 0;
-    while (n--)
-      csound->Message(csound, "%s\t", tp->inlist->arg[nn++]);
+    while (n-- > 1)
+      csound->Message(csound, "%s,", tp->inlist->arg[nn++]);
+    csound->Message(csound, "%s", tp->inlist->arg[nn++]);
   }
   csound->Message(csound, "\n");
 }
@@ -1329,24 +1333,28 @@ int32_t csoundPerfError(CSOUND *csound, OPDS *h, const char *s, ...)
     csoundErrorMsg(csound, Str("PerfError in wrong mode %d\n"), csound->mode);
   if (ip->opcod_iobufs) {
     OPCODINFO *op = ((OPCOD_IOBUFS*) ip->opcod_iobufs)->opcode_info;
+    
     /* find top level instrument instance */
     do {
       ip = ((OPCOD_IOBUFS*) ip->opcod_iobufs)->parent_ip;
     } while (ip->opcod_iobufs);
-    if (op)
+    if (op) {
       snprintf(buf, 512, Str("PERF ERROR in instr %d (opcode %s) line %d: "),
                ip->insno, op->name, t.linenum);
+    }
     else
       snprintf(buf, 512, Str("PERF ERROR in instr %d (subinstr %d) line %d: "),
                ip->insno, ip->insno, t.linenum);
   }
-  else
+  else{
+    char *name = strip_extension(csound, csound->op);
     snprintf(buf, 512, Str("PERF ERROR in instr %d (opcode %s) line %d: "),
-             ip->insno, csound->op, t.linenum);
+             ip->insno, name, t.linenum);
+   csound->Free(csound, name);
+  }
   va_start(args, s);
   csoundErrMsgV(csound, buf, s, args);
   va_end(args);
-  do_baktrace(csound, t.locn);
   if (ip->pds)
     putop(csound, &(ip->pds->optext->t));
   csoundErrorMsg(csound, "%s",  Str("   note aborted\n"));

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1496,7 +1496,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
 {
   INSTRTXT  *tp;
   INSDS     *ip;
-  OPTXT     *optxt, *anchor;
+  OPTXT     *optxt;
   OPDS      *opds, *prvids, *prvpds, *prvpdd;
   const OENTRY  *ep;
   int32_t       i, n, pextent, pextra, pextrab;
@@ -1506,7 +1506,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
   char*     opMemStart;
 
   OPARMS    *O = csound->oparms;
-  int32_t       odebug = csoundGetDebug(csound) & DEBUG_RUNTIME;
+  int32_t   odebug = csoundGetDebug(csound) & DEBUG_RUNTIME;
   ARG*      arg;
   int32_t       argStringCount;
   CS_VARIABLE* current;
@@ -1579,7 +1579,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
     const CS_TYPE** typePtr = (const CS_TYPE**)(ptr - CS_VAR_TYPE_OFFSET);
     *typePtr = current->varType;
   }
-  anchor = optxt;
+  
   while ((optxt = optxt->nxtop) != NULL) {    /* for each op in instr */
     TEXT *ttp = &optxt->t;
     ep = ttp->oentry;
@@ -1745,7 +1745,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
   if(csoundGetDebug(csound) & DEBUG_RUNTIME ||
      csoundGetDebug(csound) & DEBUG_INSTR) {
     csound->Message(csound, "instantiated instr %d\n", ip->insno);
-    optxt = anchor;
+    optxt = (OPTXT*) tp;
     while ((optxt = optxt->nxtop) != NULL) {
       csound->Message(csound, "  ");
       print_opcall(csound, &(optxt->t));

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -272,11 +272,11 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
   char *name;
   ARG *arg;
   
-  if ((n = tp->outlist->count) != 0) {
+  if (tp->outlist && (n = tp->outlist->count) != 0) {
     nn = 0;
     arg = tp->outArgs;
     CS_VARIABLE *var = (CS_VARIABLE *) arg->argPtr;
-    char *type = var->varType->varTypeName; 
+    char *type = arg->type == ARG_PFIELD ? "p" : var->varType->varTypeName; 
     char  arrtype[64]; 
     while (n-- > 1) {
       if(*type == '[') {
@@ -286,7 +286,7 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
       csound->Message(csound, "%s:%s,", tp->outlist->arg[nn++], type);
       arg = arg->next;
       var = (CS_VARIABLE *) arg->argPtr;
-      type = var->varType->varTypeName;
+      type = arg->type == ARG_PFIELD ? "p" : var->varType->varTypeName;
     }
     if(*type == '[') {
         snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
@@ -298,11 +298,15 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
     csound->Message(csound, " ");
   name = strip_extension(csound, tp->opcod);
   csound->Message(csound, "%s ", name);
-  if ((n = tp->inlist->count) != 0) {
+  if (tp->inlist  && (n = tp->inlist->count) != 0) {
     nn = 0;
     arg = tp->inArgs;
     CS_VARIABLE *var = (CS_VARIABLE *) arg->argPtr;
-    char *type = var->varType->varTypeName;
+    char *type = arg->type == ARG_CONSTANT ? "c" :
+      (arg->type == ARG_STRING ? "S" :
+       (arg->type == ARG_PFIELD ? "p" :
+        (arg->type == ARG_LABEL ? "l" :
+         var->varType->varTypeName)));
     char  arrtype[64]; 
     while (n-- > 1) {
       if(*type == '[') {
@@ -312,7 +316,11 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
       csound->Message(csound, "%s:%s,", tp->inlist->arg[nn++], type);
       arg = arg->next;
       var = (CS_VARIABLE *) arg->argPtr;
-      type = var->varType->varTypeName;
+      type = arg->type == ARG_CONSTANT ? "c" :
+      (arg->type == ARG_STRING ? "S" :
+       (arg->type == ARG_PFIELD ? "p" :
+        (arg->type == ARG_LABEL ? "l" :
+         var->varType->varTypeName)));;
     }
     if(*type == '[') {
         snprintf(arrtype, 64, "%s[]", var->subType->varTypeName); 
@@ -1488,7 +1496,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
 {
   INSTRTXT  *tp;
   INSDS     *ip;
-  OPTXT     *optxt;
+  OPTXT     *optxt, *anchor;
   OPDS      *opds, *prvids, *prvpds, *prvpdd;
   const OENTRY  *ep;
   int32_t       i, n, pextent, pextra, pextrab;
@@ -1571,7 +1579,7 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
     const CS_TYPE** typePtr = (const CS_TYPE**)(ptr - CS_VAR_TYPE_OFFSET);
     *typePtr = current->varType;
   }
-
+  anchor = optxt;
   while ((optxt = optxt->nxtop) != NULL) {    /* for each op in instr */
     TEXT *ttp = &optxt->t;
     ep = ttp->oentry;
@@ -1731,6 +1739,18 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
                         arg->type);
       }
     }
+
+  }
+  /* display instantiated instrument */
+  if(csoundGetDebug(csound) & DEBUG_RUNTIME ||
+     csoundGetDebug(csound) & DEBUG_INSTR) {
+    csound->Message(csound, "instantiated instr %d\n", ip->insno);
+    optxt = anchor;
+    while ((optxt = optxt->nxtop) != NULL) {
+      csound->Message(csound, "  ");
+      print_opcall(csound, &(optxt->t));
+    }
+    csound->Message(csound, "endin (instr %d)\n", ip->insno);
   }
   
   /* VL 13-12-13: point the memory to the local ksmps & kr variables,

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -266,11 +266,17 @@ int32_t init0(CSOUND *csound)
   return csound->inerrcnt;                        /*   return errcnt      */
 }
 
-static void print_opcall(CSOUND *csound, TEXT *tp)
+static int32_t print_opcall(CSOUND *csound, TEXT *tp)
 {
   int32_t n, nn;
   char *name;
   ARG *arg;
+
+  if(!strcmp(tp->opcod, "endin") ||
+     !strcmp(tp->opcod, "endop")) {
+    csound->Message(csound, "%sn", tp->opcod);
+    return 0;
+  }
   
   if (tp->outlist && (n = tp->outlist->count) != 0) {
     nn = 0;
@@ -294,8 +300,6 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
     }    
     csound->Message(csound, "%s:%s ", tp->outlist->arg[nn++], type);
   }
-  else
-    csound->Message(csound, " ");
   name = strip_extension(csound, tp->opcod);
   csound->Message(csound, "%s ", name);
   if (tp->inlist  && (n = tp->inlist->count) != 0) {
@@ -328,7 +332,8 @@ static void print_opcall(CSOUND *csound, TEXT *tp)
     }      
     csound->Message(csound, "%s:%s", tp->inlist->arg[nn++], type);
   }
-  csound->Message(csound, "\n");
+  csound->Message(csound,"\n");
+  return 1;
 }
 
 static void set_xtratim(CSOUND *csound, INSDS *ip)
@@ -1396,9 +1401,10 @@ int32_t csoundPerfError(CSOUND *csound, OPDS *h, const char *s, ...)
   va_start(args, s);
   csoundErrMsgV(csound, buf, s, args);
   va_end(args);
-  if (ip->pds)
+  if (ip->pds) {
     print_opcall(csound, &(ip->pds->optext->t));
-  csoundErrorMsg(csound, "%s",  Str("   note aborted\n"));
+  }
+  csoundErrorMsg(csound, "%s",  Str("...event aborted\n"));
   csound->perferrcnt++;
   xturnoff_now((CSOUND*) csound, ip);       /* rm ins fr actlist */
   return csound->perferrcnt;                /* contin from there */
@@ -1744,13 +1750,17 @@ static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
   /* display instantiated instrument */
   if(csoundGetDebug(csound) & DEBUG_RUNTIME ||
      csoundGetDebug(csound) & DEBUG_INSTR) {
-    csound->Message(csound, "instantiated instr %d\n", ip->insno);
+    csoundMessage(csound, "instantiated instr %d\n", ip->insno);
     optxt = (OPTXT*) tp;
     while ((optxt = optxt->nxtop) != NULL) {
-      csound->Message(csound, "  ");
-      print_opcall(csound, &(optxt->t));
+      if(strcmp(optxt->t.opcod, "endin") &&
+         strcmp(optxt->t.opcod, "endop")) {
+         csound->Message(csound, " ");
+         print_opcall(csound, &(optxt->t));
+      }
     }
-    csound->Message(csound, "endin (instr %d)\n", ip->insno);
+    
+    csoundMessage(csound, "endin (instr %d)\n", ip->insno);
   }
   
   /* VL 13-12-13: point the memory to the local ksmps & kr variables,

--- a/H/csound_orc_semantics.h
+++ b/H/csound_orc_semantics.h
@@ -33,6 +33,8 @@
  on returned value.  Caller should compare the returned value with the
  passed in opname to see if it is different and thus requires mfree'ing. */
 #include "find_opcode.h"
+
+char *strip_extension(CSOUND *csound, const char *s);
 char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable);
 void print_tree(CSOUND *, char *, TREE *);
 OENTRIES* find_opcode2(CSOUND*, char*);
@@ -60,6 +62,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable);
 // bison functions
 extern int32_t csound_orcget_lineno(void*);
 extern char *csound_orcget_current_pointer(void *);
+
 
 
 typedef struct csstructvar {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -120,6 +120,7 @@ def runTest():
 	["test46.csd", "if-then with expression in boolean comparison"],
 	["test47.csd", "until loop and k[]"],
 	["test48.csd", "expected failure with variable used before defined", 1],
+    ["test_array_expr_opcall.csd", "test array expr in opcall"],
     ["test_shadowing_for_loop.csd", "test local shadowing of vars in for loop"],   
     ["test_shadowing_implicit.csd", "test local shadowing of global vars for implicit types"],
     ["test_opcode_with_opt_ins.csd", "test opcode with opt ins only"],

--- a/tests/commandline/test_array_expr_opcall.csd
+++ b/tests/commandline/test_array_expr_opcall.csd
@@ -1,0 +1,17 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+instr 1
+sig:k sumarray fillarray(1,2,3)*2
+endin
+
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+


### PR DESCRIPTION
A bug involving array expressions inlined in an opcall prevented code such as this to
be successfully parsed,


```
sig:i = sumarray(fillarray(1,2,3)*2)
```

because the resulting type of `fillarray(1,2,3)*2` was not found correctly. This PR fixes the issue and adds a test.