### PR TITLE
Fixed spurious warnings on addin, subin, divin and mulin

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2073,6 +2073,10 @@ int32_t csound_compile_tree(CSOUND *csound, TREE *root, int32_t async)
     case LABEL_TOKEN:
     case STRUCT_TOKEN:
     case T_DECLARE:
+    case S_ADDIN:
+    case S_SUBIN:
+    case S_DIVIN:
+    case S_MULIN:
       break;
 
     default:


### PR DESCRIPTION
Since the introduction of proper handling of +=, -=, *= and /= (I think) some spurious compiler warnings started to appear on the console messages. For example `icnt += 1` in instr 0 gives

```
warning: Unknown TREE node of type 265 (??) found in root.
```

which should not be there. This PR fixes so that these operations are recognised by the compiler.