### PR TITLE
Removed old manual from Windows installer

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -502,13 +502,6 @@ jobs:
       - name: Run unit test framework
         run: cmake --build build --target RUN_TESTS --config Release
 
-      - name: Acquire Csound manual
-#        if: github.ref == 'refs/heads/develop'
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/csound/manual/releases/download/6.18.0/Csound6.18.0_manual_html.zip" -OutFile "./manual.zip"
-          7z x manual.zip
-
       - name: Build installer
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
@@ -582,13 +575,6 @@ jobs:
 
       - name: Run unit test framework
         run: cmake --build build --target RUN_TESTS --config Release
-
-      - name: Acquire Csound manual
-#        if: github.ref == 'refs/heads/develop'
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/csound/manual/releases/download/6.18.0/Csound6.18.0_manual_html.zip" -OutFile "./manual.zip"
-          7z x manual.zip
 
       - name: Build installer
 #        if: github.ref == 'refs/heads/develop'

--- a/installer/windows/csound7_x64_github.iss
+++ b/installer/windows/csound7_x64_github.iss
@@ -26,7 +26,6 @@
 #define BuildNumber GetEnv("GITHUB_RUN_NUMBER")
 #define AppPublisher "Csound"
 #define AppURL "https://csound.com/"
-#define ManualSourceDir "html"
 #define BuildRoot "build"
 #define ReleaseDir "build\Release"
 
@@ -79,10 +78,6 @@ Name: "{app}\include"
 ; All Csound examples go here.
 Name: "{app}\examples"; Permissions: users-modify
 #define APP_EXAMPLES "{app}\examples\"
-
-; Csound manual
-Name: "{app}\doc\manual"
-#define APP_MANUAL "{app}\doc\manual\"
 
 ; Any SoundFonts or sound samples used by Csound examples go here.
 Name: "{app}\samples"
@@ -172,14 +167,11 @@ Source: "samples\*.*"; DestDir: "{#APP_SAMPLES}"; Flags: ignoreversion recursesu
 
 Source: "{#BuildRoot}\include\float-version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
 Source: "{#BuildRoot}\include\version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
-Source: "{#ManualSourceDir}\*.*"; DestDir: "{#APP_MANUAL}"; Flags: ignoreversion recursesubdirs; Components: core
 
 [Icons]
 Name: "{group}\{cm:ProgramOnTheWeb,Csound}"; Filename: "{#AppURL}";  Components: core;
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{group}\Csound"; Filename: "cmd.exe"; Parameters: "/K csound.exe"; WorkingDir: "{#APP_BIN}"; Flags: dontcloseonexit;  Components: core
-Name: "{group}\Csound Reference Manual"; Filename: "http://csound.github.io/docs/manual/indexframes.html";  Components: core
-Name: "{group}\Csound API Reference Manual"; Filename: "http://csound.github.io/docs/api/index.html";  Components: core
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType:string; ValueName:"OPCODE7DIR64"; ValueData:"{#APP_PLUGINS64}"; Flags: preservestringtype uninsdeletevalue;  Components: core

--- a/installer/windows/csound7_x86_github.iss
+++ b/installer/windows/csound7_x86_github.iss
@@ -26,7 +26,6 @@
 #define BuildNumber GetEnv("GITHUB_RUN_NUMBER")
 #define AppPublisher "Csound"
 #define AppURL "https://csound.com/"
-#define ManualSourceDir "html"
 #define BuildRoot "build"
 #define ReleaseDir "build\Release"
 
@@ -80,10 +79,6 @@ Name: "{app}\include"
 ; All Csound examples go here.
 Name: "{app}\examples"; Permissions: users-modify
 #define APP_EXAMPLES "{app}\examples\"
-
-; Csound manual
-Name: "{app}\doc\manual"
-#define APP_MANUAL "{app}\doc\manual\"
 
 ; Any SoundFonts or sound samples used by Csound examples go here.
 Name: "{app}\samples"
@@ -173,14 +168,11 @@ Source: "samples\*.*"; DestDir: "{#APP_SAMPLES}"; Flags: ignoreversion recursesu
 
 Source: "{#BuildRoot}\include\float-version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
 Source: "{#BuildRoot}\include\version.h"; DestDir: "{#APP_INCLUDE}\csound"; Flags: ignoreversion;  Components: core
-Source: "{#ManualSourceDir}\*.*"; DestDir: "{#APP_MANUAL}"; Flags: ignoreversion recursesubdirs; Components: core
 
 [Icons]
 Name: "{group}\{cm:ProgramOnTheWeb,Csound}"; Filename: "{#AppURL}";  Components: core;
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{group}\Csound"; Filename: "cmd.exe"; Parameters: "/K csound.exe"; WorkingDir: "{#APP_BIN}"; Flags: dontcloseonexit;  Components: core
-Name: "{group}\Csound Reference Manual"; Filename: "http://csound.github.io/docs/manual/indexframes.html";  Components: core
-Name: "{group}\Csound API Reference Manual"; Filename: "http://csound.github.io/docs/api/index.html";  Components: core
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType:string; ValueName:"OPCODE7DIR"; ValueData:"{#APP_PLUGINS}"; Flags: preservestringtype uninsdeletevalue;  Components: core


### PR DESCRIPTION
The Windows installers from CI were carrying the old 6.x manual. This has now been removed from the installer. It is better to refer to the up-to-date new manual online, which can be updated more dynamically.