### PR TITLE
fix: switch expressions with more than one case sequence

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -448,8 +448,12 @@ statement_list : statement_list statement
                     in turn causes a lot of shift/reduce errors to be
                     reported.  The parser works with this, but we should
                     perhaps look at expanding the other rules to work
-                    without statement_list in them. */
-                    $$ = NULL;
+                    without statement_list in them.
+
+                    Create an empty node instead of NULL to distinguish
+                    between "no statements" and "not yet set". This is
+                    important for switch/case statement merging. */
+                    $$ = make_node(csound, LINE, LOCN, 0, NULL, NULL);
                   }
                 ;
 
@@ -592,7 +596,35 @@ case_list : case_list case
                   tempLastNode->right->next!=NULL) {
                   tempLastNode = tempLastNode->right->next;
                 }
-                tempLastNode->right->next = $2;
+                // Handle the case where tempLastNode->right is NULL or empty
+                // This happens when we have consecutive case statements
+                // without any code between them (e.g., case 1 case 2)
+                // Check for NULL or empty statement node (type == 0)
+                // IMPORTANT: Only merge if both are CASE nodes (not DEFAULT)
+                if ((tempLastNode->right == NULL ||
+                    (tempLastNode->right->type == 0 &&
+                     tempLastNode->right->left == NULL &&
+                     tempLastNode->right->right == NULL)) &&
+                    tempLastNode->type == CASE_TOKEN &&
+                    $2->type == CASE_TOKEN) {
+                  // If the first case has no statement list, we need to
+                  // merge the expressions from both cases and use the
+                  // statement list from the second case
+                  if ($2->left != NULL) {
+                    // Create an expression list using append_to_tree
+                    if (tempLastNode->left != NULL) {
+                      tempLastNode->left = append_to_tree(csound, tempLastNode->left, $2->left);
+                    } else {
+                      tempLastNode->left = $2->left;
+                    }
+                  }
+                  tempLastNode->right = $2->right;
+                  // Free the second case node since we've merged it
+                  $2->left = NULL;
+                  $2->right = NULL;
+                } else {
+                  tempLastNode->right->next = $2;
+                }
                 $$ = $1; }
             | case { $$ = $1; }
             ;

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -874,7 +874,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
     break;
   case S_EQ:
     strNcpy(op, "==", 80);
-    break;   
+    break;
   case S_NEQ:
     strNcpy(op, "!=", 80);
     break;
@@ -1589,7 +1589,12 @@ TREE* expand_switch_statement(
           caseArg = caseArg->next;
         }
 
-        if (caseNode->right != NULL) {
+        // Check if we have a real statement list (not NULL and not empty node)
+        // Empty nodes have type == 0 with NULL left and right
+        if (caseNode->right != NULL &&
+            !(caseNode->right->type == 0 &&
+              caseNode->right->left == NULL &&
+              caseNode->right->right == NULL)) {
           tempNext = caseNode->right->next;
           gotoChainTailAnchor = append_to_tree(csound, gotoChainTailAnchor, caseNode->right);
           gotoChainTailAnchor->next->next = NULL;
@@ -1599,7 +1604,18 @@ TREE* expand_switch_statement(
             copy_node(csound, endGoto)
           );
         } else {
-          tempNext = NULL;
+          // Empty case - add a goto to end to prevent fall-through
+          gotoChainTailAnchor = append_to_tree(
+            csound,
+            gotoChainTailAnchor,
+            copy_node(csound, endGoto)
+          );
+          // Still need to get the next node
+          if (caseNode->right != NULL) {
+            tempNext = caseNode->right->next;
+          } else {
+            tempNext = NULL;
+          }
         }
     } else if (caseNode->type == DEFAULT_TOKEN && gotoChainHeadDefaultCase == NULL) {
       gotoChainHeadDefaultCase = create_goto_node(csound, isPerfRate);
@@ -1863,7 +1879,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   }
 
   char* array_get = arrayType != sType ? "##array_get" : "##array_geti";
