### PR TITLE
UDO local pool

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3388,6 +3388,8 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
     case UDO_TOKEN:
       if (csoundGetDebug(csound) & DEBUG_SEMANTICS)
 	csound->Message(csound, "UDO found\n");
+      typeTable->localPool = csoundCreateVarPool(csound);
+      current->markup = typeTable->localPool;
       top = current->left;
       if (top->left != NULL && top->left->type == UDO_ANS_TOKEN) {
         top->left->markup = cs_strdup(csound, top->left->value->lexeme);

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -398,6 +398,7 @@ def runTest():
         ["test46.csd", "if-then with expression in boolean comparison"],
         ["test47.csd", "until loop and k[]"],
         ["test48.csd", "expected failure with variable used before defined", 1],
+        ["test_udo_local_pool.csd", "test udos for separate local var pool"],
         ["test_ternary_expr.csd", "test ternary expr for backwards compatibility"],
         ["test_array_expr_opcall.csd", "test array expr in opcall"],
         ["test_shadowing_for_loop.csd", "test local shadowing of vars in for loop"],

--- a/tests/commandline/test_udo_local_pool.csd
+++ b/tests/commandline/test_udo_local_pool.csd
@@ -1,0 +1,26 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+
+Sresult = "anything"
+
+opcode test1, S[], 0
+       Sresult[] fillarray "t1", "t2"
+       xout Sresult
+endop
+
+instr 1
+       Sresult[] test1
+endin
+
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
A bug was reported where UDOs were using variables defined in the instr0 local pool. This was due to the fact that UDOs never created their own local pools (as instruments do) and were reusing instr0 local pool. This UDO fixes that and adds a test for regression.