### PR TITLE
chore: bump version for release

### DIFF
--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta14",
+  "version": "7.0.0-beta15",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",
@@ -58,7 +58,7 @@
     "@babel/core": "^7.20.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
     "@babel/plugin-transform-destructuring": "^7.20.2",
-    "@csound/wasm-bin": "7.0.0-beta11",
+    "@csound/wasm-bin": "7.0.0-beta12",
     "browser-or-node": "^2.0.0",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",

--- a/wasm/browser/yarn.lock
+++ b/wasm/browser/yarn.lock
@@ -189,10 +189,10 @@
   resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-6.5.0.tgz#63cf7b77b91b54873e75f7a08fabec215c6888be"
   integrity sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==
 
-"@csound/wasm-bin@7.0.0-beta11":
-  version "7.0.0-beta11"
-  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-beta11.tgz#780c93c4a4a8ad92ae341de2719f7c8a4b75403d"
-  integrity sha512-Cc7zFj9SyIkV/YIhZENBYWpgX7mgpDBKnhTtMhuBQaU0VupDG3sE33+xn+3GiZLtt+5bh0qH9T6NN/2h0pZN7g==
+"@csound/wasm-bin@7.0.0-beta12":
+  version "7.0.0-beta12"
+  resolved "https://registry.yarnpkg.com/@csound/wasm-bin/-/wasm-bin-7.0.0-beta12.tgz#5c088758befa8df7430fd289fdc6ae77b6b6ae7f"
+  integrity sha512-yizBr/ZMHgeFA65CdWbX6indxHR6MKZK0O4JmiXMeAI/UsaLCXhCUJJXAv7y91oaLpa3DPsqddwtBJORS6qmFg==
 
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0":
   version "4.9.0"

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/wasm-bin",
-  "version": "7.0.0-beta11",
+  "version": "7.0.0-beta12",
   "description": "A package containing csound wasm binaries which can be bundled into other csound packages 📂",
   "main": "./lib/csound.wasm",
   "files": [


### PR DESCRIPTION
* new version of wasm-bin and browser have been released using these versions