### PR TITLE
Fixed regression with udo K-type args

### DIFF
--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -704,7 +704,9 @@ const char* VAR_ARG_IN_TYPES[] = {
 
 const char* POLY_OUT_TYPES[] = {
     "s", "ka",                  /* ***Deprecated*** */
-    "i", "pi", NULL
+    "i", "pi",
+    "K", "cprki",               /* k-rate with initialization */
+    NULL
 };
 
 const char* VAR_ARG_OUT_TYPES[] = {

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -595,11 +595,15 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
       if (src && dst) {
         if (src != dst) {
           // no copying of a & k types at i-time !!!
-          if(cur->varType != &CS_VAR_TYPE_A &&
-             cur->varType != &CS_VAR_TYPE_K) 
+          if((cur->varType != &CS_VAR_TYPE_A &&
+              cur->varType != &CS_VAR_TYPE_K) ||
+             // special case - K-type arg
+             inm_local->outtypes[i] == 'K') 
             cur->varType->copyValue(csound, cur->varType, dst, src, lcurip);
          }
       }
+      
+        
       cur = cur->next;
     }
   }
@@ -698,8 +702,11 @@ int32_t set_inbufs(CSOUND *csound,
     void* out = (void*) args[i];
     tmp[i + inm->outchns] = out;
 
-    if (csoundGetTypeForArg(out) != &CS_VAR_TYPE_K &&
-        csoundGetTypeForArg(out) != &CS_VAR_TYPE_A) {
+
+    if ((csoundGetTypeForArg(out) != &CS_VAR_TYPE_K &&
+         csoundGetTypeForArg(out) != &CS_VAR_TYPE_A) ||
+        // special case: K-type inputs
+          inm->intypes[i] == 'K') {
       current->varType->copyValue(csound, current->varType, out, in, h->insdshead);
     }
 

--- a/tests/commandline/udo/test_K_type.csd
+++ b/tests/commandline/udo/test_K_type.csd
@@ -10,8 +10,12 @@ instr FailNow
     exitnow(-1)
 endin
 
-opcode inc_k, k, K
-    kval xin
+opcode inc_k, k, Ki
+    kval,ival xin
+    if(ival != i(kval)) then
+     prints "Init fail on K-type\n"
+     exitnow(-1)
+    endif
     kout = kval + 1
     xout kout
 endop
@@ -27,7 +31,7 @@ gkResult init -1
 
 instr 1
     gkInput init 5
-    kresult = inc_k(gkInput)
+    kresult = inc_k(gkInput, i(gkInput))
 
     if (kresult != 6) then
         printks("ERROR: Return value failed for inc_k. kresult=%g\n", .001, kresult)

--- a/tests/commandline/udo/test_K_type.csd
+++ b/tests/commandline/udo/test_K_type.csd
@@ -58,10 +58,25 @@ instr 3
     endif
 endin
 
+opcode TestKIO,K,K
+ kval xin
+ kval = 0
+  xout kval
+endop
+
+instr 4
+input:i = 1
+output:k = TestKIO(input)
+if input:i != i(output:k) then
+  exitnow(-1)
+endif
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 0.01
 i2 0 0.01
 i3 0 0.01
+i4 0 0.01
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
The K-type used in old-style UDOs experienced regression (not caught by tests), this PR fixes the issue and tightens the tests.