### PR TITLE
Newline in struct and new-style UDO defs

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -301,7 +301,31 @@ udo_definition   : UDOSTART_DEFINITION identifier ',' UDO_IDENT ',' UDO_IDENT NE
                 $2->right = $3;
                 $$->right = $7;
               }
+              | UDOSTART_DEFINITION identifier udo_arg_list ':' NEWLINE udo_out_arg_list NEWLINE
+                statement_list UDOEND_TOKEN NEWLINE
+              {
+                TREE *udoTop = make_leaf(csound, LINE, LOCN, UDO_TOKEN,
+                                        (ORCTOKEN*)NULL);
+                $$ = udoTop;
+                udoTop->left = $2;
+                $2->left = $6;
+                $2->right = $3;
+                $$->right = $8;
+              }
             ;
+              | UDOSTART_DEFINITION identifier udo_arg_list NEWLINE ':' udo_out_arg_list NEWLINE
+                statement_list UDOEND_TOKEN NEWLINE
+              {
+                TREE *udoTop = make_leaf(csound, LINE, LOCN, UDO_TOKEN,
+                                        (ORCTOKEN*)NULL);
+                $$ = udoTop;
+                udoTop->left = $2;
+                $2->left = $6;
+                $2->right = $3;
+                $$->right = $8;
+              }
+            ;
+
 
 udo_arg_list : '(' out_arg_list ')'
              { $$ = $2;  }

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -228,6 +228,8 @@ struct_definition : STRUCT_TOKEN identifier struct_arg_list
 
 struct_arg_list : struct_arg_list ',' struct_arg
                 { $$ = append_to_tree(csound, $1, $3); }
+                | struct_arg_list ',' NEWLINE struct_arg
+                 { $$ = append_to_tree(csound, $1, $4); }
                 | struct_arg
                 ;
 

--- a/platform/vcpkg/ports/portaudio/portfile.cmake
+++ b/platform/vcpkg/ports/portaudio/portfile.cmake
@@ -1,14 +1,14 @@
-vcpkg_download_distfile(
-    ASIO_SDK
-    URLS "https://www.steinberg.net/asiosdk"
-    FILENAME ASIO-SDK_2.3.4_2025-10-15.zip
-    SHA512 57de2c0cd0df0783275987e08255abfa49da12982f9d462ac40b7f57300c36e024dcb65d100b799fb3c96a9c7c5ee86e61ceb0e68d2839324206c1629d3905ed 
-)
+#vcpkg_download_distfile(
+#    ASIO_SDK
+#   URLS "https://www.steinberg.net/asiosdk"
+#   FILENAME ASIO-SDK_2.3.4_2025-10-15.zip
+#   SHA512 57de2c0cd0df0783275987e08255abfa49da12982f9d462ac40b7f57300c36e024dcb65d100b799fb3c96a9c7c5ee86e61ceb0e68d2839324206c1629d3905ed 
+#)
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ASIO_SDK}
-)
+#vcpkg_extract_source_archive_ex(
+# OUT_SOURCE_PATH SOURCE_PATH
+#   ARCHIVE ${ASIO_SDK}
+#)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -28,10 +28,10 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PA_BUILD_STATIC)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DPA_USE_DS=ON
+        -DPA_USE_DS=OFF
         -DPA_USE_WASAPI=ON
         -DPA_USE_WDMKS=ON
-        -DPA_USE_WMME=ON
+        -DPA_USE_WMME=OFF
         -DPA_LIBNAME_ADD_SUFFIX=OFF
         -DPA_BUILD_SHARED=${PA_BUILD_SHARED}
         -DPA_BUILD_STATIC=${PA_BUILD_STATIC}

--- a/platform/vcpkg/ports/portaudio/portfile.cmake
+++ b/platform/vcpkg/ports/portaudio/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_download_distfile(
     ASIO_SDK
     URLS "https://www.steinberg.net/asiosdk"
     FILENAME asiosdk.zip
-    SHA512 d74c0bc09162640a377aaab2f2ce716f9ee7a6ef8d1aa1aa6bc223a4748c60fa900cc77b1cf6db66f8a4064a074b31a71d75cccc7de3634347865238d9c039af
+    SHA512 57de2c0cd0df0783275987e08255abfa49da12982f9d462ac40b7f57300c36e024dcb65d100b799fb3c96a9c7c5ee86e61ceb0e68d2839324206c1629d3905ed 
 )
 
 vcpkg_extract_source_archive_ex(

--- a/platform/vcpkg/ports/portaudio/portfile.cmake
+++ b/platform/vcpkg/ports/portaudio/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(
     ASIO_SDK
     URLS "https://www.steinberg.net/asiosdk"
-    FILENAME asiosdk.zip
+    FILENAME ASIO-SDK_2.3.4_2025-10-15.zip
     SHA512 57de2c0cd0df0783275987e08255abfa49da12982f9d462ac40b7f57300c36e024dcb65d100b799fb3c96a9c7c5ee86e61ceb0e68d2839324206c1629d3905ed 
 )
 


### PR DESCRIPTION
This PR introduces the possibility of breaking lines in struct and new-style definitions. This allows users to keep to a column limit for better formatting of code.

(1) struct defs can have newlines after commas,

```
struct SampleParams name:S, pitch:k,
                    start:i, loop:i
```

(2) UDOs can have newlines before or after the colon,

```
opcode NewS(var:i)
           :(i)
print var
 xout var+1
endop
```

```
opcode NewS(var:i):
           (i)
print var
 xout var+1
endop
```


