### PR TITLE
removed extraneous HAVE_INTTYPES_H definition

### DIFF
--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -31,8 +31,6 @@
 #define HAVE_IO_H
 #define HAVE_CONIO_H
 #undef OSS
-#else
-#define HAVE_INTTYPES_H
 #endif
 
 #define FLOAT MYFLT


### PR DESCRIPTION
With the latest changes in token definition, the compilation of mpadec was broken because of an extraneous `HAVE_INTTYPES_H` definition. This fixes the problem.