### PR TITLE
added per-k-cycle callback support for Csound debugger in WASM

### DIFF
--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1064,6 +1064,8 @@ static const CSOUND cenviron_ = {
   0,              /* modules loaded */
   -1,             /* audio system sr */
   0,              /* csdebug_data */
+  NULL,           /* debug_cb */
+  NULL,           /* debug_cb_data */
   0,              /* which score parser */
   0,              /* print_version */
   1,              /* inZero */

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -660,8 +660,28 @@ int32_t kperf_debug(CSOUND *csound) {
     }
   }
 
+  /* fire per-k-cycle debug callback if set (only when not stopped at a breakpoint) */
+  if (csound->debug_cb && (!data || data->status != CSDEBUG_STATUS_STOPPED)) {
+    csound->debug_cb(csound, csound->debug_cb_data);
+  }
   if (!data || data->status != CSDEBUG_STATUS_STOPPED)
     csound->spoutran(csound); /*      send to audio_out  */
 
   return 0;
+}
+
+/* ---- per-k-cycle debug callback API ---- */
+
+void csoundSetDebugCallback(CSOUND *csound,
+                            void (*cb)(CSOUND *, void *),
+                            void *userdata)
+{
+  csound->debug_cb      = cb;
+  csound->debug_cb_data = userdata;
+}
+
+void csoundRemoveDebugCallback(CSOUND *csound)
+{
+  csound->debug_cb      = NULL;
+  csound->debug_cb_data = NULL;
 }

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -64,6 +64,8 @@ void csoundDebuggerBreakpointReached(CSOUND *csound)
 
  void csoundDebuggerInit(CSOUND *csound)
 {
+    /* Idempotent: do nothing if already initialized */
+    if (csound->csdebug_data != NULL) return;
     csdebug_data_t *data =
       (csdebug_data_t *) csound->Malloc(csound, sizeof(csdebug_data_t));
     data->bkpt_anchor = (bkpt_node_t *) csound->Malloc(csound, sizeof(bkpt_node_t));

--- a/include/csdebug.h
+++ b/include/csdebug.h
@@ -154,6 +154,22 @@ extern "C" {
  * see csoundSetBreakpointCallback() */
 typedef void (*breakpoint_cb_t) (CSOUND *, debug_bkpt_info_t *, void *userdata);
 
+/** Debug k-cycle callback function type
+ *
+ * Called after every k-cycle when the debugger is active (kperf_debug),
+ * after all instruments have run, before audio output is sent.
+ * Use csoundDebugGetInstrInstances() and csoundDebugGetVariables() inside
+ * the callback to inspect active instrument variables in real time.
+ * The callback must return quickly — it fires from within the performance
+ * loop.
+ *
+ * Unlike the breakpoint callback, this callback is non-stopping: Csound
+ * continues performance normally after the callback returns.
+ *
+ * Requires csoundDebuggerInit() to have been called first.
+ */
+typedef void (*debug_cb_t)(CSOUND *csound, void *userdata);
+
 typedef struct csdebug_data_s {
     void *bkpt_buffer; /* for passing breakpoints to the running engine */
     void *cmd_buffer;     /* for passing commands to the running engine */
@@ -300,6 +316,38 @@ PUBLIC debug_variable_t *csoundDebugGetVariables(CSOUND *csound,
 PUBLIC void csoundDebugFreeVariables(CSOUND *csound,
                                      debug_variable_t *varHead);
 
+
+/** Set a per-k-cycle debug callback
+ *
+ * Registers a function that will be called after every k-cycle when the
+ * debugger is active, once all active instrument instances have been
+ * processed and before the audio output buffer is sent. This provides a
+ * non-stopping hook into the debug performance loop suitable for real-time
+ * variable inspection.
+ *
+ * Requires csoundDebuggerInit() to have been called first — the callback
+ * only fires inside kperf_debug().
+ *
+ * Inside the callback, csoundDebugGetInstrInstances() and
+ * csoundDebugGetVariables() can be used to read the current state of all
+ * active instruments.
+ *
+ * Pass NULL for cb to remove a previously set callback.
+ *
+ * @param csound   Csound instance pointer
+ * @param cb       pointer to callback function (NULL to remove)
+ * @param userdata pointer to user data passed back to the callback
+ */
+PUBLIC void csoundSetDebugCallback(CSOUND *csound,
+                                   debug_cb_t cb, void *userdata);
+
+/** Remove the per-k-cycle debug callback
+ *
+ * Equivalent to calling csoundSetDebugCallback(csound, NULL, NULL).
+ *
+ * @param csound Csound instance pointer
+ */
+PUBLIC void csoundRemoveDebugCallback(CSOUND *csound);
 
 /**  @} */
 

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1773,6 +1773,8 @@ struct CSOUND_ {
   int32_t modules_loaded;
   MYFLT _system_sr;
   void *csdebug_data; /* debugger data */
+  void (*debug_cb)(CSOUND *, void *); /* per-k-cycle debug callback, set via csoundSetDebugCallback() */
+  void *debug_cb_data;               /* userdata for debug_cb */
 
   int32_t score_parser;
   int32_t print_version;

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -14,6 +14,7 @@ if(BUILD_TESTS)
   add_executable(unittests
         channel_tests.cpp
         csound_data_structures_test.cpp
+        csound_debug_callback_test.cpp
         csound_debugger_test.cpp
         csound_message_buffer_test.cpp
         csound_option_parser_test.cpp

--- a/tests/c/csound_debug_callback_test.cpp
+++ b/tests/c/csound_debug_callback_test.cpp
@@ -1,0 +1,166 @@
+/*
+ * csound_debug_callback_test.cpp
+ *
+ * Tests for csoundSetDebugCallback() / csoundRemoveDebugCallback().
+ *
+ * The callback fires inside kperf_debug() only — it requires
+ * csoundDebuggerInit() to have been called first (which activates
+ * kperf_debug). It does NOT fire in the normal kperf() loop.
+ */
+#define __BUILDING_LIBCSOUND
+#include "csoundCore.h"
+#include "csdebug.h"
+#include "gtest/gtest.h"
+
+/* Counts every time the callback fires */
+static void debug_count_cb(CSOUND * /*csound*/, void *userdata)
+{
+    int32_t *count = (int32_t *) userdata;
+    *count += 1;
+}
+
+/* Breakpoint callback used in the "stopped" test */
+static void brkpt_noop_cb(CSOUND * /*csound*/,
+                           debug_bkpt_info_t * /*info*/,
+                           void * /*userdata*/)
+{
+}
+
+class DebugCallbackTests : public ::testing::Test {
+public:
+    virtual void SetUp()
+    {
+        csound = csoundCreate(NULL, NULL);
+        csoundCreateMessageBuffer(csound, 0);
+        csoundSetOption(csound, "-n"); /* no audio output */
+    }
+
+    virtual void TearDown()
+    {
+        csoundDestroy(csound);
+        csound = nullptr;
+    }
+
+    CSOUND *csound{nullptr};
+};
+
+/* ------------------------------------------------------------------ */
+/* 1. Set and remove without debugger active — must not crash           */
+/* ------------------------------------------------------------------ */
+TEST_F(DebugCallbackTests, testSetAndRemoveNoDebugger)
+{
+    int32_t count = 0;
+    csoundSetDebugCallback(csound, debug_count_cb, (void *) &count);
+    csoundRemoveDebugCallback(csound);
+    ASSERT_EQ(count, 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* 2. Callback fires once per k-cycle when kperf_debug is active        */
+/* ------------------------------------------------------------------ */
+TEST_F(DebugCallbackTests, testCallbackFiresInDebugMode)
+{
+    const int32_t CYCLES = 20;
+    int32_t count = 0;
+
+    csoundCompileOrc(csound, "instr 1\nasig oscil 1, p4\nendin\n", 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 2 440", 0);
+
+    csoundDebuggerInit(csound);
+    csoundSetDebugCallback(csound, debug_count_cb, (void *) &count);
+
+    for (int32_t i = 0; i < CYCLES; i++) {
+        csoundPerformKsmps(csound);
+    }
+
+    ASSERT_EQ(count, CYCLES);
+    csoundDebuggerClean(csound);
+}
+
+/* ------------------------------------------------------------------ */
+/* 3. Callback must NOT fire when csoundDebuggerInit has NOT been called */
+/*    (csoundPerformKsmps dispatches to kperf, not kperf_debug)         */
+/* ------------------------------------------------------------------ */
+TEST_F(DebugCallbackTests, testCallbackNotFiredWithoutDebugger)
+{
+    int32_t count = 0;
+
+    csoundCompileOrc(csound, "instr 1\nasig oscil 1, p4\nendin\n", 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 2 440", 0);
+
+    /* Deliberately skip csoundDebuggerInit — kperf() will be used */
+    csoundSetDebugCallback(csound, debug_count_cb, (void *) &count);
+
+    for (int32_t i = 0; i < 20; i++) {
+        csoundPerformKsmps(csound);
+    }
+
+    ASSERT_EQ(count, 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* 4. After csoundRemoveDebugCallback the callback stops firing         */
+/* ------------------------------------------------------------------ */
+TEST_F(DebugCallbackTests, testRemoveStopsFiring)
+{
+    const int32_t FIRST = 10;
+    const int32_t SECOND = 10;
+    int32_t count = 0;
+
+    csoundCompileOrc(csound, "instr 1\nasig oscil 1, p4\nendin\n", 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 4 440", 0);
+
+    csoundDebuggerInit(csound);
+    csoundSetDebugCallback(csound, debug_count_cb, (void *) &count);
+
+    for (int32_t i = 0; i < FIRST; i++) {
+        csoundPerformKsmps(csound);
+    }
+    ASSERT_EQ(count, FIRST);
+
+    csoundRemoveDebugCallback(csound);
+
+    for (int32_t i = 0; i < SECOND; i++) {
+        csoundPerformKsmps(csound);
+    }
+    /* count must not have grown after removal */
+    ASSERT_EQ(count, FIRST);
+
+    csoundDebuggerClean(csound);
+}
+
+/* ------------------------------------------------------------------ */
+/* 5. Callback must NOT fire on a k-cycle where execution is stopped    */
+/*    at a breakpoint; it resumes firing after csoundDebugContinue()    */
+/* ------------------------------------------------------------------ */
+TEST_F(DebugCallbackTests, testCallbackNotFiredWhenStopped)
+{
+    int32_t debug_count = 0;
+
+    csoundCompileOrc(csound, "instr 1\nasig oscil 1, p4\nendin\n", 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 2 440", 0);
+
+    csoundDebuggerInit(csound);
+    csoundSetDebugCallback(csound, debug_count_cb, (void *) &debug_count);
+
+    /* Set breakpoint on instr 1 with skip=0 (fires immediately) */
+    csoundSetBreakpointCallback(csound, brkpt_noop_cb, NULL);
+    csoundSetInstrumentBreakpoint(csound, 1, 0);
+
+    /* First ksmps: kperf_debug hits the breakpoint and returns early —
+       the debug callback is never reached. */
+    csoundPerformKsmps(csound);
+    ASSERT_EQ(debug_count, 0);
+
+    /* Continue execution and run one k-cycle without a breakpoint stop —
+       callback should now fire exactly once. */
+    csoundDebugContinue(csound);
+    csoundPerformKsmps(csound);
+    ASSERT_EQ(debug_count, 1);
+
+    csoundDebuggerClean(csound);
+}

--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -81,7 +81,14 @@ declare type PublicEvents =
   | "renderStarted"
   | "renderEnded"
   | "onAudioNodeCreated"
-  | "message";
+  | "message"
+  /**
+   * @property "debugCallback" - fired after every k-cycle when the Csound debugger
+   * is active (requires enableDebugCallback() to have been called before performance
+   * starts). Use csound.on("debugCallback", cb) to inspect instrument variables in
+   * real time via the debugger API.
+   */
+  | "debugCallback";
 
 /**
  * CsoundObj API.
@@ -158,6 +165,14 @@ declare interface CsoundObj {
     eventName: PublicEvents,
     listener: EventEmitter.EventListener<PublicEvents, any>,
   ) => EventEmitter;
+  /**
+   * Enables the per-k-cycle debug callback.
+   * Initializes the Csound debugger (if not already initialized) and registers
+   * the internal callback that emits a "debugCallback" event after every k-cycle.
+   * Must be called before csound.start() for reliable behaviour.
+   * Once enabled, subscribe with: csound.on("debugCallback", () => { ... })
+   */
+  enableDebugCallback: () => Promise<void>;
   /**
    * CsoundFilesystem
    */

--- a/wasm/browser/src/events.js
+++ b/wasm/browser/src/events.js
@@ -65,6 +65,7 @@ export class PublicEventAPI {
       "renderEnded",
       "onAudioNodeCreated",
       "message",
+      "kcycle",
     ]);
   }
 
@@ -122,6 +123,10 @@ export class PublicEventAPI {
 
   triggerMessage({ log }) {
     this.eventEmitter.emit("message", log);
+  }
+
+  triggerKcycle() {
+    this.eventEmitter.emit("kcycle");
   }
 
   decorateAPI(exportApi) {

--- a/wasm/browser/src/events.js
+++ b/wasm/browser/src/events.js
@@ -65,7 +65,7 @@ export class PublicEventAPI {
       "renderEnded",
       "onAudioNodeCreated",
       "message",
-      "kcycle",
+      "debugCallback",
     ]);
   }
 
@@ -125,8 +125,8 @@ export class PublicEventAPI {
     this.eventEmitter.emit("message", log);
   }
 
-  triggerKcycle() {
-    this.eventEmitter.emit("kcycle");
+  triggerDebugCallback() {
+    this.eventEmitter.emit("debugCallback");
   }
 
   decorateAPI(exportApi) {

--- a/wasm/browser/src/libcsound.js
+++ b/wasm/browser/src/libcsound.js
@@ -28,6 +28,7 @@ import {
   csoundStart,
   csoundCompileCSD,
   csoundPerformKsmps,
+  csoundSetDebugCallbackWasi,
   csoundStop,
   csoundReset,
 } from "./modules/performance";
@@ -162,6 +163,7 @@ export const api = {
   csoundStart,
   csoundCompileCSD,
   csoundPerformKsmps,
+  csoundSetDebugCallbackWasi,
   csoundStop,
   csoundReset,
   // @module/attributes

--- a/wasm/browser/src/mains/messages.main.js
+++ b/wasm/browser/src/mains/messages.main.js
@@ -27,9 +27,9 @@ export const messageEventHandler = (worker) => (event) => {
           : event.data.log,
       );
     }
-  } else if (event.data.kcycle) {
-    if (worker && worker.publicEvents && worker.publicEvents.triggerKcycle) {
-      worker.publicEvents.triggerKcycle();
+  } else if (event.data.debugCallback) {
+    if (worker && worker.publicEvents && worker.publicEvents.triggerDebugCallback) {
+      worker.publicEvents.triggerDebugCallback();
     }
   } else if (event.data["playStateChange"] && worker && worker["onPlayStateChange"]) {
     worker["onPlayStateChange"](event.data["playStateChange"]);

--- a/wasm/browser/src/mains/messages.main.js
+++ b/wasm/browser/src/mains/messages.main.js
@@ -27,6 +27,10 @@ export const messageEventHandler = (worker) => (event) => {
           : event.data.log,
       );
     }
+  } else if (event.data.kcycle) {
+    if (worker && worker.publicEvents && worker.publicEvents.triggerKcycle) {
+      worker.publicEvents.triggerKcycle();
+    }
   } else if (event.data["playStateChange"] && worker && worker["onPlayStateChange"]) {
     worker["onPlayStateChange"](event.data["playStateChange"]);
   }

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -600,6 +600,12 @@ class SharedArrayBufferMainThread {
         }
       }
     }
+
+    this.exportApi["enableDebugCallback"] = async () => {
+      const fn = this.exportApi["setDebugCallbackWasi"];
+      return typeof fn === "function" ? await fn() : -1;
+    };
+
     log(`PUBLIC API Generated and stored`)();
   }
 }

--- a/wasm/browser/src/mains/vanilla.main.js
+++ b/wasm/browser/src/mains/vanilla.main.js
@@ -367,6 +367,12 @@ class VanillaWorkerMainThread {
         }
       }
     }
+
+    this.exportApi["enableDebugCallback"] = async () => {
+      const fn = this.exportApi["setDebugCallbackWasi"];
+      return typeof fn === "function" ? await fn() : -1;
+    };
+
     log(`exportAPI generated`)();
   }
 }

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -374,6 +374,11 @@ class SingleThreadAudioWorkletMainThread {
       }
     }
 
+    this.exportApi["enableDebugCallback"] = async () => {
+      const fn = this.exportApi["setDebugCallbackWasi"];
+      return typeof fn === "function" ? await fn() : -1;
+    };
+
     return this.exportApi;
   }
 }

--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -362,6 +362,10 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
     streamBuffer,
   });
 
