### PR TITLE
fix: restore K-type support for k-rate with initialization in polymorphic input types for old-style UDOs

### DIFF
--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -675,6 +675,7 @@ const char* POLY_IN_TYPES[] = {
     "U", "Sikcpr",
     "i", "cpri",
     "k", "cprki",
+    "K", "cprki",               /* k-rate with initialization */
     "B", "Bb", NULL};
 const char* OPTIONAL_IN_TYPES[] = {
     "o", "icpr",

--- a/tests/c/csound_orc_semantics_test.cpp
+++ b/tests/c/csound_orc_semantics_test.cpp
@@ -135,6 +135,15 @@ TEST_F (OrcSemanticsTest, CheckInArgsTest)
     ASSERT_TRUE (check_in_arg("r", "k"));
     ASSERT_TRUE (check_in_arg("p", "k"));
 
+    // K type (k-rate with initialization) - accepts k, i, c, p, r
+    ASSERT_TRUE (check_in_arg("k", "K"));
+    ASSERT_TRUE (check_in_arg("i", "K"));
+    ASSERT_TRUE (check_in_arg("c", "K"));
+    ASSERT_TRUE (check_in_arg("p", "K"));
+    ASSERT_TRUE (check_in_arg("r", "K"));
+    ASSERT_FALSE (check_in_arg("a", "K"));
+    ASSERT_FALSE (check_in_arg("S", "K"));
+
     // checking var-arg types
     ASSERT_FALSE (check_in_arg("a", "m"));
     ASSERT_TRUE (check_in_arg("i", "m"));

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -658,6 +658,7 @@ def runTest():
         ["udo/test_udo_xout_const.csd", "Constants as xout inputs work"],
         ["udo/pass_by_ref.csd", "Pass-by-ref works with new-style UDOs"],
         ["udo/test_args_in.csd", "Pass-by-ref connects args correctly."],
+        ["udo/test_K_type.csd", "K-type arguments work with pass-by-ref"],
         ["udo/crashing_test.csd", "test for UDO crashing", 1],
         ["udo/test_udo_array_set.csd", "test UDO array setting"],
     ]

--- a/tests/commandline/udo/test_K_type.csd
+++ b/tests/commandline/udo/test_K_type.csd
@@ -1,0 +1,67 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+ksmps = 32
+
+instr FailNow
+    exitnow(-1)
+endin
+
+opcode inc_k, k, K
+    kval xin
+    kout = kval + 1
+    xout kout
+endop
+
+opcode sum_diff_K, kk, KK
+    kin1, kin2 xin
+    ksum = kin1 + kin2
+    kdiff = kin1 - kin2
+    xout ksum, kdiff
+endop
+
+gkResult init -1
+
+instr 1
+    gkInput init 5
+    kresult = inc_k(gkInput)
+
+    if (kresult != 6) then
+        printks("ERROR: Return value failed for inc_k. kresult=%g\n", .001, kresult)
+        schedulek("FailNow", 0, 0)
+        turnoff
+    endif
+
+    gkResult = kresult
+endin
+
+instr 2
+    k1 init 10
+    k2 init 3
+    ksum, kdiff = sum_diff_K(k1, k2)
+
+    if (ksum != 13 || kdiff != 7) then
+        printks("ERROR: SumDiffK outputs wrong values. ksum=%g kdiff=%g\n", .001, ksum, kdiff)
+        schedulek("FailNow", 0, 0)
+        turnoff
+    endif
+endin
+
+instr 3
+    if (gkResult != 6) then
+        printks("ERROR: Global K result incorrect. gkResult=%g\n", .001, gkResult)
+        schedulek("FailNow", 0, 0)
+        turnoff
+    endif
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0.01
+i2 0 0.01
+i3 0 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Old-style UDOs support "K" type that supposedly copied values at init-time. AI reported that:

The K type handling was added to csound6 in April 2023 (commits 6329e6830 and 4124c3560 by Victor Lazzarini to fix issue #1707)

This fix uses POLY_IN_TYPES to fix the issue. 