### PR TITLE
Fix: multiple webaudio nodes

### DIFF
--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -6,6 +6,7 @@ import { messageEventHandler } from "./messages.main";
 import WorkletWorker from "../../dist/__compiled.worklet.worker.inline.js";
 
 let UID = 0;
+const registeredContexts = new WeakSet();
 
 /**
  * @unrestricted
@@ -190,10 +191,15 @@ class AudioWorkletMainThread {
     }
     this.workletWorkerUrl = WorkletWorker();
 
-    try {
-      await this.audioContext.audioWorklet.addModule(this.workletWorkerUrl);
-    } catch (error) {
-      console.error("Error calling audioWorklet.addModule", error);
+    if (!registeredContexts.has(this.audioContext)) {
+      try {
+        await this.audioContext.audioWorklet.addModule(this.workletWorkerUrl);
+        registeredContexts.add(this.audioContext);
+      } catch (error) {
+        console.error("Error calling audioWorklet.addModule", error);
+      }
+    } else {
+      log("Module already registered on this AudioContext, skipping addModule")();
     }
 
     log("WorkletWorker module added")();

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -31,10 +31,17 @@ import { requestMidi } from "../utils/request-midi.js";
 import { EventPromises } from "../utils/event-promises.js";
 import WorkletWorker from "../../dist/__compiled.worklet.singlethread.worker.inline.js";
 
+const registeredContexts = new WeakSet();
+
 const initializeModule = async (audioContext) => {
+  if (registeredContexts.has(audioContext)) {
+    log("Module already registered on this AudioContext, skipping addModule")();
+    return true;
+  }
   log("Initialize Module")();
   try {
     await audioContext.audioWorklet.addModule(WorkletWorker());
+    registeredContexts.add(audioContext);
   } catch (error) {
     console.error("Error calling audioWorklet.addModule", error);
     return false;

--- a/wasm/browser/src/workers/worklet.singlethread.worker.js
+++ b/wasm/browser/src/workers/worklet.singlethread.worker.js
@@ -28,19 +28,8 @@ import loadWasm from "../module";
 import { clearArray } from "../utils/clear-array";
 import { logSinglethreadWorkletWorker as log } from "../logger";
 
-let renderSleep;
-let libraryCsound;
-let combined;
-const rtmidiQueue = [];
-
-const callUncloned = async (k, arguments_) => {
-  const caller = combined.get(k);
-  const returnValue = caller && caller.apply({}, arguments_ || []);
-  return returnValue;
-};
-
 const singlethreadWorkerRender =
-  ({ libraryCsound, workerMessagePort, wasi }) =>
+  ({ libraryCsound, workerMessagePort, setRenderSleep }) =>
   async (payload) => {
     const csound = payload["csound"];
     const kr = libraryCsound.csoundGetKr(csound);
@@ -55,7 +44,7 @@ const singlethreadWorkerRender =
         // this is immediately executed, but allows events to be picked up
         // we use the process loop instead of setTimeout(0)
         await new Promise((resolve) => {
-          renderSleep = resolve;
+          setRenderSleep(resolve);
         });
       }
     }
@@ -91,6 +80,10 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     this.result = undefined;
 
     this.rtmidiPort = undefined;
+    this.renderSleep = undefined;
+    this.libraryCsound = undefined;
+    this.combined = undefined;
+    this.rtmidiQueue = [];
 
     /** @suppress {checkTypes} */
     this.sampleRate = globalThis.sampleRate;
@@ -117,7 +110,15 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     this.running = false;
     this.started = false;
     /** @export */
-    this.callUncloned = () => console.error("Csound worklet thread is still uninitialized!");
+    this.callUncloned = async (k, arguments_) => {
+      const caller = this.combined && this.combined.get(k);
+      if (!caller) {
+        console.error("Csound worklet thread is still uninitialized!");
+        return undefined;
+      }
+      const returnValue = caller.apply({}, arguments_ || []);
+      return returnValue;
+    };
     this.port.start();
     Comlink.expose(this, this.port);
     this.workerMessagePort = new MessagePortState();
@@ -137,7 +138,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       log(`initRtMidiEventPort`)();
       this.rtmidiPort = rtmidiPort;
       this.rtmidiPort.addEventListener("message", ({ data: payload }) => {
-        rtmidiQueue.push(payload);
+        this.rtmidiQueue.push(payload);
       });
       this.rtmidiPort.start();
     };
