### PR TITLE
cmake fixes

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -102,7 +102,7 @@ jobs:
           sudo apt-get install cmake libjack-dev libpulse-dev ladspa-sdk dssi-dev autoconf libtool
 
       - name: Configure Build
-        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/linux/custom.cmake" -DBUILD_PLUGINS=1
+        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/linux/custom.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,12 +1146,6 @@ endif()
 
 list(APPEND libcsound_SRCS)
 
-list(APPEND libcsound_static_SRCS ${stdopcod_SRCS} ${cs_pvs_ops_SRCS} ${physmod_SRCS}
-${pitch_ops_SRCS}  ${oldpvoc_SRCS} ${scanops_SRCS} ${mp3in_SRCS} ${cppops_SRCS}
-${hrtf_ops_SRCS} ${sock_ops_SRCS} ${externs_SRCS} ${gens_SRCS} ${pitch_ops_SRCS}
-${newgabops_SRCS}  ${oldpvoc_SRCS} ${vbap_ops}
-)
-
 if(NOT BUILD_PLUGINS)
  list(APPEND libcsound_SRCS ${cppops_SRCS} ${scanops_SRCS} ${physmod_SRCS}
  ${mp3in_SRCS} ${hrtf_ops_SRCS} ${sock_ops_SRCS} ${externs_SRCS}
@@ -1159,7 +1153,18 @@ if(NOT BUILD_PLUGINS)
  ${pitch_ops_SRCS} ${vbap_ops} ${stdopcod_SRCS}
 )
  list(APPEND libcsound_CFLAGS -DCS_INTERNAL)
+
+ list(APPEND libcsound_static_SRCS ${stdopcod_SRCS} ${cs_pvs_ops_SRCS} ${physmod_SRCS}
+${pitch_ops_SRCS}  ${oldpvoc_SRCS} ${scanops_SRCS} ${mp3in_SRCS} ${cppops_SRCS}
+${hrtf_ops_SRCS} ${sock_ops_SRCS} ${externs_SRCS} ${gens_SRCS} ${pitch_ops_SRCS}
+${newgabops_SRCS}  ${oldpvoc_SRCS} ${vbap_ops}
+)
+else()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_PLUGINS")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DBUILD_PLUGINS")
 endif()
+
+
 
 if(UNIX)
 if(NOT BUILD_PLUGINS)

--- a/Daisy/Custom.cmake
+++ b/Daisy/Custom.cmake
@@ -21,7 +21,6 @@ set(BUILD_DEPRECATED_OPCODES OFF)
 set(BUILD_UTILITIES OFF)
 set(INSTALL_PYTHON_INTERFACE OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -Wno-incompatible-pointer-types")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w -Wno-incompatible-pointer-types") 
 
 

--- a/include/csdl.h
+++ b/include/csdl.h
@@ -161,8 +161,8 @@ PUBLIC int64_t csound_opcode_init(CSOUND *csound, OENTRY **ep)             \
 {   (void) csound; *ep = name; return (int64_t) (sizeof(name));  }         \
 PUBLIC int32_t csoundModuleInfo(void)                                       \
 { return ((CS_VERSION << 16) + (CS_SUBVER << 8) + (int32_t) sizeof(MYFLT)); } \
-OENTRY *name##_p = name; \
-int32_t name##_len = (int32_t) (sizeof(name)/sizeof(OENTRY)); \
+const OENTRY *name##_p = name; \
+const int32_t name##_len = (int32_t) (sizeof(name)/sizeof(OENTRY)); \
 
 /** LINKAGE for f-table plugins */
 

--- a/include/csdl.h
+++ b/include/csdl.h
@@ -160,7 +160,9 @@ PUBLIC  int32_t csoundModuleInfo(void)                                       \
 PUBLIC int64_t csound_opcode_init(CSOUND *csound, OENTRY **ep)             \
 {   (void) csound; *ep = name; return (int64_t) (sizeof(name));  }         \
 PUBLIC int32_t csoundModuleInfo(void)                                       \
-{ return ((CS_VERSION << 16) + (CS_SUBVER << 8) + (int32_t) sizeof(MYFLT)); }
+{ return ((CS_VERSION << 16) + (CS_SUBVER << 8) + (int32_t) sizeof(MYFLT)); } \
+OENTRY *name##_p = name; \
+int32_t name##_len = (int32_t) (sizeof(name)/sizeof(OENTRY)); \
 
 /** LINKAGE for f-table plugins */
 

--- a/include/csound.h
+++ b/include/csound.h
@@ -380,6 +380,8 @@ extern "C" {
                                     const char *channelName,
                                     void *channelValuePtr,
                                     const void *channelType);
+
+  typedef struct oentry OENTRY;
   /**
      Event Types
   */
@@ -1395,6 +1397,12 @@ extern "C" {
                                  int32_t (*init)(CSOUND *, void *),
                                  int32_t (*perf)(CSOUND *, void *),
                                  int32_t (*deinit)(CSOUND *, void *));
+
+  /** 
+   * Appends a list of opcodes given as OENTRY array of length lne
+   */
+  PUBLIC int32_t csoundAppendOpcodes(CSOUND *, const OENTRY *oplist, int32_t len);
+  
 
   /** @}*/
 #endif  /* !CSOUND_CSDL_H */


### PR DESCRIPTION
There was a problem with the cmake script to build with plugins (-DBUILD_PLUGINS=ON) instead of builtin opcodes. Firstly, the static library build ignored this option and built opcodes into the library (which defeated the purpose). Secondly, the token BUILD_PLUGINS was not being added to the library build and so the code in csmodule.c was looking for the the static module functions, which do not exist in this case.

With this now we can build static libs that are much smaller, and then we may be able to link specific opcodes when using it instead of the complete set. On the arm baremetal build, the reduction in size is substantial (from 3.8 to 1.8MB).