### PR TITLE
Boolean constants

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -147,6 +147,8 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
 "@k"            { return T_MAPK; }
 "false"         { return FALSE_TOKEN; }
 "true"          { return TRUE_TOKEN; }
+"falsek"        { return FALSEK_TOKEN; }
+"truek"         { return TRUEK_TOKEN; }
 "if"            { *lvalp = make_token(csound, yytext);
                   (*lvalp)->type = IF_TOKEN;
                   return IF_TOKEN; }

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -99,6 +99,8 @@
 %token IN_TOKEN
 %token TRUE_TOKEN
 %token FALSE_TOKEN
+%token TRUEK_TOKEN
+%token FALSEK_TOKEN
 
 
 %token S_ELIPSIS
@@ -888,11 +890,18 @@ string : STRING_TOKEN
 false_const: FALSE_TOKEN
        { $$ = make_leaf(csound, LINE,LOCN, FALSE_TOKEN,
                         make_token(csound,"false")); }
+       | FALSEK_TOKEN
+       { $$ = make_leaf(csound, LINE,LOCN, FALSEK_TOKEN,
+                        make_token(csound,"falsek")); }
+       
        ;
 
 true_const: TRUE_TOKEN
            { $$ = make_leaf(csound, LINE,LOCN, TRUE_TOKEN,
                             make_token(csound,"true")); }
+       | TRUEK_TOKEN
+       { $$ = make_leaf(csound, LINE,LOCN, TRUEK_TOKEN,
+                        make_token(csound,"truek")); }
        ;
 
          

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -820,6 +820,13 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
   if(root->type == FALSE_TOKEN)
     return create_ans_token(csound, "false");
 
+  if(root->type == TRUEK_TOKEN)
+    return create_ans_token(csound, "truek");
+
+  if(root->type == FALSEK_TOKEN)
+    return create_ans_token(csound, "falsek");
+  
+
   if(root->type == T_FUNCTION) {
     return create_expression(csound, root, line,
                              locn, typeTable);

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -573,7 +573,29 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
     *p = 1;
     }
   }
-   return cs_strdup(csound, "b");     /* boolean */
+  return cs_strdup(csound, "b");     /* boolean */
+  case FALSEK_TOKEN: {  // trap false expr here
+    CS_VARIABLE *var = find_var_from_pools(csound, "falsek",
+                                           "falsek", typeTable);
+    if(var == NULL) {
+    var = add_global_variable(csound, &csound->engineState,
+                        (CS_TYPE*)&CS_VAR_TYPE_b, "falsek", NULL);
+    int32_t *p = (int32_t *) &(var->memBlock->value);
+    *p = 0;
+    }
+  }
+  return cs_strdup(csound, "B");  /* Boolean */
+  case TRUEK_TOKEN: { // trap true expr here
+     CS_VARIABLE *var = find_var_from_pools(csound, "truek",
+                                           "truek", typeTable);
+    if(var == NULL) {   
+     var = add_global_variable(csound, &csound->engineState,
+                        (CS_TYPE*)&CS_VAR_TYPE_b, "truek", NULL);
+    int32_t *p = (int32_t *) &(var->memBlock->value);
+    *p = 1;
+    }
+  }
+  return cs_strdup(csound, "B");     /* Boolean */ 
   case STRING_TOKEN:
     return cs_strdup(csound, "S");   /* quoted String */
   case LABEL_TOKEN:


### PR DESCRIPTION
The boolean read-only vars `true` and `false` are init-time boolean type. This PR adds the read-only perf-time boolean variables `truek` and `falsek`, so we can have a similar facility for perf-time code.