### PR TITLE
midi default instr

### DIFF
--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -760,7 +760,7 @@ int32_t insert_midi(CSOUND *csound, int32_t insno, MCHNBLK *chn, MEVENT *mep)
 
   if (UNLIKELY(csound->advanceCnt))
     return 0;
-  if (UNLIKELY(insno <= 0 || csound->engineState.instrtxtp[insno]->muted == 0))
+  if (UNLIKELY(insno < 0 || csound->engineState.instrtxtp[insno]->muted == 0))
     return 0;     /* muted */
 
   tp = csound->engineState.instrtxtp[insno];

--- a/InOut/midirecv.c
+++ b/InOut/midirecv.c
@@ -390,8 +390,9 @@ void m_chn_init_all(CSOUND *csound)
           n <= (int32_t) csound->engineState.maxinsno &&
           csound->engineState.instrtxtp[n] != NULL)
         chn->insno = (int16_t) n;
-      else if (defaultinsno > 0)
+      else if (defaultinsno >= 0) {
         chn->insno = (int16_t) defaultinsno;
+      }
       else
         chn->insno = (int16_t) -1;        /* else mute channel */
       /* reset all controllers */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -572,6 +572,7 @@ def runTest():
         ["testnewline.csd", "test newline in statements"],
         ["test_string_in_event.csd", "test multiple strings in realtime event"],
         ["testmidichannels.csd", "test use of mapped multiport channels"],
+        ["test_midi_default.csd", "test midi default instr"],
         ["test_instr_type.csd", "test instr type and variables"],
         ["test_delete_instr.csd", "test creating and deleting instr"],
         ["test_create_instr.csd", "testing creating and scheduling instr"],

--- a/tests/commandline/test_midi_default.csd
+++ b/tests/commandline/test_midi_default.csd
@@ -1,0 +1,10 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -F catherine.mid -T --midi-velocity-amp=4 --midi-key-cps=5
+</CsOptions>
+<CsInstruments>
+out(madsr:a(0.01,0.1,0.7,0.1)*vco2(p4*0.5,p5))
+</CsInstruments>
+<CsScore>
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR allows Csound to default midi input to instruments starting from 0.