### PR TITLE
oscbnk entry in OENTRY corrected for new plugin interface

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -2269,9 +2269,13 @@ const OENTRY opcodlst_1[] = {
    (SUBR) resonbnk_init, (SUBR) resonbnk},
   { "inrg", S(INRANGE), WI, "", "ky", (SUBR)inRange_i, (SUBR)inRange },
   { "OSClisten", S(ROSC), 0, "kNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN",
-    "SS", NULL, (SUBR) readOSC_perf},
+    "SS", NULL, (SUBR) readOSC_perf, NULL, NULL, 2},
   { "OSClisten", S(ROSCA), 0, "kk[]",
-    "SS", (SUBR) readOSCarray_init, (SUBR) readOSCarray_perf},
+    "SS", (SUBR) readOSCarray_init, (SUBR) readOSCarray_perf, NULL, NULL, 2},
+  { "osclisten", S(ROSC), 0, "kNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN",
+    "SS", NULL, (SUBR) readOSC_perf},  /* Alias */
+  { "osclisten", S(ROSCA), 0, "kk[]",
+    "SS", (SUBR) readOSCarray_init, (SUBR) readOSCarray_perf},  /* Alias */
   { "midifileopen", S(MFILE), 0, "i", "So", midi_file_opcode},
   { "midifileplay", S(MFILE), 0, "", "o", midi_file_play},
   { "midifilepause", S(MFILE), 0, "", "o", midi_file_pause},

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1176,7 +1176,7 @@ static OENTRY localops[] = {
     { "OSCcount", S(OSCcount), 0,  "k", "",
     (SUBR)OSCcounter, (SUBR)OSCcounter, NULL, NULL, 2 },
   /* aliases */
-  { "oscsenslo", S(OSCSEND), 0,  "", "kSkSN",
+  { "oscsendlo", S(OSCSEND), 0,  "", "kSkSN",
     (SUBR)osc_send_set, (SUBR)osc_send, (SUBR) oscsend_deinit, NULL},
   { "oscinit", S(OSCINIT), 0, "i", "i",
     (SUBR)osc_listener_init, NULL, (SUBR) OSC_deinit , NULL },

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -3001,7 +3001,7 @@ static int32_t vco2(CSOUND *csound, VCO2 *p)
   static const OENTRY localops[] =
     {
   { "oscbnk", sizeof(OSCBNK), TR, "a", "kkkkiikkkkikkkkkkikooooooo",
-    (SUBR) oscbnkset, (SUBR) oscbnk },
+    (SUBR) oscbnkset, (SUBR) oscbnk, NULL, 2 },
    { "oscilbank",     sizeof(OSCBNK),     TR,  "a",  "kkkkiikkkkikkkkkkikooooooo",
      (SUBR) oscbnkset, (SUBR) oscbnk                }, /* alias */
    { "grain2",     sizeof(GRAIN2),     TR,      "a",    "kkkikiooo",

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -3001,7 +3001,7 @@ static int32_t vco2(CSOUND *csound, VCO2 *p)
   static const OENTRY localops[] =
     {
   { "oscbnk", sizeof(OSCBNK), TR, "a", "kkkkiikkkkikkkkkkikooooooo",
-    (SUBR) oscbnkset, (SUBR) oscbnk, NULL, 2 },
+    (SUBR) oscbnkset, (SUBR) oscbnk, NULL, NULL, 2 },
    { "oscilbank",     sizeof(OSCBNK),     TR,  "a",  "kkkkiikkkkikkkkkkikooooooo",
      (SUBR) oscbnkset, (SUBR) oscbnk                }, /* alias */
    { "grain2",     sizeof(GRAIN2),     TR,      "a",    "kkkikiooo",

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -3001,7 +3001,7 @@ static int32_t vco2(CSOUND *csound, VCO2 *p)
   static const OENTRY localops[] =
     {
   { "oscbnk", sizeof(OSCBNK), TR, "a", "kkkkiikkkkikkkkkkikooooooo",
-    (SUBR) oscbnkset, NULL, (SUBR) oscbnk, NULL, 2 },
+    (SUBR) oscbnkset, (SUBR) oscbnk },
    { "oscilbank",     sizeof(OSCBNK),     TR,  "a",  "kkkkiikkkkikkkkkkikooooooo",
      (SUBR) oscbnkset, (SUBR) oscbnk                }, /* alias */
    { "grain2",     sizeof(GRAIN2),     TR,      "a",    "kkkikiooo",


### PR DESCRIPTION
Needed for all oscbnk syntax to work