### PR TITLE
Allowing instr 0 code to be recalled

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -785,7 +785,7 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
     }
     else {                                        /* IV - Oct 31 2002 */
       insno = abs((int32_t) evt->p[1]);
-      if (UNLIKELY((unsigned int)(insno-1) >=
+      if (UNLIKELY((unsigned int) insno >
                    (uint32_t) csound->engineState.maxinsno ||
                    csound->engineState.instrtxtp[insno] == NULL)) {
         print_score_error(csound, rtEvt,
@@ -835,7 +835,7 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
     }
     else {                                        /* IV - Oct 31 2002 */
       insno = abs((int32_t) evt->p[1]);
-      if (UNLIKELY((unsigned int)(insno-1) >=
+      if (UNLIKELY((unsigned int) insno >
                    (unsigned int)csound->engineState.maxinsno ||
                    csound->engineState.instrtxtp[insno] == NULL)) {
         print_score_error(csound, rtEvt,
@@ -1371,7 +1371,7 @@ static int32_t insert_event_node(CSOUND *csound, EVTNODE *e, int64_t time_ofs) {
     else
       i = (int32_t) fabs((double) pf[1]);
 
-    if (UNLIKELY((uint32_t) (i - 1) >=
+    if (UNLIKELY((uint32_t) i >
                  (uint32_t) csound->engineState.maxinsno ||
                  csound->engineState.instrtxtp[i] == NULL)) {
       if (i > INT32_MAX-10)

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -398,6 +398,7 @@ def runTest():
         ["test46.csd", "if-then with expression in boolean comparison"],
         ["test47.csd", "until loop and k[]"],
         ["test48.csd", "expected failure with variable used before defined", 1],
+        ["test_instr0_call.csd", "testing ability to call instr 0"],
         ["test_udo_local_pool.csd", "test udos for separate local var pool"],
         ["test_ternary_expr.csd", "test ternary expr for backwards compatibility"],
         ["test_array_expr_opcall.csd", "test array expr in opcall"],

--- a/tests/commandline/test_instr0_call.csd
+++ b/tests/commandline/test_instr0_call.csd
@@ -1,0 +1,13 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+prints "hello world!!!\n"
+</CsInstruments>
+<CsScore>
+i0 0 0
+</CsScore>
+</CsoundSynthesizer>
+
+


### PR DESCRIPTION
This PR makes some minor adjustments to allow instr 0 code to be recalled by other instruments or events. The infrastructure supports it well, so it seems useful to open this up to users. 

Currently we can run instr0 by instantiating an InstrDef and run an init-pass on it

```
prints "Hello World!\n"
instr 1
 zero:InstrDef = init(0)
 res:i = init(create(zero))
endin
```
resulting in

```
new alloc for instr 1:
new free alloc for instr 0:
Hello World!
```

With the simple changes in this PR, we can now also just schedule it 

```
prints "Hello World!\n"
instr 1
 schedule(0,0,0)
endin
```

resulting in

```
SECTION 1:
new alloc for instr 1:
new alloc for instr 0:
Hello World!
```

Note that in 7.0 there is no actual bar on having perf code in instr 0. Currently, to run it we would need to call a `perf()` on it:

```
out(oscili(p4,p5))
instr 1
 zero:InstrDef = init(0)
 zeroins:Instr = create(zero)
 res:i = init(zeroins,p4,p5)
 resp:k = perf(zeroins)
endin
```

With these changes, we can now also run perf code as well, since the infrastructure supports it. 

```
out(oscili(p4,p5))
instr 1
 schedule(0,0,p3,p4,p5)
endin
```


