### PR TITLE
fix: issue with garbage data in sflib_open_fd()

### DIFF
--- a/InOut/soundfile.c
+++ b/InOut/soundfile.c
@@ -38,12 +38,12 @@ int32_t sflib_command(void *handle, int32_t cmd, void *data, int32_t datasize)  
 
 void *sflib_open_fd(int32_t fd, int32_t mode, SFLIB_INFO *sfinfo, int32_t close_desc) {
       SNDFILE *handle;
-      SF_INFO info;
-      if(mode == SFM_WRITE) {
-        info.samplerate = sfinfo->samplerate;
-        info.channels = sfinfo->channels;
-        info.format = sfinfo->format;
-      }
+      SF_INFO info = {
+        .samplerate = sfinfo->samplerate,
+        .channels = sfinfo->channels,
+        .format = sfinfo->format,
+        .frames = sfinfo->frames,
+      };
       handle = sf_open_fd(fd, mode, &info, close_desc);
       if(mode == SFM_READ) {
         sfinfo->samplerate = info.samplerate;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -309,6 +309,7 @@ def runTest():
             "-odac -d -+rtaudio=dummy",
         ],
         ["test_named_instr_ramps.csd", "test named instrument ramps"],
+        ["test_gen01.csd", "testing GEN01 importing files"],
     ]
 
     arrayTests = [

--- a/tests/commandline/test_gen01.csd
+++ b/tests/commandline/test_gen01.csd
@@ -1,0 +1,31 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+0dbfs = 1
+
+;; Raw Input
+;
+; Writing raw bytes from this file to wavetables.
+; This way, we do not have to keep track of a separate file to read.
+;
+table_number@global:i = init:i(0)
+;
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -1, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -2, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -3, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -4, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -5, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -6, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -7, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -8, 0)
+table_number = ftgen(0, 0, 0, 1, "test_gen01.csd", 0, -9, 0)
+
+
+</CsInstruments>
+<CsScore>
+e 0
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
I recently encountered an issue where (loading [lorem_ipsum.txt](https://github.com/user-attachments/files/23546992/lorem_ipsum.txt) from [lorem_ipsum.csd](https://github.com/user-attachments/files/23546995/lorem_ipsum.csd.txt)) GEN01 cannot open ".txt" files on Asahi Linux (Fedora 42, AArch64). This used to work on _6.18.1_ but doesn't on the _7.0.0-beta.10_ tag.

Running csound and lorem_ipsum.csd in a debugger reveals the call `handle = sf_open_fd(fd, mode, &info, close_desc);` in `void *sflib_open_fd(int32_t fd, int32_t mode, SFLIB_INFO *sfinfo, int32_t close_desc)` returning `NULL` when passed an uninitialized `SF_INFO info`, while loading "lorem_ipsum.txt".

I think always initializing `SF_INFO info` with data from `SFLIB_INFO *sfinfo` shouldn't hurt considering that `SF_INFO info` would contain garbage data when passed to `sf_open_fd`otherwise.

Best,
Vinni