### PR TITLE
wasm: add null guard to mkdir and fix bug in readStdOut

### DIFF
--- a/wasm/browser/src/filesystem/wasi.js
+++ b/wasm/browser/src/filesystem/wasi.js
@@ -182,7 +182,7 @@ WASI.prototype.findEntry = function (filePath) {
   const normalized = normalizeAbsolutePath(filePath);
   const entries = Object.values(this.fd);
   for (const entry of entries) {
-    if (entry && entry.path === normalized) {
+    if (entry?.path === normalized) {
       return entry;
     }
   }
@@ -1162,7 +1162,7 @@ WASI.prototype.readdir = function (dirname /* string */) {
   const prefixPath = absoluteDir === "/" ? "/" : `${absoluteDir}/`;
   const files = [];
   Object.values(this.fd).forEach((entry) => {
-    if (!entry || !entry.path) {
+    if (!entry?.path) {
       return;
     }
     const { path } = entry;
@@ -1242,7 +1242,7 @@ WASI.prototype.mkdir = function (dirname /* string */) {
   const cleanPath = this.resolvePath(dirname);
   const files = [];
   Object.values(this.fd).forEach((entry) => {
-    if (!entry || !entry.path) {
+    if (!entry?.path) {
       return;
     }
     return entry.path.startsWith(cleanPath) && files.push(entry.path);

--- a/wasm/browser/src/filesystem/wasi.js
+++ b/wasm/browser/src/filesystem/wasi.js
@@ -1222,7 +1222,7 @@ WASI.prototype.readFile = function (fname /* string */) {
 };
 
 WASI.prototype.readStdOut = function () {
-  const maybeFd = Object.values(this.fd[0]);
+  const maybeFd = this.fd[1];
   const buffers = (maybeFd && maybeFd.buffers) || [];
   return concatUint8Arrays(buffers);
 };
@@ -1241,8 +1241,11 @@ WASI.prototype.unlink = function (fname /* string */) {
 WASI.prototype.mkdir = function (dirname /* string */) {
   const cleanPath = this.resolvePath(dirname);
   const files = [];
-  Object.values(this.fd).forEach(({ path }) => {
-    return path.startsWith(cleanPath) && files.push(path);
+  Object.values(this.fd).forEach((entry) => {
+    if (!entry || !entry.path) {
+      return;
+    }
+    return entry.path.startsWith(cleanPath) && files.push(entry.path);
   });
 
   const alreadyExist = files.length > 0;

--- a/wasm/browser/src/filesystem/wasi.js
+++ b/wasm/browser/src/filesystem/wasi.js
@@ -1151,7 +1151,7 @@ WASI.prototype.sock_shutdown = function () {
 // helpers
 
 WASI.prototype.findBuffers = function (filePath /* string */) {
-  const maybeFd = Object.values(this.fd).find(({ path }) => path === filePath);
+  const maybeFd = Object.values(this.fd).find((entry) => entry?.path === filePath);
   return maybeFd && maybeFd.buffers;
 };
 
@@ -1184,7 +1184,7 @@ WASI.prototype.writeFile = function (fname /* string */, data /* Uint8Array */) 
   const filePath = this.resolvePath(fname);
 
   const nextFd = Object.keys(this.fd).length;
-  const maybeOldFd = Object.values(this.fd).find(({ path }) => path === filePath);
+  const maybeOldFd = Object.values(this.fd).find((entry) => entry?.path === filePath);
 
   this.fd[nextFd] = {
     fd: nextFd,
@@ -1229,7 +1229,7 @@ WASI.prototype.readStdOut = function () {
 
 WASI.prototype.unlink = function (fname /* string */) {
   const filePath = this.resolvePath(fname);
-  const maybeFd = Object.values(this.fd).find(({ path }) => path === filePath);
+  const maybeFd = Object.values(this.fd).find((entry) => entry?.path === filePath);
 
   if (maybeFd) {
     delete this.fd[maybeFd.fd];
@@ -1263,7 +1263,7 @@ WASI.prototype.mkdir = function (dirname /* string */) {
 
 WASI.prototype.stat = function (fname /* string */) {
   const filePath = this.resolvePath(fname);
-  const maybeFd = Object.values(this.fd).find(({ path }) => path === filePath);
+  const maybeFd = Object.values(this.fd).find((entry) => entry?.path === filePath);
 
   if (!maybeFd) {
     return undefined;
@@ -1307,6 +1307,6 @@ WASI.prototype.stat = function (fname /* string */) {
 
 WASI.prototype.pathExists = function (fname /* string */) {
   const filePath = this.resolvePath(fname);
-  const maybeFd = Object.values(this.fd).find(({ path }) => path === filePath);
+  const maybeFd = Object.values(this.fd).find((entry) => entry?.path === filePath);
   return !!maybeFd;
 };

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -964,6 +964,60 @@ e
         await csoundObj.terminateInstance();
       });
 
+      it("fs operations work after unlink creates holes in fd table", async function () {
+        const csoundObj = await Csound(test);
+
+        // Create files, then unlink one to create a hole (undefined entry) in the fd array
+        await csoundObj.fs.writeFile("file_a.txt", new TextEncoder().encode("AAA"));
+        await csoundObj.fs.writeFile("file_b.txt", new TextEncoder().encode("BBB"));
+        await csoundObj.fs.writeFile("file_c.txt", new TextEncoder().encode("CCC"));
+
+        // Unlink the middle file — this creates an undefined slot in this.fd
+        await csoundObj.fs.unlink("file_b.txt");
+
+        // All of these iterate Object.values(this.fd) and must handle the hole:
+
+        // readdir should still work
+        const files = await csoundObj.fs.readdir("/");
+        assert.include(files, "file_a.txt", "readdir lists file_a.txt after unlink");
+        assert.include(files, "file_c.txt", "readdir lists file_c.txt after unlink");
+        assert.notInclude(files, "file_b.txt", "readdir does not list unlinked file_b.txt");
+
+        // writeFile should still work (its find for existing files must not crash)
+        await csoundObj.fs.writeFile("file_d.txt", new TextEncoder().encode("DDD"));
+        assert.include(
+          await csoundObj.fs.readdir("/"),
+          "file_d.txt",
+          "writeFile works after unlink",
+        );
+
+        // stat should still work
+        const statA = await csoundObj.fs.stat("file_a.txt");
+        assert.isObject(statA, "stat works for file_a.txt after unlink");
+        assert.equal(statA.size, 3, "stat returns correct size");
+        const statB = await csoundObj.fs.stat("file_b.txt");
+        assert.isUndefined(statB, "stat returns undefined for unlinked file");
+
+        // pathExists should still work
+        assert.isTrue(
+          await csoundObj.fs.pathExists("file_a.txt"),
+          "pathExists returns true for existing file after unlink",
+        );
+        assert.isFalse(
+          await csoundObj.fs.pathExists("file_b.txt"),
+          "pathExists returns false for unlinked file",
+        );
+
+        // mkdir should still work
+        await csoundObj.fs.mkdir("new_dir");
+        assert.isTrue(
+          await csoundObj.fs.pathExists("new_dir"),
+          "mkdir works after unlink creates holes in fd table",
+        );
+
+        await csoundObj.terminateInstance();
+      });
+
       it("it fails with error when #include references a non-existent file", async function () {
         const csoundObj = await Csound(test);
         await csoundObj.fs.writeFile(


### PR DESCRIPTION
this could explain why I ended up making workaround reading the logs many years back. We don't currently make use of readStdOut, but better if it's correct.