### PR TITLE
fix: update lexer to handle leading tabs for labels and add tests for label indentation

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -328,7 +328,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
             }
 }
 
-^[ ]*{IDENT}:/[ \t\n]  { char *pp = yytext;
+^[ \t]*{IDENT}:/[ \t\n]  { char *pp = yytext;
                   while (*pp==' ' || *pp=='\t') pp++;
                   *lvalp = make_label(csound, pp); return LABEL_TOKEN;
                 }
@@ -387,7 +387,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
   {IDENT} {
     csound->Message(csound, "unsupported UDO arg type: %s", yytext);
     return ERROR_TOKEN;
-  }  
+  }
 }
 
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -421,6 +421,7 @@ def runTest():
         ["test_switch_statement.csd", "tests the new switch statement operator"],
         ["nested_strings.csd", "test nested strings works with schedule [issue #861]"],
         ["test_label_within_if_block.csd", "test label within if block"],
+        ["test_labels.csd", "test labels with tab and space indentation"],
         ["test_newstyle_udo_optargs.csd", "test newstyle UDO optional args"],
         [
             "test_arrays.csd",

--- a/tests/commandline/test_labels.csd
+++ b/tests/commandline/test_labels.csd
@@ -1,0 +1,58 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs  = 1
+
+; Test opcode with label indented with tab
+opcode test,0,0
+	SKIP:
+endop
+
+; Test opcode with label indented with spaces
+opcode test2,0,0
+    SKIP2:
+endop
+
+; Test opcode with label with no indentation
+opcode test3,0,0
+SKIP3:
+endop
+
+; Test instrument with label indented with tab
+instr 1
+	Label1:
+	print 1
+	goto Label1Done
+	Label1Done:
+endin
+
+; Test instrument with label indented with spaces
+instr 2
+    Label2:
+    print 2
+    goto Label2Done
+    Label2Done:
+endin
+
+; Test instrument with mixed indentation (tabs and spaces)
+instr 3
+		TabLabel:
+        SpaceLabel:
+	print 3
+endin
+
+</CsInstruments>
+<CsScore>
+
+i 1 0 0.01
+i 2 0 0.01
+i 3 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
* test added for labels with leading spaces and tabs
* fixes https://github.com/csound/csound/issues/2382