### PR TITLE
fix: switch expressions with more than one case sequence, take 2

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -592,7 +592,28 @@ case_list : case_list case
                   tempLastNode->right->next!=NULL) {
                   tempLastNode = tempLastNode->right->next;
                 }
-                tempLastNode->right->next = $2;
+                // Handle the case where tempLastNode->right is NULL
+                if (tempLastNode->right == NULL &&
+                    tempLastNode->type == CASE_TOKEN &&
+                    $2->type == CASE_TOKEN) {
+                  // If the first case has no statement list, we need to
+                  // merge the expressions from both cases and use the
+                  // statement list from the second case
+                  if ($2->left != NULL) {
+                    // Create an expression list using append_to_tree
+                    if (tempLastNode->left != NULL) {
+                      tempLastNode->left = append_to_tree(csound, tempLastNode->left, $2->left);
+                    } else {
+                      tempLastNode->left = $2->left;
+                    }
+                  }
+                  tempLastNode->right = $2->right;
+                  // Free the second case node since we've merged it
+                  $2->left = NULL;
+                  $2->right = NULL;
+                } else if (tempLastNode->right != NULL) {
+                  tempLastNode->right->next = $2;
+                }
                 $$ = $1; }
             | case { $$ = $1; }
             ;

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -874,7 +874,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
     break;
   case S_EQ:
     strNcpy(op, "==", 80);
-    break;   
+    break;
   case S_NEQ:
     strNcpy(op, "!=", 80);
     break;
@@ -1589,7 +1589,12 @@ TREE* expand_switch_statement(
           caseArg = caseArg->next;
         }
 
-        if (caseNode->right != NULL) {
+        // Check if we have a real statement list (not NULL and not empty node)
+        // Empty nodes have type == 0 with NULL left and right
+        if (caseNode->right != NULL &&
+            !(caseNode->right->type == 0 &&
+              caseNode->right->left == NULL &&
+              caseNode->right->right == NULL)) {
           tempNext = caseNode->right->next;
           gotoChainTailAnchor = append_to_tree(csound, gotoChainTailAnchor, caseNode->right);
           gotoChainTailAnchor->next->next = NULL;
@@ -1599,7 +1604,18 @@ TREE* expand_switch_statement(
             copy_node(csound, endGoto)
           );
         } else {
-          tempNext = NULL;
+          // Empty case - add a goto to end to prevent fall-through
+          gotoChainTailAnchor = append_to_tree(
+            csound,
+            gotoChainTailAnchor,
+            copy_node(csound, endGoto)
+          );
+          // Still need to get the next node
+          if (caseNode->right != NULL) {
+            tempNext = caseNode->right->next;
+          } else {
+            tempNext = NULL;
+          }
         }
     } else if (caseNode->type == DEFAULT_TOKEN && gotoChainHeadDefaultCase == NULL) {
       gotoChainHeadDefaultCase = create_goto_node(csound, isPerfRate);
@@ -1654,11 +1670,15 @@ TREE* expand_switch_statement(
     gotoChainHeadAnchor,
     gotoChainTail
   );
+  TREE* endLabelNode = copy_node(csound, endLabel);
   append_to_tree(
     csound,
     gotoChainHeadAnchor,
-    copy_node(csound, endLabel)
+    endLabelNode
   );
+
+  // Link code after endsw
+  endLabelNode->next = current->next;
 
   return gotoChainHead;
 }
@@ -1863,7 +1883,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   }
 
   char* array_get = arrayType != sType ? "##array_get" : "##array_geti";
-  TREE* arrayGetStatement = create_opcode_token(csound, array_get); 
+  TREE* arrayGetStatement = create_opcode_token(csound, array_get);
   arrayGetStatement->left = current->left;
 
   arrayGetStatement->right = copy_node(csound, arrayIdent);

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3005,7 +3005,7 @@ void initializeStructVar(CSOUND* csound, CS_VARIABLE* var, MYFLT* mem) {
   CS_STRUCT_VAR* structVar = (CS_STRUCT_VAR*)mem;
   const CS_TYPE* type = var->varType;
   CONS_CELL* members = type->members;
-  
+
   int32_t len = cs_cons_length(members);
   int32_t i;
 

--- a/tests/commandline/test_switch_statement.csd
+++ b/tests/commandline/test_switch_statement.csd
@@ -52,6 +52,49 @@ instr 5
   endsw
 endin
 
+// cases can be combined
+instr 6
+  iAssertCase = 0
+  iAssertDefault = 0
+  switch p4
+    case 1
+    case 2
+      prints "1 or 2\n"
+      iAssertCase = 1
+    default
+      prints "Default\n"
+      iAssertDefault = 1
+  endsw
+  if iAssertCase == 0 && p4 < 3 then
+    prints "assert error, expected 1 or 2\n"
+    exitnow(-1)
+  endif
+  if iAssertDefault == 0 && p4 >= 3 then
+    prints "assert error, default was expected but did not execute\n"
+    exitnow(-1)
+  endif
+endin
+
+// cases without statement are correctly ignored
+instr 7
+  iAssertDefault = 0
+  switch p4
+    case 1
+    case 2
+    default
+      prints "Default, val: %d\n", p4
+      iAssertDefault = 1
+  endsw
+  if iAssertDefault == 0 && p4 == 3 then
+    prints "assert error, default not executed when expected\n"
+    exitnow(-1)
+  endif
+  if iAssertDefault == 1 && p4 < 3 then
+    prints "assert error, fell back to default when not expected\n"
+    exitnow(-1)
+  endif
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 0 1
@@ -59,5 +102,11 @@ i 2 0 0
 i 3 0 0
 i 4 0 0
 i 5 0 0.1
+i 6 0 0 1
+i 6 0 0 2
+i 6 0 0 3
+i 7 0 0 1
+i 7 0 0 2
+i 7 0 0 3
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Same as, https://github.com/csound/csound/pull/2434 but I'm trying a different approach of handling empty statement that doesn't require changing the logic about null vs empty tree.

Much simpler approach, going to close the other PR.

These changes address part of the reported issues in https://github.com/csound/csound/issues/2430
Rest of the issues will be fixed in a followup PR.