### PR TITLE
lint: prevent scope leak in macro expansion

### DIFF
--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -418,7 +418,7 @@ static inline int64 MYFLT2LRND64(double fval)
 #ifdef HAVE_C99
 #define MYFLT2UINT64(x) ((uint64_t) llrint(x))
 #else
-#define MYFLT2UINT64(x) ((uint64_t) (tval + 0.5)) 
+#define MYFLT2UINT64(x) ((uint64_t) ((x) + 0.5)) 
 #endif
 
 /* inline functions and macros for clamping denormals to zero */


### PR DESCRIPTION
Another finding from the rabbit.

In current code, the main call site passes a variable named tval, so the mistake was hidden. Using tval makes it fragile: it can fail to compile or use the wrong value depending on local variable names. Also, on many builds HAVE_C99 is enabled, so the code uses the other branch (llrint) and never hits this buggy fallback.