### PR TITLE
Fix: global state webaudio

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -336,6 +336,13 @@ static TREE *create_cond_expression(CSOUND *csound,
     last = last->next;
   }
 
+  if(last->left == NULL) {
+    csound->Message(csound,
+                    "missing boolean expression in " 
+                    "conditional expression, line %d\n", root->line-1);
+    return NULL;
+  }
+
   if (left[0]=='S' || right[0]=='S') {
     type = (last->left->value->lexeme[1]=='B') ?2 : 1;
     eq = (last->left->value->lexeme[1]=='B') ?"#=.S" : "=.S";
@@ -1214,13 +1221,14 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
                                     currentArg->line, currentArg->locn,
                                     typeTable);
       }
-      nextArg = currentArg->next;
-      csound->Free(csound, currentArg);
+     
 
       if (expressionNodes == NULL) {
-        csound->Message(csound, "Error: create_expression returned NULL\n");
+        csound->Message(csound, "error creating expression.\n");
         return NULL;
       }
+      nextArg = currentArg->next;
+      csound->Free(csound, currentArg);
 
       /* Set as anchor if necessary */
       anchor = append_to_tree(csound, anchor, expressionNodes);

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -220,11 +220,20 @@ const OENTRY opcodlst_1[] = {
   { "||",     S(LOGCL),0,  /* 0,*/     "b",    "bb",   or,     NULL             },
   { "||.0",     S(LOGCL),0,  /* 0,*/       "B",    "BB",   NULL,     or              },
   /* end boolean */
-  { ":cond.i",     S(CONVAL),0,        "i",    "bii",  conval                  },
-  { ":cond.k",     S(CONVAL),0,         "k",    "Bkk",  NULL,   conval          },
-  { ":cond.a",     S(CONVAL),0,         "a",    "Bxx",  NULL,   aconval },
-  { ":cond.s",     S(CONVAL),0,        "S",    "bSS",  conval, NULL         },
-  { ":cond.S",     S(CONVAL),0,        "S",    "BSS",  conval, conval       },
+  /** These "cond" opcodes are not used anymore, but the entries are - for tree checking 
+      the code needs to be changed so it doesn't depend on these entries anymore
+  */
+  { ":cond.i",     0,0,        "i",    "bii" },
+  { ":cond.b",     0,0,        "b",    "bbb" },
+  { ":cond.b",     0,0,        "b",    "bib" },
+  { ":cond.b",     0,0,        "b",    "bbi" },
+  { ":cond.k",     0,0,        "k",    "Bkk" },
+  { ":cond.B",     0,0,        "B",    "BBB" },
+  { ":cond.B",     0,0,        "B",    "BkB" },
+  { ":cond.B",     0,0,        "B",    "BBk" },
+  { ":cond.a",     0,0,        "a",    "Bxx"},
+  { ":cond.s",     0,0,        "S",    "bSS" },
+  { ":cond.S",     0,0,        "S",    "BSS" },
   { "##add.ii",  S(AOP),0,          "i",    "ii",   addkk                   },
   { "##sub.ii",  S(AOP),0,          "i",    "ii",   subkk                   },
   { "##mul.ii",  S(AOP),0,          "i",    "ii",   mulkk                   },

--- a/tests/commandline/test_ternary_expr.csd
+++ b/tests/commandline/test_ternary_expr.csd
@@ -9,11 +9,20 @@ instr 1
 i1 = 0
 i1 = i1 < 0 ? 0: 1
 print i1
+test:b = i1 > 0 ? true : false
+print test
+k1 = 1
+k2 = 0
+k1 = k1 > 0 ? k1: k2
+printk2 k1
+asig1 = 0
+asig2 = rand(0.1)
+out (k1 < 0 ? asig1 : asig2)
 endin
 
 </CsInstruments>
 <CsScore>
-i1 1 0
+i1 1 1
 </CsScore>
 </CsoundSynthesizer>
 

--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta23",
+  "version": "7.0.0-beta24",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",

--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csound/browser",
-  "version": "7.0.0-beta24",
+  "version": "7.0.0-beta25",
   "module": "./dist/csound.js",
   "typings": "index.d.ts",
   "type": "module",

--- a/wasm/browser/src/index.js
+++ b/wasm/browser/src/index.js
@@ -57,6 +57,7 @@ const Csound = async function ({
       log("Single Thread AudioWorklet")();
       const instance = new SingleThreadAudioWorkletMainThread({
         audioContext,
+        audioContextIsProvided,
         inputChannelCount: inputChannelCount || 2,
         outputChannelCount: outputChannelCount || 2,
       });

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -183,10 +183,24 @@ class SharedArrayBufferMainThread {
         });
         this.callbackBuffer = {};
         log(`event: realtimePerformanceEnded received, beginning cleanup`)();
+        // Preserve audio configuration while re-initializing SAB runtime state.
+        const userProvidedSampleRate = Atomics.load(this.audioStatePointer, AUDIO_STATE.SAMPLE_RATE);
+        const userProvidedNchnls = Atomics.load(this.audioStatePointer, AUDIO_STATE.NCHNLS);
+        const userProvidedNchnlsInput = Atomics.load(this.audioStatePointer, AUDIO_STATE.NCHNLS_I);
+
         // re-initialize SAB
         initialSharedState.forEach((value, index) => {
           Atomics.store(this.audioStatePointer, index, value);
         });
+        if (userProvidedSampleRate > -1) {
+          Atomics.store(this.audioStatePointer, AUDIO_STATE.SAMPLE_RATE, userProvidedSampleRate);
+        }
+        if (userProvidedNchnls > -1) {
+          Atomics.store(this.audioStatePointer, AUDIO_STATE.NCHNLS, userProvidedNchnls);
+        }
+        if (userProvidedNchnlsInput > -1) {
+          Atomics.store(this.audioStatePointer, AUDIO_STATE.NCHNLS_I, userProvidedNchnlsInput);
+        }
         break;
       }
       case "renderStarted": {
@@ -331,6 +345,27 @@ class SharedArrayBufferMainThread {
       ]),
     );
     this.csoundInstance = csoundInstance;
