### PR TITLE
Fix: WebMidi

### DIFF
--- a/wasm/browser/externs.js
+++ b/wasm/browser/externs.js
@@ -185,6 +185,8 @@ var WasmInst;
  * getNchnls: function(CsoundInst): Promise.<number>,
  * getInputName: function(CsoundInst): Promise.<string>,
  * getSr: function(CsoundInst): Promise.<number>,
+ * _isRequestingRtMidiInput: function(CsoundInst): Promise.<number>,
+ * csoundPushMidiMessage: function(CsoundInst, number, number, number): void,
  * }}
  */
 var CsoundObj;
@@ -232,3 +234,14 @@ var InitializeMessagePortPayload;
  * initializeMessagePort: function(Object): Promise<void>,
  * }}  */
 var SABMainProxy;
+
+/** @typedef {{
+ * handleMidiInput: function(Object): void,
+ * eventPromises: Object,
+ * publicEvents: Object,
+ * hasSharedArrayBuffer: boolean,
+ * audioStatePointer: Int32Array,
+ * audioStreamIn: SharedArrayBuffer,
+ * audioStreamOut: SharedArrayBuffer,
+ * }}  */
+var CsoundWorkerMain;

--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta12",
+  "version": "7.0.0-beta13",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",

--- a/wasm/browser/src/mains/old-spn.main.js
+++ b/wasm/browser/src/mains/old-spn.main.js
@@ -13,9 +13,12 @@ let proxyPort;
 
 let UID = 0;
 
