### PR TITLE
Implement break/continue for until and while loops

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -198,6 +198,12 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
 "enduntil"      { *lvalp = make_token(csound, yytext);
                   (*lvalp)->type = OD_TOKEN;
                   return OD_TOKEN; }
+"break"         { *lvalp = make_token(csound, yytext);
+                  (*lvalp)->type = BREAK_TOKEN;
+                  return BREAK_TOKEN; }
+"continue"      { *lvalp = make_token(csound, yytext);
+                  (*lvalp)->type = CONTINUE_TOKEN;
+                  return CONTINUE_TOKEN; }
 "switch"        { *lvalp = make_token(csound, yytext);
                   (*lvalp)->type = SWITCH_TOKEN;
                   return SWITCH_TOKEN; }

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -89,6 +89,8 @@
 %token WHILE_TOKEN
 %token DO_TOKEN
 %token OD_TOKEN
+%token BREAK_TOKEN
+%token CONTINUE_TOKEN
 %token SWITCH_TOKEN
 %token CASE_TOKEN
 %token DEFAULT_TOKEN
@@ -465,6 +467,10 @@ statement : out_arg_list assignment expr_list NEWLINE
           | while
           | switch
           | for_in
+          | BREAK_TOKEN
+            { $$ = make_leaf(csound, LINE, LOCN, BREAK_TOKEN, (ORCTOKEN *)$1); }
+          | CONTINUE_TOKEN
+            { $$ = make_leaf(csound, LINE, LOCN, CONTINUE_TOKEN, (ORCTOKEN *)$1); }
           | LABEL_TOKEN
             { $$ = make_leaf(csound, LINE, LOCN, LABEL_TOKEN, (ORCTOKEN *)$1); }
           | NEWLINE

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1572,7 +1572,7 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 }
 
 TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
-                           char* arrayArgType) {
+                           char* arrayArgType, LOOP_JUMP_TARGETS* targets) {
 
   const CS_TYPE *iType = &CS_VAR_TYPE_I;
   const CS_TYPE *kType = &CS_VAR_TYPE_K;
@@ -1693,16 +1693,32 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   }
   arrayGetStatement->next = current->right->right;
 
-  strNcpy(op, isPerfRate ? "loop_lt.k" : "loop_lt.i", 10);
+  int32_t continueTargetCounter = csound->genlabs++;
+  TREE* continueTargetLabel = create_synthetic_label(csound, continueTargetCounter);
+  typeTable->labelList = cs_cons(csound,
+                                 cs_strdup(csound, continueTargetLabel->value->lexeme),
+                                 typeTable->labelList);
+  TREE* continueTargetIdent = create_synthetic_ident(csound, continueTargetCounter);
 
-  TREE* loopLtStatement = create_opcode_token(csound, op);
+  int32_t breakTargetCounter = csound->genlabs++;
+  TREE* breakTargetLabel = create_synthetic_label(csound, breakTargetCounter);
+  typeTable->labelList = cs_cons(csound,
+                                 cs_strdup(csound, breakTargetLabel->value->lexeme),
+                                 typeTable->labelList);
+  TREE* breakTargetIdent = create_synthetic_ident(csound, breakTargetCounter);
+
   TREE* tail = tree_tail(current->right->right);
-  tail->next = loopLtStatement;
+  tail->next = continueTargetLabel;
+
+  strNcpy(op, isPerfRate ? "loop_lt.k" : "loop_lt.i", 10);
+  TREE* loopLtStatement = create_opcode_token(csound, op);
+  continueTargetLabel->next = loopLtStatement;
 
   TREE* indexArgToken = copy_node(csound, indexIdent);
   loopLtStatement->right = indexArgToken;
   // VL: need to set the next statement after loop
-  loopLtStatement->next = current->next;
+  loopLtStatement->next = breakTargetLabel;
+  breakTargetLabel->next = current->next;
 
   // loop less-than arg1: increment by 1
   TREE *oneToken = create_empty_token(csound);
@@ -1729,6 +1745,11 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   csound->Free(csound, arrayName);
   csound->Free(csound, arrayLengthName);
   csound->Free(csound, op);
