### PR TITLE
Fix for backwards compatibility in ternary expressions

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -330,7 +330,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
             }
 }
 
-{IDENT}:/[ \t\n]  { char *pp = yytext;
+^[ ]*{IDENT}:/[ \t\n]  { char *pp = yytext;
                   while (*pp==' ' || *pp=='\t') pp++;
                   *lvalp = make_label(csound, pp); return LABEL_TOKEN;
                 }

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -704,14 +704,6 @@ struct_expr : struct_expr '.' identifier
 ternary_expr : expr '?' expr ':' expr %prec '?'
             { $$ = make_node(csound,LINE,LOCN, '?', $1,
                              make_node(csound, LINE,LOCN, ':', $3, $5)); }
-           /* VL: backwards compatibility, ident read as label */
-           | expr '?' LABEL_TOKEN expr %prec '?'
-            {
-              $$ = make_node(csound,LINE,LOCN, '?', $1,
-                             make_node(csound, LINE,LOCN, ':',
-                             make_leaf(csound, LINE, LOCN, T_IDENT,
-                                       (ORCTOKEN *)$3), $4));
-            }   
           | expr '?' expr ':' error
           | expr '?' expr error
           | expr '?' error

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -704,6 +704,14 @@ struct_expr : struct_expr '.' identifier
 ternary_expr : expr '?' expr ':' expr %prec '?'
             { $$ = make_node(csound,LINE,LOCN, '?', $1,
                              make_node(csound, LINE,LOCN, ':', $3, $5)); }
+           /* VL: backwards compatibility, ident read as label */
+           | expr '?' LABEL_TOKEN expr %prec '?'
+            {
+              $$ = make_node(csound,LINE,LOCN, '?', $1,
+                             make_node(csound, LINE,LOCN, ':',
+                             make_leaf(csound, LINE, LOCN, T_IDENT,
+                                       (ORCTOKEN *)$3), $4));
+            }   
           | expr '?' expr ':' error
           | expr '?' expr error
           | expr '?' error

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -579,7 +579,7 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
                                            "falsek", typeTable);
     if(var == NULL) {
     var = add_global_variable(csound, &csound->engineState,
-                        (CS_TYPE*)&CS_VAR_TYPE_b, "falsek", NULL);
+                        (CS_TYPE*)&CS_VAR_TYPE_B, "falsek", NULL);
     int32_t *p = (int32_t *) &(var->memBlock->value);
     *p = 0;
     }
@@ -590,7 +590,7 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
                                            "truek", typeTable);
     if(var == NULL) {   
      var = add_global_variable(csound, &csound->engineState,
-                        (CS_TYPE*)&CS_VAR_TYPE_b, "truek", NULL);
+                        (CS_TYPE*)&CS_VAR_TYPE_B, "truek", NULL);
     int32_t *p = (int32_t *) &(var->memBlock->value);
     *p = 1;
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -120,6 +120,7 @@ def runTest():
 	["test46.csd", "if-then with expression in boolean comparison"],
 	["test47.csd", "until loop and k[]"],
 	["test48.csd", "expected failure with variable used before defined", 1],
+    ["test_ternary_expr.csd", "test ternary expr for backwards compatibility"],
     ["test_array_expr_opcall.csd", "test array expr in opcall"],
     ["test_shadowing_for_loop.csd", "test local shadowing of vars in for loop"],   
     ["test_shadowing_implicit.csd", "test local shadowing of global vars for implicit types"],

--- a/tests/commandline/test_ternary_expr.csd
+++ b/tests/commandline/test_ternary_expr.csd
@@ -1,0 +1,20 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs=1
+
+instr 1
+i1 = 0
+i1 = i1 < 0 ? 0: 1
+print i1
+endin
+
+</CsInstruments>
+<CsScore>
+i1 1 0
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
This fixes an issue reported where the expression

`k2 = k0 > 0 ? k0: -1`

gives a parsing error.