### PR TITLE
Fix python shebang lines

### DIFF
--- a/installer/misc/mkpackage.py
+++ b/installer/misc/mkpackage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import re

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Csound Test Suite
 # By Steven Yi <stevenyi at gmail dot com>

--- a/tests/regression/test.py
+++ b/tests/regression/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Csound6 Regresson Test Suite
 # By Steven Yi<stevenyi at gmail dot com>John ffitch

--- a/tests/soak/runtests.py
+++ b/tests/soak/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tests/soak/xx.py
+++ b/tests/soak/xx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Using `env` seems to be more portable (I hope CI can handle it too). On OpenBSD, for example, the python executable is not located in `/usr/bin`.
