### PR TITLE
Array names fix

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1741,6 +1741,7 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
         if(csoundFindVariableWithName(csound, typeTable->localPool, varName)
 	      == NULL){
 	   argLetter[0] = *varName;
+           if(argLetter[0] == 'g') argLetter[0] = varName[1];
            type =
 	   csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
            var = csoundCreateVariable(csound, csound->typePool,
@@ -1780,14 +1781,32 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
       (var && var->varType == &CS_VAR_TYPE_OPCODEREF)) {    
     if (annotation != NULL) {
       // check for global annotation
-      pool = find_global_annotation(lvarName, typeTable);
+      pool = find_global_annotation(lvarName, typeTable);     
+      if(pool == csound->engineState.varPool
+         || pool == typeTable->globalPool) {
+        // remove var from pool
+        if(var)
+          cs_hash_table_remove(csound, get_var_pool(csound,
+                                                    typeTable,
+                                                    var->varName)->table,
+                               var->varName);
+      }
       varType = csoundGetTypeWithVarTypeName(csound->typePool, annotation);
     } else {
       t = lvarName;
       argLetter[1] = 0;
 
       if (*t == '#') t++;
-      if (*t == 'g') pool = typeTable->globalPool;
+      if (*t == 'g') {
+           pool = typeTable->globalPool;
+       // remove var from pool    
+       if(var) 
+         cs_hash_table_remove(csound,
+                              get_var_pool(csound,
+                                           typeTable,
+                                           var->varName)->table,
+                              var->varName);
+      }
       if (*t == 'g') t++;
 
       argLetter[0] = *t; 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1775,7 +1775,9 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
   // search on  all pools
   var = find_var_from_pools(csound, t, t, typeTable);
   csound->Free(csound, t);
-  if (var == NULL) {
+  if (var == NULL ||
+      // treat the case of global opcode ref vars
+      (var && var->varType == &CS_VAR_TYPE_OPCODEREF)) {    
     if (annotation != NULL) {
       // check for global annotation
       pool = find_global_annotation(lvarName, typeTable);
@@ -1809,7 +1811,7 @@ void add_array_arg(CSOUND* csound, char* varName, char* annotation,
        // and different type array subtype
        varType = csoundGetTypeWithVarTypeName(csound->typePool, annotation);
        if(varType != var->subType)
-         synterr(csound, "%s:%s[] - type mismatch for existing "
+         synterr(csound, "%s:%s[] -- type mismatch for existing "
                           "array variable %s:%s%s",
                  varName, varType->varTypeName, varName,
                  var->subType ? var->subType->varTypeName :

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -239,6 +239,7 @@ def runTest():
         ["test_gen_array.csd", "testing genarray shorthand"],
         ["test_array_annotation.csd", "testing array type annotation for opcodes"],
         ["test_slice_array.csd", "testing slice shorthand"],
+        ["test_array_name.csd", "test arrays using opcode ref var names"]
     ]
 
 

--- a/tests/commandline/test_array_name.csd
+++ b/tests/commandline/test_array_name.csd
@@ -1,0 +1,21 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs=1
+
+gauss[] init 1 //
+pitchamdf@global:i[] = [1,2,3]
+
+instr 1
+pitch:i[] = [1,2,3,4]
+printarray(pitchamdf)
+gauss[0] = 1
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Treating the array case #2327 when names are the same as read-only opcode ref vars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting for array type mismatches.
  * Enhanced handling of array arguments involving global opcode references, including better alignment of argument identifiers.
  * Added cleanup when globals that shadow locals are converted/handled, preventing stale variable references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->