### PR TITLE
Adding column ranges to parse parameters

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -53,12 +53,7 @@ ORCTOKEN *make_label(CSOUND *, char *s);
 #define YY_EXTRA_TYPE  PARSE_PARM *
 #define PARM    yyget_extra(yyscanner)
 
-/* #define YY_INPUT(buf,result,max_size)  {\ */
-/*     result = get_next_char(buf, max_size, yyg); \ */
-/*     if ( UNLIKELY( result <= 0  )) \ */
-/*       result = YY_NULL; \ */
-/*     } */
-
+#define YY_USER_ACTION PARM->first_column = yycolumn; PARM->last_column = yycolumn + yyleng - 1; yycolumn += yyleng;
 #define YY_USER_INIT
 
 struct yyguts_t;
@@ -571,9 +566,9 @@ ERSTR           "}R"
 {FILE}          { BEGIN(src); }
 
 <src>{
-  [ \t]*     /* eat the whitespace */
+  [ \t]*     /* eat the whitespace */ {yycolumn += yyleng;}
   {FNAME}    { PARM->locn = atoll(yytext); }
-  "\n"       { BEGIN(INITIAL); }
+  "\n"       { BEGIN(INITIAL);}
 }
 
 .               {
@@ -589,14 +584,16 @@ ERSTR           "}R"
 
 <ignorenewline>{
   "\n" {
+    yycolumn = 1;
     csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                          yyscanner);
   }
 }
 
-<INITIAL>"\n"            { csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
+<INITIAL>"\n" { yycolumn = 1;
+                csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                        yyscanner);
-                  return NEWLINE; }
+                return NEWLINE; }
 
 %%
 
@@ -729,3 +726,16 @@ uint64_t csound_orcget_ilocn(void *yyscanner)
 //    struct yyguts_t *yyg  = (struct yyguts_t*)yyscanner;
     return PARM->ilocn;
 }
