### PR TITLE
Define PTHREAD_SPINLOCK_INITIALIZER on *BSD

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -59,7 +59,7 @@
 #include "namedins.h"
 #include "find_opcode.h"
 
-#if defined(linux) || defined(__HAIKU__) || defined(__EMSCRIPTEN__) ||         \
+#if defined(linux) || defined(BSD) || defined(__HAIKU__) || defined(__EMSCRIPTEN__) ||         \
     defined(__CYGWIN__)
 #define PTHREAD_SPINLOCK_INITIALIZER 0
 #endif


### PR DESCRIPTION
This is the last change needed to compile without errors on OpenBSD.