### PR TITLE
Bugfix/arraytype

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -53,7 +53,6 @@ int32_t add_udo_definition(CSOUND *csound, bool newStyle, char *opname,
 const char* SYNTHESIZED_ARG = "_synthesized";
 const char* UNARY_PLUS = "_unary_plus";
 
-
 char* csoundStrdup(CSOUND* csound, const char* str) {
   size_t len;
   char* retVal;
@@ -490,6 +489,32 @@ static char *resolve_struct_expr_type(CSOUND *csound, TREE *tree,
   return result;
 }
 
+/* convert array type string from type[] to [type]
+   accepts multidimensional type strings (type[][]) 
+   non-op for non-array type strings
+*/
+static const char *convert_array_type_string(CSOUND *csound,
+                                       const char *str) {
+  const char *check = str;
+  char dim = 0;
+  while(*check != '\0') {
+    if(*check == '[') dim++;
+    check++;
+  }
+  if(dim){
+    int len = (int) strlen(str);
+    char *arr = csoundCalloc(csound, strlen(str)+1);
+    for(int i = 0; i < dim; i++) {
+      arr[i] = '[';
+    }
+    memcpy(arr+dim, str, len-dim);
+    for(int i = len-dim; i < len; i++) {
+      arr[i] = ']';
+    }
+    return arr;
+  } else return str;
+}
+
 /* This function gets arg type with checking type table */
 char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
 {
@@ -882,7 +907,6 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
     }
     __attribute__((fallthrough));
   case T_IDENT:
-
     s = tree->value->lexeme;
     if (s == NULL) {
       /* VL: 8/3/2018
@@ -912,8 +936,6 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
        // found this, return type.
        return csoundStrdup(csound, varType->varTypeName);
      }
-
-
 
     if (is_reserved(s)) {
       return csoundStrdup(csound, "r");                              /* rsvd */
@@ -950,7 +972,6 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
       csound->Free(csound, s_copy);
     }
 
-
     if (UNLIKELY(var == NULL)) {
       synterr(csound, Str("get_arg_type2: Variable '%s' used before defined, line %d"),
               tree->value->lexeme, tree->line);
@@ -970,7 +991,10 @@ char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
       }
 
   case T_TYPED_IDENT:
-    return csoundStrdup(csound, tree->value->optype);
+    // in the case of arrays, we need to convert from type[] to [type]
+    // so that semantic analysis can identify the type correctly
+    return csoundStrdup(csound,
+                        convert_array_type_string(csound, tree->value->optype));
   case STRUCT_EXPR:
     return resolve_struct_expr_type(csound, tree, typeTable);
 

--- a/tests/commandline/structs/test_struct_arrays.csd
+++ b/tests/commandline/structs/test_struct_arrays.csd
@@ -9,14 +9,16 @@ nchnls	=	2
 struct MyType imaginary:i, real:i
 
 opcode processMyType(dummy:i[], input:MyType[]):i
-
+data:MyType[] init lenarray(input)
 ilen = lenarray(input)
 print ilen
 indx = 0
 while (indx < ilen) do
+  data[indx].real = input[indx].real
   temp:MyType = input[indx]
   print temp.imaginary
   print temp.real
+  ivar = data[indx].real
   indx += 1
 od
 indx = 0
@@ -39,6 +41,8 @@ while (indx < 4) do
 
   var0[indx].imaginary = (indx * 2) * 2
   var0[indx].real = ((indx + 1) * 2) * 2
+  print var0[index].real
+  print var0[indx].imaginary
 
   indx += 1
 

--- a/tests/commandline/structs/test_struct_arrays.csd
+++ b/tests/commandline/structs/test_struct_arrays.csd
@@ -14,11 +14,10 @@ ilen = lenarray(input)
 print ilen
 indx = 0
 while (indx < ilen) do
-  data[indx].real = input[indx].real
+  data[indx] = input[indx]
   temp:MyType = input[indx]
   print temp.imaginary
   print temp.real
-  ivar = data[indx].real
   indx += 1
 od
 indx = 0

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -12,7 +12,13 @@ if k1 != k2 then
 endif
 endop
 
+test@global:Complex[] init 2
+test[0] = 1,2
+test[1] = 3,4
+
+
 instr 1
+ printk2 real(test[0])
  Ca:Complex[] init 10
  ca:Complex = 0,1
  cc:Complex = complex(1,1)*complex(2,2)


### PR DESCRIPTION
A bug was found where explicit-typed arrays with multi-character type names were failing semantic tests, for example,
at instrument 0

```
test:Complex[] init 2
```
gave

```
syntax error, Unable to find opcode entry for 'init'
  with matching argument types, line 15 columns 16-19
Found:
  Complex[] init c
```

The problem is that `Complex[]` is not an internally-recognised type,  but `:Complex;[]`.  The bug is that when an argument with token type  `T_TYPED_IDENT`, the `tree->value->optype` is passed as `Complex[]`, but the semantic analysis wants `[Complex]`.  If the token is `T_IDENT`, however, the type string is generated by `create_array_arg_type()` correctly.

When the array declaration is inside an instrument, the lexer creates a `T_IDENT`, otherwise it creates a `T_TYPED_IDENT`. So any declaration outside instruments, including those in UDOs, fail. 

This PR fixes the bug by adding a conversion function for `T_TYPED_IDENT` cases. It is a non-op for non-array type strings.

Tests added.

NB: the lexer creating a different token for declarations if they are inside an instrument is a bit dodgy - may need to be reviewed later.