+
+uint32_t csound_orcget_first_column(void *yyscanner)
+{
+  //   struct yyguts_t *yyg  = (struct yyguts_t*)yyscanner;
+    return PARM->first_column;
+}
+
+uint32_t csound_orcget_last_column(void *yyscanner)
+{
+  //   struct yyguts_t *yyg  = (struct yyguts_t*)yyscanner;
+    return PARM->last_column;
+}
+

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -309,6 +309,7 @@ ERSTR           "}R"
   }
 
   "\n"  { /* The next two should be one case but I cannot get that to work */
+           yycolumn = 1;
            if (PARM->xstrptr+2>=PARM->xstrmax) {
                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
@@ -557,7 +558,9 @@ ERSTR           "}R"
 {WHITE}         { }
 
 {SLINE}         { BEGIN(sline); }
-<sline>{INTGR}   { csound_orcset_lineno(atoi(yytext), yyscanner); }
+<sline>{INTGR}   { csound_orcset_lineno(atoi(yytext), yyscanner);
+                  yycolumn = 0; /* reset for new source line;
+                                    0 accounts for trailing space in #sline format */ }
 <sline>[ \t]*   { BEGIN(INITIAL);}
 {LINE}          { BEGIN(line); }
 
@@ -570,7 +573,7 @@ ERSTR           "}R"
 {FILE}          { BEGIN(src); }
 
 <src>{
-  [ \t]*     /* eat the whitespace */ 
+  [ \t]*     /* eat the whitespace */
   {FNAME}    { PARM->locn = atoll(yytext); }
   "\n"       { BEGIN(INITIAL); yycolumn = 1;}
 }
@@ -622,7 +625,7 @@ ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
     if (csound->parserNamedInstrFlag == 1) {
         return ans;
     }
-    ans->type = type; 
+    ans->type = type;
     return ans;
 }
 

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -597,6 +597,11 @@ ERSTR           "}R"
 
 %%
 
+#if defined(_WIN32) || defined(_WIN64)
+# define strtok_r strtok_s
+#endif
+
+
 ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
 {
     int32_t type = T_IDENT;

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -597,11 +597,6 @@ ERSTR           "}R"
 
 %%
 
-#if defined(_WIN32) || defined(_WIN64)
-# define strtok_r strtok_s
-#endif
-
-
 ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
 {
     int32_t type = T_IDENT;

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -40,13 +40,13 @@
 #include "filesys.h"
 YYSTYPE *yylval_param;
 YYLTYPE *yylloc_param;
-ORCTOKEN *make_string(CSOUND *, char *);
-extern ORCTOKEN *lookup_token(CSOUND *, char *, void *);
-ORCTOKEN *new_token(CSOUND *csound, int32_t type);
-ORCTOKEN *make_int(CSOUND *, char *);
-ORCTOKEN *make_num(CSOUND *, char *);
-ORCTOKEN *make_token(CSOUND *, char *s);
-ORCTOKEN *make_label(CSOUND *, char *s);
+ ORCTOKEN *make_string(CSOUND *, char *, void*);
+ ORCTOKEN *lookup_token(CSOUND *, char *, void *);
+ ORCTOKEN *new_token(CSOUND *csound, int32_t type, void *yyscanner);
+ ORCTOKEN *make_int(CSOUND *, char *, void*);
+ ORCTOKEN *make_num(CSOUND *, char *,  void*);
+ ORCTOKEN *make_token(CSOUND *, char *s,  void*);
+ ORCTOKEN *make_label(CSOUND *, char *s,  void*);
 #define namedInstrFlag csound->parserNamedInstrFlag
 #include "parse_param.h"
 
@@ -57,8 +57,8 @@ ORCTOKEN *make_label(CSOUND *, char *s);
 #define YY_USER_INIT
 
 struct yyguts_t;
-ORCTOKEN *do_at(CSOUND *, int32_t, struct yyguts_t*);
-int get_next_char(char *, int32_t, struct yyguts_t*);
+ ORCTOKEN *do_at(CSOUND *, int32_t, void*, char*);
+int get_next_char(char *, int32_t, void*);
 %}
 %option reentrant
 %option bison-bridge
@@ -125,7 +125,7 @@ ERSTR           "}R"
 "-="            { return S_SUBIN; }
 "*="            { return S_MULIN; }
 "/="            { return S_DIVIN; }
-"="             { *lvalp = make_token(csound, "=");
+"="             { *lvalp = make_token(csound, "=", yyscanner);
                   (*lvalp)->type = '=';
                   return '='; }
 ">"             { return S_GT; }
@@ -138,8 +138,8 @@ ERSTR           "}R"
 
 \xC2?\xAC{OPTWHITE} { return '~'; } /* BACKWARDS COMPATABILITY */
 
-"@@"{OPTWHITE}{INTGR}     { *lvalp = do_at(csound, 1, yyg); return INTEGER_TOKEN; }
-"@"{OPTWHITE}{INTGR}      { *lvalp = do_at(csound, 0, yyg); return INTEGER_TOKEN; }
+"@@"{OPTWHITE}{INTGR}     { *lvalp = do_at(csound, 1, yyscanner, yytext); return INTEGER_TOKEN; }
+"@"{OPTWHITE}{INTGR}      { *lvalp = do_at(csound, 0, yyscanner, yytext); return INTEGER_TOKEN; }
 "@i"            { return T_MAPI; }
 "@k"            { return T_MAPK; }
 "false"         { return FALSE_TOKEN; }
@@ -147,86 +147,86 @@ ERSTR           "}R"
 "falsek"        { return FALSEK_TOKEN; }
 "truek"         { return TRUEK_TOKEN; }
 "if"\([ \t]*    { yyless(2);
-                  *lvalp = make_token(csound, "if");
+                  *lvalp = make_token(csound, "if", yyscanner);
                   (*lvalp)->type = IF_TOKEN;
                   return IF_TOKEN; }
-"if"            { *lvalp = make_token(csound, yytext);
+"if"            { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = IF_TOKEN;
                   return IF_TOKEN; }
-"then"          { *lvalp = make_token(csound, yytext);
+"then"          { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = THEN_TOKEN;
                   return THEN_TOKEN; }
-"ithen"         { *lvalp = make_token(csound, yytext);
+"ithen"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ITHEN_TOKEN;
                   return ITHEN_TOKEN; }
-"kthen"         { *lvalp = make_token(csound, yytext);
+"kthen"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = KTHEN_TOKEN;
                   return KTHEN_TOKEN; }
 "elseif"\([ \t]* { yyless(6);
-                  *lvalp = make_token(csound, "elseif");
+                  *lvalp = make_token(csound, "elseif", yyscanner);
                   (*lvalp)->type = ELSEIF_TOKEN;
                   return ELSEIF_TOKEN; }
-"elseif"        { *lvalp = make_token(csound, yytext);
+"elseif"        { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ELSEIF_TOKEN;
                   return ELSEIF_TOKEN; }
-"else"          { *lvalp = make_token(csound, yytext);
+"else"          { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ELSE_TOKEN;
                   return ELSE_TOKEN; }
-"endif"         { *lvalp = make_token(csound, yytext);
+"endif"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ENDIF_TOKEN;
                   return ENDIF_TOKEN; }
-"fi"            { *lvalp = make_token(csound, yytext);
+"fi"            { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ENDIF_TOKEN;
                   return ENDIF_TOKEN; }
 "until"\([ \t]* { yyless(5);
-                  *lvalp = make_token(csound, "until");
+                  *lvalp = make_token(csound, "until", yyscanner);
                   (*lvalp)->type = UNTIL_TOKEN;
                   return UNTIL_TOKEN; }
-"until"         { *lvalp = make_token(csound, yytext);
+"until"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = UNTIL_TOKEN;
                   return UNTIL_TOKEN; }
 "while"\([ \t]* { yyless(5);
-                  *lvalp = make_token(csound, "while");
+                  *lvalp = make_token(csound, "while", yyscanner);
                   (*lvalp)->type = WHILE_TOKEN;
                   return WHILE_TOKEN; }
-"while"         { *lvalp = make_token(csound, yytext);
+"while"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = WHILE_TOKEN;
                   return WHILE_TOKEN; }
-"do"            { *lvalp = make_token(csound, yytext);
+"do"            { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = DO_TOKEN;
                   return DO_TOKEN; }
-"od"            { *lvalp = make_token(csound, yytext);
+"od"            { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = OD_TOKEN;
                   return OD_TOKEN; }
-"enduntil"      { *lvalp = make_token(csound, yytext);
+"enduntil"      { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = OD_TOKEN;
                   return OD_TOKEN; }
-"break"         { *lvalp = make_token(csound, yytext);
+"break"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = BREAK_TOKEN;
                   return BREAK_TOKEN; }
-"continue"      { *lvalp = make_token(csound, yytext);
+"continue"      { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = CONTINUE_TOKEN;
                   return CONTINUE_TOKEN; }
-"switch"        { *lvalp = make_token(csound, yytext);
+"switch"        { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = SWITCH_TOKEN;
                   return SWITCH_TOKEN; }
-"case"          { *lvalp = make_token(csound, yytext);
+"case"          { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = CASE_TOKEN;
                   return CASE_TOKEN; }
-"default"       { *lvalp = make_token(csound, yytext);
+"default"       { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = DEFAULT_TOKEN;
                   return DEFAULT_TOKEN; }
-"endsw"         { *lvalp = make_token(csound, yytext);
+"endsw"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ENDSW_TOKEN;
                   return ENDSW_TOKEN; }
 
-"goto"          { *lvalp = make_token(csound, yytext);
+"goto"          { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = GOTO_TOKEN;
                   return GOTO_TOKEN; };
-"igoto"         { *lvalp = make_token(csound, yytext);
+"igoto"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = IGOTO_TOKEN;
                   return IGOTO_TOKEN; };
-"kgoto"         { *lvalp = make_token(csound, yytext);
+"kgoto"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = KGOTO_TOKEN;
                   return KGOTO_TOKEN; };
 "struct"        {
@@ -236,13 +236,13 @@ ERSTR           "}R"
                   namedInstrFlag = 1;
                   return INSTR_TOKEN;
                 }
-"endin"         { *lvalp = make_token(csound, yytext);
+"endin"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = ENDIN_TOKEN;
                   return ENDIN_TOKEN; }
 "void"          { return VOID_TOKEN; }
 
 
-"for"           {  *lvalp = make_token(csound, yytext);
+"for"           {  *lvalp = make_token(csound, yytext, yyscanner);
                    (*lvalp)->type = FOR_TOKEN;
                    BEGIN(forloop);
                    return FOR_TOKEN; }
@@ -253,7 +253,7 @@ ERSTR           "}R"
   [ \t]*          /* eat the whitespace */
   {IDENT}/[ \t]*   { char *pp = yytext;
                     while (*pp==' ' || *pp=='\t') pp++;
-                    *lvalp = make_token(csound, pp);
+                    *lvalp = make_token(csound, pp, yyscanner);
                     if (strcmp(pp, "in") == 0) {
                       BEGIN(INITIAL);
                       return IN_TOKEN;
@@ -300,7 +300,7 @@ ERSTR           "}R"
            PARM->xstrbuff[PARM->xstrptr++] = '"';
            PARM->xstrbuff[PARM->xstrptr] = '\0';
            /* printf("xstrbuff:>>%s<<\n", PARM->xstrbuff); */
-           *lvalp = make_string(csound, PARM->xstrbuff);
+           *lvalp = make_string(csound, PARM->xstrbuff, yyscanner);
             free(PARM->xstrbuff);
             return STRING_TOKEN;
           }
@@ -366,7 +366,7 @@ ERSTR           "}R"
            BEGIN(INITIAL);
            PARM->xstrbuff[PARM->xstrptr++] = '"';
            PARM->xstrbuff[PARM->xstrptr] = '\0';
-           *lvalp = make_string(csound, PARM->xstrbuff);
+           *lvalp = make_string(csound, PARM->xstrbuff, yyscanner);
             free(PARM->xstrbuff);
             return STRING_TOKEN;
           }
@@ -398,7 +398,7 @@ ERSTR           "}R"
 
 ^[ \t]*{IDENT}:/[ \t\n]  { char *pp = yytext;
                   while (*pp==' ' || *pp=='\t') pp++;
-                  *lvalp = make_label(csound, pp); return LABEL_TOKEN;
+                  *lvalp = make_label(csound, pp, yyscanner); return LABEL_TOKEN;
                 }
 
 "declare"       { BEGIN(declare);
@@ -409,7 +409,7 @@ ERSTR           "}R"
                   return UDOSTART_DEFINITION;
                 }
 "endop"         {
-                  *lvalp = new_token(csound, UDOEND_TOKEN); return UDOEND_TOKEN;
+  *lvalp = new_token(csound, UDOEND_TOKEN, yyscanner); return UDOEND_TOKEN;
                 }
 
 
@@ -507,12 +507,12 @@ ERSTR           "}R"
                       buff[n++] = ch;
                     }
                   }
-                  *lvalp = make_string(csound, buff);
+                  *lvalp = make_string(csound, buff, yyscanner);
                   free(buff);
                   return (STRING_TOKEN);
                 }
 
-"0dbfs"         { *lvalp = make_token(csound, yytext);
+"0dbfs"         { *lvalp = make_token(csound, yytext, yyscanner);
                   (*lvalp)->type = T_IDENT;
                   /* csound->Message(csound,"%d\n", (*lvalp)->type); */
                   return T_IDENT; }
@@ -537,7 +537,7 @@ ERSTR           "}R"
                       *lvalp = lookup_token(csound, yytext, yyscanner);
                       return (*lvalp)->type+1; }
 {INTGR}         {
-                    *lvalp = make_int(csound, yytext); return (INTEGER_TOKEN);
+                    *lvalp = make_int(csound, yytext, yyscanner); return (INTEGER_TOKEN);
                     /*csound->Message(csound,"%d\n", (*lvalp)->type);*/
                     return ((*lvalp)->type);
                 }
@@ -549,7 +549,7 @@ ERSTR           "}R"
 
 {SYMBOL}     { return *yytext;}
 
-{NUMBER}        { *lvalp = make_num(csound, yytext); return (NUMBER_TOKEN); }
+{NUMBER}        { *lvalp = make_num(csound, yytext, yyscanner); return (NUMBER_TOKEN); }
 {WHITE}         { }
 
 {SLINE}         { BEGIN(sline); }
@@ -597,31 +597,53 @@ ERSTR           "}R"
 
 %%
 
-  /* unused at the moment
-static inline int isNameChar(int c, int pos)
+ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
 {
-    c = (int) ((unsigned char) c);
-    return (isalpha(c) || (pos && (c == '_' || isdigit(c))));
-}
-  */
+    int32_t type = T_IDENT;
+    ORCTOKEN *ans;
 
-ORCTOKEN *new_token(CSOUND *csound, int32_t type)
-{
-    ORCTOKEN *ans = (ORCTOKEN*)csound->Calloc(csound, sizeof(ORCTOKEN));
-    ans->type = type;
+    if(UNLIKELY(csoundGetDebug(csound) & DEBUG_SEMANTICS))
+      csound->Message(csound, "Looking up token for: %s\n", s);
+    ans = new_token(csound, T_IDENT, yyscanner);
+    if (strchr(s, ':') != NULL) {
+        char* th;
+        char* baseName = strtok_r(s, ":", &th);
+        char* annotation = strtok_r(NULL, ":", &th);
+        ans->lexeme = csoundStrdup(csound, baseName);
+        ans->optype = csoundStrdup(csound, annotation);
+        type = T_TYPED_IDENT;
+    } else {
+        ans->lexeme = csoundStrdup(csound, s);
+    }
+    if (csound->parserNamedInstrFlag == 1) {
+        return ans;
+    }
+    ans->type = type; // never reached?
     return ans;
 }
 
-ORCTOKEN *make_token(CSOUND *csound, char *s)
+
+ORCTOKEN *new_token(CSOUND *csound, int32_t type, void *yyscanner)
 {
-    ORCTOKEN *ans = new_token(csound, STRING_TOKEN);
+    ORCTOKEN *ans = (ORCTOKEN*)csound->Calloc(csound, sizeof(ORCTOKEN));
+    ans->type = type;
+    if(yyscanner) {
+     ans->first_column = PARM->first_column;
+     ans->last_column = PARM->last_column;
+    }
+    return ans;
+}
+
+ORCTOKEN *make_token(CSOUND *csound, char *s, void *yyscanner)
+{
+  ORCTOKEN *ans = new_token(csound, STRING_TOKEN, yyscanner);
     ans->lexeme = csoundStrdup(csound, s);
     return ans;
 }
 
-ORCTOKEN *make_label(CSOUND *csound, char *s)
+ORCTOKEN *make_label(CSOUND *csound, char *s, void *yyscanner)
 {
-    ORCTOKEN *ans = new_token(csound, LABEL_TOKEN);
+    ORCTOKEN *ans = new_token(csound, LABEL_TOKEN, yyscanner);
     int32_t len;
     char *ps = s;
     while (*ps != ':') ps++;
@@ -632,21 +654,9 @@ ORCTOKEN *make_label(CSOUND *csound, char *s)
     return ans;
 }
 
-/*
-static void check_newline_for_label(char*s, void* yyscanner) {
-    char *ps = s;
-    while (*ps != ':') ps++;
-    while(*ps != '\0') {
-      if (*ps=='\n')
-        csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),yyscanner);
-      ps++;
-    }
-}
-*/
-
-ORCTOKEN *make_string(CSOUND *csound, char *s)
+ORCTOKEN *make_string(CSOUND *csound, char *s, void *yyscanner)
 {
-    ORCTOKEN *ans = new_token(csound, STRING_TOKEN);
+  ORCTOKEN *ans = new_token(csound, STRING_TOKEN, yyscanner);
     int32_t len = (int32_t) strlen(s);
 /* Keep the quote marks */
     ans->lexeme = (char*)csound->Calloc(csound, len + 1);
@@ -655,17 +665,16 @@ ORCTOKEN *make_string(CSOUND *csound, char *s)
     return ans;
 }
 
-ORCTOKEN *do_at(CSOUND *csound, int32_t k, struct yyguts_t *yyg)
-{
+ORCTOKEN *do_at(CSOUND *csound, int32_t k, void *yyscanner, char *yytex){
     int n, i = 1;
     ORCTOKEN *ans;
     char buf[16];
-    char *s = yytext;
+    char *s = yytex;
     int32_t len;
     while (*s=='@') s++;
     n = atoi(s);
     while (i<=n-k && i< 0x4000000) i <<= 1;
-    ans = new_token(csound, INTEGER_TOKEN);
+    ans = new_token(csound, INTEGER_TOKEN, yyscanner);
     snprintf(buf, 16, "%d", i+k);
     len = (int32_t) strlen(buf);
     ans->lexeme = (char*)csound->Calloc(csound, len + 1);
@@ -674,10 +683,10 @@ ORCTOKEN *do_at(CSOUND *csound, int32_t k, struct yyguts_t *yyg)
     return ans;
 }
 
-ORCTOKEN *make_int(CSOUND *csound, char *s)
+ORCTOKEN *make_int(CSOUND *csound, char *s, void *yyscanner)
 {
     int n = atoi(s);
-    ORCTOKEN *ans = new_token(csound, INTEGER_TOKEN);
+    ORCTOKEN *ans = new_token(csound, INTEGER_TOKEN, yyscanner);
     int32_t len = (int32_t) strlen(s);
     ans->lexeme = (char*)csound->Calloc(csound, len + 1);
     strNcpy(ans->lexeme, s, len+1);
@@ -685,10 +694,10 @@ ORCTOKEN *make_int(CSOUND *csound, char *s)
     return ans;
 }
 
-ORCTOKEN *make_num(CSOUND *csound, char *s)
+ORCTOKEN *make_num(CSOUND *csound, char *s, void *yyscanner)
 {
     double n = atof(s);
-    ORCTOKEN *ans = new_token(csound, NUMBER_TOKEN);
+    ORCTOKEN *ans = new_token(csound, NUMBER_TOKEN, yyscanner);
     int32_t len = (int32_t) strlen(s);
     ans->lexeme = (char*)csound->Calloc(csound, len + 1);
     strNcpy(ans->lexeme, s, len+1);
@@ -738,4 +747,5 @@ uint32_t csound_orcget_last_column(void *yyscanner)
   //   struct yyguts_t *yyg  = (struct yyguts_t*)yyscanner;
     return PARM->last_column;
 }
+
 

--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -107,7 +107,9 @@ ERSTR           "}R"
 %%
 <*>"\r"            { } /* EATUP THIS PART OF WINDOWS NEWLINE */
 
-{CONT}          { csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
+{CONT}          {
+                  yycolumn = 1;
+                  csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                        yyscanner);
                 }
 "->"            { return S_ELIPSIS; }
@@ -373,6 +375,7 @@ ERSTR           "}R"
   }
 
   "\n"  { /* The next two should be one case but I cannot get that to work */
+           yycolumn = 1;
            if (PARM->xstrptr+2>=PARM->xstrmax) {
                PARM->xstrbuff = (char *)realloc(PARM->xstrbuff,
                                                        PARM->xstrmax+=80);
@@ -449,9 +452,10 @@ ERSTR           "}R"
                   (*lvalp)->type = UDO_IDENT;
                   return (*lvalp)->type; }
   "\n"     { BEGIN(INITIAL);
-                   csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
-                                        yyscanner);
-                  return NEWLINE; }
+             yycolumn = 1;
+             csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
+                                   yyscanner);
+             return NEWLINE; }
   {IDENT} {
     csound->Message(csound, "unsupported UDO arg type: %s", yytext);
     return ERROR_TOKEN;
@@ -560,15 +564,15 @@ ERSTR           "}R"
 <line>{
   [ \t]*     /* eat the whitespace */
   {INTGR}   { csound_orcset_lineno(atoi(yytext), yyscanner); }
-  "\n"      {BEGIN(INITIAL);}
+  "\n"      {BEGIN(INITIAL); yycolumn = 1;}
 }
 
 {FILE}          { BEGIN(src); }
 
 <src>{
-  [ \t]*     /* eat the whitespace */ {yycolumn += yyleng;}
+  [ \t]*     /* eat the whitespace */ 
   {FNAME}    { PARM->locn = atoll(yytext); }
-  "\n"       { BEGIN(INITIAL);}
+  "\n"       { BEGIN(INITIAL); yycolumn = 1;}
 }
 
 .               {
@@ -618,7 +622,7 @@ ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
     if (csound->parserNamedInstrFlag == 1) {
         return ans;
     }
-    ans->type = type; // never reached?
+    ans->type = type; 
     return ans;
 }
 

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -26,6 +26,7 @@
 %lex-param { CSOUND * csound }
 %lex-param {yyscan_t *scanner}
 
+
 %token NEWLINE
 %token S_NEQ
 %token S_AND

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -335,15 +335,15 @@ udo_arg_list : '(' out_arg_list ')'
              | '(' out_arg_list_array ')'
              { $$ = $2;  }
              | '(' ')'
-             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0")); }
+             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0", NULL)); }
              ;
 
 udo_out_arg_list : '(' out_type_list ')'
              { $$ = $2; }
              | '(' ')'
-             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0")); }
+             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0", NULL)); }
              | VOID_TOKEN
-             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0")); }
+             { $$ = make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, "0", NULL)); }
              | out_type
              ;
 
@@ -626,7 +626,7 @@ for_in : FOR_TOKEN identifier in expr DO_TOKEN statement_list OD_TOKEN
 
 declare_definition : DECLARE_TOKEN identifier udo_arg_list ':' udo_out_arg_list NEWLINE
  {
-   $$ = make_leaf(csound, LINE, LOCN, T_DECLARE, make_token(csound, $2->value->lexeme));
+   $$ = make_leaf(csound, LINE, LOCN, T_DECLARE, make_token(csound, $2->value->lexeme, NULL));
    $$->left = $2;
    $$->left->left = $5;
    $$->left->right = $3;
@@ -663,20 +663,20 @@ expr    : function_call
 
 
 gen_array : '[' expr S_ELIPSIS2 expr_list  ']' {
-            $$ = make_leaf(csound, LINE,LOCN, T_FUNCTION, make_token(csound, "genarray"));
+            $$ = make_leaf(csound, LINE,LOCN, T_FUNCTION, make_token(csound, "genarray", NULL));
             $$->right = $2;
             append_to_tree(csound, $$->right, $4);
              }
 
 slice_array : identifier '[' expr ':' expr_list  ']' {
-            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray"));
+            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
             $$->right = append_to_tree(csound, $$->right, $3);
             append_to_tree(csound, $$->right, $5);
            }
 
 static_array : '[' expr_list ']' {
-            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "fillarray"));
+            $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "fillarray", NULL));
             $$->right = $2;
           }
 
@@ -692,7 +692,7 @@ array_expr :  array_expr '[' expr ']'
           {
            char* arrayName = $1->value->lexeme;
             $$ = make_node(csound, LINE, LOCN, T_ARRAY,
-              	   make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, arrayName)), $3);
+                           make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, arrayName, NULL)), $3);
           }
           | function_call '[' expr ']'
           {
@@ -709,7 +709,7 @@ struct_expr : struct_expr '.' identifier
                 csound, LINE, LOCN, STRUCT_EXPR,
                 $1,
                 make_leaf(
-                  csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName)
+                          csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName, NULL)
                 )
               );
             }
@@ -721,7 +721,7 @@ struct_expr : struct_expr '.' identifier
                                   $3->left->value->lexeme :
                                   $3->value->lexeme;
               TREE* memberLeaf = make_leaf(csound, LINE, LOCN, T_MEMBER_IDENT,
-                                           make_token(csound, memberName));
+                                           make_token(csound, memberName, NULL));
               TREE* structMember = make_node(csound, LINE, LOCN, STRUCT_EXPR, $1, memberLeaf);
               /* Now make the array_expr index the struct member */
               $3->left = structMember;
@@ -740,8 +740,8 @@ struct_expr : struct_expr '.' identifier
                 $3->value->lexeme;
 
               $$ = make_node(csound, LINE, LOCN, STRUCT_EXPR,
-                make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, structName)),
-                make_leaf(csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName))
+                             make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, structName, NULL)),
+                             make_leaf(csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName, NULL))
               );
               $3->left = $$;
               $$ = $3;
