### PR TITLE
WebAudio: Fix microphone input on prod build

### DIFF
--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta11",
+  "version": "7.0.0-beta12",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",
@@ -58,7 +58,7 @@
     "@babel/core": "^7.20.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
     "@babel/plugin-transform-destructuring": "^7.20.2",
-    "@csound/wasm-bin": "7.0.0-beta9",
+    "@csound/wasm-bin": "7.0.0-beta10",
     "browser-or-node": "^2.0.0",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",

--- a/wasm/browser/src/mains/io.utils.js
+++ b/wasm/browser/src/mains/io.utils.js
@@ -36,11 +36,11 @@ export async function enableAudioInput() {
   console.log("enabling audio input");
   requestMicrophoneNode(async (stream) => {
     if (stream) {
-      const audioContext = await this.getAudioContext();
+      const audioContext = await this["getAudioContext"]();
       const liveInput = audioContext.createMediaStreamSource(stream);
       this.inputsCount = liveInput.channelCount;
 
-      const node = await this.getNode();
+      const node = await this["getNode"]();
       liveInput.connect(node);
     }
   });

--- a/wasm/browser/yarn.lock
+++ b/wasm/browser/yarn.lock
@@ -263,10 +263,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@csound/wasm-bin@7.0.0-beta9":
-  version "7.0.0-beta9"
-  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-beta9.tgz#4ca2d6965225e3280ba883ebfc4dd318460996be"
-  integrity sha512-sa+y6+VtpBQ+iWbSYfgxSrUZrXPsapfl+3+4RnV8lnH6WAwpTn1/CAdTyWOEfZ3fnAcHRohJCpmfrlvP1e42IQ==
+"@csound/wasm-bin@7.0.0-beta10":
+  version "7.0.0-beta10"
+  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-beta10.tgz#38b2940c62a32db7e175a3c2614eed51ace17b43"
+  integrity sha512-OaWcH0YPMamYbKjQ0wF0VAIWyKNEU1NoEDf3PV/odAKRq1sEWHS7jOZ4zY39lYdmDexzONoIV239qHF0wMa96g==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/wasm-bin",
-  "version": "7.0.0-beta9",
+  "version": "7.0.0-beta10",
   "description": "A package containing csound wasm binaries which can be bundled into other csound packages 📂",
   "main": "./lib/csound.wasm",
   "files": [


### PR DESCRIPTION
Production build had an issue where optimization caused an issue that prevented enableAudioInput() (e.g., microphone input) from working. 

I built a new wasm-bin with latest from develop, as well as locally tested with build:prod version of @csound/browser. Went ahead and released new versions of both wasm-bin and browser packages.