### PR TITLE
Reedefinition issue fix

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1892,7 +1892,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   TREE* tail = tree_tail(current->right->right);
   tail->next = continueTargetLabel;
 
-  strNcpy(op, isPerfRate ? "loop_lt.k" : "loop_lt.i", 10);
+  strNcpy(op, isPerfRate ? "looplt.k" : "looplt.i", 10);
   TREE* loopLtStatement = create_opcode_token(csound, op);
   continueTargetLabel->next = loopLtStatement;
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2047,11 +2047,23 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
   // search on  all pools
   var = find_var_from_pools(csound, t, t, typeTable);
   csound->Free(csound, t);
-  if (var == NULL) {
+  // VL: since arrays are now also created here now, we
+  // need to apply similar checks to add_array_arg()
+  if (var == NULL ||
+      (var && var->varType == &CS_VAR_TYPE_OPCODEREF)) {
     if (annotation != NULL) {
       // check for global annotation in explicit-type rhs vars
       lvarName = cs_strdup(csound, varName);
       pool = find_global_annotation(lvarName, typeTable);
+      if(pool == csound->engineState.varPool
+         || pool == typeTable->globalPool) {
+        // remove var from pool
+        if(var)
+          cs_hash_table_remove(csound,
+                               get_var_pool(csound,typeTable,
+                                            var->varName)->table,
+                               var->varName);
+      }  
       // check to see if annotation is optional type
       char *nm = check_optional_type(csound, annotation);
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -554,6 +554,7 @@ def runTest():
             "test_instr_type_var_new_compilation.csd",
             "testing schedule of named instr in new compilations",
         ],
+        ["test_redef_array.csd", "test redef of OpcodeDef by an array"],
         ["test_ambiguous_opcall.csd", "test ambiguous opcall examples"],
         ["test_opcode_type.csd", "tests opcode type"],
         ["test_opcode_obj_loop.csd", "tests array of opcode objects in loops"],

--- a/tests/commandline/test_redef_array.csd
+++ b/tests/commandline/test_redef_array.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+
+partials@global:k[] init 7
+
+instr 1
+
+for val,i in partials do
+partials[i] = 1
+od
+turnoff
+
+endin
+schedule(1,0,1)
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
This PR fixes a regression introduced since the big merge of the structs array support. The issue was that in the previous code the function `add_args()` dealt with creating normal vars and `add_array_args()` dealt with creating array vars. Since the merge, code has been added to make `add_args()` handle arrays. This means that redefinition of existing vars by arrays were now handled by this function - without the extra checks needed in the case of OpcodeDef vars. This resulted in the crash reported.

This PR adds that check. It also fixes the new name adopted for `looplt` without the underscores.

A related question is whether `add_arg()` should handle arrays at all, but this is out of scope for the fix.

closes #2383 