@@ -757,8 +757,8 @@ struct_expr : struct_expr '.' identifier
               // Important: Clear the next pointer of $3 to prevent it from being processed separately
               $3->next = NULL;
               $$ = make_node(csound, LINE, LOCN, STRUCT_EXPR,
-                     make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, structName)),
-                     make_leaf(csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName))
+                             make_leaf(csound, LINE, LOCN, T_IDENT, make_token(csound, structName, NULL)),
+                             make_leaf(csound, LINE, LOCN, T_MEMBER_IDENT, make_token(csound, memberName, NULL))
                    );
             }
             ;
@@ -871,13 +871,13 @@ out_arg_list_array : out_arg_list_array ',' array_expr
 
 array_identifier: array_identifier '[' ']' {
             append_to_tree(csound, $1->right,
-	             make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[")));
+                           make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[", NULL)));
             $$ = $1;
           }
           | identifier '[' ']' {
             $$ = $1;
             $1->type = T_ARRAY_IDENT;
-	          $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "["));
+            $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[", NULL));
           }
           | typed_identifier '[' ']' {
             $$ = $1;
@@ -892,47 +892,47 @@ array_identifier: array_identifier '[' ']' {
               } else {
                 // This is array access syntax, convert to T_ARRAY_IDENT
                 $1->type = T_ARRAY_IDENT;
-                $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "["));
+                $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[", NULL));
               }
             } else {
               // No type annotation, treat as array access
               $1->type = T_ARRAY_IDENT;
-              $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "["));
+              $$->right = make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[", NULL));
             }
           }
           ;
 
 /* ORCTOKEN wrappings and simplifications */
 assignment : '='
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=")); }
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL)); }
               | S_ADDIN
-                { $$ = make_leaf(csound,LINE,LOCN, S_ADDIN, make_token(csound, "##addin")); }
+                { $$ = make_leaf(csound,LINE,LOCN, S_ADDIN, make_token(csound, "##addin", NULL)); }
               | S_SUBIN
-                { $$ = make_leaf(csound,LINE,LOCN, S_SUBIN, make_token(csound, "##subin")); }
+                { $$ = make_leaf(csound,LINE,LOCN, S_SUBIN, make_token(csound, "##subin", NULL)); }
               | S_DIVIN
-                { $$ = make_leaf(csound,LINE,LOCN, S_DIVIN, make_token(csound, "##divin")); }
+                { $$ = make_leaf(csound,LINE,LOCN, S_DIVIN, make_token(csound, "##divin", NULL)); }
               | S_MULIN
-                { $$ = make_leaf(csound,LINE,LOCN, S_MULIN, make_token(csound, "##mulin")); }
+                { $$ = make_leaf(csound,LINE,LOCN, S_MULIN, make_token(csound, "##mulin", NULL)); }
               ;
 
 /* special case for array expressions */
 assignment_array : '='
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=")); }
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL)); }
               | S_ADDIN
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "="));
-                  $$->right = make_leaf(csound, LINE, LOCN, '+', make_token(csound, "+"));
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL));
+                  $$->right = make_leaf(csound, LINE, LOCN, '+', make_token(csound, "+", NULL));
                 }
               | S_SUBIN
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "="));
-                  $$->right = make_leaf(csound, LINE, LOCN, '-', make_token(csound, "-"));
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL));
+                  $$->right = make_leaf(csound, LINE, LOCN, '-', make_token(csound, "-", NULL));
                 }
               | S_DIVIN
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "="));
-                  $$->right = make_leaf(csound, LINE, LOCN, '/', make_token(csound, "/"));
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL));
+                  $$->right = make_leaf(csound, LINE, LOCN, '/', make_token(csound, "/", NULL));
                 }
               | S_MULIN
-                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "="));
-                  $$->right = make_leaf(csound, LINE, LOCN, '*', make_token(csound, "*"));
+                { $$ = make_leaf(csound,LINE,LOCN, T_ASSIGNMENT, make_token(csound, "=", NULL));
+                  $$->right = make_leaf(csound, LINE, LOCN, '*', make_token(csound, "*", NULL));
                 }
               ;
 
