### PR TITLE
Fixed array expressions.

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1554,6 +1554,18 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
   // now remove any : or ; leftover in typename
   type = remove_type_quoting(csound, arg);
 
+  /** This is doubtful code leading to garbled types
+      - restoring previous (from dbc1ce2b1)
+
+    NB: changing the check 
+      if (!hasLeadingBracket && !isSingleChar)
+    to 
+      if (!hasLeadingBracket && isSingleChar)
+
+   fixes the issue, but the previous code
+   seems to be clearer, exiting early if nothing needs
+   to be done.
+
   // treat the case where we have typename[]
   // but NOT for single-letter array types like S[] or i[]
   char *typ = type;
@@ -1563,8 +1575,8 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
   while(*type != '\0') {
     if(*type == '[' && *(type+1) ==  ']') {
       // Only strip if this is NOT the internal [typename] format
-      // and a single-letter array type like S[] or i[]
-      if (!hasLeadingBracket && isSingleChar) {
+      // and NOT a single-letter array type like S[] or i[]
+      if (!hasLeadingBracket && !isSingleChar) {
         *type = '\0';
       }
       break;
@@ -1572,6 +1584,40 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
     type++;
   }
   type = typ;
+  
+  **/
+
+  // Check if this is already a properly formatted struct array type
+  // (e.g., ":MyType;[]")
+  if (arg[0] == ':' && strstr(arg, ";[") != NULL) {
+    // This is already in external format, return as-is
+    csound->Free(csound, type);
+    return cs_strdup(csound, arg);
+  }
+
+  // If this is already in external primitive array form like "k[]" or "a[][]",
+  // do not attempt to convert it; just return a copy as-is.
+  if (arg[0] != '[' && arg[0] != ':' && strchr(arg, '[') != NULL) {
+    csound->Free(csound, type);
+    return cs_strdup(csound, arg);
+  }
+
+  // Safely handle internal typename[] forms in the internal "[..."
+  // representation Avoid reading past the end by using explicit bounds checks
+  {
+    size_t tlen = strlen(type);
+    if (tlen >= 2) {
+      char *scan = type + 1;   // start after first char
+      char *end = type + tlen; // points at NUL
+      while (scan < end) {
+        if ((scan + 1) < end && *scan == '[' && *(scan + 1) == ']') {
+          *scan = '\0';
+          break;
+        }
+        scan++;
+      }
+    }
+  }
 
   // update arg & len
   arg = type;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1563,7 +1563,7 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
   while(*type != '\0') {
     if(*type == '[' && *(type+1) ==  ']') {
       // Only strip if this is NOT the internal [typename] format
-      // and NOT a single-letter array type like S[] or i[]
+      // and a single-letter array type like S[] or i[]
       if (!hasLeadingBracket && isSingleChar) {
         *type = '\0';
       }

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1555,7 +1555,7 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
   type = remove_type_quoting(csound, arg);
 
   /** This is doubtful code leading to garbled types
-      - restoring previous (from dbc1ce2b1)
+      - restoring previous (dbc1ce2b1)
 
     NB: changing the check 
       if (!hasLeadingBracket && !isSingleChar)

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1564,7 +1564,7 @@ char* convert_internal_to_external(CSOUND* csound, char* arg) {
     if(*type == '[' && *(type+1) ==  ']') {
       // Only strip if this is NOT the internal [typename] format
       // and NOT a single-letter array type like S[] or i[]
-      if (!hasLeadingBracket && !isSingleChar) {
+      if (!hasLeadingBracket && isSingleChar) {
         *type = '\0';
       }
       break;

--- a/InOut/libmpadec/mpadec_config.h
+++ b/InOut/libmpadec/mpadec_config.h
@@ -31,8 +31,6 @@
 #define HAVE_IO_H
 #define HAVE_CONIO_H
 #undef OSS
-#else
-#define HAVE_INTTYPES_H
 #endif
 
 #define FLOAT MYFLT

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1178,8 +1178,8 @@ static OENTRY localops[] = {
     { "OSCcount", S(OSCcount), 0,  "k", "",
     (SUBR)OSCcounter, (SUBR)OSCcounter, NULL, NULL, 2 },
   /* aliases */
-  { "OSCsend_lo", S(OSCSEND), 0,  "", "kSkSN",
-    (SUBR)osc_send_set, (SUBR)osc_send, (SUBR) oscsend_deinit, NULL },
+  { "oscsendlo", S(OSCSEND), 0,  "", "kSkSN",
+    (SUBR)osc_send_set, (SUBR)osc_send, (SUBR) oscsend_deinit, NULL},
   { "oscinit", S(OSCINIT), 0, "i", "i",
     (SUBR)osc_listener_init, NULL, (SUBR) OSC_deinit , NULL },
   { "oscinitm", S(OSCINITM), 0,  "i", "Si",

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1178,7 +1178,7 @@ static OENTRY localops[] = {
     { "OSCcount", S(OSCcount), 0,  "k", "",
     (SUBR)OSCcounter, (SUBR)OSCcounter, NULL, NULL, 2 },
   /* aliases */
-  { "oscsendlo", S(OSCSEND), 0,  "", "kSkSN",
+  { "oscsenslo", S(OSCSEND), 0,  "", "kSkSN",
     (SUBR)osc_send_set, (SUBR)osc_send, (SUBR) oscsend_deinit, NULL},
   { "oscinit", S(OSCINIT), 0, "i", "i",
     (SUBR)osc_listener_init, NULL, (SUBR) OSC_deinit , NULL },

--- a/Opcodes/mixer.cpp
+++ b/Opcodes/mixer.cpp
@@ -317,20 +317,20 @@ static OENTRY localops[] = {
   /* aliases */
   {(char *)"mixersetlevel", sizeof(MixerSetLevel), _CW,  (char *)"",
    (char *)"iik", (SUBR)&MixerSetLevel::init_, (SUBR)&MixerSetLevel::kontrol_,
-   0, NULL, 2},
+   0, NULL},
   {(char *)"mixersetleveli", sizeof(MixerSetLevel), _CW,  (char *)"",
-   (char *)"iii", (SUBR)&MixerSetLevel::init_, 0, 0, NULL, 2},
+   (char *)"iii", (SUBR)&MixerSetLevel::init_, 0, 0, NULL},
   {(char *)"mixergetlevel", sizeof(MixerGetLevel), _CR,  (char *)"k",
    (char *)"ii", (SUBR)&MixerGetLevel::init_, (SUBR)&MixerGetLevel::kontrol_,
-   0, NULL, 2},
+   0, NULL},
   {(char *)"mixersend", sizeof(MixerSend), _CW,  (char *)"", (char *)"aiii",
-   (SUBR)&MixerSend::init_, (SUBR)&MixerSend::audio_, NULL, NULL, 2},
+   (SUBR)&MixerSend::init_, (SUBR)&MixerSend::audio_, NULL, NULL},
   {(char *)"mixerreceive", sizeof(MixerReceive), _CR,  (char *)"a",
    (char *)"ii", (SUBR)&MixerReceive::init_, (SUBR)&MixerReceive::audio_,
    0, NULL, 2},
   {(char *)"mixerclear", sizeof(MixerClear), 0,  (char *)"", (char *)"",
-   (SUBR)&MixerClear::init_, (SUBR)&MixerClear::audio_, NULL, NULL, 2},
-  {NULL, 0, 0, NULL, NULL, (SUBR)NULL, (SUBR)NULL, (SUBR)NULL, NULL, 2}};
+   (SUBR)&MixerClear::init_, (SUBR)&MixerClear::audio_, NULL, NULL},
+  {NULL, 0, 0, NULL, NULL, (SUBR)NULL, (SUBR)NULL, (SUBR)NULL, NULL}};
 
 PUBLIC int32_t csoundModuleCreate_mixer(CSOUND *csound) {
   std::map<CSOUND *, std::map<size_t, std::vector<std::vector<MYFLT>>>>
@@ -405,6 +405,7 @@ PUBLIC int32_t csoundModuleInit_mixer(CSOUND *csound) {
                                 (int32_t (*)(CSOUND *, void *))ep->init,
                                 (int32_t (*)(CSOUND *, void *))ep->perf,
                                 (int32_t (*)(CSOUND *, void *))ep->deinit);
+    csound->Deprecate(csound, ep->opname, ep->outypes, ep->intypes, ep->deprecated);
     ep++;
   }
   // need to register reset callback

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -785,6 +785,9 @@ static OENTRY sockrecv_localops[] = {
     (SUBR) send_srecv, NULL },
   { "OSCraw", S(RAWOSC), 0, "S[]k", "i",
     (SUBR) init_raw_osc, (SUBR) perf_raw_osc,
+    (SUBR) destroy_raw_osc, NULL, 2},
+    { "oscraw", S(RAWOSC), 0, "S[]k", "i",
+    (SUBR) init_raw_osc, (SUBR) perf_raw_osc,
     (SUBR) destroy_raw_osc, NULL}
 };
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -618,6 +618,7 @@ def runTest():
         ["arrays/test_array_copy.csd", "test array copy operations"],
         ["test_arrays_constant_index.csd", "test arrays with constant index"],
         ["test_arrays_in_udo.csd", "test arrays in UDO"],
+        ["test_array_in_expression.csd", "test expressions involving arrays"],
     ]
 
     structTests = [

--- a/tests/commandline/test_array_in_expression.csd
+++ b/tests/commandline/test_array_in_expression.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs = 1
+instr 1
+kA[] fillarray 1, 2, 3
+kB[] fillarray 2, 4, 6
+kC[] = (kA * kB) * 0.5
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
This PR fixes an issue reported by @gesellkammer where the type of array in an expression was mangled.

```
kA[] fillarray 1, 2, 3
kB[] fillarray 2, 4, 6
kC[] = (kA * kB) * 0.5

error:

error: opcode '##mul' for expression with arg types :k[;c not found, line 17
SEMERR: opcode '##mul' for expression with arg types :k[;c not found, line 17
```
The above code now works and has been added to a test.

