### PR TITLE
Fix for pass-by-ref UDO arguments

### DIFF
--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -98,7 +98,10 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
     ARGLST *outlist = optext->t.outlist;
     ARGLST *inlist = optext->t.inlist;
     bool isUdo = optext->t.oentry->useropinfo != NULL;
-
+    OENTRY *oentry = optext->t.oentry;
+    // actual pointer offset, the max number of out args
+    int32_t leno = (int32_t) strlen(oentry->outypes);
+    
     for (i = 0; i < outlist->count; i++) {
       char *varName = outlist->arg[i];
       MYFLT *argPtr = (MYFLT *)cs_hash_table_get(csound, arg_ptr_map, varName);
@@ -124,10 +127,10 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
 
         if(isUdo) {
             UOPCODE *udoData = (UOPCODE *)ichain;
-            udoData->ar[outlist->count + i] = argPtr;
+            udoData->ar[leno + i] = argPtr;
         } else {
             MYFLT** argStart = (MYFLT**)(ichain + 1);
-            argStart[outlist->count + i] = argPtr;
+            argStart[leno + i] = argPtr;
         }
       }
     }
@@ -142,6 +145,9 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
     ARGLST *outlist = optext->t.outlist;
     ARGLST *inlist = optext->t.inlist;
     bool isUdo = optext->t.oentry->useropinfo != NULL;
+    OENTRY *oentry = optext->t.oentry;
+    // actual pointer offset, the max number of out args
+    int32_t leno = (int32_t) strlen(oentry->outypes);    
 
     for (i = 0; i < outlist->count; i++) {
       char *varName = outlist->arg[i];
@@ -167,10 +173,10 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
         // printf("Cur value: %g\n", *(MYFLT*)argPtr);
         if(isUdo) {
             UOPCODE *udoData = (UOPCODE *)pchain;
-            udoData->ar[outlist->count + i] = argPtr;
+            udoData->ar[leno + i] = argPtr;
         } else {
             MYFLT** argStart = (MYFLT**)(pchain + 1);
-            argStart[outlist->count + i] = argPtr;
+            argStart[leno + i] = argPtr;
         }
       }
     }

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -136,8 +136,7 @@ typedef struct instr {
   int32_t active;          /* To count activations for control */
   int32_t pending_release; /* To count instruments in release phase */
   int32_t maxalloc;
-  int32_t
-      turnoff_mode; /* Optionally turnoff instruments instances above maxalloc*/
+  int32_t turnoff_mode; /* Opt turnoff instruments instances above maxalloc */
   MYFLT cpuload;    /* % load this instrumemnt makes */
   struct opcodinfo *opcode_info; /* UDO info (when instrs are UDOs) */
   char *insname;                 /* instrument name */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -250,6 +250,7 @@ def runTest():
         ["udo/fail_invalid_xout.csd", "fail due to invalid xout", 1],
         ["udo/test_udo_xout_const.csd", "Constants as xout inputs work"],
         ["udo/pass_by_ref.csd", "Pass-by-ref works with new-style UDOs"],
+        ["udo/test_args_in.csd", "Pass-by-ref connects args correctly."],
     ]
 
     maxallocTests = [

--- a/tests/commandline/udo/test_args_in.csd
+++ b/tests/commandline/udo/test_args_in.csd
@@ -1,0 +1,23 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n 
+</CsOptions>
+<CsInstruments>
+0dbfs=1
+opcode Test(sig:k,fn:i):(a)
+a1 flooper2 sig,1,0, 3, 0.1,fn
+xout a1
+endop
+
+i1 ftgen 1, 0, 0, 1, "../fox.wav", 0, 0, 1
+instr 1
+a1 Test 0.5,1
+out a1
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+


### PR DESCRIPTION
This PR fixes the issues raised in #2290 where input args were not connected properly into opcodes of multiple input args.