### PR TITLE
Type 2 for - in loop with explicitly typed index variable

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -640,6 +640,24 @@ for_in : FOR_TOKEN identifier in expr DO_TOKEN statement_list OD_TOKEN
           $$->next = $4;
           $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $$, $5);
           }
+         | FOR_TOKEN typed_identifier ',' typed_identifier in expr DO_TOKEN statement_list OD_TOKEN
+        {
+          $5->left = $6;
+          $5->right = $8;
+          $$ = make_leaf(csound,LINE,LOCN, T_TYPED_IDENT, 
+                         lookup_token(csound, $2->value->lexeme, NULL));
+          $$->next = make_leaf(csound,LINE,LOCN, T_TYPED_IDENT, 
+                         lookup_token(csound, $4->value->lexeme, NULL));
+          $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $$, $5);
+          }
+        | FOR_TOKEN identifier ',' typed_identifier in expr DO_TOKEN statement_list OD_TOKEN
+        {
+          $2->next = make_leaf(csound,LINE,LOCN, T_TYPED_IDENT, 
+                         lookup_token(csound, $4->value->lexeme, NULL));
+          $5->left = $6;
+          $5->right = $8;
+          $$ = make_node(csound,LINE,LOCN, FOR_TOKEN, $2, $5);
+        }
         ;
 
 declare_definition : DECLARE_TOKEN identifier udo_arg_list ':' udo_out_arg_list NEWLINE

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1807,10 +1807,18 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
 
   // if an index var is given, we use it to define the loop time (i or k)
   if (current->left->next != NULL) {
-    char *vartype;    
+    char *vartype;
+    int32_t isItime = !isPerfRate;
     vartype = current->left->next->value->optype;
     if(vartype)
       isPerfRate = strcmp("k",vartype) == 0 ? 1 : 0;
+    if(isPerfRate == 0 &&
+       isItime == 0) {
+      synterr(csound, "cannot run a perf-time loop"
+              " with an i-time index, line %d",
+              current->line);
+      csoundLongJmp(csound, 0);
+    }
   }
   
   char* op = (char *)csound->Malloc(csound, 10);

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1805,6 +1805,14 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
      arrayType == xType) isPerfRate = 1;
   else isPerfRate = 0;
 
+  // if an index var is given, we use it to define the loop time (i or k)
+  if (current->left->next != NULL) {
+    char *vartype;    
+    vartype = current->left->next->value->optype;
+    if(vartype)
+      isPerfRate = strcmp("k",vartype) == 0 ? 1 : 0;
+  }
+  
   char* op = (char *)csound->Malloc(csound, 10);
   // create index counter
   TREE *indexAssign = create_empty_token(csound);
@@ -1899,7 +1907,8 @@ TREE* expand_for_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable,
     loopLabel->next = optionalUserIndexAssign;
   }
 
-  char* array_get = arrayType != sType ? "##array_get" : "##array_geti";
+  char* array_get = isPerfRate ? "##array_get" :
+    (arrayType == sType ? "##array_geti" : "##array_get"); 
   TREE* arrayGetStatement = create_opcode_token(csound, array_get); 
   arrayGetStatement->left = current->left;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -527,6 +527,7 @@ def runTest():
         ["test_invalid_ternary.csd", "test expression", 1],
         ["test_for_in.csd", "for in loop"],
         ["test_for_in2.csd", "for in loop (2nd form)"],
+        ["test_for_loop_index_var_typed.csd", "for in loop with typed index var"],        
         ["test_opcode_as_function.csd", "test expression"],
         ["test_fsig_udo.csd", "UDO with f-sig arg"],
         ["test_karrays_udo.csd", "UDO with k[] arg"],

--- a/tests/commandline/test_for_loop_index_var_typed.csd
+++ b/tests/commandline/test_for_loop_index_var_typed.csd
@@ -1,0 +1,26 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+instr 1
+arr:k[] init 3
+for var:S, ndx:k in ["1", "2", "3"] do
+  printf "hello %s\n", ndx+1, var
+  arr[ndx] = ndx+1
+od
+if arr[1] != 2 then
+  // if the above loop ran at init-time
+  // we will exit here.
+  printks "instr1 fail\n", 1
+  exitnowk(-1)
+endif
+turnoff
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
As discussed in #2381 this PR implements a proposal put there to use an explicitly typed loop index variable to define the loop type (init vs perf time).

- Currently the index variable type and the loop type is defined by the array variable type ('k' for k, a, and complex, 'i' for the rest) 
- This PR adds the means of using an explicitly type index variable to define the loop type.

The cases are as follows

(a) non-typed array and index variables -> loop type defined by the array type

```
karr[] = [1,2,3]
for val, index in karr do   // perf-time loop; val and index are k-vars
```

(b) typed array variable, non-typed index variable

```
for val:k, index in [1,2,3]  // perf-time loop, val and index are k-vars
```

(c) non-typed array variable, typed index variable

```
for val, index:k in [1,2,3]  // perf-time loop, val and index are k-vars 
```

(d) typed array and typed index variable

```
for val:S, index:k in ["1","2","3"]   // perf-time loop val is a string and index is a k-var 
```

Trying to run an i-time loop with a k-var array variable is user error and gives
a syntax error

```
for val:k, ndx:i in [1,2,3] do
```

```
syntax error, cannot run a perf-time loop with an i-time index, line 11
```