+/**
+ * @unrestricted
+ */
 class ScriptProcessorNodeMainThread {
   constructor({ audioContext, audioContextIsProvided, autoConnect }) {
-    this.isRequestingMidi = false;
+    this["isRequestingMidi"] = false;
     this.isRequestingInput = false;
     this.contextUid = undefined;
     this.iFrameElement = undefined;
@@ -274,10 +277,10 @@ class ScriptProcessorNodeMainThread {
 
     this.publicEvents.triggerOnAudioNodeCreated(audioNode);
 
-    if (this.isRequestingMidi && this.csoundWorkerMain && this.csoundWorkerMain.handleMidiInput) {
+    if (this["isRequestingMidi"] && this.csoundWorkerMain && this.csoundWorkerMain["handleMidiInput"]) {
       log("requesting for web-midi connection")();
       requestMidi({
-        onMidiMessage: this.csoundWorkerMain.handleMidiInput.bind(this.csoundWorkerMain),
+        onMidiMessage: this.csoundWorkerMain["handleMidiInput"].bind(this.csoundWorkerMain),
       });
     }
   }

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -222,7 +222,7 @@ class SharedArrayBufferMainThread {
       this.audioStatePointer,
       AUDIO_STATE.IS_REQUESTING_MIC,
     );
-    this.audioWorker.isRequestingMidi = Atomics.load(
+    this.audioWorker["isRequestingMidi"] = Atomics.load(
       this.audioStatePointer,
       AUDIO_STATE.IS_REQUESTING_RTMIDI,
     );

--- a/wasm/browser/src/mains/spn.main.js
+++ b/wasm/browser/src/mains/spn.main.js
@@ -227,10 +227,10 @@ class ScriptProcessorNodeSingleThread {
       this.eventPromises.createStartPromise();
 
       const startResult = this.csoundApi.csoundStart(this.csoundInstance);
-      if (this.csoundApi._isRequestingRtMidiInput(this.csoundInstance)) {
+      if (this.csoundApi["_isRequestingRtMidiInput"](this.csoundInstance)) {
         requestMidi({
           onMidiMessage: ({ data: event }) =>
-            this.csoundApi.csoundPushMidiMessage(this.csoundInstance, event[0], event[1], event[2]),
+            this.csoundApi["csoundPushMidiMessage"](this.csoundInstance, event[0], event[1], event[2]),
         });
       }
       this.running = true;

--- a/wasm/browser/src/mains/vanilla.main.js
+++ b/wasm/browser/src/mains/vanilla.main.js
@@ -87,7 +87,7 @@ class VanillaWorkerMainThread {
     this.audioWorker.sampleRate = await this.exportApi.getSr(this.csoundInstance);
     const inputName = await this.exportApi.getInputName(this.csoundInstance);
     this.audioWorker.isRequestingInput = inputName.includes("adc");
-    this.audioWorker.isRequestingMidi = await this.exportApi._isRequestingRtMidiInput(
+    this.audioWorker["isRequestingMidi"] = await this.exportApi["_isRequestingRtMidiInput"](
       this.csoundInstance,
     );
     this.audioWorker.outputsCount = await this.exportApi.getNchnls(this.csoundInstance);

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -7,6 +7,9 @@ import WorkletWorker from "../../dist/__compiled.worklet.worker.inline.js";
 
 let UID = 0;
 
+/**
+ * @unrestricted
+ */
 class AudioWorkletMainThread {
   constructor({ audioContext, audioContextIsProvided, autoConnect }) {
     this.autoConnect = autoConnect;
@@ -20,7 +23,7 @@ class AudioWorkletMainThread {
     this.csoundWorkerMain = undefined;
     this.workletWorkerUrl = undefined;
     this.workletProxy = undefined;
-    this.isRequestingMidi = false;
+    this["isRequestingMidi"] = false;
     this.isRequestingInput = false;
 
     // never default these, get it from
@@ -203,10 +206,10 @@ class AudioWorkletMainThread {
     const contextUid = `audioWorklet${UID}`;
     UID += 1;
 
-    if (this.isRequestingMidi) {
+    if (this["isRequestingMidi"]) {
       log("requesting for web-midi connection");
       requestMidi({
-        onMidiMessage: this.csoundWorkerMain.handleMidiInput.bind(this.csoundWorkerMain),
+        onMidiMessage: this.csoundWorkerMain["handleMidiInput"].bind(this.csoundWorkerMain),
       });
     }
 

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -43,6 +43,9 @@ const initializeModule = async (audioContext) => {
   return true;
 };
 
+/**
+ * @unrestricted
+ */
 class SingleThreadAudioWorkletMainThread {
   constructor({ audioContext, inputChannelCount = 1, outputChannelCount = 2 }) {
     /** @type {(WorkletSinglethreadProxy | undefined)} */
@@ -63,6 +66,7 @@ class SingleThreadAudioWorkletMainThread {
 
     /** @export */
     this.onPlayStateChange = this.onPlayStateChange.bind(this);
+    this["handleMidiInput"] = this.handleMidiInput.bind(this);
     this.currentPlayState = undefined;
     this.midiPortStarted = false;
   }
@@ -264,7 +268,7 @@ class SingleThreadAudioWorkletMainThread {
 
               if (isRequestingMidi) {
                 requestMidi({
-                  onMidiMessage: this.handleMidiInput.bind(this),
+                  onMidiMessage: this["handleMidiInput"],
                 });
               }
 

--- a/wasm/browser/src/workers/common.utils.js
+++ b/wasm/browser/src/workers/common.utils.js
@@ -27,7 +27,7 @@ export const handleCsoundStart =
     }
 
     setTimeout(() => {
-      const isRequestingRtMidiInput = libraryCsound._isRequestingRtMidiInput(csound);
+      const isRequestingRtMidiInput = libraryCsound["_isRequestingRtMidiInput"](csound);
       const isExpectingRealtimeOutput =
         shouldDemonize || isRequestingRtMidiInput || outputName.includes("dac");
 

--- a/wasm/browser/src/workers/sab.worker.js
+++ b/wasm/browser/src/workers/sab.worker.js
@@ -51,7 +51,7 @@ const sabCreateRealtimeAudioThread =
     });
 
     // Prompt for midi-input on demand
-    const isRequestingRtMidiInput = libraryCsound._isRequestingRtMidiInput(csound);
+    const isRequestingRtMidiInput = libraryCsound["_isRequestingRtMidiInput"](csound);
 
     // Prompt for microphone only on demand!
     const isExpectingInput =
@@ -195,7 +195,7 @@ const sabCreateRealtimeAudioThread =
             const status = Atomics.load(midiBuffer, absIndex);
             const data1 = Atomics.load(midiBuffer, absIndex + 1);
             const data2 = Atomics.load(midiBuffer, absIndex + 2);
-            libraryCsound.csoundPushMidiMessage(csound, status, data1, data2);
+            libraryCsound["csoundPushMidiMessage"](csound, status, data1, data2);
           }
 
           Atomics.store(

--- a/wasm/browser/src/workers/vanilla.worker.js
+++ b/wasm/browser/src/workers/vanilla.worker.js
@@ -84,7 +84,7 @@ const createRealtimeAudioThread =
 
       if (rtmidiQueue.length > 0) {
         rtmidiQueue.forEach((event) => {
-          libraryCsound.csoundPushMidiMessage(csound, event[0], event[1], event[2]);
+          libraryCsound["csoundPushMidiMessage"](csound, event[0], event[1], event[2]);
         });
         clearArray(rtmidiQueue);
       }

--- a/wasm/browser/src/workers/worklet.singlethread.worker.js
+++ b/wasm/browser/src/workers/worklet.singlethread.worker.js
@@ -276,7 +276,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
 
     if (rtmidiQueue.length > 0) {
       rtmidiQueue.forEach((event) => {
-        libraryCsound.csoundPushMidiMessage(this.csound, event[0], event[1], event[2]);
+        libraryCsound["csoundPushMidiMessage"](this.csound, event[0], event[1], event[2]);
       });
       clearArray(rtmidiQueue);
     }


### PR DESCRIPTION
* Use bracket notation for MIDI and worker methods to prevent minification issues with production build
* Packaged already released for @csound/browser 7.0.0-beta13 to npm