### PR TITLE
Reinstated commented out code in portmidi output code

### DIFF
--- a/InOut/pmidi.c
+++ b/InOut/pmidi.c
@@ -453,8 +453,8 @@ static int32_t WriteMidiData_(CSOUND *csound, void *userData,
     int32_t             n, st;
     PmEvent         mev;
     PortMidiStream  *midistream;
-    //PmTimestamp time = (PmTimestamp)
-    //(csound->GetCurrentTimeSamples(csound)*csound->GetEngineSr(csound)/1000);
+    PmTimestamp time = (PmTimestamp)
+      (csound->GetCurrentTimeSamples(csound)*csound->GetEngineSr(csound)/1000);
     
     /*
      * Writes to user-defined MIDI output.
@@ -482,7 +482,7 @@ static int32_t WriteMidiData_(CSOUND *csound, void *userData,
       }
 
       mev.message = (PmMessage) 0;
-      mev.timestamp =  0;// time;
+      mev.timestamp =  time;
       mev.message |= (PmMessage) Pm_Message(st, 0, 0);
       if (datbyts[(st - 0x80) >> 4] > 0)
         mev.message |= (PmMessage) Pm_Message(0, (int32_t)*(mbuf++), 0);


### PR DESCRIPTION
For some reason, pmidi.c had the latest MIDI out accurate timing code commented out. This PR reinstantes it.