@@ -965,19 +965,19 @@ string : STRING_TOKEN
 
 false_const: FALSE_TOKEN
        { $$ = make_leaf(csound, LINE,LOCN, FALSE_TOKEN,
-                        make_token(csound,"false")); }
+                        make_token(csound,"false", NULL)); }
        | FALSEK_TOKEN
        { $$ = make_leaf(csound, LINE,LOCN, FALSEK_TOKEN,
-                        make_token(csound,"falsek")); }
+                        make_token(csound,"falsek", NULL)); }
 
        ;
 
 true_const: TRUE_TOKEN
            { $$ = make_leaf(csound, LINE,LOCN, TRUE_TOKEN,
-                            make_token(csound,"true")); }
+                            make_token(csound,"true", NULL)); }
        | TRUEK_TOKEN
        { $$ = make_leaf(csound, LINE,LOCN, TRUEK_TOKEN,
-                        make_token(csound,"truek")); }
+                        make_token(csound,"truek", NULL)); }
        ;
 
 

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -40,10 +40,6 @@
 
 #include "csound_orc_expressions.h"
 
-#if defined(_WIN32) || defined(_WIN64)
-# define strtok_r strtok_s
-#endif
-
 extern const char *SYNTHESIZED_ARG;
 static const char *INSTR_NAME_FIRST = "::^inm_first^::";
 static ARG *create_arg(CSOUND *csound, INSTRTXT *ip, char *s,

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -31,8 +31,8 @@
 #include <inttypes.h>
 
 
-ORCTOKEN *make_token(CSOUND *, char *);
-ORCTOKEN *make_label(CSOUND *, char *);
+ORCTOKEN *make_token(CSOUND *, char *, void *);
+ORCTOKEN *make_label(CSOUND *, char *, void *);
 
 static TREE *create_boolean_expression(CSOUND*, TREE*, int32_t,  uint64_t,
                                        TYPE_TABLE*);
@@ -162,7 +162,7 @@ static TREE *create_unary_token(CSOUND *csound, char *sym)
   ans->len = 0;
   ans->rate = -1;
   ans->markup = NULL;
-  ans->value = make_int(csound, sym);
+  ans->value = make_int(csound, sym, NULL);
   return ans;
 }
 
@@ -171,7 +171,7 @@ TREE * create_opcode_token(CSOUND *csound, char* op)
 {
   TREE *ans = create_empty_token(csound);
   ans->type = T_OPCALL;
-  ans->value = make_token(csound, op);
+  ans->value = make_token(csound, op, NULL);
   ans->value->type = T_OPCALL;
   return ans;
 }
@@ -180,7 +180,7 @@ static TREE * create_ans_token(CSOUND *csound, char* var)
 {
   TREE *ans = create_empty_token(csound);
   ans->type = T_IDENT;
-  ans->value = make_token(csound, var);
+  ans->value = make_token(csound, var, NULL);
   ans->value->type = ans->type;
   return ans;
 
@@ -227,7 +227,7 @@ static TREE * create_goto_token(CSOUND *csound, char * booleanVar,
   opTree = create_opcode_token(csound, op);
   bVar = create_empty_token(csound);
   bVar->type = T_IDENT;
-  bVar->value = make_token(csound, booleanVar);
+  bVar->value = make_token(csound, booleanVar, NULL);
   bVar->value->type = bVar->type;
 
   opTree->left = NULL;
@@ -365,7 +365,7 @@ static TREE *create_cond_expression(CSOUND *csound,
   last->next = create_opcode_token(csound, type==1?"cigoto":"ckgoto");
   xx = create_empty_token(csound);
   xx->type = T_IDENT;
-  xx->value = make_token(csound, last->left->value->lexeme);
+  xx->value = make_token(csound, last->left->value->lexeme, NULL);
   xx->value->type = T_IDENT;
   last = last->next;
   last->left = NULL;
@@ -987,7 +987,7 @@ static TREE *create_synthetic_ident(CSOUND *csound, int32 count)
   snprintf(label, 32, "__synthetic_%"PRIi32, count);
   if (UNLIKELY(csoundGetDebug(csound) & DEBUG_EXPRESSIONS))
     csound->Message(csound, "Creating Synthetic T_IDENT: %s\n", label);
-  token = make_token(csound, label);
+  token = make_token(csound, label, NULL);
   token->type = T_IDENT;
   csound->Free(csound, label);
   return make_leaf(csound, -1, 0, T_IDENT, token);
@@ -1000,7 +1000,7 @@ static TREE *create_synthetic_label(CSOUND *csound, int32 count)
   snprintf(label, 32, "__synthetic_%"PRIi32":", count);
   if (UNLIKELY(csoundGetDebug(csound) & DEBUG_EXPRESSIONS))
     csound->Message(csound, "Creating Synthetic label: %s\n", label);
-  token = make_label(csound, label);
+  token = make_label(csound, label, NULL);
   if (UNLIKELY(csoundGetDebug(csound) & DEBUG_EXPRESSIONS))
     csound->Message(csound, "**** label lexeme >>%s<<\n", token->lexeme);
   csound->Free(csound, label);
@@ -1019,7 +1019,7 @@ void handle_negative_number(CSOUND* csound, TREE* root)
     negativeNumber[len + 2] = '\0';
     root->type = root->right->type;
     root->value = root->right->type == INTEGER_TOKEN ?
-      make_int(csound, negativeNumber) : make_num(csound, negativeNumber);
+      make_int(csound, negativeNumber, NULL) : make_num(csound, negativeNumber, NULL);
     root->value->lexeme = negativeNumber;
   }
 }
@@ -1136,7 +1136,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
   snprintf(tempVarName, sizeof(tempVarName), "#structArrayTemp%d#", csound->struct_array_temp_counter++);
 
   // Step 1: temp:Type = array[index]
-  ORCTOKEN* tempToken = make_token(csound, tempVarName);
+  ORCTOKEN* tempToken = make_token(csound, tempVarName, NULL);
   tempToken->type = T_TYPED_IDENT;
   tempToken->optype = csoundStrdup(csound, cleanTypeName);
 
@@ -1152,12 +1152,12 @@ int expand_struct_array_member_assignment(CSOUND* csound,
   TREE* setMemberOp = create_opcode_token(csound, "##member_set");
   setMemberOp->type = T_OPCALL;
   setMemberOp->right = make_leaf(csound, current->line, current->locn, T_IDENT,
-                                 make_token(csound, tempVarName));
+                                 make_token(csound, tempVarName, NULL));
 
   char indexBuf[32];
   snprintf(indexBuf, sizeof(indexBuf), "%d", memberIndex);
   TREE* memberIndexNode = make_leaf(csound, current->line, current->locn,
-                                   INTEGER_TOKEN, make_int(csound, indexBuf));
+                                    INTEGER_TOKEN, make_int(csound, indexBuf, NULL));
   setMemberOp->right->next = memberIndexNode;
   memberIndexNode->next = copy_node(csound, valueExpr);
 
@@ -1165,10 +1165,10 @@ int expand_struct_array_member_assignment(CSOUND* csound,
   TREE* arraySetAssignment = make_node(csound, current->line, current->locn, T_ASSIGNMENT,
                                       copy_node(csound, arrayExpr),
                                       make_leaf(csound, current->line, current->locn, T_IDENT,
-                                               make_token(csound, tempVarName)));
+                                                make_token(csound, tempVarName, NULL)));
 
   // T_ASSIGNMENT needs a value token for verify_opcode
-  arraySetAssignment->value = make_token(csound, "=");
+  arraySetAssignment->value = make_token(csound, "=", NULL);
   arraySetAssignment->value->type = T_ASSIGNMENT;
 
   // Chain the operations
@@ -1334,7 +1334,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       arraySet->right->next =
         make_leaf(csound, temp->line, temp->locn,
                   T_IDENT, make_token(csound,
-                                      temp->value->lexeme));
+                                      temp->value->lexeme, NULL));
       arraySet->right->next->next =
         currentArg->right; // TODO - check if this handles expressions
 
