### PR TITLE
fix: revert safety checks in array arithmetic operations

### DIFF
--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -2111,14 +2111,6 @@ int32_t subin(CSOUND *csound, ASSIGN *p)
 
 int32_t subina(CSOUND *csound, ASSIGN *p)
 {
-  // SAFETY CHECK: This function should only be called for array operations
-  // If we're here for a scalar operation, it's a bug in the opcode resolution
-  // Fall back to scalar subtraction to prevent buffer overflow
-  *p->r -= *p->a;
-  return OK;
-
-  // Original array code (commented out to prevent buffer overflow):
-  /*
   MYFLT* val = p->a;
   MYFLT* ans = p->r;
   uint32_t    offset = p->h.insdshead->ksmps_offset;
@@ -2130,7 +2122,6 @@ int32_t subina(CSOUND *csound, ASSIGN *p)
       ans[n] -= val[n];
   CSOUND_SPOUT_SPINUNLOCK
     return OK;
-  */
 }
 
 int32_t subinak(CSOUND *csound, ASSIGN *p)
@@ -2151,14 +2142,6 @@ int32_t subinak(CSOUND *csound, ASSIGN *p)
 
 int32_t mulina(CSOUND *csound, ASSIGN *p)
 {
-  // SAFETY CHECK: This function should only be called for array operations
-  // If we're here for a scalar operation, it's a bug in the opcode resolution
-  // Fall back to scalar multiplication to prevent buffer overflow
-  *p->r *= *p->a;
-  return OK;
-
-  // Original array code (commented out to prevent buffer overflow):
-  /*
   MYFLT* val = p->a;
   MYFLT* ans = p->r;
   uint32_t    offset = p->h.insdshead->ksmps_offset;
@@ -2170,7 +2153,6 @@ int32_t mulina(CSOUND *csound, ASSIGN *p)
       ans[n] *= val[n];
   CSOUND_SPOUT_SPINUNLOCK
     return OK;
-  */
 }
 
 int32_t mulinak(CSOUND *csound, ASSIGN *p)
@@ -2207,14 +2189,6 @@ int32_t divin(CSOUND *csound, ASSIGN *p)
 
 int32_t divina(CSOUND *csound, ASSIGN *p)
 {
-  // SAFETY CHECK: This function should only be called for array operations
-  // If we're here for a scalar operation, it's a bug in the opcode resolution
-  // Fall back to scalar division to prevent buffer overflow
-  *p->r /= *p->a;
-  return OK;
-
-  // Original array code (commented out to prevent buffer overflow):
-  /*
   MYFLT* val = p->a;
   MYFLT* ans = p->r;
   uint32_t    offset = p->h.insdshead->ksmps_offset;
@@ -2226,7 +2200,6 @@ int32_t divina(CSOUND *csound, ASSIGN *p)
       ans[n] /= val[n];
   CSOUND_SPOUT_SPINUNLOCK
     return OK;
-  */
 }
 
 int32_t divinak(CSOUND *csound, ASSIGN *p)


### PR DESCRIPTION
Removed scalar fallback code from subina, mulina, and divina functions that was added as a safety measure. Restored original array operation implementations.

Found issues with zippering distortion when using *= in test code:

```
sr=48000
ksmps=64
nchnls=2
0dbfs=1

instr 1
  asig = vco2(1, p4)
  asig += vco2(.5, p4 * 2, 10)

  idepth = 4
  ioct = octcps(p4)
  print ioct

  aenv = transegr:a(0, 4, 0, 1, 10, -4.2, 0)

  acut = aenv * idepth + ioct - 1
  acut = cpsoct:a(acut)

  asig = zdf_2pole(asig, acut, 0.5)

  asig *= (aenv * .7 * p5)



  ;asig *= linen:a(1, 0.05, p3 + 10, .01)

  out(asig, asig)
endin
```

that changed when ksmps was set to 1. (Distorted audio was present in rendered wav audio.)

## Summary (from AI analysis)

1. **Original code** (working): mulina, subina, divina all had per-sample loops
2. **Oct 7, 2025** - Commit `9e30b6853` ("struct arrays impl") **broke** these functions by commenting out the loops, mistakenly thinking they shouldn't be called for scalar audio operations
3. **Oct 21, 2025** - Commit `8f458e301` fixed addina, but **forgot** to fix subina, mulina, divina

The "SAFETY CHECK" comments were based on a misunderstanding. These functions **are** supposed to handle scalar audio-rate compound assignments and process all samples in the k-period.