### PR TITLE
Feature/rawstrs

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -94,8 +94,8 @@ FNAME           [a-zA-Z0-9/:.+-_]+
 LPAREN          "("
 RPAREN          ")"
 SYMBOL          [\[\]+\-*/%\^\?:.,!]
-RSTR            "```"
-ERSTR           "'''"
+RSTR            "R{"
+ERSTR           "}R"
 
    
 %s ignorenewline
@@ -333,7 +333,7 @@ ERSTR           "'''"
             }
 }
 
-"```"   {
+"R{"   {
                   PARM->xstrbuff = (char *)malloc(128);
                   PARM->xstrptr = 0; PARM->xstrmax = 128;
                   PARM->xstrbuff[PARM->xstrptr++] = '"';
@@ -343,20 +343,19 @@ ERSTR           "'''"
                 }
 
 <rstr>{
-  "```" {
+  "R{" {
              PARM->xsubstr += 1; // substr start
              if (PARM->xstrptr+4>=PARM->xstrmax) {
                 PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
                csound->DebugMsg(csound,"Extending rstr buffer\n");
              }
-             PARM->xstrbuff[PARM->xstrptr++] = '`';
-             PARM->xstrbuff[PARM->xstrptr++] = '`';
-             PARM->xstrbuff[PARM->xstrptr++] = '`';
+             PARM->xstrbuff[PARM->xstrptr++] = 'R';
+             PARM->xstrbuff[PARM->xstrptr++] = '{';
              PARM->xstrbuff[PARM->xstrptr] = '\0';
          }
 
-  "'''"   {
+  "}R"   {
     if(PARM->xsubstr) {
             PARM->xsubstr -= 1; // substr end
            if (PARM->xstrptr+4>=PARM->xstrmax) {
@@ -364,9 +363,8 @@ ERSTR           "'''"
                                                        PARM->xstrmax+=80);
                csound->DebugMsg(csound,"Extending rstr buffer\n");
            }
-             PARM->xstrbuff[PARM->xstrptr++] = '\'';
-             PARM->xstrbuff[PARM->xstrptr++] = '\'';
-             PARM->xstrbuff[PARM->xstrptr++] = '\'';
+             PARM->xstrbuff[PARM->xstrptr++] = '}';
+             PARM->xstrbuff[PARM->xstrptr++] = 'R';
            PARM->xstrbuff[PARM->xstrptr] = '\0';
     } else {
            BEGIN(INITIAL);

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -94,12 +94,16 @@ FNAME           [a-zA-Z0-9/:.+-_]+
 LPAREN          "("
 RPAREN          ")"
 SYMBOL          [\[\]+\-*/%\^\?:.,!]
+RSTR            "```"
+ERSTR           "'''"
 
+   
 %s ignorenewline
 %x line
 %x sline
 %x src
 %x xstr
+%x rstr   
 %x declare
 %x udodef
 %x udoarg
@@ -240,14 +244,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
                   (*lvalp)->type = ENDIN_TOKEN;
                   return ENDIN_TOKEN; }
 "void"          { return VOID_TOKEN; }
-"\{\{"          {
-                  PARM->xstrbuff = (char *)malloc(128);
-                  PARM->xstrptr = 0; PARM->xstrmax = 128;
-                  PARM->xstrbuff[PARM->xstrptr++] = '"';
-                  PARM->xstrbuff[PARM->xstrptr] = '\0';
-                  PARM->xsubstr = 0;
-                  BEGIN(xstr);
-                }
+
 
 "for"           {  *lvalp = make_token(csound, yytext);
                    (*lvalp)->type = FOR_TOKEN;
@@ -270,10 +267,18 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
                   }
 }
 
+"\{\{"          {
+                  PARM->xstrbuff = (char *)malloc(128);
+                  PARM->xstrptr = 0; PARM->xstrmax = 128;
+                  PARM->xstrbuff[PARM->xstrptr++] = '"';
+                  PARM->xstrbuff[PARM->xstrptr] = '\0';
+                  PARM->xsubstr = 0;
+                  BEGIN(xstr);
+                }
 <xstr>{
   "\{\{" {
              PARM->xsubstr += 1; // substr start
-             if (PARM->xstrptr+3==PARM->xstrmax) {
+             if (PARM->xstrptr+3>=PARM->xstrmax) {
                 PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
                csound->DebugMsg(csound,"Extending xstr buffer\n");
@@ -286,7 +291,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
   "}}"   {
     if(PARM->xsubstr) {
             PARM->xsubstr -= 1; // substr end
-           if (PARM->xstrptr+3==PARM->xstrmax) {
+           if (PARM->xstrptr+3>=PARM->xstrmax) {
                 PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
                csound->DebugMsg(csound,"Extending xstr buffer\n");
@@ -306,7 +311,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
   }
 
   "\n"  { /* The next two should be one case but I cannot get that to work */
-           if (PARM->xstrptr+2==PARM->xstrmax) {
+           if (PARM->xstrptr+2>=PARM->xstrmax) {
                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
                csound->DebugMsg(csound,"Extending xstr buffer\n");
@@ -317,7 +322,7 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
            }
 
   .        {
-            if (PARM->xstrptr+2==PARM->xstrmax) {
+            if (PARM->xstrptr+2>=PARM->xstrmax) {
                 PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
                  csound->DebugMsg(csound,"Extending xstr buffer\n");
@@ -327,6 +332,75 @@ SYMBOL          [\[\]+\-*/%\^\?:.,!]
               PARM->xstrbuff[PARM->xstrptr] = '\0';
             }
 }
+
+"```"   {
+                  PARM->xstrbuff = (char *)malloc(128);
+                  PARM->xstrptr = 0; PARM->xstrmax = 128;
+                  PARM->xstrbuff[PARM->xstrptr++] = '"';
+                  PARM->xstrbuff[PARM->xstrptr] = '\0';
+                  PARM->xsubstr = 0;
+                  BEGIN(rstr);
+                }
+
+<rstr>{
+  "```" {
+             PARM->xsubstr += 1; // substr start
+             if (PARM->xstrptr+4>=PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+               csound->DebugMsg(csound,"Extending rstr buffer\n");
+             }
+             PARM->xstrbuff[PARM->xstrptr++] = '`';
+             PARM->xstrbuff[PARM->xstrptr++] = '`';
+             PARM->xstrbuff[PARM->xstrptr++] = '`';
+             PARM->xstrbuff[PARM->xstrptr] = '\0';
+         }
+
+  "'''"   {
+    if(PARM->xsubstr) {
+            PARM->xsubstr -= 1; // substr end
+           if (PARM->xstrptr+4>=PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+               csound->DebugMsg(csound,"Extending rstr buffer\n");
+           }
+             PARM->xstrbuff[PARM->xstrptr++] = '\'';
+             PARM->xstrbuff[PARM->xstrptr++] = '\'';
+             PARM->xstrbuff[PARM->xstrptr++] = '\'';
+           PARM->xstrbuff[PARM->xstrptr] = '\0';
+    } else {
+           BEGIN(INITIAL);
+           PARM->xstrbuff[PARM->xstrptr++] = '"';
+           PARM->xstrbuff[PARM->xstrptr] = '\0';
+           *lvalp = make_string(csound, PARM->xstrbuff);
+            free(PARM->xstrbuff);
+            return STRING_TOKEN;
+          }
+  }
+
+  "\n"  { /* The next two should be one case but I cannot get that to work */
+           if (PARM->xstrptr+2>=PARM->xstrmax) {
+               PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+               csound->DebugMsg(csound,"Extending xstr buffer\n");
+           }
+            //csound->DebugMsg(csound,"Adding newline (%.2x)\n", yytext[0]);
+               PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
+               PARM->xstrbuff[PARM->xstrptr] = '\0';
+           }
+
+  .        {
+            if (PARM->xstrptr+2>=PARM->xstrmax) {
+                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
+                                                       PARM->xstrmax+=80);
+                 csound->DebugMsg(csound,"Extending xstr buffer\n");
+               }
+              //csound->DebugMsg(csound,"Adding (%.2x)\n", yytext[0]);
+              PARM->xstrbuff[PARM->xstrptr++] = yytext[0];
+              PARM->xstrbuff[PARM->xstrptr] = '\0';
+            }
+ }
+
 
 ^[ \t]*{IDENT}:/[ \t\n]  { char *pp = yytext;
                   while (*pp==' ' || *pp=='\t') pp++;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -588,6 +588,7 @@ def runTest():
         ],
         ["test_named_instr_ramps.csd", "test named instrument ramps"],
         ["test_gen01.csd", "testing GEN01 importing files"],
+        ["test_raw_strings.csd", "test new-style raw strings"],
     ]
 
     arrayTests = [

--- a/tests/commandline/test_raw_strings.csd
+++ b/tests/commandline/test_raw_strings.csd
@@ -1,0 +1,24 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+instr 1
+ prints R{ "type": "checkBox",
+            "bounds":{"left":%d, "top":%d, "width":30, "height":30},
+            "channels": [{"id": "check%d", "range": {"defaultValue": 0}}],
+            "style": {
+            "on": {"backgroundColor": "#ffa71e"},
+            "off": {"backgroundColor": "#d5d5d5ff"}
+            }
+            }
+            R{ %s }R \n}R, 1, 1, 1, "embedded string"
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
This adds new-style raw strings with the delimiters `R{` and `}R`, which are similar to C++ (but simpler). The old-style delimiters continue to work. Both of them support embedded raw strings, which are passed uninterpreted just like ordinary strings.

Example:

```
instr 1
 prints R{ "type": "checkBox",
            "bounds":{"left":%d, "top":%d, "width":30, "height":30},
            "channels": [{"id": "check%d", "range": {"defaultValue": 0}}],
            "style": {
            "on": {"backgroundColor": "#ffa71e"},
            "off": {"backgroundColor": "#d5d5d5ff"}
            }
            }
            R{ %s }R \n}R, 1, 1, 1, "embedded string"
endin
```

Test added. Closes #2403 