@@ -1506,7 +1506,7 @@ TREE* create_equality_statement(
   TREE* right
 ) {
   TREE *equalityNode = create_empty_token(csound);
-  equalityNode->value = make_token(csound, "==");
+  equalityNode->value = make_token(csound, "==", NULL);
   equalityNode->type = S_EQ;
   equalityNode->value->type = S_EQ;
   equalityNode->left = left;
@@ -1807,17 +1807,17 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   char* op = (char *)csound->Malloc(csound, 10);
   // create index counter
   TREE *indexAssign = create_empty_token(csound);
-  indexAssign->value = make_token(csound, "=");
+  indexAssign->value = make_token(csound, "=", NULL);
   indexAssign->type = T_ASSIGNMENT;
   indexAssign->value->type = T_ASSIGNMENT;
   char *indexName = create_synthetic_var_name(csound,csound->genlabs++,
                                               isPerfRate ? 'k' : 'i');
   TREE *indexIdent = create_empty_token(csound);
-  indexIdent->value = make_token(csound, indexName);
+  indexIdent->value = make_token(csound, indexName, NULL);
   indexIdent->type = T_IDENT;
   indexIdent->value->type = T_IDENT;
   TREE *zeroToken = create_empty_token(csound);
-  zeroToken->value = make_token(csound, "0");
+  zeroToken->value = make_token(csound, "0", NULL);
   zeroToken->value->value = 0;
   zeroToken->type = INTEGER_TOKEN;
   zeroToken->value->type = INTEGER_TOKEN;
@@ -1825,7 +1825,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   indexAssign->right = zeroToken;
 
   TREE *arrayAssign = create_empty_token(csound);
-  arrayAssign->value = make_token(csound, "=");
+  arrayAssign->value = make_token(csound, "=", NULL);
   arrayAssign->type = T_ASSIGNMENT;
   arrayAssign->value->type = T_ASSIGNMENT;
 
@@ -1834,7 +1834,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   // with the exception of 'i' and 'k' which may be used interchangeably
   char *arrayName = create_synthetic_array_var_name(csound,csound->genlabs++,'x');
   TREE *arrayIdent = create_empty_token(csound);
-  arrayIdent->value = make_token(csound, arrayName);
+  arrayIdent->value = make_token(csound, arrayName, NULL);
   arrayIdent->type = T_ARRAY_IDENT;
   arrayIdent->value->type = T_ARRAY_IDENT;
   add_array_arg(csound, arrayName, arrayArgType, 1, typeTable);
@@ -1844,18 +1844,18 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
   indexAssign->next = arrayAssign;
 
   TREE *arrayLength = create_empty_token(csound);
-  arrayLength->value = make_token(csound, "=");
+  arrayLength->value = make_token(csound, "=", NULL);
   arrayLength->type = T_ASSIGNMENT;
   arrayLength->value->type = T_ASSIGNMENT;
   char *arrayLengthName = create_synthetic_var_name(csound,csound->genlabs++,
                                                     isPerfRate ? 'k' : 'i');
   TREE *arrayLengthIdent = create_empty_token(csound);
-  arrayLengthIdent->value = make_token(csound, arrayLengthName);
+  arrayLengthIdent->value = make_token(csound, arrayLengthName, NULL);
   arrayLengthIdent->type = T_IDENT;
   arrayLengthIdent->value->type = T_IDENT;
   arrayLength->left = arrayLengthIdent;
   TREE *arrayLengthFn = create_empty_token(csound);
-  arrayLengthFn->value = make_token(csound, "lenarray");
+  arrayLengthFn->value = make_token(csound, "lenarray", NULL);
   arrayLengthFn->type = T_FUNCTION;
   arrayLengthFn->value->type = T_FUNCTION;
   TREE *arrayLengthArrayIdent = copy_node(csound, arrayIdent);
@@ -1889,7 +1889,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
     add_arg(csound, current->left->next->value->lexeme, isPerfRate ? "k" : "i", typeTable, NULL);
     hasOptionalIndex = 1;
     TREE *optionalUserIndexAssign = create_empty_token(csound);
-    optionalUserIndexAssign->value = make_token(csound, "=");
+    optionalUserIndexAssign->value = make_token(csound, "=", NULL);
     optionalUserIndexAssign->type = T_ASSIGNMENT;
     optionalUserIndexAssign->value->type = T_ASSIGNMENT;
     optionalUserIndexAssign->left = current->left->next;
@@ -1940,7 +1940,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   // loop less-than arg1: increment by 1
   TREE *oneToken = create_empty_token(csound);
-  oneToken->value = make_token(csound, "1");
+  oneToken->value = make_token(csound, "1", NULL);
   oneToken->value->value = 1;
   oneToken->type = INTEGER_TOKEN;
   oneToken->value->type = INTEGER_TOKEN;
@@ -1953,7 +1953,7 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   // loop less-than arg3: goto label
   TREE *labelGotoIdent = create_empty_token(csound);
-  labelGotoIdent->value = make_token(csound, loopLabel->value->lexeme);
+  labelGotoIdent->value = make_token(csound, loopLabel->value->lexeme, NULL);
   labelGotoIdent->type = T_IDENT;
   labelGotoIdent->value->type = T_IDENT;
   arrayLengthArgToken->next = labelGotoIdent;

--- a/Engine/csound_orc_optimize.c
+++ b/Engine/csound_orc_optimize.c
@@ -32,7 +32,7 @@ static TREE * create_fun_token(CSOUND *csound, TREE *right, char *fname)
     ans = (TREE*)csound->Malloc(csound, sizeof(TREE));
     if (UNLIKELY(ans == NULL)) exit(1);
     ans->type = T_FUNCTION;
-    ans->value = make_token(csound, fname);
+    ans->value = make_token(csound, fname, NULL);
     ans->value->type = T_FUNCTION;
     ans->left = NULL;
     ans->right = right;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3868,27 +3868,16 @@ void csound_orcerror(PARSE_PARM *pp, void *yyscanner,
 
   IGN(pp);
   IGN(astTree);
-  char ch;
   char *p = csound_orcget_current_pointer(yyscanner)-1;
   int32_t line = csound_orcget_lineno(yyscanner);
   uint64_t files = csound_orcget_locn(yyscanner);
+  uint32_t column1 = csound_orcget_first_column(yyscanner);
+  uint32_t column2 = csound_orcget_last_column(yyscanner);  
   if (UNLIKELY(*p=='\0' || *p=='\n')) line--;
-  csound->ErrorMsg(csound, Str("\n%s (token \"%s\"), "),
+  csound->ErrorMsg(csound, Str("%s (token \"%s\"), "),
                   str, csound_orcget_text(yyscanner));
-  csound->ErrorMsg(csound, Str(" line %d\n>>>"), line);
-  while ((ch=*--p) != '\n' && ch != '\0');
-  do {
-    ch = *++p;
-    if (UNLIKELY(ch == '\n')) break;
-    // Now get rid of any continuations
-    if (ch=='#' && strncmp(p,"sline ",6)) {
-      p+=7; while (isdigit(*p)) p++;
-    }
-    else csound->ErrorMsg(csound, "%c", ch);
-  } while (ch != '\n' && ch != '\0');
-  csound->ErrorMsg(csound, " <<<\n");
+  csound->ErrorMsg(csound, Str(" line %d, columns %d,%d\n"), line, column1, column2);
   do_baktrace(csound, files);
-
 }
 
 void do_baktrace(CSOUND *csound, uint64_t files)

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -35,9 +35,6 @@
 #include "csound_orc_semantics.h"
 #include "csound_orc_compile.h"
 
-#if defined(_WIN32) || defined(_WIN64)
-# define strtok_r strtok_s
-#endif
 
 static CS_VAR_POOL *find_global_annotation(char *varName,
                                            TYPE_TABLE* typeTable);

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -56,34 +56,6 @@ int32_t add_udo_definition(CSOUND *csound, bool newStyle, char *opname,
 const char* SYNTHESIZED_ARG = "_synthesized";
 const char* UNARY_PLUS = "_unary_plus";
 
-/* VL - 20.10.24 moved here from symbtab.c
-   as this is a more appropriate place for it
-*/
-ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
-{
-    IGN(yyscanner);
-    int32_t type = T_IDENT;
-    ORCTOKEN *ans;
-
-    if(UNLIKELY(csoundGetDebug(csound) & DEBUG_SEMANTICS))
-      csound->Message(csound, "Looking up token for: %s\n", s);
-    ans = new_token(csound, T_IDENT);
-    if (strchr(s, ':') != NULL) {
-        char* th;
-        char* baseName = strtok_r(s, ":", &th);
-        char* annotation = strtok_r(NULL, ":", &th);
-        ans->lexeme = csoundStrdup(csound, baseName);
-        ans->optype = csoundStrdup(csound, annotation);
-        type = T_TYPED_IDENT;
-    } else {
-        ans->lexeme = csoundStrdup(csound, s);
-    }
-    if (csound->parserNamedInstrFlag == 1) {
-        return ans;
-    }
-    ans->type = type;
-    return ans;
-}
 
 char* csoundStrdup(CSOUND* csound, const char* str) {
   size_t len;
@@ -2706,8 +2678,10 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
 
   OENTRIES* entries = find_opcode2(csound, opcodeName);
   if (UNLIKELY(entries == NULL || entries->count == 0)) {
-    synterr(csound, Str("unable to find opcode with name: %s, line %d\n"),
-            root->value->lexeme, root->line);
+    synterr(csound, Str("unable to find opcode with name: %s, line %d," 
+                         " columns %d-%d"),
+            root->value->lexeme, root->line,
+            root->value->first_column, root->value->last_column);
     if (entries != NULL) {
       csound->Free(csound, entries);
     }
@@ -2757,8 +2731,11 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
   if(oentry && oentry->deprecated) {
     if(oentry->deprecated == 1) {
       if(csound->oparms->error_deprecated) {
-        synterr(csound, "opcode %s is deprecated, line %d", oentry->opname,
-                root->line);
+        synterr(csound, "opcode %s is deprecated, line %d,"
+                " columns %d-%d",
+                oentry->opname,
+                root->line, root->value->first_column,
+                root->value->last_column);
         csoundMessage(csound, Str(" %s %s %s\n"),
                         leftArgString ? leftArgString : "",
                         oentry->opname, rightArgString ? rightArgString : "");
@@ -2769,15 +2746,22 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
     }
     else if(oentry->deprecated == 2) {
       if(csound->oparms->error_deprecated) {
-        synterr(csound, "opcode %s has been renamed (uppercase to lowercase / underscores removed), line %d",
-                oentry->opname, root->line);
+        synterr(csound, "opcode %s has been renamed"
+                " (uppercase to lowercase / underscores removed), line %d"
+                " columns %d-%d",
+                oentry->opname, root->line,root->value->first_column,
+                root->value->last_column);
         csoundMessage(csound, Str(" %s %s %s\n"),
                         leftArgString ? leftArgString : "",
                         oentry->opname, rightArgString ? rightArgString : "");
         return 0;
        }
-      else csoundWarning(csound, "opcode %s has been renamed (uppercase to lowercase / underscores removed), line %d",
-                         oentry->opname, root->line);
+      else csoundWarning(csound, "opcode %s has been renamed"
+                         " (uppercase to lowercase / underscores removed), line %d"
+                         " columns %d-%d",
+                         oentry->opname, root->line,
+                         root->value->first_column,
+                         root->value->last_column);
     }
    }
 
@@ -2787,7 +2771,10 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
     int32_t i;
     char *name = strip_extension(csound, opcodeName);
     synterr(csound, Str("Unable to find opcode entry for \'%s\'\n"
-                        "  with matching argument types, line %d"), name, root->line);
+                        "  with matching argument types, line %d"
+                        " columns %d-%d"), name, root->line,
+                          root->value->first_column,
+                         root->value->last_column);
     csound->Free(csound, name);
     name = strip_extension(csound, root->value->lexeme);
     csoundMessage(csound, Str("Found:\n  %s %s %s\n"),
@@ -2804,8 +2791,11 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
       csound->Free(csound, name);
     }
 
-    csoundMessage(csound, Str("\nLine: %d\n"),
-                  root->line);
+    csoundMessage(csound, Str("\nLine: %d\n"
+                              " columns %d-%d"),
+                  root->line,
+                  root->value->first_column,
+                  root->value->last_column);
     do_baktrace(csound, root->locn);
 
     csound->Free(csound, leftArgString);
@@ -3944,8 +3934,10 @@ TREE* copy_node(CSOUND* csound, TREE* tree) {
     ans->left = (tree->left == NULL) ? NULL : copy_node(csound, tree->left);
     ans->right = (tree->right == NULL) ? NULL : copy_node(csound, tree->right);
     if (tree->value != NULL) {
-      ans->value = make_token(csound, tree->value->lexeme);
+      ans->value = make_token(csound, tree->value->lexeme, NULL);
       ans->value->optype = csoundStrdup(csound, tree->value->optype);
+      ans->value->first_column = tree->value->first_column;
+      ans->value->last_column = tree->value->last_column;
     } else {
       ans->value = NULL;
     }
@@ -3975,8 +3967,10 @@ TREE* copy_node_shallow(CSOUND* csound, TREE* tree) {
     ans->right = tree->right;
 
     if (tree->value != NULL) {
-      ans->value = make_token(csound, tree->value->lexeme);
+      ans->value = make_token(csound, tree->value->lexeme, NULL);
       ans->value->optype = csoundStrdup(csound, tree->value->optype);
+      ans->value->first_column = tree->value->first_column;
+      ans->value->last_column = tree->value->last_column;      
     } else {
       ans->value = NULL;
     }
@@ -4449,7 +4443,7 @@ void handle_optional_args(CSOUND *csound, TREE *l)
         case 'O':             /* Will this work?  Doubtful code.... */
         case 'o':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
-                           make_int(csound, "0"));
+                           make_int(csound, "0", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);
@@ -4457,14 +4451,14 @@ void handle_optional_args(CSOUND *csound, TREE *l)
         case 'P':
         case 'p':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
-                           make_int(csound, "1"));
+                           make_int(csound, "1", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);
           break;
         case 'q':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
-                           make_int(csound, "10"));
+                           make_int(csound, "10", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);
@@ -4473,14 +4467,14 @@ void handle_optional_args(CSOUND *csound, TREE *l)
         case 'V':
         case 'v':
           temp = make_leaf(csound, l->line, l->locn, NUMBER_TOKEN,
-                           make_num(csound, ".5"));
+                           make_num(csound, ".5", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);
           break;
         case 'h':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
-                           make_int(csound, "127"));
+                           make_int(csound, "127", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);
@@ -4488,7 +4482,7 @@ void handle_optional_args(CSOUND *csound, TREE *l)
         case 'J':
         case 'j':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
-                           make_int(csound, "-1"));
+                           make_int(csound, "-1", NULL));
           temp->markup = &SYNTHESIZED_ARG;
           if (l->right==NULL) l->right = temp;
           else append_to_tree(csound, l->right, temp);

