### PR TITLE
Warning on duplicate default

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1646,7 +1646,10 @@ TREE* expand_switch_statement(
         defaultCaseBody = copy_node(csound, endGoto);
       }
     } else {
-      /* Ignore duplicate default clauses. */
+      /* Ignore duplicate default clauses: print a warning */
+      csound->Warning(csound,
+                      "duplicate default case in switch, line %d",
+                      caseNode->line-1);
     }
 
     caseNode = tempNext;


### PR DESCRIPTION
This PR adds a warning when a duplicate default case is found in a switch block.
Closes #2316 