### PR TITLE
Fixed double closing of files in mp3len

### DIFF
--- a/Opcodes/mp3in.c
+++ b/Opcodes/mp3in.c
@@ -299,11 +299,9 @@ int32_t mp3len_(CSOUND *csound, MP3LEN *p, int32_t stringname)
   }
   if (UNLIKELY((r = mp3dec_get_info(mpa, &mpainfo, MPADEC_INFO_STREAM)) !=
                MP3DEC_RETCODE_OK)) {
-    fclose(f);
     mp3dec_uninit(mpa);
     return csound->InitError(csound, "%s", mp3dec_error(r));
   }
-  fclose(f);
   if(!strcmp(GetOpcodeName(&p->h), "mp3len"))
     *p->ir = (MYFLT) mpainfo.duration;
   else if(!strcmp(GetOpcodeName(&p->h), "mp3sr"))


### PR DESCRIPTION
The code for mp3len etc was closing the mp3 files twice (once in the opcode and once in the mp3 uninit function).  This causes no problem on the desktop but crashes wasm.

https://editor.p5js.org/vlazzarini/sketches/L_gIW4Wwz

This PR should fix the problem.

@hlolli @kunstmusik could you make a new release for browser once this is merged?