@@ -160,10 +161,8 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       this.wasi = wasi;
       wasm.wasi = wasi;
 
-      libraryCsound = libcsoundFactory(wasm);
-      /** @suppress {checkTypes} */
-      this.callUncloned = callUncloned;
-      this.csound = libraryCsound.csoundCreate(0);
+      this.libraryCsound = libcsoundFactory(wasm);
+      this.csound = this.libraryCsound.csoundCreate(0);
       this.result = 0;
       this.running = false;
       this.isRendering = false;
@@ -175,7 +174,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       };
 
       const allAPI = {
-        ...libraryCsound,
+        ...this.libraryCsound,
         csoundCreate,
         csoundReset: this.resetCsound.bind(this),
         csoundStop: this.stop.bind(this),
@@ -183,7 +182,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
         wasm,
       };
 
-      combined = new Map(Object.entries(allAPI));
+      this.combined = new Map(Object.entries(allAPI));
       log("wasm initialized and api generated")();
       resolver();
     });
@@ -215,12 +214,12 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     const cs = this.csound;
 
     if (callReset) {
-      libraryCsound.csoundReset(cs);
+      this.libraryCsound.csoundReset(cs);
     }
 
-    libraryCsound.csoundSetMidiCallbacks(cs);
+    this.libraryCsound.csoundSetMidiCallbacks(cs);
     if (this.sampleRate) {
-      const result = libraryCsound.csoundSetOption(cs, "--sample-rate=" + this.sampleRate);
+      const result = this.libraryCsound.csoundSetOption(cs, "--sample-rate=" + this.sampleRate);
       result !== 0 && console.error("csoundSetOption sample-rate failed:", result);
     }
     this.nchnls = -1;
@@ -230,7 +229,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
 
   stop() {
     if (this.csound) {
-      libraryCsound.csoundStop(this.csound);
+      this.libraryCsound.csoundStop(this.csound);
     }
     this.workerMessagePort.broadcastPlayState("realtimePerformanceEnded");
   }