+
+  targets->continueTargetIdent = continueTargetIdent;
+  targets->breakTargetIdent = breakTargetIdent;
+  targets->breakTargetLabel = breakTargetLabel;
+  targets->gotoType = (isPerfRate == 1 ? 0 : 1);
 
   return indexAssign;
 }

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1490,7 +1490,8 @@ TREE* expand_switch_statement(
    5. add goto token that goes to top label
    6. end label */
 TREE* expand_until_statement(CSOUND* csound, TREE* current,
-                             TYPE_TABLE* typeTable, int32_t dowhile)
+                             TYPE_TABLE* typeTable, int32_t dowhile,
+                             LOOP_JUMP_TARGETS* targets)
 {
   TREE* anchor = NULL;
   TREE* expressionNodes = NULL;
@@ -1550,6 +1551,8 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 
 
   labelEnd = create_synthetic_label(csound, endLabelCounter);
+  TREE *labelEndIdent = create_synthetic_ident(csound,
+                                               endLabelCounter);
   TREE *topLabel = create_synthetic_ident(csound,
                                           topLabelCounter);
   TREE *gotoTopLabelToken = create_simple_goto_token(csound,
@@ -1561,6 +1564,10 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 
 
   labelEnd->next = current->next;
+  targets->continueTargetIdent = topLabel;
+  targets->breakTargetIdent = labelEndIdent;
+  targets->breakTargetLabel = labelEnd;
+  targets->gotoType = (gotoType==1 ? 0 : 1);
   return anchor;
 }
 
@@ -1748,3 +1755,10 @@ int32_t is_statement_expansion_required(TREE* root) {
   return 0;
 }
 
+TREE* convert_break_to_goto(CSOUND* csound, LOOP_JUMP_TARGETS* targets) {
+  return create_simple_goto_token(csound, copy_node(csound, targets->breakTargetIdent), targets->gotoType);
+}
+
+TREE* convert_continue_to_goto(CSOUND* csound, LOOP_JUMP_TARGETS* targets) {
+  return create_simple_goto_token(csound, copy_node(csound, targets->continueTargetIdent), targets->gotoType);
+}

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2630,6 +2630,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
   TREE* transformed;
   TREE* top;
   char *udo_name = NULL;
+  CONS_CELL* activeLoopStack = NULL;
 
   CONS_CELL* parentLabelList = typeTable->labelList;
   typeTable->labelList = get_label_list(csound, root);
@@ -2795,7 +2796,9 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       continue;
 
     case UNTIL_TOKEN:
-    case WHILE_TOKEN:
+    case WHILE_TOKEN: {
+      LOOP_JUMP_TARGETS* targets = csound->Calloc(csound, sizeof(LOOP_JUMP_TARGETS));
+
       if (!verify_until_statement(csound, current, typeTable)) {
         synterr(csound, "loop conditional expression not valid, line %d",
                 current->line - 2);
@@ -2803,13 +2806,16 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       }
 
       current = expand_until_statement(csound, current,
-                                       typeTable, current->type==WHILE_TOKEN);
+                                       typeTable, current->type==WHILE_TOKEN,
+                                       targets);
 
       if (previous != NULL) {
         previous->next = current;
       }
 
+      activeLoopStack = cs_cons(csound, targets, activeLoopStack);
       continue;
+    }
 
     case SWITCH_TOKEN: {
       char* switchArgType = get_arg_type2(csound, current->left, typeTable);
@@ -2890,8 +2896,55 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
     }
     continue;
     
