### PR TITLE
Misc fixes

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -60,7 +60,7 @@ void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE *t,
                         OPDS *ids);
 OENTRY* find_opcode(CSOUND*, char*);
 void sanitize(CSOUND *csound);
-void add_opcode_defs(CSOUND *csound);
+
 
 
 
@@ -2193,7 +2193,6 @@ int32_t csound_compile_orc(CSOUND *csound, const char *str, int32_t async) {
     return retVal;
   }
 
-  add_opcode_defs(csound);
   root = csoundParseOrc(csound, str);
   if (LIKELY(root != NULL)) {
     // Parser already ran verify_tree; do not re-verify here to avoid pool/markup reentrancy hazards

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -4206,12 +4206,13 @@ static void print_tree_xml(CSOUND *csound, TREE *l, int32_t n, int32_t which)
   case '^':
   case '(':
   case ')':
-  case T_ASSIGNMENT:
   case '|':
   case '&':
   case '#':
   case '~':
     csound->Message(csound,"name=\"%c\"", l->type); break;
+  case T_ASSIGNMENT:
+    csound->Message(csound,"name=\"T_ASSIGNMENT\""); break;
   case NEWLINE:
     csound->Message(csound,"name=\"NEWLINE\""); break;
   case S_NEQ:

--- a/Engine/new_orc_parser.c
+++ b/Engine/new_orc_parser.c
@@ -28,6 +28,7 @@
 #include "score_param.h"
 #include "csound_orc_semantics.h"
 #include "new_orc_parser.h"
+void add_opcode_defs(CSOUND *csound);
 
 #if defined(HAVE_DIRENT_H)
 #  include <dirent.h>
@@ -101,6 +102,7 @@ static void add_include_udo_dir(CSOUND *csound, CORFIL *xx)
 TREE *csoundParseOrc(CSOUND *csound, const char *str)
 {
     int32_t err;
+    add_opcode_defs(csound);  // add global OpcodeDef variables
     csound->parserNamedInstrFlag = 2;
     {
       PRE_PARM    qq;


### PR DESCRIPTION
This PR:

- fixes tree printing for assignment expressions
-  moves opcode def readonly var creation from compile_tree to orcparse function. This allows the orcparse function to be called independently in the correct way.