### PR TITLE
added support for explicitly typing in for - in loops

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -263,6 +263,18 @@ ERSTR           "}R"
                       return T_IDENT;
                     }
                   }
+  
+  [ \t]*          /* eat the whitespace */
+  {TYPED_IDENTIFIER}/[ \t]*   { char *pp = yytext;
+                    while (*pp==' ' || *pp=='\t') pp++;
+                    *lvalp = make_token(csound, pp, yyscanner);
+                    if (strcmp(pp, "in") == 0) {
+                      BEGIN(INITIAL);
+                      return IN_TOKEN;
+                    } else {
+                      return T_TYPED_IDENT;
+                    }
+                  }
 }
 
 "\{\{"          {

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -622,6 +622,24 @@ for_in : FOR_TOKEN identifier in expr DO_TOKEN statement_list OD_TOKEN
           $5->right = $8;
           $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $2, $5);
         }
+         | FOR_TOKEN typed_identifier in expr DO_TOKEN statement_list OD_TOKEN
+        {
+          $3->left = $4;
+          $3->right = $6;
+          $$ = make_node(csound,LINE,LOCN, FOR_TOKEN,
+                         make_leaf(csound,LINE,LOCN, T_TYPED_IDENT, 
+                                   lookup_token(csound, $2->value->lexeme, NULL)), $3);
+        }
+         | FOR_TOKEN typed_identifier ',' identifier in expr DO_TOKEN statement_list OD_TOKEN
+        {
+          
+          $5->left = $6;
+          $5->right = $8;
+          $$ = make_leaf(csound,LINE,LOCN, T_TYPED_IDENT, 
+                         lookup_token(csound, $2->value->lexeme, NULL));
+          $$->next = $4;
+          $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $$, $5);
+          }
         ;
 
 declare_definition : DECLARE_TOKEN identifier udo_arg_list ':' udo_out_arg_list NEWLINE

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3644,8 +3644,11 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       typ = remove_type_quoting(csound, atype);
       if(var == NULL) {
        // check for optype
-        if(current->left->value->optype != NULL) typ = current->left->value->optype;        
-       // now create the arg based on the detected type
+        if(current->left->value->optype != NULL) {
+          csoundFree(csound, typ);
+          typ = csoundStrdup(csound, current->left->value->optype);
+        }
+       // now create the arg based on the array type
        add_arg(csound, current->left->value->lexeme, typ,
 	       typeTable, current);
        } else {
@@ -3675,6 +3678,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
 			    var->varType->varTypeName, current->line);
           }
 	}
+       csoundFree(csound, typ);
        typ = csoundStrdup(csound, var->varType->varTypeName);
       }
       LOOP_JUMP_TARGETS* targets = csound->Calloc(csound, sizeof(LOOP_JUMP_TARGETS));

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3643,7 +3643,9 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       atype[strlen(atype)-1] = '\0'; // remove ']'
       typ = remove_type_quoting(csound, atype);
       if(var == NULL) {
-       // now create the arg based on the array type
+       // check for optype
+        if(current->left->value->optype != NULL) typ = current->left->value->optype;        
+       // now create the arg based on the detected type
        add_arg(csound, current->left->value->lexeme, typ,
 	       typeTable, current);
        } else {

--- a/tests/commandline/test_for_in.csd
+++ b/tests/commandline/test_for_in.csd
@@ -14,7 +14,7 @@ seed(0)
 */
 
 /* case 1
-   loop var is not declared
+   loop var is not declared and type not given
    loop type follows array type
    (i-type in this case)
 */
@@ -25,14 +25,14 @@ od
 endin
 
 /* case 2
-   loop var is declared
+   loop var is either previously declared or
+   the variable type is given explicitly
    loop type follows var type
    if a conversion is possible (e.g. k and i)
    regardless of array type
 */
 instr 2
-j:k init 0
-for j in [1,2,3] do
+for j:k in [1,2,3] do
  printk2 j
 od
 turnoff


### PR DESCRIPTION
This PR introduces support for explicitly typing the loop variable in a `for ... in` loop:

```
/* case 2
   loop var is either previously declared or
   the variable type is given explicitly
   loop type follows var type
   if a conversion is possible (e.g. k and i)
   regardless of array type
*/
instr 2
for j:k in [1,2,3] do
 printk2 j
od
turnoff
endin
```

also works in the second form of the loop,

```
iarr[] = [1,2,3,4]
for kvar:k, n in iarr do
   printk2 kvar
   printk2 n
od
```