--- a/Engine/parse_param.h
+++ b/Engine/parse_param.h
@@ -57,6 +57,8 @@ typedef struct parse_parm_s {
     int             xstrptr,xstrmax;
     uint64_t        iline;      /* Line number for start of instrument */
     uint64_t        ilocn;      /* and location */
+    uint32_t        first_column;
+    uint32_t        last_column;  
     int             xsubstr;    /* count for substr */
 } PARSE_PARM;
 
@@ -69,4 +71,6 @@ extern uint8_t file_to_int(CSOUND*, const char*);
 extern void csound_orcput_ilocn(void *, uint64_t, uint64_t);
 extern uint64_t csound_orcget_iline(void *);
 extern uint64_t csound_orcget_ilocn(void *);
+extern uint32_t csound_orcget_first_column(void *);
+extern uint32_t csound_orcget_last_column(void *);
 #endif

--- a/Engine/symbtab.c
+++ b/Engine/symbtab.c
@@ -39,10 +39,6 @@
 #define PARSER_DEBUG (0)
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
-# define strtok_r strtok_s
-#endif
-
 static char* map_udo_in_arg_type(char* in) {
     if(strlen(in) == 1) {
       if (strchr("ijopqvh", *in) != NULL) {

--- a/H/csound_orc.h
+++ b/H/csound_orc.h
@@ -53,9 +53,9 @@ typedef struct type_table {
 
 TREE* make_node(CSOUND *, int32_t, uint64_t, int32_t, TREE*, TREE*);
 TREE* make_leaf(CSOUND *, int32_t, uint64_t, int32_t, ORCTOKEN*);
-ORCTOKEN* make_int(CSOUND *,char *);
-ORCTOKEN* make_num(CSOUND *,char *);
-ORCTOKEN *make_token(CSOUND *csound, char *s);
+ORCTOKEN* make_int(CSOUND *,char *, void*);
+ORCTOKEN* make_num(CSOUND *,char *, void *);
+ORCTOKEN *make_token(CSOUND *csound, char *s, void *);
 TREE* copy_node(CSOUND*, TREE*);
 extern void csp_orc_sa_print_list(CSOUND*);
 

--- a/H/tok.h
+++ b/H/tok.h
@@ -28,6 +28,6 @@
 
 /* typedef int32_t    (*SUBR)(void *, void *); */
 
-extern ORCTOKEN *new_token(CSOUND *, int32_t);
+extern ORCTOKEN *new_token(CSOUND *, int32_t, void *);
 
 #endif

--- a/InOut/midifile.c
+++ b/InOut/midifile.c
@@ -597,7 +597,7 @@ static int32_t midi_file_open(CSOUND *csound, const char *name, uint8_t port)
     fd = csound->FileOpen(csound, &f, CSFILE_STD, name, "rb",
                           "SFDIR;SSDIR;MFDIR", CSFTYPE_STD_MIDI, 0);
     if (UNLIKELY(fd == NULL)) {
-      csound->ErrorMsg(csound, Str(" *** error opening MIDI file '%s': %s"),
+      csound->ErrorMsg(csound, Str(" *** error opening MIDI file '%s': %s\n"),
                        name, strerror(errno));
       return -1;
     }

--- a/Top/csound_messages.c
+++ b/Top/csound_messages.c
@@ -109,6 +109,7 @@ void csoundDefaultMessageCallback(CSOUND *csound, int32_t attr,
       csound->csoundMessageStringCallback(csound, attr, csound->message_string);
     }
   }
+  
 }
 
  void csoundMessage(CSOUND *csound, const char *format, ...) {
@@ -127,6 +128,7 @@ void csoundDefaultMessageCallback(CSOUND *csound, int32_t attr,
 
  void csoundMessageS(CSOUND *csound, int32_t attr, const char *format,
                            ...) {
+
   if (!(csound->oparms->msglevel & CS_NOMSG)) {
     va_list args;
     va_start(args, format);
@@ -188,6 +190,7 @@ void csoundErrMsgV(CSOUND *csound, const char *hdr, const char *msg,
 
 void csoundErrorMsgS(CSOUND *csound, int32_t attr, const char *msg, ...) {
   va_list args;
+
   va_start(args, msg);
   csoundMessageV(csound, CSOUNDMSG_ERROR | attr, msg, args);
   va_end(args);

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -1274,12 +1274,12 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
         r = check_short_licence(csound, cf);
         result = r && result;
       }
-      else if (blank_buffer(/*csound,*/ buffer)) continue;
+      else if (blank_buffer(buffer)) continue;
       else if (started && strchr(p, '<') == buffer){
-        if(result > 0) // reading failed before here
-        csoundMessage(csound, Str("unknown CSD tag: %s"), buffer);
-        else
-          csoundMessage(csound, "\n");
+        if(result > 0) // we have an unknown tag
+         csoundMessage(csound, Str("unknown CSD tag: %s"), buffer);
+        else  // some other issue
+         csoundMessage(csound, "\n");
       }
     }
     if (UNLIKELY(!started)) {

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -410,7 +410,7 @@ int32_t read_options(CSOUND *csound, CORFIL *cf, int32_t readingCsOptions)
       else argdecode(csound, argc, argv);
     }
     if (UNLIKELY(readingCsOptions))
-      csoundErrorMsg(csound, Str("Missing end tag </CsOptions>"));
+      csoundErrorMsg(csound, Str("Missing end tag </CsOptions>\n"));
     return FALSE;
 }
 
@@ -504,7 +504,7 @@ static int32_t create_orchestra(CSOUND *csound, CORFIL *cf)
         goto nxt;
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsInstruments>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsInstruments>\n"));
     corfile_rm(csound, &incore);
     return FALSE;
 }
@@ -545,7 +545,7 @@ static int32_t create_orchestra(CSOUND *csound, CORFIL *cf)
       else
         corfile_puts(csound, buffer, incore);
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsInstruments>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsInstruments>\n"));
     corfile_rm(csound, &incore);
     return FALSE;
 }
@@ -616,7 +616,7 @@ static int32_t create_score(CSOUND *csound, CORFIL *cf)
         goto nxt;
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsScore>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsScore>\n"));
     return FALSE;
 }
 #else
@@ -642,7 +642,7 @@ static int32_t create_score(CSOUND *csound, CORFIL *cf)
       else
         corfile_puts(csound, buffer, csound->scorestr);
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsScore>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsScore>\n"));
     return FALSE;
 }
 #endif
@@ -887,7 +887,7 @@ static int32_t create_MIDI2(CSOUND *csound, CORFIL *cf)
         }
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsMidifileB>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsMidifileB>\n"));
     return FALSE;
 }
 
@@ -922,7 +922,7 @@ static int32_t create_sample(CSOUND *csound, char *buffer, CORFIL *cf)
         }
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsSampleB>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsSampleB>\n"));
     return FALSE;
 }
 
@@ -965,7 +965,7 @@ static int32_t create_file(CSOUND *csound, char *buffer, CORFIL *cf)
         }
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsFileB>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsFileB>\n"));
     return FALSE;
 }
 
@@ -1006,7 +1006,7 @@ static int32_t create_corfile(CSOUND *csound, char *buffer, CORFIL *cf)
         }
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsFileC>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsFileC>\n"));
     return FALSE;
 }
 #endif
@@ -1049,7 +1049,7 @@ static int32_t create_filea(CSOUND *csound, char *buffer, CORFIL *cf)
       fputs(buff, smpf);
     }
     if (UNLIKELY(res==FALSE))
-      csoundErrorMsg(csound, Str("Missing end tag </CsFile>"));
+      csoundErrorMsg(csound, Str("Missing end tag </CsFile>\n"));
     csoundFileClose(csound, fd);
     add_tmpfile(csound, filename);              /* IV - Feb 03 2005 */
     return res;
@@ -1100,7 +1100,7 @@ static int32_t check_version(CSOUND *csound, CORFIL *cf)
         }
       }
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsVersion>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsVersion>\n"));
     return FALSE;
 }
 
@@ -1127,7 +1127,7 @@ static int32_t check_licence(CSOUND *csound, CORFIL *cf)
       strlcat(licence, p, len);
     }
     csound->Free(csound, licence);
-    csoundErrorMsg(csound, Str("Missing end tag </CsLicence>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsLicence>\n"));
     return FALSE;
 }
 
@@ -1145,7 +1145,7 @@ static int32_t check_short_licence(CSOUND *csound, CORFIL *cf)
       }
       type = atoi(buff);
     }
-    csoundErrorMsg(csound, Str("Missing end tag </CsShortLicence>"));
+    csoundErrorMsg(csound, Str("Missing end tag </CsShortLicence>\n"));
     return FALSE;
 }
 
@@ -1197,7 +1197,7 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
           do {
             if (UNLIKELY(my_fgets_cf(csound, buffer,
                                    CSD_MAX_LINE_LEN, cf) == NULL)) {
-              csoundErrorMsg(csound, Str("Missing end tag </CsOptions>"));
+              csoundErrorMsg(csound, Str("Missing end tag </CsOptions>\n"));
               result = FALSE;
               break;
             }
@@ -1231,7 +1231,7 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
           do {
             if (UNLIKELY(my_fgets_cf(csound, buffer,
                                    CSD_MAX_LINE_LEN, cf) == NULL)) {
-              csoundErrorMsg(csound, Str("Missing end tag </CsMidiFileB>"));
+              csoundErrorMsg(csound, Str("Missing end tag </CsMidiFileB>\n"));
               result = FALSE;
               break;
             }
@@ -1276,7 +1276,10 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
       }
       else if (blank_buffer(/*csound,*/ buffer)) continue;
       else if (started && strchr(p, '<') == buffer){
-        csoundMessage(csound, Str("unknown CSD tag: %s\n"), buffer);
+        if(result > 0) // reading failed before here
+        csoundMessage(csound, Str("unknown CSD tag: %s"), buffer);
+        else
+          csoundMessage(csound, "\n");
       }
     }
     if (UNLIKELY(!started)) {

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -416,7 +416,7 @@ int32_t read_options(CSOUND *csound, CORFIL *cf, int32_t readingCsOptions)
 
 
 
-#if 1
+#if 0
 static int32_t all_blank(char* start, char* end)
 {
     while (start != end) {
@@ -551,7 +551,7 @@ static int32_t create_orchestra(CSOUND *csound, CORFIL *cf)
 }
 #endif
 
-#if 1
+#if 0
 static int32_t create_score(CSOUND *csound, CORFIL *cf)
 {
     char   *p, *q;
@@ -633,7 +633,7 @@ static int32_t create_score(CSOUND *csound, CORFIL *cf)
       while (isblank(*p)) p++;
       if (strstr(p, "</CsScore>") == p) {
         //#ifdef SCORE_PARSER
-        corfile_puts(csound, "\n#exit\n", csound->scorestr);
+        corfile_puts(csound, "\ne\n#exit\n", csound->scorestr);
         corfile_putc(csound, '\0', csound->scorestr); /* For use in bison/flex */
         corfile_putc(csound, '\0', csound->scorestr); /* For use in bison/flex */
         //#endif
@@ -1276,7 +1276,6 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
       }
       else if (blank_buffer(buffer)) continue;
       else if (started && strchr(p, '<') == buffer){
-        if(result > 0) // we have an unknown tag
          csoundMessage(csound, Str("unknown CSD tag: %s"), buffer);
       }
     }

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -479,7 +479,7 @@ static int32_t create_orchestra(CSOUND *csound, CORFIL *cf)
           }
           else if (c=='"') { state =  0; goto top;}
         }