+
+    // Ensure Csound aligns with requested audio setup before user compilation/start.
+    const userProvidedSampleRate = Atomics.load(audioStatePointer, AUDIO_STATE.SAMPLE_RATE);
+    const userProvidedNchnls = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS);
+    const userProvidedNchnlsInput = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS_I);
+
+    if (userProvidedSampleRate > -1) {
+      await proxyPort["callUncloned"]("csoundSetOption", [
+        csoundInstance,
+        "--sample-rate=" + userProvidedSampleRate,
+      ]);
+    }
+    if (userProvidedNchnls > -1) {
+      await proxyPort["callUncloned"]("csoundSetOption", [csoundInstance, "--nchnls=" + userProvidedNchnls]);
+    }
+    if (userProvidedNchnlsInput > -1) {
+      await proxyPort["callUncloned"]("csoundSetOption", [
+        csoundInstance,
+        "--nchnls_i=" + userProvidedNchnlsInput,
+      ]);
+    }
 
     this.ipcMessagePorts.mainMessagePort.start();
     this.ipcMessagePorts.mainMessagePortAudio.start();

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -15,6 +15,7 @@ class AudioWorkletMainThread {
   constructor({ audioContext, audioContextIsProvided, autoConnect }) {
     this.autoConnect = autoConnect;
     this.audioContextIsProvided = audioContextIsProvided;
+    this.audioContextOwnedByInstance = !audioContextIsProvided;
     /** @type {({ mainMessagePortAudio: EventTarget } | undefined)} */
     this.ipcMessagePorts = undefined;
     this.audioContext = audioContext;
@@ -49,7 +50,7 @@ class AudioWorkletMainThread {
       delete this.audioWorkletNode;
     }
     if (this.audioContext) {
-      if (this.audioContext.state !== "closed") {
+      if (this.audioContextOwnedByInstance && this.audioContext.state !== "closed") {
         try {
           await this.audioContext.close();
         } catch {}
@@ -109,7 +110,7 @@ class AudioWorkletMainThread {
             : "",
         )();
         if (
-          !this.audioContextIsProvided &&
+          this.audioContextOwnedByInstance &&
           this.autoConnect &&
           this.audioContext &&
           this.audioContext.state !== "closed"
@@ -172,6 +173,7 @@ class AudioWorkletMainThread {
         console.error(`fatal: the provided AudioContext was undefined`);
       }
       this.audioContext = new (WebkitAudioContext())({ sampleRate: this.sampleRate });
+      this.audioContextOwnedByInstance = true;
     }
 
     if (this.audioContext.state === "closed") {
@@ -179,10 +181,12 @@ class AudioWorkletMainThread {
         console.error(`fatal: the provided AudioContext was closed, falling back new AudioContext`);
       }
       this.audioContext = new (WebkitAudioContext())({ sampleRate: this.sampleRate });
+      this.audioContextOwnedByInstance = true;
     }
 
     if (this.sampleRate !== this.audioContext.sampleRate) {
       this.audioContext = new (WebkitAudioContext())({ sampleRate: this.sampleRate });
+      this.audioContextOwnedByInstance = true;
       // if this.audioContextIsProvided is true
       // it should already be picked
       if (this.audioContextIsProvided) {

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -45,6 +45,11 @@ class AudioWorkletMainThread {
   }
 
   async terminateInstance() {
+    if (this.workletProxy) {
+      try {
+        await this.workletProxy["terminate"]();
+      } catch {}
+    }
     if (this.audioWorkletNode) {
       this.audioWorkletNode.disconnect();
       delete this.audioWorkletNode;

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -53,7 +53,12 @@ const initializeModule = async (audioContext) => {
  * @unrestricted
  */
 class SingleThreadAudioWorkletMainThread {
-  constructor({ audioContext, inputChannelCount = 1, outputChannelCount = 2 }) {
+  constructor({
+    audioContext,
+    audioContextIsProvided = false,
+    inputChannelCount = 1,
+    outputChannelCount = 2,
+  }) {
     /** @type {(WorkletSinglethreadProxy | undefined)} */
     this.workletProxy = undefined;
     this.node = undefined;
@@ -65,6 +70,7 @@ class SingleThreadAudioWorkletMainThread {
     this.eventPromises = new EventPromises();
 
     this.audioContext = audioContext;
+    this.audioContextIsProvided = audioContextIsProvided;
     this.inputChannelCount = inputChannelCount;
     this.outputChannelCount = outputChannelCount;
 
@@ -84,7 +90,7 @@ class SingleThreadAudioWorkletMainThread {
       delete this.node;
     }
     if (this.audioContext) {
-      if (this.audioContext.state !== "closed") {
+      if (!this.audioContextIsProvided && this.audioContext.state !== "closed") {
         await this.audioContext.close();
       }
       delete this.audioContext;

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -85,6 +85,11 @@ class SingleThreadAudioWorkletMainThread {
   }
 
   async terminateInstance() {
+    if (this.workletProxy) {
+      try {
+        await this.workletProxy["terminate"]();
+      } catch {}
+    }
     if (this.node) {
       this.node.disconnect();
       delete this.node;

--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -8,39 +8,6 @@ const PAGE_SIZE = 65536;
 const PAGES_PER_MB = 16; // 1048576 bytes per MB / PAGE_SIZE
 const WASI_LONGJMP_PREFIX = "CSOUND_WASI_LONGJMP:";
 
-// shared state
-const jumpTable = new Map(); // maps jmpbuf pointers to JS frames
-let tempRet0 = 0; // for 64-bit return value handling
-
-function saveSetjmp(jmpbuf, label) {
-  jumpTable.set(jmpbuf, label);
-  return 0;
-}
-
-function testSetjmp(jmpbuf) {
-  return jumpTable.has(jmpbuf) ? 1 : 0;
-}
-
-function longjmp(jmpbuf, value) {
-  const label = jumpTable.get(jmpbuf);
-  if (!label) {
-    throw new Error(`Invalid longjmp target ${jmpbuf}`);
-  }
-  throw `csound exit with code: ${value}`;
-}
-
-function __wasm_longjmp(_, value) {
-  throw `csound exit with code: ${value}`;
-}
-
-function getTempRet0() {
-  return tempRet0;
-}
-
-function setTempRet0(value) {
-  tempRet0 = value;
-}
-
 export const csoundWasiJsMessageCallback = ({ memory, messagePort, streamBuffer }) => {
   return function (_, __, length_, offset) {
     if (!memory) {
@@ -234,6 +201,33 @@ export function getBinaryHeaderData(input) {
 
 export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
   const wasi = new WASI({ preopens: { "/": "/" } });
+  const jumpTable = new Map(); // maps jmpbuf pointers to JS frames
+  let tempRet0 = 0; // for 64-bit return value handling
+
+  const saveSetjmp = (jmpbuf, label) => {
+    jumpTable.set(jmpbuf, label);
+    return 0;
+  };
+
+  const testSetjmp = (jmpbuf) => (jumpTable.has(jmpbuf) ? 1 : 0);
+
+  const longjmp = (jmpbuf, value) => {
+    const label = jumpTable.get(jmpbuf);
+    if (!label) {
+      throw new Error(`Invalid longjmp target ${jmpbuf}`);
+    }
+    throw `csound exit with code: ${value}`;
+  };
+
+  const __wasm_longjmp = (_, value) => {
+    throw `csound exit with code: ${value}`;
+  };
+
+  const getTempRet0 = () => tempRet0;
+
+  const setTempRet0 = (value) => {
+    tempRet0 = value;
+  };
 
   const wasmCompressed = new Uint8Array(wasmDataURI);
   const wasmZlib = new Inflate(wasmCompressed);

--- a/wasm/browser/src/workers/sab.worker.js
+++ b/wasm/browser/src/workers/sab.worker.js
@@ -25,6 +25,29 @@ const callUncloned = async (k, arguments_) => {
   return returnValue;
 };
 
+const applyUserProvidedAudioParams = ({ audioStateBuffer, csound, libraryCsound }) => {
+  if (!audioStateBuffer) {
+    return;
+  }
+  const audioStatePointer = new Int32Array(audioStateBuffer);
+  const userProvidedNchnls = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS);
+  const userProvidedNchnlsIn = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS_I);
+  const userProvidedSr = Atomics.load(audioStatePointer, AUDIO_STATE.SAMPLE_RATE);
+
+  if (userProvidedNchnls > -1) {
+    const result = libraryCsound.csoundSetOption(csound, "--nchnls=" + userProvidedNchnls);
+    result !== 0 && console.error("csoundSetOption nchnls failed:", result);
+  }
+  if (userProvidedNchnlsIn > -1) {
+    const result = libraryCsound.csoundSetOption(csound, "--nchnls_i=" + userProvidedNchnlsIn);
+    result !== 0 && console.error("csoundSetOption nchnls_i failed:", result);
+  }
+  if (userProvidedSr > -1) {
+    const result = libraryCsound.csoundSetOption(csound, "--sample-rate=" + userProvidedSr);
+    result !== 0 && console.error("csoundSetOption sample-rate failed:", result);
+  }
+};
+
 const sabCreateRealtimeAudioThread =
   ({
     libraryCsound,
@@ -45,10 +68,24 @@ const sabCreateRealtimeAudioThread =
 
     const audioStatePointer = new Int32Array(audioStateBuffer);
 
+    // Preserve user-provided audio config across state reset.
+    const userProvidedNchnls = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS);
+    const userProvidedNchnlsIn = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS_I);
+    const userProvidedSr = Atomics.load(audioStatePointer, AUDIO_STATE.SAMPLE_RATE);
+
     // In case of multiple performances, let's reset the sab state
     initialSharedState.forEach((value, index) => {
       Atomics.store(audioStatePointer, index, value);
     });
+    if (userProvidedNchnls > -1) {
+      Atomics.store(audioStatePointer, AUDIO_STATE.NCHNLS, userProvidedNchnls);
+    }
+    if (userProvidedNchnlsIn > -1) {
+      Atomics.store(audioStatePointer, AUDIO_STATE.NCHNLS_I, userProvidedNchnlsIn);
+    }
+    if (userProvidedSr > -1) {
+      Atomics.store(audioStatePointer, AUDIO_STATE.SAMPLE_RATE, userProvidedSr);
+    }
 
     // Prompt for midi-input on demand
     const isRequestingRtMidiInput = libraryCsound["_isRequestingRtMidiInput"](csound);
@@ -57,24 +94,6 @@ const sabCreateRealtimeAudioThread =
     const isExpectingInput =
       Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS_I) === 0 &&
       libraryCsound.csoundGetInputName(csound).includes("adc");
-
-    // Store Csound AudioParams for upcoming performance
-    const userProvidedNchnls = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS);
-    const userProvidedNchnlsIn = Atomics.load(audioStatePointer, AUDIO_STATE.NCHNLS_I);
-    const userProvidedSr = Atomics.load(audioStatePointer, AUDIO_STATE.SAMPLE_RATE);
-
-    if (userProvidedNchnls > -1) {
-      const result = libraryCsound.csoundSetOption(csound, "--nchnls=" + userProvidedNchnls);
-      result !== 0 && console.error("csoundSetOption nchnls failed:", result);
-    }
-    if (userProvidedNchnlsIn > -1) {
-      const result = libraryCsound.csoundSetOption(csound, "--nchnls_i=" + userProvidedNchnlsIn);
-      result !== 0 && console.error("csoundSetOption nchnls_i failed:", result);
-    }
-    if (userProvidedSr > -1) {
-      const result = libraryCsound.csoundSetOption(csound, "--sample-rate=" + userProvidedSr);
-      result !== 0 && console.error("csoundSetOption sample-rate failed:", result);
-    }
 
     const nchnls = libraryCsound.csoundGetNchnls(csound);
 
@@ -404,8 +423,14 @@ const initialize = async (payload) => {
 
   const libraryCsound = libcsoundFactory(wasm);
 
-  const startHandler = (_, arguments_) =>
-    handleCsoundStart(
+  const startHandler = (_, arguments_) => {
+    applyUserProvidedAudioParams({
+      audioStateBuffer: arguments_ && arguments_["audioStateBuffer"],
+      csound: arguments_ && arguments_["csound"],
+      libraryCsound,
+    });
+
+    return handleCsoundStart(
       workerMessagePort,
       libraryCsound,
       wasi,
@@ -428,6 +453,7 @@ const initialize = async (payload) => {
         releaseResumed,
       }),
     )(arguments_);
+  };
 
   const allAPI = { ...libraryCsound, csoundStart: startHandler, wasm };
   combined = new Map(Object.entries(allAPI));

--- a/wasm/browser/src/workers/worklet.singlethread.worker.js
+++ b/wasm/browser/src/workers/worklet.singlethread.worker.js
@@ -95,6 +95,8 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     /** @export */
     this.stop = this.stop.bind(this);
     /** @export */
+    this.terminate = this.terminate.bind(this);
+    /** @export */
     this.process = this.process.bind(this);
     /** @export */
     this.resume = this.resume.bind(this);
@@ -109,6 +111,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     this.isPaused = false;
     this.running = false;
     this.started = false;
+    this.isTerminated = false;
     /** @export */
     this.callUncloned = async (k, arguments_) => {
       const caller = this.combined && this.combined.get(k);
@@ -167,6 +170,7 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       this.running = false;
       this.isRendering = false;
       this.started = false;
+      this.isTerminated = false;
       this.resetCsound(false);
 
       const csoundCreate = async (v) => {
@@ -244,6 +248,20 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
     this.workerMessagePort.broadcastPlayState("realtimePerformanceEnded");
   }
 
+  terminate() {
+    if (this.isTerminated) {
+      return;
+    }
+    this.isTerminated = true;
+    const resolveRenderSleep = this.renderSleep;
+    this.renderSleep = undefined;
+    if (typeof resolveRenderSleep === "function") {
+      resolveRenderSleep();
+    }
+    clearArray(this.rtmidiQueue);
+    this.stop();
+  }
+
   pause() {
     if (!this.isPaused) {
       this.workerMessagePort.broadcastPlayState("realtimePerformancePaused");
@@ -263,6 +281,11 @@ class WorkletSinglethreadWorker extends AudioWorkletProcessor {
       const resolve = this.renderSleep;
       this.renderSleep = undefined;
       resolve();
+    }
+
+    if (this.isTerminated) {
+      (outputs[0] || []).forEach((array) => array.fill(0));
+      return false;
     }
 
     if (this.isRendering || this.isPaused || !this.csoundOutputBuffer || !this.running) {

--- a/wasm/browser/src/workers/worklet.worker.js
+++ b/wasm/browser/src/workers/worklet.worker.js
@@ -434,6 +434,7 @@ const initialize = async (payload) => {
     startPromiz = resolve;
   });
   audioNode.initCallbacks({ workerMessagePort, audioInputPort, audioFramePort, startPromiz });
+  activeNodes.delete(nodeUid);
   await startPromise;
 };
 

--- a/wasm/browser/src/workers/worklet.worker.js
+++ b/wasm/browser/src/workers/worklet.worker.js
@@ -254,7 +254,10 @@ class CsoundWorkletProcessor extends AudioWorkletProcessor {
     this.pause = this.pause.bind(this);
     /** @export */
     this.resume = this.resume.bind(this);
+    /** @export */
+    this.terminate = this.terminate.bind(this);
     this.isPaused = false;
+    this.isTerminated = false;
     // this.sampleRate = sampleRate;
     this.ksmps = ksmps;
     this.inputsCount = inputsCount;
@@ -304,7 +307,10 @@ class CsoundWorkletProcessor extends AudioWorkletProcessor {
       this.actualProcess = processVanillaBuffers.bind(this);
       this.updateVanillaFrames = this.updateVanillaFrames.bind(this);
     }
-    Comlink.expose({ initialize, pause: this.pause, resume: this.resume }, this.port);
+    Comlink.expose(
+      { initialize, pause: this.pause, resume: this.resume, terminate: this.terminate },
+      this.port,
+    );
     log(`Worker thread was constructed`)();
   }
 
@@ -367,7 +373,28 @@ class CsoundWorkletProcessor extends AudioWorkletProcessor {
     this.workerMessagePort.broadcastPlayState("realtimePerformanceResumed");
   }
 
+  terminate() {
+    this.isTerminated = true;
+    this.isPaused = false;
+    this.messagePortsReady = false;
+    this.startPromiz = undefined;
+    this.audioFramePort = undefined;
+    this.audioInputPort = undefined;
+    this.workerMessagePort = undefined;
+    this.sharedArrayBuffer = undefined;
+    this.audioStreamIn = undefined;
+    this.audioStreamOut = undefined;
+    this.sabInputChannels = [];
+    this.sabOutputChannels = [];
+    this.vanillaInputChannels = [];
+    this.vanillaOutputChannels = [];
+  }
+
   process(inputs, outputs) {
+    if (this.isTerminated) {
+      ((outputs && outputs[0]) || []).forEach((array) => array.fill(0));
+      return false;
+    }
     return this.isPaused || !this.messagePortsReady ? true : this.actualProcess(inputs, outputs);
   }
 }

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -453,6 +453,71 @@ e
         }
       });
 
+      it("does not close shared AudioContext when terminating one instance", async function () {
+        const backendConfig = {
+          useWorker: Boolean(test.useWorker),
+          useSAB: test.useSAB === true,
+        };
+
+        const sharedAudioContext = new (window.AudioContext || window.webkitAudioContext)({
+          latencyHint: "interactive",
+        });
+
+        let csound1;
+        let csound2;
+
+        try {
+          csound1 = await Csound({
+            useWorker: backendConfig.useWorker,
+            useSAB: backendConfig.useSAB,
+            audioContext: sharedAudioContext,
+            autoConnect: false,
+          });
+          csound2 = await Csound({
+            useWorker: backendConfig.useWorker,
+            useSAB: backendConfig.useSAB,
+            audioContext: sharedAudioContext,
+            autoConnect: false,
+          });
+
+          assert.notEqual(
+            sharedAudioContext.state,
+            "closed",
+            `${test.name}: shared AudioContext should start open`,
+          );
+
+          await csound1.terminateInstance();
+
+          assert.notEqual(
+            sharedAudioContext.state,
+            "closed",
+            `${test.name}: terminating one instance must not close shared AudioContext`,
+          );
+
+          await csound2.terminateInstance();
+
+          assert.notEqual(
+            sharedAudioContext.state,
+            "closed",
+            `${test.name}: terminating second instance must not close shared AudioContext`,
+          );
+        } finally {
+          if (csound2 && csound2.terminateInstance) {
+            try {
+              await csound2.terminateInstance();
+            } catch {}
+          }
+          if (csound1 && csound1.terminateInstance) {
+            try {
+              await csound1.terminateInstance();
+            } catch {}
+          }
+          if (sharedAudioContext && sharedAudioContext.state !== "closed") {
+            await sharedAudioContext.close();
+          }
+        }
+      });
+
       /* DISABLED due to removed API functions in CS7
       it("can read and write ftables in realtime", async function () {
         const csoundObj = await Csound(test);


### PR DESCRIPTION
This PR improves wasm/browser instance isolation and shared-context lifecycle safety in the WebAudio paths.

It addresses three areas:

1. Prevents AudioContext ownership bugs when multiple Csound instances share a user-provided context.
2. Removes module-global wasm host state that could leak across instances in shared worklet scopes.
3. Cleans up retained node mappings in the worklet worker.