### PR TITLE
Fix for newstyle pass-by-copy

### DIFF
--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -494,6 +494,23 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
     memcpy(&(lcurip->p1), &(parent_ip->p1), 3 * sizeof(CS_VAR_MEM));
   }
 
+   // check for setksmps or over/undersample
+  csound->curip = lcurip;
+  csound->ids = (OPDS *) (lcurip->nxti);
+  ATOMIC_SET(p->ip->init_done, 0);
+  csound->mode = 1;
+  buf->iflag = 0;
+  int err = 0;
+  while (csound->ids != NULL && err == 0) {
+    csound->op = csound->ids->optext->t.oentry->opname;
+    if(strcmp("setksmps", csound->op) == 0  ||
+       strcmp("oversample", csound->op) == 0 ||
+       strcmp("undersample", csound->op) == 0)
+       err = (*csound->ids->init)
+               (csound, csound->ids);
+    csound->ids = csound->ids->nxti;
+  }
+
   inm->passByRef = buf->opcode_info->newStyle &&
     parent_ip->ksmps == p->ip->ksmps &&
     parent_ip->esr == p->ip->esr;
@@ -509,10 +526,14 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   ATOMIC_SET(p->ip->init_done, 0);
   csound->mode = 1;
   buf->iflag = 0;
-  int err = 0;
+  err = 0;
   while (csound->ids != NULL && err == 0) {
     csound->op = csound->ids->optext->t.oentry->opname;
-    err = (*csound->ids->init)(csound, csound->ids);
+    // don't run setksmps etc 
+    if(strcmp("setksmps", csound->op) != 0 ||
+       strcmp("oversample", csound->op) != 0 ||
+       strcmp("undersample", csound->op) != 0)
+      err = (*csound->ids->init)(csound, csound->ids);
     csound->ids = csound->ids->nxti;
   }
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -530,8 +530,8 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   while (csound->ids != NULL && err == 0) {
     csound->op = csound->ids->optext->t.oentry->opname;
     // don't run setksmps etc 
-    if(strcmp("setksmps", csound->op) != 0 ||
-       strcmp("oversample", csound->op) != 0 ||
+    if(strcmp("setksmps", csound->op) != 0 &&
+       strcmp("oversample", csound->op) != 0 &&
        strcmp("undersample", csound->op) != 0)
       err = (*csound->ids->init)(csound, csound->ids);
     csound->ids = csound->ids->nxti;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -531,6 +531,7 @@ def runTest():
         ["test_karrays_udo.csd", "UDO with k[] arg"],
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
+        ["test_newstyle_passbycopy.csd", "test newstyle udo with setksmps"],
         ["test_polymorphic_udo.csd", "test polymorphic udo"],
         ["test_udo_a_array.csd", "test udo with a-array"],
         ["test_udo_2d_array.csd", "test udo with 2d-array"],

--- a/tests/commandline/test_newstyle_passbycopy.csd
+++ b/tests/commandline/test_newstyle_passbycopy.csd
@@ -1,0 +1,41 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n 
+</CsOptions>
+<CsInstruments>
+0dbfs=1
+
+opcode testVco, a, i
+  setksmps 1
+  iFreq xin
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
+opcode testVco2(iFreq:i):a
+  setksmps 1
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
+
+instr 1
+krms rms testVco2(400)-testVco(400);
+if krms > 0 then
+  printk2 krms
+  event "i", 2, 0, 0
+endif
+turnoff
+endin
+
+instr 2
+exitnow(-1)
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>
+
+

--- a/tests/commandline/test_newstyle_passbycopy.csd
+++ b/tests/commandline/test_newstyle_passbycopy.csd
@@ -18,11 +18,41 @@ opcode testVco2(iFreq:i):a
   xout aSig
 endop
 
+opcode testVcoOver, a, i
+  oversample 2
+  iFreq xin
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
+opcode testVcoOver2(iFreq:i):a
+  oversample 2
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
+opcode testVcoUnder, a, i
+  undersample 2
+  iFreq xin
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
+opcode testVcoUnder2(iFreq:i):a
+  undersample 2
+  aSig vco2 1, iFreq
+  xout aSig
+endop
+
 
 instr 1
-krms rms testVco2(400)-testVco(400);
-if krms > 0 then
-  printk2 krms
+krms1 rms testVco2(400)-testVco(400)
+krms2 rms testVcoOver2(400)-testVcoOver(400)
+krms3 rms testVcoUnder2(400)-testVcoUnder(400)
+if (krms1 + krms2 + krms3) > 0 then
+  printk2 krms1
+  printk2 krms2
+  printk2 krms3
   event "i", 2, 0, 0
 endif
 turnoff
@@ -37,5 +67,4 @@ endin
 i1 0 1
 </CsScore>
 </CsoundSynthesizer>
-
 


### PR DESCRIPTION
The following code produced garbage

```
opcode testVco(iFreq:i):a
  setksmps 1
  aSig vco2 1, iFreq
  xout aSig
endop
```

because it ran as pass-by-ref when it should have been pass-by-copy. The test for this was put *before* the init-pass, so setksmps changed the ksmps *after* the test passed.
Relocated the test to after running either setksmps, oversample or undersample so that it can check for local ksmps or sr.

Added test for this.