@@ -250,8 +249,10 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
   }
 
   process(inputs, outputs) {
-    if (typeof renderSleep === "function") {
-      renderSleep();
+    if (typeof this.renderSleep === "function") {
+      const resolve = this.renderSleep;
+      this.renderSleep = undefined;
+      resolve();
     }
 
     if (!this.isRendering && (this.isPaused || !this.csoundOutputBuffer || !this.running)) {
@@ -273,11 +274,11 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       this.workerMessagePort.broadcastPlayState("realtimePerformanceStarted");
     }
 
-    if (rtmidiQueue.length > 0) {
-      rtmidiQueue.forEach((event) => {
-        libraryCsound["csoundPushMidiMessage"](this.csound, event[0], event[1], event[2]);
+    if (this.rtmidiQueue.length > 0) {
+      this.rtmidiQueue.forEach((event) => {
+        this.libraryCsound["csoundPushMidiMessage"](this.csound, event[0], event[1], event[2]);
       });
-      clearArray(rtmidiQueue);
+      clearArray(this.rtmidiQueue);
     }
 
     const input = inputs[0];
@@ -299,7 +300,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     for (let index = 0; index < bufferLength; index++, cnt++) {
       if (cnt >= ksmps && result === 0) {
         // if we need more samples from Csound
-        result = libraryCsound.csoundPerformKsmps(this.csound);
+        result = this.libraryCsound.csoundPerformKsmps(this.csound);
         cnt = 0;
 
         if (result !== 0) {
@@ -314,7 +315,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       if (!csOut || csOut.length === 0) {
         csOut = this.csoundOutputBuffer = new Float64Array(
           this.wasm.wasi.memory.buffer,
-          libraryCsound.csoundGetSpout(this.csound),
+          this.libraryCsound.csoundGetSpout(this.csound),
           ksmps * nchnls,
         );
       }
@@ -322,7 +323,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       if (!csIn || csIn.length === 0) {
         csIn = this.csoundInputBuffer = new Float64Array(
           this.wasm.wasi.memory.buffer,
-          libraryCsound.csoundGetSpin(this.csound),
+          this.libraryCsound.csoundGetSpin(this.csound),
           ksmps * nchnlsIn,
         );
       }
@@ -377,13 +378,13 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
 
   async isRequestingInput() {
     const cs = this.csound;
-    const inputName = libraryCsound.csoundGetInputName(cs) || "";
+    const inputName = this.libraryCsound.csoundGetInputName(cs) || "";
     return inputName.includes("adc");
   }
 
   async isRequestingRealtimeOutput() {
     const cs = this.csound;
-    const outputName = libraryCsound.csoundGetOutputName(cs) || "";
+    const outputName = this.libraryCsound.csoundGetOutputName(cs) || "";
     return outputName.includes("dac");
   }
 
@@ -394,15 +395,15 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     } else {
       log("worklet thread is starting..")();
       const cs = this.csound;
-      const ksmps = libraryCsound.csoundGetKsmps(cs);
+      const ksmps = this.libraryCsound.csoundGetKsmps(cs);
       this.ksmps = ksmps;
       this.cnt = ksmps;
-      this.nchnls = libraryCsound.csoundGetNchnls(cs);
-      this.nchnls_i = libraryCsound.csoundGetNchnlsInput(cs);
+      this.nchnls = this.libraryCsound.csoundGetNchnls(cs);
+      this.nchnls_i = this.libraryCsound.csoundGetNchnlsInput(cs);
 
-      this.zerodBFS = libraryCsound.csoundGet0dBFS(cs);
+      this.zerodBFS = this.libraryCsound.csoundGet0dBFS(cs);
 
-      returnValueValue = libraryCsound.csoundStart(cs);
+      returnValueValue = this.libraryCsound.csoundStart(cs);
 
       if (returnValueValue !== 0) {
         return returnValueValue;
@@ -413,12 +414,12 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       if (isExpectingRealtimeOutput) {
         this.csoundOutputBuffer = new Float64Array(
           this.wasm.wasi.memory.buffer,
-          libraryCsound.csoundGetSpout(cs),
+          this.libraryCsound.csoundGetSpout(cs),
           ksmps * this.nchnls,
         );
         this.csoundInputBuffer = new Float64Array(
           this.wasm.wasi.memory.buffer,
-          libraryCsound.csoundGetSpin(cs),
+          this.libraryCsound.csoundGetSpin(cs),
           ksmps * this.nchnls_i,
         );
         log("csoundStart called with {} return val", returnValueValue)();
@@ -429,9 +430,11 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
         this.isRendering = true;
 
         singlethreadWorkerRender({
-          libraryCsound,
+          libraryCsound: this.libraryCsound,
           workerMessagePort: this.workerMessagePort,
-          wasi: this.wasi,
+          setRenderSleep: (resolve) => {
+            this.renderSleep = resolve;
+          },
         })({ csound: cs })
           .then(() => {
             this.workerMessagePort.broadcastPlayState("renderEnded");

--- a/wasm/browser/tests/multiCsound.html
+++ b/wasm/browser/tests/multiCsound.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>multiCsound issue #2467 repro</title>
+  </head>
+  <body>
+    <script type="module">
+      import { Csound } from "/dist/csound.js";
+
+      const code = `
+instr 1
+  out linenr(oscili(0dbfs*p4,p5),0.01,0.5,0.01)
+endin
+`;
+
+      const ac = new AudioContext();
+
+      async function getCsoundInstance(ctx) {
+        const c = await Csound({ audioContext: ctx, autoConnect: false });
+        await c.setOption("-odac");
+        await c.compileOrc(code);
+        await c.start();
+        return c;
+      }
+
+      const csound1 = await getCsoundInstance(ac);
+      const csound2 = await getCsoundInstance(ac);
+
+      const node1 = await csound1.getNode();
+      const node2 = await csound2.getNode();
+
+      node1.connect(ac.destination);
+      node2.connect(ac.destination);
+
+      await csound1.inputMessage("i1 0 1 0.2 440");
+      await csound2.inputMessage("i1 0 1 0.2 500");
+    </script>
+  </body>
+</html>

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -349,70 +349,98 @@ e
         }
       });
 
-      it("keeps multi-instance singlethread worklets isolated on shared AudioContext", async function () {
-        if (test.name !== "SINGLE THREAD, AW") {
-          return;
-        }
+      it("keeps multi-instance worklets isolated on shared AudioContext", async function () {
+        const backendConfig = {
+          useWorker: Boolean(test.useWorker),
+          useSAB: test.useSAB === true,
+        };
 
         const sharedAudioContext = new (window.AudioContext || window.webkitAudioContext)({
           latencyHint: "interactive",
         });
-        const csound1 = await Csound({
-          ...test,
-          audioContext: sharedAudioContext,
-          autoConnect: false,
-        });
-        const csound2 = await Csound({
-          ...test,
-          audioContext: sharedAudioContext,
-          autoConnect: false,
-        });
 
-        const eventStartSpy1 = sinon.spy();
-        const eventStartSpy2 = sinon.spy();
-        csound1.on("realtimePerformanceStarted", eventStartSpy1);
-        csound2.on("realtimePerformanceStarted", eventStartSpy2);
+        let csound1;
+        let csound2;
+        let node1;
+        let node2;
 
-        const realtimeOrc = `
-        instr 1
-          out oscili(.25, 440)
-        endin
-      `;
+        try {
+          csound1 = await Csound({
+            useWorker: backendConfig.useWorker,
+            useSAB: backendConfig.useSAB,
+            audioContext: sharedAudioContext,
+            autoConnect: false,
+          });
+          csound2 = await Csound({
+            useWorker: backendConfig.useWorker,
+            useSAB: backendConfig.useSAB,
+            audioContext: sharedAudioContext,
+            autoConnect: false,
+          });
 
-        await csound1.setOption("-odac");
-        await csound2.setOption("-odac");
-        assert.equal(await csound1.compileOrc(realtimeOrc), 0);
-        assert.equal(await csound2.compileOrc(realtimeOrc), 0);
+          const realtimeOrc = `
+          instr 1
+            chnset(p4, "last")
+            out oscili(.25, p5)
+          endin
+        `;
 
-        const node1 = await csound1.getNode();
-        const node2 = await csound2.getNode();
-        node1.connect(sharedAudioContext.destination);
-        node2.connect(sharedAudioContext.destination);
+          await csound1.setOption("-odac");
+          await csound2.setOption("-odac");
+          assert.equal(await csound1.compileOrc(realtimeOrc), 0);
+          assert.equal(await csound2.compileOrc(realtimeOrc), 0);
 
-        await csound1.start();
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        assert.isTrue(
-          eventStartSpy1.calledOnce,
-          "csound1 emits realtimePerformanceStarted when csound1.start() is called",
-        );
-        assert.isFalse(
-          eventStartSpy2.called,
-          "csound2 must not emit realtimePerformanceStarted while only csound1.start() is called",
-        );
+          node1 = await csound1.getNode();
+          node2 = await csound2.getNode();
+          node1.connect(sharedAudioContext.destination);
+          node2.connect(sharedAudioContext.destination);
 
-        await csound2.start();
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        assert.isTrue(
-          eventStartSpy2.calledOnce,
-          "csound2 emits realtimePerformanceStarted when csound2.start() is called",
-        );
+          await csound1.start();
+          await csound2.start();
 
-        await csound1.stop();
-        await csound2.stop();
-        node1.disconnect();
-        node2.disconnect();
-        await csound2.terminateInstance();
-        await csound1.terminateInstance();
+          await csound1.inputMessage("i1 0 0.2 111 440");
+          await csound2.inputMessage("i1 0 0.2 222 550");
+          await new Promise((resolve) => setTimeout(resolve, 250));
+
+          assert.closeTo(
+            await csound1.getControlChannel("last"),
+            111,
+            0.001,
+            `${test.name}: csound1 should keep its own channel/message state`,
+          );
+          assert.closeTo(
+            await csound2.getControlChannel("last"),
+            222,
+            0.001,
+            `${test.name}: csound2 should keep its own channel/message state`,
+          );
+        } finally {
+          if (node1) {
+            node1.disconnect();
+          }
+          if (node2) {
+            node2.disconnect();
+          }
+          if (csound1) {
+            try {
+              await csound1.stop();
+            } catch {}
+          }
+          if (csound2) {
+            try {
+              await csound2.stop();
+            } catch {}
+          }
+          if (csound2 && csound2.terminateInstance) {
+            await csound2.terminateInstance();
+          }
+          if (csound1 && csound1.terminateInstance) {
+            await csound1.terminateInstance();
+          }
+          if (sharedAudioContext && sharedAudioContext.state !== "closed") {
+            await sharedAudioContext.close();
+          }
+        }
       });
 
     /* DISABLED due to removed API functions in CS7

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -349,6 +349,72 @@ e
         }
       });
 
+      it("keeps multi-instance singlethread worklets isolated on shared AudioContext", async function () {
+        if (test.name !== "SINGLE THREAD, AW") {
+          return;
+        }
+
+        const sharedAudioContext = new (window.AudioContext || window.webkitAudioContext)({
+          latencyHint: "interactive",
+        });
+        const csound1 = await Csound({
+          ...test,
+          audioContext: sharedAudioContext,
+          autoConnect: false,
+        });
+        const csound2 = await Csound({
+          ...test,
+          audioContext: sharedAudioContext,
+          autoConnect: false,
+        });
+
+        const eventStartSpy1 = sinon.spy();
+        const eventStartSpy2 = sinon.spy();
+        csound1.on("realtimePerformanceStarted", eventStartSpy1);
+        csound2.on("realtimePerformanceStarted", eventStartSpy2);
+
+        const realtimeOrc = `
+        instr 1
+          out oscili(.25, 440)
+        endin
+      `;
+
+        await csound1.setOption("-odac");
+        await csound2.setOption("-odac");
+        assert.equal(await csound1.compileOrc(realtimeOrc), 0);
+        assert.equal(await csound2.compileOrc(realtimeOrc), 0);
+
+        const node1 = await csound1.getNode();
+        const node2 = await csound2.getNode();
+        node1.connect(sharedAudioContext.destination);
+        node2.connect(sharedAudioContext.destination);
+
+        await csound1.start();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        assert.isTrue(
+          eventStartSpy1.calledOnce,
+          "csound1 emits realtimePerformanceStarted when csound1.start() is called",
+        );
+        assert.isFalse(
+          eventStartSpy2.called,
+          "csound2 must not emit realtimePerformanceStarted while only csound1.start() is called",
+        );
+
+        await csound2.start();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        assert.isTrue(
+          eventStartSpy2.calledOnce,
+          "csound2 emits realtimePerformanceStarted when csound2.start() is called",
+        );
+
+        await csound1.stop();
+        await csound2.stop();
+        node1.disconnect();
+        node2.disconnect();
+        await csound2.terminateInstance();
+        await csound1.terminateInstance();
+      });
+
     /* DISABLED due to removed API functions in CS7
       it("can read and write ftables in realtime", async function () {
         const csoundObj = await Csound(test);

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -390,13 +390,29 @@ e
           assert.equal(await csound1.compileOrc(realtimeOrc), 0);
           assert.equal(await csound2.compileOrc(realtimeOrc), 0);
 
-          node1 = await csound1.getNode();
-          node2 = await csound2.getNode();
-          node1.connect(sharedAudioContext.destination);
-          node2.connect(sharedAudioContext.destination);
+          // In worker mode, the AudioWorkletNode is created lazily during start(),
+          // so we must initiate start() before awaiting getNode().
+          // getNode() returns immediately in singlethread mode, or waits for the
+          // onAudioNodeCreated event in worker mode.
+          if (backendConfig.useWorker) {
+            const [startResult1, startResult2] = await Promise.all([
+              csound1.start(),
+              csound2.start(),
+            ]);
 
-          await csound1.start();
-          await csound2.start();
+            node1 = await csound1.getNode();
+            node2 = await csound2.getNode();
+            node1.connect(sharedAudioContext.destination);
+            node2.connect(sharedAudioContext.destination);
+          } else {
+            node1 = await csound1.getNode();
+            node2 = await csound2.getNode();
+            node1.connect(sharedAudioContext.destination);
+            node2.connect(sharedAudioContext.destination);
+
+            await csound1.start();
+            await csound2.start();
+          }
 
           await csound1.inputMessage("i1 0 0.2 111 440");
           await csound2.inputMessage("i1 0 0.2 222 550");


### PR DESCRIPTION
Moves state from global to instance for single-thread workers; fixes issue with multiple csound instances in webaudio (issue #2467)