### PR TITLE
fix: s with p-field no longer aborts piece.

### DIFF
--- a/Engine/swritestr.c
+++ b/Engine/swritestr.c
@@ -147,6 +147,17 @@ void swritestr(CSOUND *csound, CORFIL *sco, int32_t first)
       corfile_putc(csound, '\n', sco);
       break;
     case 's':
+      if (bp->pcnt > 0) {
+        char buffer[80];
+        if(csound->engineStatus & CS_STATE_COMP) // realtime event
+        CS_SPRINTF(buffer, "e  %f %f\n", bp->p2val, bp->newp2);
+        else // score event
+        CS_SPRINTF(buffer, "f 0  %f %f\n", bp->p2val, bp->newp2);
+        corfile_puts(csound, buffer, sco);
+      }
+      corfile_putc(csound, c, sco);
+      corfile_putc(csound, LF, sco);
+      break;
     case 'e':
       if (bp->pcnt > 0) {
         char buffer[80];


### PR DESCRIPTION
Noticed the Csound 7 executable (as of 360cbe7 and 7.0.0-beta.9) terminating the performance early when encountering an s with a p-field in the score as can be seen in the [mrp](https://github.com/user-attachments/files/22866818/csound_terminating_early_on_s-statement_with_p-field.csd.txt). (Attached as .txt because GitHub won't accept .csd files.)

I expected to hear i1 at 440Hz from second 0 to 1 and at 110Hz from second 2 to 3.
However, only the first note is played back to me on Asahi Linux (Fedora 42).
Scores with s statements without p-field are played entirely as can be seen [here](https://github.com/user-attachments/files/22866819/csound_terminating_normally_on_s-statement_without_p-field.csd.txt).


Removing this else statement in swritestr.c leads to all s and e statements being added to CSOUND::scstr like in Csound 6 and fixes the above-mentioned behavior, at least for any of my .csd files including the mrp.
While this commit fixes my particular issue regarding s statements with p-fields, I am unsure whether this might regress the fix from 92a51fc406.

Best,
Vinni