### PR TITLE
Fixed segfault in structs with Opcode types

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2995,7 +2995,7 @@ int32_t initStructVar(CSOUND* csound, void* p) {
   for (i = 0; i < len; i++) {
     CS_VAR_MEM* mem = structVar->members[i];
     mem->varType->copyValue(csound, mem->varType, &mem->value,
-                            init->inArgs[i], NULL);
+                            init->inArgs[i], init->h.insdshead);
   }
 
   return CSOUND_SUCCESS;

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -1175,11 +1175,17 @@ int32_t context_check(CSOUND *csound, OPCODEOBJ *obj, INSDS *insds) {
   if(obj->dataspace->insdshead == insds) return OK;
   INSDS *ip = obj->dataspace->insdshead;
   INSDS *ctx = insds;
+  if(ctx) {
   // different SR always fails check
   if(ip->esr != ctx->esr) return NOTOK;
   // ksmps less than ctx fails check
   if(ip->ksmps < ctx->ksmps) return NOTOK;
   // otherwise there is no context incompatibility
+  }
+  else {
+    csound->Warning(csound, "no valid context for opcode object\n");
+    return NOTOK;
+  }
   return OK;
 }
 

--- a/tests/commandline/structs/test_structs.csd
+++ b/tests/commandline/structs/test_structs.csd
@@ -9,6 +9,8 @@ nchnls	=	2
 struct MyType  imaginary:k, real:k, kimaginary, kreal
 struct MyType2 x:i, y:i
 
+struct MyType3 var:i, opc:Opcode
+
 opcode processMyType(var:MyType):(MyType)
   retVal:MyType init 0, 0, 0, 0
   retVal.imaginary = var.imaginary + 1 
@@ -20,6 +22,7 @@ endop
 
 instr 1
 
+var1:MyType3 init 1, create(sqrt)
 var0:MyType init 1, 2, 3, 4
 ;var1:MyType = init:MyType(0, 0, 1, 1)
 

--- a/tests/commandline/structs/test_structs.csd
+++ b/tests/commandline/structs/test_structs.csd
@@ -9,7 +9,7 @@ nchnls	=	2
 struct MyType  imaginary:k, real:k, kimaginary, kreal
 struct MyType2 x:i, y:i
 
-struct MyType3 var:i, opc:Opcode
+struct MyType3 val:i, opc:Opcode
 
 opcode processMyType(var:MyType):(MyType)
   retVal:MyType init 0, 0, 0, 0
@@ -22,10 +22,13 @@ endop
 
 instr 1
 
-var1:MyType3 init 1, create(sqrt)
-var0:MyType init 1, 2, 3, 4
-;var1:MyType = init:MyType(0, 0, 1, 1)
+var1:MyType3 init 2, create(sqrt)
+res:i = init(var1.opc, var1.val)
+if res != sqrt(var1.val) then
+  exitnow(-1)
+endif
 
+var0:MyType init 1, 2, 3, 4
 var0.imaginary init 5
 var0.real init 6
 var0.kimaginary init 7


### PR DESCRIPTION
Structs using Opcode types were causing a segfault because the context was not passed at initialisation. Test added. Closes #2461 