-        csoundErrorMsg(csound, Str("missing \" to terminate string"));
+        csoundErrorMsg(csound, Str("CsInstruments: missing \" to terminate string\n"));
         corfile_rm(csound, &incore);
         return FALSE;
       }
@@ -600,7 +600,7 @@ static int32_t create_score(CSOUND *csound, CORFIL *cf)
           }
           else if (c=='"') { state =  0; goto top;}
         }
-        csoundErrorMsg(csound, Str("missing \" to terminate string"));
+        csoundErrorMsg(csound, Str("CsScore: missing \" to terminate string\n"));
         corfile_rm(csound, &csound->scorestr);
         return FALSE;
       }
@@ -1278,8 +1278,6 @@ int32_t read_unified_file4(CSOUND *csound, CORFIL *cf)
       else if (started && strchr(p, '<') == buffer){
         if(result > 0) // we have an unknown tag
          csoundMessage(csound, Str("unknown CSD tag: %s"), buffer);
-        else  // some other issue
-         csoundMessage(csound, "\n");
       }
     }
     if (UNLIKELY(!started)) {

--- a/include/csound_compiler.h
+++ b/include/csound_compiler.h
@@ -34,6 +34,8 @@ extern "C" {
     int32_t              value;
     double           fvalue;
     char             *optype;
+    uint32_t        first_column;
+    uint32_t        last_column;    
     struct ORCTOKEN  *next;
   } ORCTOKEN;
 

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -607,4 +607,9 @@ typedef int32_t spin_lock_t;
 #else
 # define ignore_value(x) ((void) (x))
 #endif
+
+#if defined(_WIN32) || defined(_WIN64)
+# define strtok_r strtok_s
+#endif
+
 #endif  /* CSOUND_SYSDEP_H */

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -167,6 +167,505 @@ TEST_F (OrcCompileTests, testLineNumber)
     ASSERT_TRUE(tree != NULL);
 }
 
