### PR TITLE
Avoid %n format specifier

### DIFF
--- a/util/dnoise.c
+++ b/util/dnoise.c
@@ -1209,8 +1209,12 @@ static int32_t writebuffer(CSOUND *csound, SNDFILE *outfd,
       csound->MessageS(csound, CSOUNDMSG_REALTIME, ".");
       break;
     case 3:
-      csound->MessageS(csound, CSOUNDMSG_REALTIME, "%d%n", *nrecs, &n);
-      while (n--) csound->MessageS(csound, CSOUNDMSG_REALTIME, "\b");
+      {
+        char msg[32];
+        n = snprintf(msg, sizeof(msg), "%d", *nrecs);
+        csound->MessageS(csound, CSOUNDMSG_REALTIME, "%s", msg);
+        while (n--) csound->MessageS(csound, CSOUNDMSG_REALTIME, "\b");
+      }
       break;
     case 4:
       csound->MessageS(csound, CSOUNDMSG_REALTIME, "\a");

--- a/util/mixer.c
+++ b/util/mixer.c
@@ -635,8 +635,9 @@ static SNDFILE *MXsndgetset(CSOUND *csound, inputs *ddd)
         break;
       case 3:
         {
-          int32_t n;
-          csound->MessageS(csound, CSOUNDMSG_REALTIME, "%d%n", block, &n);
+          char msg[32];
+          int32_t n = snprintf(msg, sizeof(msg), "%d", block);
+          csound->MessageS(csound, CSOUNDMSG_REALTIME, "%s", msg);
           while (n--) csound->MessageS(csound, CSOUNDMSG_REALTIME, "\b");
         }
         break;

--- a/util/new_srconv.c
+++ b/util/new_srconv.c
@@ -103,8 +103,7 @@ static void heartbeater(void)
       break;
     case 3:
       {
-        int32_t n;
-        fprintf(stderr, "%d%n", block, &n);
+        int32_t n = fprintf(stderr, "%d", block);
         while (n--) fprintf(stderr, "\010");
       }
       break;


### PR DESCRIPTION
The `%n` format specifier for `printf` and friends is not portable.

It has been disabled in OpenBSD because of its security implications:
https://man.openbsd.org/printf.3

It also doesn't work with MSVC for the same reason:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions

The compiler-warnings in OpenBSD disappear with this change, but I don't really know how to test this ..