-  TREE* arrayGetStatement = create_opcode_token(csound, array_get); 
+  TREE* arrayGetStatement = create_opcode_token(csound, array_get);
   arrayGetStatement->left = current->left;
 
   arrayGetStatement->right = copy_node(csound, arrayIdent);

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1389,7 +1389,11 @@ TREE* expand_if_statement(CSOUND* csound,
       tempRight = ifBlockCurrent->right;
 
       if (ifBlockCurrent->type == ELSE_TOKEN) {
-        append_to_tree(csound, anchor, tempRight);
+        // Filter out empty nodes from else branch
+        if (tempRight != NULL &&
+            !(tempRight->type == 0 && tempRight->left == NULL && tempRight->right == NULL)) {
+          append_to_tree(csound, anchor, tempRight);
+        }
         break;
       }
 
@@ -1408,6 +1412,13 @@ TREE* expand_if_statement(CSOUND* csound,
         int32_t gotoType;
 
         statements = tempRight->right;
+
+        // Filter out empty nodes from branch statements
+        if (statements != NULL &&
+            statements->type == 0 && statements->left == NULL && statements->right == NULL) {
+          statements = NULL;
+        }
+
         label = create_synthetic_ident(csound, csound->genlabs);
         labelEnd = create_synthetic_label(csound, csound->genlabs++);
         tempRight->right = label;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3005,7 +3005,7 @@ void initializeStructVar(CSOUND* csound, CS_VARIABLE* var, MYFLT* mem) {
   CS_STRUCT_VAR* structVar = (CS_STRUCT_VAR*)mem;
   const CS_TYPE* type = var->varType;
   CONS_CELL* members = type->members;
-  
+
   int32_t len = cs_cons_length(members);
   int32_t i;
 
@@ -3415,6 +3415,11 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
   char *udo_name = NULL;
   CONS_CELL* activeLoopStack = NULL;
 
+  // Don't process empty statements
+  if (root != NULL && root->type == 0 && root->left == NULL && root->right == NULL) {
+    return NULL;
+  }
+
   CONS_CELL* parentLabelList = typeTable->labelList;
   typeTable->labelList = get_label_list(csound, root);
   if (UNLIKELY(csoundGetDebug(csound) & DEBUG_SEMANTICS))
@@ -3443,7 +3448,8 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
 
         newRight = verify_tree(csound, current->right, typeTable);
 
-        if (newRight == NULL) {
+        // Allow empty statements except if there were semantic errors
+        if (newRight == NULL && csound->synterrcnt > 0) {
           cs_cons_free(csound, typeTable->labelList);
           typeTable->labelList = parentLabelList;
           return NULL;
@@ -3508,7 +3514,9 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
 
         newRight = verify_tree(csound, current->right, typeTable);
 
-        if (newRight == NULL) {
+        // Allow empty UDO bodies (newRight == NULL is valid)
+        // But if there were semantic errors, we should still fail
+        if (newRight == NULL && csound->synterrcnt > 0) {
           cs_cons_free(csound, typeTable->labelList);
           typeTable->labelList = parentLabelList;
           return NULL;
@@ -3775,6 +3783,13 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       csound->inZero = 1;
       /* fall through */
     default:
+      // Skip empty statements
+      if (current->type == 0 && current->left == NULL && current->right == NULL) {
+        // Skip this node but don't add it to the anchor chain
+        current = current->next;
+        continue;
+      }
+
       // Check for struct array member assignments: array[index].member = value
       if ((current->type == '=' || current->type == T_ASSIGNMENT) &&
           current->left && current->left->type == STRUCT_EXPR &&

--- a/tests/commandline/test_switch_statement.csd
+++ b/tests/commandline/test_switch_statement.csd
@@ -52,6 +52,49 @@ instr 5
   endsw
 endin
 
+// cases can be combined
+instr 6
+  iAssertCase = 0
+  iAssertDefault = 0
+  switch p4
+    case 1
+    case 2
+      prints "1 or 2\n"
+      iAssertCase = 1
+    default
+      prints "Default\n"
+      iAssertDefault = 1
+  endsw
+  if iAssertCase == 0 && p4 < 3 then
+    prints "assert error, expected 1 or 2\n"
+    exitnow(-1)
+  endif
+  if iAssertDefault == 1 && p4 >= 3 then
+    prints "assert error, fell back to default when not expected\n"
+    exitnow(-1)
+  endif
+endin
+
+// cases without statement are correctly ignored
+instr 7
+  iAssertDefault = 0
+  switch p4
+    case 1
+    case 2
+    default
+      prints "Default, val: %d\n", p4
+      iAssertDefault = 1
+  endsw
+  if iAssertDefault == 0 && p4 == 3 then
+    prints "assert error, default not executed when expected\n"
+    exitnow(-1)
+  endif
+  if iAssertDefault == 1 && p4 < 3 then
+    prints "assert error, fell back to default when not expected\n"
+    exitnow(-1)
+  endif
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 0 1
@@ -59,5 +102,11 @@ i 2 0 0
 i 3 0 0
 i 4 0 0
 i 5 0 0.1
+i 6 0 0 1
+i 6 0 0 2
+i 6 0 0 3
+i 7 0 0 1
+i 7 0 0 2
+i 7 0 0 3
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Addresses part of the reported issues in #2430