### PR TITLE
Fix operator precedence for bitwise operators in conditionals (match Csound 6 behavior)

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -115,14 +115,14 @@
 /* Precedence Rules */
 %right '?'
 %left S_AND S_OR
-%left '|'
-%left '&'
 %left S_LT S_GT S_LE S_GE S_EQ S_NEQ '=' // VL 6.8.25 for backwards compat
+%left '|'
+%left '#'
+%left '&'
 %left S_BITSHIFT_LEFT S_BITSHIFT_RIGHT
 %left '+' '-'
 %left '*' '/' '%'
 %left '^'
-%left '#'
 %right S_UNOT
 %right S_UMINUS
 %right S_UPLUS

--- a/tests/commandline/test_bitwise_and_in_conditional.csd
+++ b/tests/commandline/test_bitwise_and_in_conditional.csd
@@ -1,0 +1,52 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+#include "libassert.orc"
+
+instr 1
+  ival = 7
+
+  ;; bitwise AND in conditional context (if-then)
+  if (ival & 4 == 4) then
+    prints "PASS: ival & 4 == 4 is true\n"
+  else
+    prints "FAIL: ival & 4 == 4 should be true\n"
+    exitnow(-1)
+  endif
+
+  if (ival & 2 == 2) then
+    prints "PASS: ival & 2 == 2 is true\n"
+  else
+    prints "FAIL: ival & 2 == 2 should be true\n"
+    exitnow(-1)
+  endif
+
+  if (ival & 1 == 1) then
+    prints "PASS: ival & 1 == 1 is true\n"
+  else
+    prints "FAIL: ival & 1 == 1 should be true\n"
+    exitnow(-1)
+  endif
+
+  ;; also test in elseif
+  if (ival == 0) then
+    prints "FAIL: should not be here\n"
+    exitnow(-1)
+  elseif (ival & 1 == 1) then
+    prints "PASS: elseif with bitwise AND works\n"
+  else
+    prints "FAIL: elseif bitwise AND should work\n"
+    exitnow(-1)
+  endif
+
+  prints "ALL BITWISE AND CONDITIONAL TESTS PASSED\n"
+  exitnow 0
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Found an issue regarding bitwise operator precedence and an older project. The issue was subtle where matching the grammar of CS6 did not match the behavior of CS6 for operator precedence. AI summary below explains the issue well. 

## Fix operator precedence for bitwise operators in conditionals (match Csound 6 behavior)

### Problem

Expressions like `if (iop4map & 4 == 4) then` fail to parse with:

```
syntax error, opcode '##and' for expression with arg types ib not found, line 242
```

The `&` operator maps to `##and`, which has variants for `ii`, `kk`, `ka`, `ak`, and `aa` — but not `ib`. The `b` (boolean) type comes from `==` being evaluated first, producing a boolean result that's then passed as the right-hand operand of `&`.

### Root cause

In the bison grammar (csound_orc.y), `%left` declarations appearing **later** in the file have **higher** precedence. The ordering on `develop` is:

```
%left '|'
%left '&'
%left S_LT S_GT S_LE S_GE S_EQ S_NEQ '='
```

This gives `==` higher precedence than `&`, so `a & 4 == 4` parses as `a & (4 == 4)`. The boolean result of `(4 == 4)` is type `b`, and `##and(i, b)` has no matching opcode — hence the error.

### Git history

- dd8fa9794 — *"fix: correct operator precedence for bitwise operators"* — correctly moved comparison operators below bitwise operators
- 8a210ea1d  — *"fix: revert operator precedence change to match Csound 6"* — reverted the fix, reasoning that it should match Csound 6's `%left` declaration order

The revert was well-intentioned but based on a misunderstanding: Csound 6's `%left` declarations happened to have the **same** order, but that order was irrelevant because **Csound 6's grammar structure overrode it**.

### Csound 6 vs Csound 7 grammar analysis

Csound 6 used a hierarchy of separate non-terminals to enforce operator precedence structurally:

| Non-terminal | Operators |
|---|---|
| `bexpr` | `&&`, `\|\|`, comparisons (`==`, `!=`, `<`, `>`, `<=`, `>=`) |
| `expr` | ternary, delegates to `iexp` |
| `iexp` | `+`, `-` |
| `iterm` | `*`, `/`, `%` |
| `ifac` | `&`, `\|`, `#`, `<<`, `>>`, atoms, function calls |

In Csound 6, an `if` statement used `bexpr`, which was defined as `expr COMPARISON expr`. Each side of the comparison resolved through `iexp` → `iterm` → `ifac`, where bitwise operators lived at the `ifac` level. This structural nesting **guaranteed** that bitwise operators bound tighter than comparisons, regardless of `%left` declarations.

Csound 7 flattened the grammar into a single `expr` non-terminal for all operators. This makes `%left` declarations the **sole** mechanism for precedence. The `%left` declarations must therefore be reordered to match Csound 6's **effective** precedence, not its (irrelevant) `%left` declaration order.

### Fix

Reorder `%left` declarations in csound_orc.y so that:
- Comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`, `=`) have **lower** precedence than bitwise operators
- `#` (bitwise XOR) sits between `|` and `&` (standard bitwise ordering)

```
// Before (broken):                    // After (fixed):
%left S_AND S_OR                       %left S_AND S_OR
%left '|'                              %left S_LT S_GT S_LE S_GE S_EQ S_NEQ '='
%left '&'                              %left '|'
%left S_LT S_GT S_LE S_GE S_EQ S_NEQ '='   %left '#'
%left S_BITSHIFT_LEFT S_BITSHIFT_RIGHT %left '&'
%left '+' '-'                          %left S_BITSHIFT_LEFT S_BITSHIFT_RIGHT
%left '*' '/' '%'                      %left '+' '-'
%left '^'                              %left '*' '/' '%'
%left '#'                              %left '^'
```

Now `a & 4 == 4` correctly parses as `(a & 4) == 4`, matching Csound 6 behavior.

### Testing

- Added test_bitwise_and_in_conditional.csd — tests `if (ival & N == N) then` and `elseif` variants
- All 259 existing csdtests pass with no regressions
- The existing `test_op_precedence.csd` (Test 190) continues to pass