### PR TITLE
Improved UDO error msgs

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -386,6 +386,10 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
                    csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                         yyscanner);
                   return NEWLINE; }
+  {IDENT} {
+    csound->Message(csound, "unsupported UDO arg type: %s", yytext);
+    return ERROR_TOKEN;
+  }  
 }
 
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3083,7 +3083,7 @@ void csound_orcerror(PARSE_PARM *pp, void *yyscanner,
   int32_t line = csound_orcget_lineno(yyscanner);
   uint64_t files = csound_orcget_locn(yyscanner);
   if (UNLIKELY(*p=='\0' || *p=='\n')) line--;
-  csound->ErrorMsg(csound, Str("\nerror: %s  (token \"%s\")"),
+  csound->ErrorMsg(csound, Str("\nerror: %s (token \"%s\")\n"),
                   str, csound_orcget_text(yyscanner));
   do_baktrace(csound, files);
   csound->ErrorMsg(csound, Str(" line %d:\n>>>"), line);


### PR DESCRIPTION
Classic UDO failing with non-supported args now gives a better error message.

closes #2329 