+// Helper to dump AST tree for debugging column number tests
+static void dump_tree(TREE *t, int depth) {
+    if (!t) return;
+    for (int i = 0; i < depth; i++) printf("  ");
+    printf("type=%d line=%d", t->type, t->line);
+    if (t->value) {
+        printf(" lexeme=\"%s\" cols=%u-%u",
+               t->value->lexeme ? t->value->lexeme : "(null)",
+               t->value->first_column, t->value->last_column);
+    }
+    printf("\n");
+    if (t->left) {
+        for (int i = 0; i < depth; i++) printf("  ");
+        printf(" LEFT:\n");
+        dump_tree(t->left, depth + 1);
+    }
+    if (t->right) {
+        for (int i = 0; i < depth; i++) printf("  ");
+        printf(" RIGHT:\n");
+        dump_tree(t->right, depth + 1);
+    }
+    if (t->next) {
+        dump_tree(t->next, depth);
+    }
+}
+
+// Test basic column number tracking on tokens
+TEST_F (OrcCompileTests, testColumnNumbers)
+{
+    //          col: 123456789
+    const char *orc = "instr 1\n"        // line 1: "1" at col 7
+                      "k1 = 440\n"       // line 2: "k1" cols 1-2, "440" cols 6-8
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    // csoundParseOrc returns a root node (type=0);
+    // the instr block is linked via ->next
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+
+    // LEFT child: instrument number "1"
+    ASSERT_TRUE(instr->left != NULL);
+    ASSERT_TRUE(instr->left->value != NULL);
+    ASSERT_STREQ("1", instr->left->value->lexeme);
+    ASSERT_EQ(7u, instr->left->value->first_column);
+    ASSERT_EQ(7u, instr->left->value->last_column);
+
+    // RIGHT child: the body "k1 = 440"
+    TREE *body = instr->right;
+    ASSERT_TRUE(body != NULL);
+
+    // body LEFT: "k1" identifier
+    ASSERT_TRUE(body->left != NULL);
+    ASSERT_TRUE(body->left->value != NULL);
+    ASSERT_STREQ("k1", body->left->value->lexeme);
+    ASSERT_EQ(1u, body->left->value->first_column);
+    ASSERT_EQ(2u, body->left->value->last_column);
+
+    // body RIGHT: "440" number
+    ASSERT_TRUE(body->right != NULL);
+    ASSERT_TRUE(body->right->value != NULL);
+    ASSERT_STREQ("440", body->right->value->lexeme);
+    ASSERT_EQ(6u, body->right->value->first_column);
+    ASSERT_EQ(8u, body->right->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test that column numbers reset correctly across multiple lines
+TEST_F (OrcCompileTests, testColumnNumbersMultiLine)
+{
+    //          col: 123456789012345
+    const char *orc = "instr 1\n"
+                      "k1 = 100\n"       // line 2: "k1" cols 1-2
+                      "k2 = 200\n"       // line 3: "k2" cols 1-2 (reset from prev line)
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    // First statement: k1
+    TREE *stmt1 = instr->right;
+    ASSERT_TRUE(stmt1->left != NULL && stmt1->left->value != NULL);
+    ASSERT_STREQ("k1", stmt1->left->value->lexeme);
+    ASSERT_EQ(1u, stmt1->left->value->first_column);
+    ASSERT_EQ(2u, stmt1->left->value->last_column);
+
+    // Second statement: k2 (via stmt1->next)
+    TREE *stmt2 = stmt1->next;
+    ASSERT_TRUE(stmt2 != NULL);
+    ASSERT_TRUE(stmt2->left != NULL && stmt2->left->value != NULL);
+    ASSERT_STREQ("k2", stmt2->left->value->lexeme);
+    ASSERT_EQ(1u, stmt2->left->value->first_column);
+    ASSERT_EQ(2u, stmt2->left->value->last_column);
+
+    // Verify the values too
+    ASSERT_TRUE(stmt1->right != NULL && stmt1->right->value != NULL);
+    ASSERT_STREQ("100", stmt1->right->value->lexeme);
+    ASSERT_EQ(6u, stmt1->right->value->first_column);
+    ASSERT_EQ(8u, stmt1->right->value->last_column);
+
+    ASSERT_TRUE(stmt2->right != NULL && stmt2->right->value != NULL);
+    ASSERT_STREQ("200", stmt2->right->value->lexeme);
+    ASSERT_EQ(6u, stmt2->right->value->first_column);
+    ASSERT_EQ(8u, stmt2->right->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test column tracking through xstr ({{ }}) multi-line strings
+// BUG: <xstr> newline rule does not reset yycolumn, so the column
+// reported for the STRING_TOKEN (at the closing }}) is wrong.
+TEST_F (OrcCompileTests, testColumnNumbersXstr)
+{
+    const char *orc = "instr 1\n"                 // line 1
+                      "Sval = {{\n"                // line 2: Sval col 1-4
+                      "hello\n"                    // line 3: inside string
+                      "}}\n"                       // line 4: }} at cols 1-2
+                      "k1 = 440\n"                 // line 5
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    // First statement: Sval = {{ ... }}
+    TREE *stmt1 = instr->right;
+    ASSERT_TRUE(stmt1->left != NULL && stmt1->left->value != NULL);
+    ASSERT_STREQ("Sval", stmt1->left->value->lexeme);
+    ASSERT_EQ(1u, stmt1->left->value->first_column);
+    ASSERT_EQ(4u, stmt1->left->value->last_column);
+
+    // The STRING_TOKEN (right child) should have columns of the
+    // closing }} which is at columns 1-2 on its line.
+    // BUG: without yycolumn reset in <xstr> newline, this will be 17-18
+    ASSERT_TRUE(stmt1->right != NULL && stmt1->right->value != NULL);
+    ASSERT_EQ(1u, stmt1->right->value->first_column);
+    ASSERT_EQ(2u, stmt1->right->value->last_column);
+
+    // Second statement: k1 = 440 (should be correct regardless,
+    // since the newline after }} hits the INITIAL rule)
+    TREE *stmt2 = stmt1->next;
+    ASSERT_TRUE(stmt2 != NULL);
+    ASSERT_TRUE(stmt2->left != NULL && stmt2->left->value != NULL);
+    ASSERT_STREQ("k1", stmt2->left->value->lexeme);
+    ASSERT_EQ(1u, stmt2->left->value->first_column);
+    ASSERT_EQ(2u, stmt2->left->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test column tracking through rstr (R{ }R) multi-line strings.
+// The <rstr> newline rule was already fixed with yycolumn = 1.
+TEST_F (OrcCompileTests, testColumnNumbersRstr)
+{
+    //                                        R{ starts rstr
+    const char *orc = "instr 1\n"                 // line 1
+                      "Sval = R{\n"                // line 2: Sval col 1-4
+                      "hello\n"                    // line 3: inside string
+                      "}R\n"                       // line 4: }R at cols 1-2
+                      "k1 = 440\n"                 // line 5
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    // First statement: Sval = R{ ... }R
+    TREE *stmt1 = instr->right;
+    ASSERT_TRUE(stmt1->left != NULL && stmt1->left->value != NULL);
+    ASSERT_STREQ("Sval", stmt1->left->value->lexeme);
+
+    // The STRING_TOKEN for rstr: }R at cols 1-2 on its line
+    ASSERT_TRUE(stmt1->right != NULL && stmt1->right->value != NULL);
+    ASSERT_EQ(1u, stmt1->right->value->first_column);
+    ASSERT_EQ(2u, stmt1->right->value->last_column);
+
+    // k1 after the rstr
+    TREE *stmt2 = stmt1->next;
+    ASSERT_TRUE(stmt2 != NULL);
+    ASSERT_TRUE(stmt2->left != NULL && stmt2->left->value != NULL);
+    ASSERT_STREQ("k1", stmt2->left->value->lexeme);
+    ASSERT_EQ(1u, stmt2->left->value->first_column);
+    ASSERT_EQ(2u, stmt2->left->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test that error messages contain column information
+TEST_F (OrcCompileTests, testColumnNumbersInErrors)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    // Deliberate error: unknown opcode at a known column position
+    //          col: 1234567890123456
+    const char *orc = "instr 1\n"
+                      "k1 badopcode 440\n"  // "badopcode" at cols 4-12
+                      "endin\n";
+
+    int32_t result = csoundCompileOrc(csound, orc);
+
+    // Scan message buffer for column info
+    bool found_column = false;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg && strstr(msg, "columns")) {
+            found_column = true;
+            printf("Error message with columns: %s\n", msg);
+        }
+        csoundPopFirstMessage(csound);
+    }
+    ASSERT_TRUE(found_column);
+}
+
+// Test that "unable to find opcode" error includes correct column range
+TEST_F (OrcCompileTests, testErrorMsgUnknownOpcodeColumns)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 1234567890123456
+    const char *orc = "instr 1\n"
+                      "k1 badopcode 440\n"  // "badopcode" at cols 4-12
+                      "endin\n";
+
+    csoundCompileOrc(csound, orc);
+
+    // Collect all messages into one string for easier matching
+    std::string allMessages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // verify_opcode emits "columns %d-%d" with the opcode token columns
+    // "badopcode" starts at col 4, ends at col 12
+    ASSERT_TRUE(allMessages.find("columns 4-12") != std::string::npos)
+        << "Expected 'columns 4-12' in error output, got:\n" << allMessages;
+}
+
+// Test that syntax errors (parser-level) include column info
+TEST_F (OrcCompileTests, testErrorMsgSyntaxErrorColumns)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 123456789
+    const char *orc = "instr 1\n"
+                      "k1 = +\n"  // syntax error: unexpected +
+                      "endin\n";
+
+    csoundCompileOrc(csound, orc);
+
+    // Collect all messages
+    std::string allMessages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // csound_orcerror emits "columns %d,%d" (note: comma separator)
+    ASSERT_TRUE(allMessages.find("columns") != std::string::npos)
+        << "Expected 'columns' in syntax error output, got:\n" << allMessages;
+}
+
+// Test that error for wrong argument types includes column info
+TEST_F (OrcCompileTests, testErrorMsgWrongArgsColumns)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 123456789012345678
+    const char *orc = "instr 1\n"
+                      "k1 oscil \"bad\"\n"  // wrong arg type for oscil
+                      "endin\n";
+
+    csoundCompileOrc(csound, orc);
+
+    // Collect all messages
+    std::string allMessages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // Should contain column info from verify_opcode error path
+    ASSERT_TRUE(allMessages.find("columns") != std::string::npos)
+        << "Expected 'columns' in arg-mismatch error output, got:\n" << allMessages;
+    // "oscil" at cols 4-8
+    ASSERT_TRUE(allMessages.find("columns 4-8") != std::string::npos)
+        << "Expected 'columns 4-8' for 'oscil' in error output, got:\n" << allMessages;
+}
+
+// Test that error columns work correctly with leading whitespace
+TEST_F (OrcCompileTests, testErrorMsgColumnsWithIndentation)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 1234567890123456789012
+    const char *orc = "instr 1\n"
+                      "    k1 badopcode 440\n"  // "badopcode" at cols 8-16
+                      "endin\n";
+
+    csoundCompileOrc(csound, orc);
+
+    // Collect all messages
+    std::string allMessages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // "badopcode" at cols 8-16 (4 spaces + "k1 " = 7, then badopcode at 8)
+    ASSERT_TRUE(allMessages.find("columns 8-16") != std::string::npos)
+        << "Expected 'columns 8-16' for indented 'badopcode', got:\n" << allMessages;
+}
+
+// Test that errors at different column offsets report the correct positions
+TEST_F (OrcCompileTests, testErrorMsgDifferentColumnOffsets)
+{
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 123456789012345678
+    const char *orc = "instr 1\n"
+                      "k1 bad1 440\n"       // "bad1" at cols 4-7
+                      "endin\n";
+
+    csoundCompileOrc(csound, orc);
+
+    std::string allMessages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // "bad1" at cols 4-7
+    ASSERT_TRUE(allMessages.find("columns 4-7") != std::string::npos)
+        << "Expected 'columns 4-7' for 'bad1', got:\n" << allMessages;
+
+    // Now try a different column offset in a fresh instance
+    csoundReset(csound);
+    csoundCreateMessageBuffer(csound, 0);
+
+    //          col: 123456789012345678901
+    const char *orc2 = "instr 1\n"
+                       "k1 = 1\n"
+                       "   k2 badop2 440\n"  // "badop2" at cols 7-12
+                       "endin\n";
+
+    csoundCompileOrc(csound, orc2);
+
+    std::string allMessages2;
+    while (csoundGetMessageCnt(csound)) {
+        const char *msg = csoundGetFirstMessage(csound);
+        if (msg) allMessages2 += msg;
+        csoundPopFirstMessage(csound);
+    }
+
+    // "badop2" at cols 7-12
+    ASSERT_TRUE(allMessages2.find("columns 7-12") != std::string::npos)
+        << "Expected 'columns 7-12' for 'badop2', got:\n" << allMessages2;
+}
+
+// Test column tracking across line continuation (\)
+// Preprocessor converts \<LF> to inline #sline N directive;
+// the <sline> rule must reset yycolumn so subsequent tokens
+// get correct source columns.
+TEST_F (OrcCompileTests, testColumnNumbersContinuation)
+{
+    //                   col: 12345678
+    const char *orc = "instr 1\n"
+                      "k1 = \\\n"           // line 2: k1 cols 1-2, \ joins next line
+                      "     440\n"           // line 3: 440 at cols 6-8
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    TREE *stmt1 = instr->right;
+    ASSERT_TRUE(stmt1->left != NULL && stmt1->left->value != NULL);
+    ASSERT_STREQ("k1", stmt1->left->value->lexeme);
+    ASSERT_EQ(1u, stmt1->left->value->first_column);
+    ASSERT_EQ(2u, stmt1->left->value->last_column);
+
+    // After \, the preprocessor emits #sline which resets yycolumn.
+    // Five spaces of source indentation then advance to col 6.
+    // "440" should be at columns 6-8.
+    ASSERT_TRUE(stmt1->right != NULL && stmt1->right->value != NULL);
+    ASSERT_STREQ("440", stmt1->right->value->lexeme);
+    ASSERT_EQ(6u, stmt1->right->value->first_column);
+    ASSERT_EQ(8u, stmt1->right->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test column tracking inside parentheses (ignorenewline state)
+// Newlines inside parens should reset yycolumn but not return NEWLINE.
+// Note: the parser expands (100 + 200) into an implicit ##add node
+// with a temp #i0 variable, so the AST has 3 statements:
+//   ##add(100, 200) -> #i0, k1 = #i0, k2 = 300
+TEST_F (OrcCompileTests, testColumnNumbersIgnoreNewline)
+{
+    const char *orc = "instr 1\n"
+                      "k1 = (100 +\n"      // line 2: ( triggers ignorenewline
+                      " 200)\n"             // line 3: 200 at cols 2-4
+                      "k2 = 300\n"          // line 4: k2 at cols 1-2
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    // First node is the implicit ##add operation.
+    // Its right children contain the operands:
+    //   100 at cols 7-9 (line 2), 200 at cols 2-4 (line 3, after newline)
+    TREE *add_node = instr->right;
+    ASSERT_TRUE(add_node->right != NULL && add_node->right->value != NULL);
+    ASSERT_STREQ("100", add_node->right->value->lexeme);
+    ASSERT_EQ(7u, add_node->right->value->first_column);
+    ASSERT_EQ(9u, add_node->right->value->last_column);
+
+    // "200" is the next operand of ##add
+    ASSERT_TRUE(add_node->right->next != NULL && add_node->right->next->value != NULL);
+    ASSERT_STREQ("200", add_node->right->next->value->lexeme);
+    ASSERT_EQ(2u, add_node->right->next->value->first_column);
+    ASSERT_EQ(4u, add_node->right->next->value->last_column);
+
+    // Third statement: k2 = 300
+    TREE *k2_stmt = add_node->next->next;
+    ASSERT_TRUE(k2_stmt != NULL);
+    ASSERT_TRUE(k2_stmt->left != NULL && k2_stmt->left->value != NULL);
+    ASSERT_STREQ("k2", k2_stmt->left->value->lexeme);
+    ASSERT_EQ(1u, k2_stmt->left->value->first_column);
+    ASSERT_EQ(2u, k2_stmt->left->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
+// Test column tracking for regular quoted strings ("...")
+// Note: flex input() used for string scanning bypasses YY_USER_ACTION,
+// so the token columns reflect the opening quote position only.
+// Next-line tokens are still correct because newline resets yycolumn.
+TEST_F (OrcCompileTests, testColumnNumbersQuotedString)
+{
+    const char *orc = "instr 1\n"
+                      "S1 = \"hello\"\n"     // line 2: S1 cols 1-2, "hello" starts at col 6
+                      "k1 = 440\n"            // line 3: k1 at cols 1-2 (after newline reset)
+                      "endin\n";
+
+    TREE *tree = csoundParseOrc(csound, orc);
+    ASSERT_TRUE(tree != NULL);
+
+    TREE *instr = tree->next;
+    ASSERT_TRUE(instr != NULL);
+    ASSERT_TRUE(instr->right != NULL);
+
+    // S1 = "hello"
+    TREE *stmt1 = instr->right;
+    ASSERT_TRUE(stmt1->left != NULL && stmt1->left->value != NULL);
+    ASSERT_STREQ("S1", stmt1->left->value->lexeme);
+    ASSERT_EQ(1u, stmt1->left->value->first_column);
+    ASSERT_EQ(2u, stmt1->left->value->last_column);
+
+    // The STRING_TOKEN first_column points to the opening quote
+    ASSERT_TRUE(stmt1->right != NULL && stmt1->right->value != NULL);
+    ASSERT_EQ(6u, stmt1->right->value->first_column);
+
+    // k1 on the next line should have correct columns (newline resets yycolumn)
+    TREE *stmt2 = stmt1->next;
+    ASSERT_TRUE(stmt2 != NULL);
+    ASSERT_TRUE(stmt2->left != NULL && stmt2->left->value != NULL);
+    ASSERT_STREQ("k1", stmt2->left->value->lexeme);
+    ASSERT_EQ(1u, stmt2->left->value->first_column);
+    ASSERT_EQ(2u, stmt2->left->value->last_column);
+
+    csoundDeleteTree(csound, tree);
+}
+
 TEST_F (OrcCompileTests, testStringsInEvent)
 {
     const char* instrument = R"(


### PR DESCRIPTION
This PR adds column ranges to parse parameters in the lexer.

 - csound_orcerror() modified to use this for better diagnostics
 - ~future enhancements may add this to the TREE (through make_node() etc)~ column ranges added to ORCTOKEN
 - verify_tree() modified to use this for better diagnostics - demonstrates the use in the parser.
 - this is now available for other synterr() applications (beyond the scope of the PR)

NB: synthetic tokens do not set line ranges, as we would expect them not to raise syntax errors themselves.

closes #545