### PR TITLE
Correct FSF mailing address

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ GNU Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this software; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-02110-1301 USA
+Foundation, Inc., 31 Milk St, #960789, Boston, MA
+02196-2140 USA
 
 # GETTING STARTED
 


### PR DESCRIPTION
I noticed that in 2024 the free software foundation moved from a physical office to being fully remote. As such, the mailing address has changed as well. I got the new address and information about its update from here: https://en.wikipedia.org/wiki/Free_Software_Foundation
And the new address is also listed on their website: https://www.fsf.org/about/contact/mailing