### PR TITLE
Fix for mfree locks

### DIFF
--- a/Engine/memalloc.c
+++ b/Engine/memalloc.c
@@ -208,6 +208,7 @@ void mfree(CSOUND *csound, void *p)
       return;
     }
     pp->magic = 0;
+    CSOUND_MEM_SPINLOCK
 #else
     pp = HDR_PTR(p);
 


### PR DESCRIPTION
In debug builds, locking/unlocking was unbalanced leading to an early exit on MacOS. This PR fixes it.