-    case LABEL_TOKEN:
+    case LABEL_TOKEN: {
+      if (activeLoopStack != NULL) {
+        LOOP_JUMP_TARGETS* currentTargets = (LOOP_JUMP_TARGETS*)activeLoopStack->value;
+        if (currentTargets->breakTargetLabel == current) {
+          CONS_CELL* temp = activeLoopStack;
+          activeLoopStack = activeLoopStack->next;
+          csound->Free(csound, temp->value);
+          csound->Free(csound, temp);
+        }
+      }
       break;
+    }
+
+    case BREAK_TOKEN: {
+      TREE* breakGoto;
+
+      if (activeLoopStack == NULL) {
+        synterr(csound,Str("line:%d found break statement outside of loop."),
+                current->line);
+        return NULL;
+      }
+
+      breakGoto = convert_break_to_goto(csound, (LOOP_JUMP_TARGETS*)activeLoopStack->value);
+      if (previous != NULL) {
+        previous->next = breakGoto;
+      }
+      breakGoto->next = current->next;
+      current = breakGoto;
+      continue;
+    }
+
+    case CONTINUE_TOKEN: {
+      TREE* continueGoto;
+
+      if (activeLoopStack == NULL) {
+        synterr(csound,Str("line:%d found continue statement outside of loop."),
+                current->line);
+        return NULL;
+      }
+
+      continueGoto = convert_continue_to_goto(csound,
+                        (LOOP_JUMP_TARGETS*)activeLoopStack->value);
+      if (previous != NULL) {
+        previous->next = continueGoto;
+      }
+      continueGoto->next = current->next;
+      current = continueGoto;
+      continue;
+    }
 
     case '+':
     case '-':
@@ -2979,6 +3032,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
   if (csoundGetDebug(csound) & DEBUG_SEMANTICS)
     csound->Message(csound, "[End Verifying AST]\n");
 
+  cs_cons_free_complete(csound, activeLoopStack);
   cs_cons_free(csound, typeTable->labelList);
   typeTable->labelList = parentLabelList;
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2887,12 +2887,14 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
 	} 
        typ = cs_strdup(csound, var->varType->varTypeName);
       }
-      current = expand_for_statement(csound, current, typeTable, typ);
+      LOOP_JUMP_TARGETS* targets = csound->Calloc(csound, sizeof(LOOP_JUMP_TARGETS));
+      current = expand_for_statement(csound, current, typeTable, typ, targets);
       csound->Free(csound, atype);
       csound->Free(csound, typ);
       if (previous != NULL) {
         previous->next = current;
       }
+      activeLoopStack = cs_cons(csound, targets, activeLoopStack);
     }
     continue;
     

--- a/H/csound_orc_expressions.h
+++ b/H/csound_orc_expressions.h
@@ -47,7 +47,8 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
 TREE* expand_switch_statement(CSOUND* csound, TREE* current,TYPE_TABLE* typeTable,
   char* switchArgType);
 TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable);
-TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable, char* arrayArgType);
+TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable, char* arrayArgType,
+                           LOOP_JUMP_TARGETS* targets);
 char *remove_type_quoting(CSOUND *csound, const char *outype);
 TREE * create_opcode_token(CSOUND *csound, char* op);
 TREE* convert_break_to_goto(CSOUND* csound, LOOP_JUMP_TARGETS* targets);

--- a/H/csound_orc_expressions.h
+++ b/H/csound_orc_expressions.h
@@ -27,6 +27,13 @@
 
 #include "csound_orc.h"
 
+typedef struct {
+    TREE* continueTargetIdent;
+    TREE* breakTargetIdent;
+    TREE* breakTargetLabel;
+    int32_t gotoType;
+} LOOP_JUMP_TARGETS;
+
 CONS_CELL* cs_cons(CSOUND* csound, void* val, CONS_CELL* cons);
 CONS_CELL* cs_cons_append(CONS_CELL* cons1, CONS_CELL* cons2);
 
@@ -36,13 +43,15 @@ int32_t is_statement_expansion_required(TREE* root);
 void handle_optional_args(CSOUND *csound, TREE *l);
 TREE* expand_if_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable);
 TREE* expand_until_statement(CSOUND* csound, TREE* current,
-                             TYPE_TABLE* typeTable, int32_t);
+                             TYPE_TABLE* typeTable, int32_t, LOOP_JUMP_TARGETS* targets);
 TREE* expand_switch_statement(CSOUND* csound, TREE* current,TYPE_TABLE* typeTable,
   char* switchArgType);
 TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable);
 TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable, char* arrayArgType);
 char *remove_type_quoting(CSOUND *csound, const char *outype);
 TREE * create_opcode_token(CSOUND *csound, char* op);
