### PR TITLE
Do not redefine psignal and enable dlopen on *BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1406,6 +1406,11 @@ if(LINUX)
     endif()
 endif()
 
+if(BSD)
+    message(STATUS "Building on BSD.")
+    add_definitions(-DBSD)
+endif()
+
 if((APPLE AND NOT IOS) OR (OSXCROSS_TARGET))
     message(STATUS "Building on OSX")
     add_definitions(-DMACOSX -DPIPES -DNO_FLTK_THREADS -DHAVE_SOCKETS)

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -91,7 +91,7 @@
 #endif
 
 #if !(defined (__wasi__))
-#if defined(LINUX) || defined(NEW_MACH_CODE) || defined(__HAIKU__)
+#if defined(LINUX) || defined(BSD) || defined(NEW_MACH_CODE) || defined(__HAIKU__)
 #include <dlfcn.h>
 #elif defined(WIN32)
 #include <windows.h>
@@ -1049,7 +1049,7 @@ void *csoundGetLibrarySymbol(void *library, const char *procedureName)
   return (void*) GetProcAddress((HMODULE) library, procedureName);
 }
 
-#elif  !(defined(__wasi__)) && (defined(LINUX) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
+#elif  !(defined(__wasi__)) && (defined(LINUX) || defined(BSD) || defined(NEW_MACH_CODE) || defined(__HAIKU__))
 
 int32_t csoundOpenLibrary(void **library, const char *libraryPath)
 {

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1389,7 +1389,7 @@ static void psignal_(int sig, char *str) {
   fprintf(stderr, "%s: %s\n", str, signal_to_string(sig));
 }
 #else
-#if !defined(__CYGWIN__)
+#if !defined(__CYGWIN__) && !defined(BSD)
 void psignal(int sig, const char *str) {
   fprintf(stderr, "%s: %s\n", str, signal_to_string(sig));
 }


### PR DESCRIPTION
I have tested this change on OpenBSD only. It should help on DragonFlyBSD, FreeBSD, and NetBSD as well.