### PR TITLE
Include net/if.h on the BSDs

### DIFF
--- a/H/remote.h
+++ b/H/remote.h
@@ -38,7 +38,7 @@
     #endif
     #include <sys/socket.h>
     #include <netinet/in.h>
-    #ifdef MACOSX
+    #if defined (MACOSX) || defined(BSD)
       #include <net/if.h>
     #endif
     #ifdef LINUX


### PR DESCRIPTION
This header contains the definition of `IFNAMSIZ` (used in `OOps/remote.c`).

While this pull request works fine for me on OpenBSD, I don't think it is a good solution.
In my opinion it would be better to use the standard `IF_NAMESIZE` instead of `IFNAMSIZ` and also use `net/if.h` on linux (instead of `linux/if.h`).
However, since I don't use Linux, it's difficult for me to implement this.

(See https://pubs.opengroup.org/onlinepubs/009695399/basedefs/net/if.h.html)