+TREE* convert_break_to_goto(CSOUND* csound, LOOP_JUMP_TARGETS* targets);
+TREE* convert_continue_to_goto(CSOUND* csound, LOOP_JUMP_TARGETS* targets);
 
 
 #endif

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -214,6 +214,9 @@ def runTest():
     ["test_midifile_ops.csd", "testing midifile opcodes"],
     ["test_csound_object.csd", "test Csound object opcodes"],
     ["test_true_false.csd", "testing true/false booleans"],
+    ["test_break_continue.csd", "testing break/continue statements in while/until/for loops"],
+    ["test_break_outside_loop_fails.csd", "testing break outside loop gives parser error", 1],
+    ["test_continue_outside_loop_fails.csd", "testing continue outside loop gives parser error", 1],
     ]
 
     arrayTests = [["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test_break_continue.csd
+++ b/tests/commandline/test_break_continue.csd
@@ -1,0 +1,108 @@
+<CsoundSynthesizer>
+<CsInstruments>
+
+// Test break jumps to right target
+instr 1
+    sum:i = 0
+    until (p4 < 0) do
+        p4 = p4 - 1
+        if (p4 == 2) then
+            break
+        endif
+        sum = sum + p4
+    od
+
+    if (sum != 7) then
+        exitnow(-1)
+    endif
+endin
+
+// Test continue jumps to right target
+instr 2
+    sum:i = 0
+    while (p4 > 0) do
+        p4 = p4 - 1
+        if (p4 == 2) then
+            continue
+        endif
+        sum = sum + p4
+    od
+
+    if (sum != 8) then
+        exitnow(-1)
+    endif
+endin
+
+// Test break in for loop
+instr 3
+    sum:i = 0
+    for ind in [1, 10, 100] do
+        if (ind > 10) then
+            break
+        endif
+        sum = sum + ind
+    od
+
+    if (sum != 11) then
+        exitnow(-1)
+    endif
+endin
+
+// Test continue in for loop
+instr 4
+    sum:i = 0
+    for val, ind in [1, 10, 100, 1000] do
+        if (ind == 2) then
+            continue
+        endif
+        sum = sum + val
+    od
+
+    if (sum != 1011) then
+        exitnow(-1)
+    endif
+endin
+
+// Test nested loops
+instr 5
+    sum:i = 0
+    for v1 in [1, 3, 5, 7] do
+        for v2 in [2, 4, 6, 8] do
+            rem:i = v2 % 4
+            if (rem == 0) then
+                continue
+            endif
+            sum = sum + v2
+        od
+        if (v1 > 4) then
+            break
+        endif
+    od
+
+    if (sum != 24) then
+        exitnow(-1)
+    endif
+endin
+
+// Test perf-rate loop
+instr 6
+    val:k init 0
+    for val in [2, 4, 6] do
+        if (val == 4) then
+            break
+        elseif (val == 2) then
+            continue
+        endif
+    od
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1 5
+i2 0 1 5
+i3 0 1
+i4 0 1
+i5 0 1
+i6 0 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_break_outside_loop_fails.csd
+++ b/tests/commandline/test_break_outside_loop_fails.csd
@@ -1,0 +1,19 @@
+<CsoundSynthesizer>
+<CsInstruments>
+
+instr 1
+    a:i = 1
+    b:i = 2
+    c:i = 3
+    break
+
+    while (c>0) do
+        c = c - 1
+    od
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_continue_outside_loop_fails.csd
+++ b/tests/commandline/test_continue_outside_loop_fails.csd
@@ -1,0 +1,19 @@
+<CsoundSynthesizer>
+<CsInstruments>
+
+instr 1
+    a:i = 1
+    b:i = 2
+    c:i = 3
+
+    while (c>0) do
+        c = c - 1
+    od
+    continue
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
There are a few pieces to this:
- add the tokens to the lexer and parser
- in expand_until(), keep track of the targets for break and continue statements for later conversion into gotos
- in verify_tree(), maintain a stack of active loops (to properly handle nested loops)
- when we expand an until/while loop, push onto the stack
- when we encounter the ending label of a loop, pop off the stack
- if we encounter a break/continue statement when there are no active loops, throw an error