+  options["env"]["csoundWasiJsDebugCallback"] = () => {
+    messagePort.post({ kcycle: true });
+  };
+
   options["env"]["printDebugCallback"] = (offset, length) => {
     const buf = new Uint8Array(memory.buffer, offset, length);
     const string = uint2String(buf);

--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -363,7 +363,7 @@ export default async function ({ wasmDataURI, withPlugins = [], messagePort }) {
   });
 
   options["env"]["csoundWasiJsDebugCallback"] = () => {
-    messagePort.post({ kcycle: true });
+    messagePort.post({ debugCallback: true });
   };
 
   options["env"]["printDebugCallback"] = (offset, length) => {

--- a/wasm/browser/src/modules/performance.js
+++ b/wasm/browser/src/modules/performance.js
@@ -119,6 +119,12 @@ export const csoundPerformKsmps = (wasm) => (csound) => wasm.exports["csoundPerf
 
 csoundPerformKsmps["toString"] = () => "performKsmps = async (csound) => Number;";
 
+export const csoundSetDebugCallbackWasi = (wasm) => (csound) =>
+  wasm.exports["csoundSetDebugCallbackWasi"](csound);
+
+csoundSetDebugCallbackWasi["toString"] = () =>
+  "setDebugCallbackWasi = async (csound) => undefined;";
+
 /**
  * Dummy function to enable stop mechanism
  * @function

--- a/wasm/src/csound_wasm.c
+++ b/wasm/src/csound_wasm.c
@@ -3,6 +3,7 @@
 #include "ugen.h"
 #include <ctype.h>
 #include <limits.h>
+#include "csdebug.h"
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -109,6 +110,21 @@ void csoundWasiCMessageCallback(CSOUND *csound, int attr, const char *format, va
 __attribute__((used))
 void __wasi_js_csoundSetMessageStringCallback() {
   return csoundSetDefaultMessageCallback(&csoundWasiCMessageCallback);
+}
+
+/* ---- per-k-cycle debug callback: C → JS ---- */
+
+/* JS import: signals JS that a k-cycle just completed (debug mode) */
+void csoundWasiJsDebugCallback(void) __attribute__((
+     used,
+    __import_module__("env"),
+    __import_name__("csoundWasiJsDebugCallback")
+));
+
+static void csoundWasiCDebugCallback(CSOUND *csound, void *userdata) {
+  (void)csound;
+  (void)userdata;
+  (* csoundWasiJsDebugCallback)();
 }
 
 // copy/paste from upstream csound-emscripten
@@ -224,6 +240,12 @@ int csoundResetWasi(CSOUND *csound) {
   csoundReset(csound);
   csoundSetMidiCallbacks(csound);
   return CSOUND_SUCCESS;
+}
+
+__attribute__((used))
+void csoundSetDebugCallbackWasi(CSOUND *csound) {
+  csoundDebuggerInit(csound);
+  csoundSetDebugCallback(csound, &csoundWasiCDebugCallback, NULL);
 }
 
 // Keep a stable non-null pointer for JS string reads.

--- a/wasm/src/csound_wasm.c
+++ b/wasm/src/csound_wasm.c
@@ -244,6 +244,8 @@ int csoundResetWasi(CSOUND *csound) {
 
 __attribute__((used))
 void csoundSetDebugCallbackWasi(CSOUND *csound) {
+  /* csoundDebuggerInit is idempotent — safe to call even if already
+     initialized or if called multiple times. */
   csoundDebuggerInit(csound);
   csoundSetDebugCallback(csound, &csoundWasiCDebugCallback, NULL);
 }

--- a/wasm/src/exports.json
+++ b/wasm/src/exports.json
@@ -13,6 +13,7 @@
   "csoundCreateWasi",
   "csoundPerformKsmpsWasi",
   "csoundStartWasi",
+  "csoundSetDebugCallbackWasi",
   "csoundAppendEnv",
   "allocCsMidiDeviceStruct",
   "freeStringMem",
@@ -219,5 +220,11 @@
   "csoundUgenGraphDelete",
   "csoundUgenGraphDeleteAll",
   "csoundUgenVarGetDataAsFloat64Array",
-  "csoundUgenVarGetKsmps"
+  "csoundUgenVarGetKsmps",
+  "csoundSetDebugCallback",
+  "csoundRemoveDebugCallback",
+  "csoundDebugGetInstrInstances",
+  "csoundDebugFreeInstrInstances",
+  "csoundDebugGetVariables",
+  "csoundDebugFreeVariables"
 ]


### PR DESCRIPTION
Adds a non-stopping per-k-cycle callback hook to Csound's performance loop, exposed both in the C API and in the WASM/browser API.

C API (csdebug.h, Top):

- New kcycle_cb_t typedef
- csoundSetKcycleCallback(csound, cb, userdata) and csoundRemoveKcycleCallback(csound)
- Hooked into both kperf (normal) and kperf_debug (debug mode) loops
- Does not require csoundDebuggerInit() — works in any performance mode
- Inside the callback, csoundDebugGetInstrInstances() / csoundDebugGetVariables() can be used for real-time variable inspection

WASM/browser API (wasm):

- csoundSetKcycleCallbackWasi exposed as a WASM export
- "kcycle" event added to the JS event system
- enableKcycleEvents() convenience method added to all main-thread variants (SAB, vanilla, single-thread worklet)
- k-cycle events propagated back to the main thread via messagePort