### PR TITLE
Ensuring T_TYPED_IDENT

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -47,7 +47,7 @@ YYLTYPE *yylloc_param;
  ORCTOKEN *make_num(CSOUND *, char *,  void*);
  ORCTOKEN *make_token(CSOUND *, char *s,  void*);
  ORCTOKEN *make_label(CSOUND *, char *s,  void*);
-#define namedInstrFlag csound->parserNamedInstrFlag
+
 #include "parse_param.h"
 
 #define YY_EXTRA_TYPE  PARSE_PARM *
@@ -235,7 +235,6 @@ ERSTR           "}R"
                   return STRUCT_TOKEN;
                 }
 "instr"         {
-                  namedInstrFlag = 1;
                   return INSTR_TOKEN;
                 }
 "endin"         { *lvalp = make_token(csound, yytext, yyscanner);
@@ -633,9 +632,6 @@ ORCTOKEN *lookup_token(CSOUND *csound, char *s, void *yyscanner)
         type = T_TYPED_IDENT;
     } else {
         ans->lexeme = csoundStrdup(csound, s);
-    }
-    if (csound->parserNamedInstrFlag == 1) {
-        return ans;
     }
     ans->type = type;
     return ans;

--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -245,7 +245,6 @@ instr_definition : INSTR_TOKEN instr_id_list NEWLINE
                                   csound_orcget_ilocn(scanner), INSTR_TOKEN,
                                   $2, $5);
                     csp_orc_sa_instr_finalize(csound);
-                    namedInstrFlag = 0;
                  }
                 | INSTR_TOKEN NEWLINE error
                  { csound->ErrorMsg(csound, Str("No number following instr\n"));

--- a/Engine/new_orc_parser.c
+++ b/Engine/new_orc_parser.c
@@ -103,7 +103,6 @@ TREE *csoundParseOrc(CSOUND *csound, const char *str)
 {
     int32_t err;
     add_opcode_defs(csound);  // add global OpcodeDef variables
-    csound->parserNamedInstrFlag = 2;
     {
       PRE_PARM    qq;
       /* Preprocess */

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1035,7 +1035,6 @@ static const CSOUND cenviron_ = {
   1,              /* orcLineOffset */
   0,              /* scoLineOffset */
   NULL,           /* csdname */
-  0,              /*  parserNamedInstrFlag */
   0,              /*  tran_nchnlsi */
   0,              /* Count of score strings */
   0,              /* length of current strings space */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1755,9 +1755,7 @@ struct CSOUND_ {
   uint32_t tempStatus;   /* keeps track of which files are temps */
   int32_t orcLineOffset; /* 1 less than 1st orch line in the CSD */
   int32_t scoLineOffset; /* 1 less than 1st score line in the CSD */
-  char *csdname;
-  /* original CSD name; do not free() */
-  int32_t parserNamedInstrFlag;
+  char *csdname; /* original CSD name; do not free() */
   int32_t tran_nchnlsi;
   int32_t scnt;         /* Count of strings */
   int32_t strsiz;       /* length of current strings space */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -581,6 +581,11 @@ def runTest():
             "test_bool_with_explicit_type.csd",
             "test use of explicit type in bool expression",
         ],
+        [
+            "test_fail_typed_ident_expression.csd",
+            "expected failure: explicit type annotation used in expression",
+            1,
+        ],
         ["test_explicit_globals.csd", "test global declaration of explicit types"],
         [
             "test_fail_mismatched_types.csd",

--- a/tests/commandline/test_fail_typed_ident_expression.csd
+++ b/tests/commandline/test_fail_typed_ident_expression.csd
@@ -1,0 +1,24 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+
+; Explicit type annotations are legal on declaration sites, but not inside
+; regular expressions. This should fail to parse if the lexer returns
+; T_TYPED_IDENT consistently inside instruments.
+
+instr 1
+  input:i = 1
+  output:k = input
+
+  if input:i != i(output:k) then
+    exitnow(-1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/udo/test_K_type.csd
+++ b/tests/commandline/udo/test_K_type.csd
@@ -71,7 +71,7 @@ endop
 instr 4
 input:i = 1
 output:k = TestKIO(input)
-if input:i != i(output:k) then
+if input != i(output) then
   exitnow(-1)
 endif
 endin


### PR DESCRIPTION
In #2532 we have noted that the use of T_IDENT and T_TYPED_IDENT tokens is not consistent across the Csound code. This is due to the use of a legacy parser flag `namedInstrFlag`, which is not relevant anymore. 

This PR removes that flag altogether from the code, enabling all explicitly typed identifiers to be made into T_TYPED_IDENT regardless of where they appear in the code. This means that using explicit typing for variables generally is only legal on the left-hand side of an expression, or in special cases such as UDO parameter lists or for-in variable lists.

A test had to be adjusted for this, since it used that discrepancy and it's not anymore allowed.

Closes #2532