### PR TITLE
Implement jitter-free MIDI output for portmidi

### DIFF
--- a/Android/CsoundAndroid/jni/AndroidCsound.hpp
+++ b/Android/CsoundAndroid/jni/AndroidCsound.hpp
@@ -27,7 +27,7 @@
 #endif
 #include "csound.hpp"
 #include "csound_misc.h"
-extern "C" long csoundGetKcounter(CSOUND *csound);
+
 class PUBLIC AndroidCsound : public Csound {
   int asyncProcess;
   void initControls() {

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -165,7 +165,22 @@ extern "C" {
 #include "environ.h"
 #include "remote.h"
 
-typedef struct opcodinfo OPCODINFO;
+  /* Holds UDO information, when an instrument is
+     defined as a UDO
+  */
+  typedef struct opcodinfo {
+    int32    instno;
+    char    *name, *intypes, *outtypes;
+    int16   inchns, outchns;
+    bool newStyle;
+    bool passByRef;
+    CS_VAR_POOL* out_arg_pool;
+    CS_VAR_POOL* in_arg_pool;
+    struct instr *ip;
+    OENTRY *oentry;
+    struct opcodinfo *prv;
+  } OPCODINFO;
+
 
   /**
    * This struct will hold the current engine state after compilation
@@ -182,22 +197,6 @@ typedef struct opcodinfo OPCODINFO;
     OPCODINFO     *opcodeInfo;
   } ENGINE_STATE;
 
-
-  /* Holds UDO information, when an instrument is
-     defined as a UDO
-  */
-  typedef struct opcodinfo {
-    int32    instno;
-    char    *name, *intypes, *outtypes;
-    int16   inchns, outchns;
-    bool newStyle;
-    bool passByRef;
-    CS_VAR_POOL* out_arg_pool;
-    CS_VAR_POOL* in_arg_pool;
-    struct instr *ip;
-    OENTRY *oentry;
-    struct opcodinfo *prv;
-  } OPCODINFO;
 
   /**
    * plugin module info

--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -363,7 +363,8 @@ static int32_t OpenMidiOutDevice_(CSOUND *csound, void **userData, const char *d
 
     retval = Pm_OpenOutput(&midistream,
                            (PmDeviceID) portMidi_getRealDeviceID(devnum, 1),
-                           NULL, 512L, (PmTimeProcPtr) NULL, NULL, 0L);
+                           NULL, 512L, (PmTimeProcPtr) NULL, NULL,
+    1000*csound->GetOutputBufferSize(csound)/csound->GetEngineSr(csound));
     if (UNLIKELY(retval != pmNoError)) {
       return portMidiErrMsg(csound, Str("error opening output device %d: %s"),
                                     devnum, Pm_GetErrorText(retval));
@@ -452,6 +453,9 @@ static int32_t WriteMidiData_(CSOUND *csound, void *userData,
     int32_t             n, st;
     PmEvent         mev;
     PortMidiStream  *midistream;
+    //PmTimestamp time = (PmTimestamp)
+    //(csound->GetCurrentTimeSamples(csound)*csound->GetEngineSr(csound)/1000);
+    
     /*
      * Writes to user-defined MIDI output.
      */
@@ -476,8 +480,9 @@ static int32_t WriteMidiData_(CSOUND *csound, void *userData,
         portMidiErrMsg(csound, Str("MIDI out: truncated message"));
         break;
       }
+
       mev.message = (PmMessage) 0;
-      mev.timestamp = (PmTimestamp) 0;
+      mev.timestamp =  0;// time;
       mev.message |= (PmMessage) Pm_Message(st, 0, 0);
       if (datbyts[(st - 0x80) >> 4] > 0)
         mev.message |= (PmMessage) Pm_Message(0, (int32_t)*(mbuf++), 0);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -578,6 +578,9 @@ static const CSOUND cenviron_ = {
     csoundSprintf, // csoundSprintf
     csoundSscanf,  // csoundSscanf
     csoundDeprecate,
+    csoundGetSr,
+    csoundGetKr,
+    csoundGetKcounter,
     /* space for API expansion: 50 slots */
     {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
      NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
@@ -1552,7 +1555,7 @@ MYFLT csoundEvalCode(CSOUND *csound, const char *str)
   return csound->e0dbfs;
 }
 
- uint64_t csoundGetKcounter(CSOUND *csound) {
+uint64_t csoundGetKcounter(CSOUND *csound) {
   return csound->kcounter;
 }
 

--- a/iOS/Csound-for-iOS/src/iOSCsound.hpp
+++ b/iOS/Csound-for-iOS/src/iOSCsound.hpp
@@ -24,7 +24,7 @@
 
 #include "csound.hpp"
 #include "csound_misc.h"
-extern "C" long csoundGetKcounter(CSOUND *csound);
+
 class PUBLIC iOSCsound : public Csound {
   void initControls() {
     // set up pause controls

--- a/include/csound.h
+++ b/include/csound.h
@@ -447,6 +447,11 @@ extern "C" {
   PUBLIC uint32_t csoundGetKsmps(CSOUND *);
 
   /**
+   * Returns the current k-cycle count in control frames
+   */
+  PUBLIC uint64_t csoundGetKcounter(CSOUND *csound);
+
+  /**
    * Returns the number of audio channels in the Csound instance.
    * If isInput = 0, the value of nchnls is returned,
    * otherwise nchnls_i. If this variable is

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1432,16 +1432,28 @@ struct CSOUND_ {
   const CSOUND_UTIL *(*GetUtility)(CSOUND *csound);
   /* Fast power of two function from a precomputed table */
   MYFLT (*Pow2)(CSOUND *, MYFLT a);
+  /* String localisation */
 #if defined(__CUDACC__) || defined(__MACH__)
   char *(*LocalizeString)(const char *);
 #else
   char *(*LocalizeString)(const char *)__attribute__((format_arg(1)));
 #endif
+  /* String conversion */
   double (*Strtod)(char *nptr, char **);
+  /* String formatted printing */
   int32_t (*Sprintf)(char *str, const char *format, ...);
+  /* String formatted scanning */
   int32_t (*Sscanf)(char *str, const char *format, ...);
+  /* Set opcode as deprecated */
   int32_t (*Deprecate)(CSOUND *csound, char *name,
                        char *o, char *i, int32_t deprec);
+  /* Get engine sampling rate */
+  MYFLT   (*GetEngineSr) (CSOUND *csound);
+  /* Get engine control rate */
+  MYFLT   (*GetEngineKr) (CSOUND *csound);
+  /* Get engine kcounter value */
+  uint64_t (*GetKcounter) (CSOUND *csound);
+  
   /**@}*/
   /** @name Placeholders
       To allow the API to grow while maintining backward binary compatibility.


### PR DESCRIPTION
A well-known issue with MIDI output is that it can be very jittery, particularly as computing loads change and the MIDI output buffer is not small.

The reason for this is that MIDI output does not use any form of timestamping, relying instead on the timing of performKsmps calls, which is not a clock, let alone a reliable one.

The solution is to use Csound k-count time and timestamp the messages appropriately. 

For this to work with plugin backends, we need to get the Csound sample rate from the module API. This had been removed to avoid confusion between engine and local sample rates. I have restored it now as GetEngineSr() to make it explicit, alongside a couple of other engine attributes.

I have tested and I can get ms resolution on message timing (the minimum supported by portmidi). 

NB: Other output backends should be modified to implement this (out of scope for this PR).