### PR TITLE
Circular buffer API improvements

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -533,7 +533,9 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run tests
-        run: cmake --build build --target csdtests
+        run: |
+          cd build
+          make csdtests
 
       - name: Run unit test framework
         run: ctest --test-dir build -C Release -j --output-on-failure

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -693,7 +693,7 @@ jobs:
       # - name: Run unit tests
       #   run: ctest --test-dir build -j$(nproc) --output-on-failure
       - name: Run CSD tests
-          run: cmake --build build --target csdtests
+        run: cmake --build build --target csdtests
 
   windows_build_32bit:
     name: Windows 32-bit build (mingw/vcpkg)

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -533,9 +533,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run tests
-        run: |
-          cd build
-          make csdtests
+        run: cmake --build build --target csdtests
 
       - name: Run unit test framework
         run: ctest --test-dir build -C Release -j --output-on-failure
@@ -694,8 +692,8 @@ jobs:
 
       # - name: Run unit tests
       #   run: ctest --test-dir build -j$(nproc) --output-on-failure
-      # - name: Run CSD tests
-      #   run: cmake --build build --target csdtests
+      - name: Run CSD tests
+          run: cmake --build build --target csdtests
 
   windows_build_32bit:
     name: Windows 32-bit build (mingw/vcpkg)

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -692,8 +692,8 @@ jobs:
 
       # - name: Run unit tests
       #   run: ctest --test-dir build -j$(nproc) --output-on-failure
-      - name: Run CSD tests
-        run: cmake --build build --target csdtests
+      #- name: Run CSD tests
+      #  run: cmake --build build --target csdtests
 
   windows_build_32bit:
     name: Windows 32-bit build (mingw/vcpkg)

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -533,7 +533,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run tests
-        run: cmake --build build --target csdtests
+        run: cmake --build build --config Release --target csdtests
 
       - name: Run unit test framework
         run: ctest --test-dir build -C Release -j --output-on-failure
@@ -610,7 +610,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run tests
-        run: cmake --build build --target csdtests
+        run: cmake --build build --config Release --target csdtests
 
       - name: Run unit test framework
         run: ctest --test-dir build -C Release -j --output-on-failure

--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -49,7 +49,7 @@ void *csoundCreateCircularBuffer(CSOUND *csound, int32_t numelem, int32_t elemsi
     return (void *)p;
 }
 
-int32_t checkspace(circular_buffer *p, int32_t writeCheck){
+static int32_t checkspace(circular_buffer *p, int32_t writeCheck){
     csoundSpinLock(&p->lock);
     int32_t wp = p->wp, rp = p->rp, numelem = p->numelem, res;
     if(writeCheck){
@@ -66,9 +66,15 @@ int32_t checkspace(circular_buffer *p, int32_t writeCheck){
     return res;
 }
 
+int32_t csoundCheckCircularBuffer(CSOUND *csound, void *p, int32_t flag){
+  (void) csound;
+  return checkspace(p, flag); // internal space count includes one extra slot
+}
+
+
 int32_t csoundReadCircularBuffer(CSOUND *csound, void *p, void *out, int32_t items)
 {
-    IGN(csound);
+    (void)csound;
     if (p == NULL) return 0;
     {
       int32_t remaining;

--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -68,6 +68,7 @@ static int32_t checkspace(circular_buffer *p, int32_t writeCheck){
 
 int32_t csoundCheckCircularBuffer(CSOUND *csound, void *p, int32_t flag){
   (void) csound;
+  if(p == NULL) return 0;
   return checkspace(p, flag); // internal space count includes one extra slot
 }
 

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -760,7 +760,7 @@ int32_t diskin2_perf_synchronous(CSOUND *csound, DISKIN2 *p)
 int32_t diskin_file_read(CSOUND *csound, DISKIN2 *p)
 {
     /* nsmps is bufsize in frames */
-    int32_t nsmps = csoundCheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
+    int32_t nsmps = csound->CheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
     int32_t i, nn;
     double  d, frac_d, x, c, v, pidwarp_d;
     MYFLT   frac, a0, a1, a2, a3, onedwarp, winFact;
@@ -1224,7 +1224,7 @@ uintptr_t diskin_io_thread_array(void *p){
 int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
 {
     /* nsmps is bufsize in frames */
-    int32_t nsmps = csoundCheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
+    int32_t nsmps = csound->CheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
     int32_t i, nn;
     double  d, frac_d, x, c, v, pidwarp_d;
     MYFLT   frac, a0, a1, a2, a3, onedwarp, winFact;

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -755,12 +755,11 @@ int32_t diskin2_perf_synchronous(CSOUND *csound, DISKIN2 *p)
     return NOTOK;
 }
 
-int32_t checkspace(void *p, int32_t writeCheck);
 
 int32_t diskin_file_read(CSOUND *csound, DISKIN2 *p)
 {
     /* nsmps is bufsize in frames */
-    int32_t nsmps = checkspace(p->cb,1)/p->nChannels;
+    int32_t nsmps = csoundCheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
     int32_t i, nn;
     double  d, frac_d, x, c, v, pidwarp_d;
     MYFLT   frac, a0, a1, a2, a3, onedwarp, winFact;
@@ -1224,7 +1223,7 @@ uintptr_t diskin_io_thread_array(void *p){
 int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
 {
     /* nsmps is bufsize in frames */
-    int32_t nsmps = checkspace(p->cb,1)/p->nChannels;
+    int32_t nsmps = csoundCheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
     int32_t i, nn;
     double  d, frac_d, x, c, v, pidwarp_d;
     MYFLT   frac, a0, a1, a2, a3, onedwarp, winFact;

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -546,6 +546,7 @@ int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
 #endif
     csound->Free(csound, current);
     csound->DestroyCircularBuffer(csound, ((DISKIN2 *)p)->cb);
+    ((DISKIN2 *)p)->cb = NULL;
   }
 
   return OK;

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -372,7 +372,7 @@ static const CSOUND cenviron_ = {
     csoundSystemSr,
     csoundGetSr,
     csoundGetKr,
-    csoundGetKcounter,    
+    csoundGetKcounter,
     /* channels */
     csoundGetChannelPtr,
     csoundListChannels,
@@ -495,6 +495,7 @@ static const CSOUND cenviron_ = {
     csoundCreateCircularBuffer,
     csoundReadCircularBuffer,
     csoundWriteCircularBuffer,
+    csoundCheckCircularBuffer,
     csoundPeekCircularBuffer,
     csoundFlushCircularBuffer,
     csoundDestroyCircularBuffer,

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1101,7 +1101,7 @@ struct CSOUND_ {
   /* Get engine control rate */
   MYFLT   (*GetEngineKr) (CSOUND *csound);
   /* Get engine kcounter value */
-  uint64_t (*GetEngineKcounter) (CSOUND *csound);  
+  uint64_t (*GetEngineKcounter) (CSOUND *csound);
   /**@}*/
 
   /** @name Software bus */
@@ -1281,6 +1281,7 @@ struct CSOUND_ {
   void *(*CreateCircularBuffer)(CSOUND *, int32_t, int32_t);
   int32_t (*ReadCircularBuffer)(CSOUND *, void *, void *, int32_t);
   int32_t (*WriteCircularBuffer)(CSOUND *, void *, const void *, int32_t);
+  int32_t (*CheckCircularBuffer)(CSOUND *, void *, int32_t);
   int32_t (*PeekCircularBuffer)(CSOUND *, void *, void *, int32_t);
   void (*FlushCircularBuffer)(CSOUND *, void *);
   void (*DestroyCircularBuffer)(CSOUND *, void *);
@@ -1462,7 +1463,7 @@ struct CSOUND_ {
   int32_t (*Sscanf)(char *str, const char *format, ...);
   /* Set opcode as deprecated */
   int32_t (*Deprecate)(CSOUND *csound, char *name,
-                       char *o, char *i, int32_t deprec);  
+                       char *o, char *i, int32_t deprec);
   /**@}*/
   /** @name Placeholders
       To allow the API to grow while maintining backward binary compatibility.

--- a/include/csound_circular_buffer.h
+++ b/include/csound_circular_buffer.h
@@ -83,6 +83,17 @@ extern "C" {
    */
   PUBLIC void csoundFlushCircularBuffer(CSOUND *csound, void *p);
 
+  
+  /**
+   * Check the available space in a circular buffer
+   * @param csound This value is currently ignored.
+   * @param p pointer to an existing circular buffer
+   * @param flag zero for reading space, non-zero for writing space
+   * @returns the available space for reading or writing
+   */
+  PUBLIC int32_t csoundCheckCircularBuffer(CSOUND *csound, void *p, int32_t flag);
+
+  
   /**
    * Free circular buffer
    */

--- a/tests/c/csound_circular_buffer_test.cpp
+++ b/tests/c/csound_circular_buffer_test.cpp
@@ -166,6 +166,20 @@ TEST_F (CircularBufferTests, testPeeking)
     }
 }
 
+#define SIZ 128
+TEST_F (CircularBufferTests, testCheckSpace)
+{
+    int32_t i;
+    float buf[SIZ];
+    i = csoundWriteCircularBuffer(csound, rb, buf, SIZ);
+    ASSERT_EQ(i, SIZ);
+    i = csoundCheckCircularBuffer(csound, rb, 1);
+    ASSERT_EQ(i, 512 - SIZ);
+    i = csoundCheckCircularBuffer(csound, rb, 0);
+    ASSERT_EQ(i, SIZ);    
+}
+
+
 TEST_F (CircularBufferTests, testWraping)
 {
     int32_t i;
@@ -185,6 +199,8 @@ TEST_F (CircularBufferTests, testWraping)
         ASSERT_EQ (written, 1);
     }
 }
+
+
 
 extern "C" {
 void csoundFree(CSOUND *, void *);

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -6,6 +6,8 @@
 #   make csdtests         - Run CSD tests normally (non-verbose)
 #   make csdtests-verbose - Run CSD tests with verbose output
 
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 # Build the common test arguments
 set(COMMON_TEST_ARGS --csound-executable=${CMAKE_BINARY_DIR}/csound --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -14,13 +16,13 @@ if (MINGW)
   # For MinGW with Wine runtime
   list(APPEND PLATFORM_ARGS --runtime-environment=wine --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
   add_custom_target(csdtests
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
   )
   # Verbose variant target
   add_custom_target(csdtests-verbose
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --runtime-environment=wine
@@ -31,13 +33,13 @@ elseif (EMSCRIPTEN)
   # For Emscripten with Node.js runtime
   list(APPEND PLATFORM_ARGS --runtime-environment=${EMSDK_NODE} --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
   add_custom_target(csdtests
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
   )
   # Verbose variant target
   add_custom_target(csdtests-verbose
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --runtime-environment=${EMSDK_NODE}
@@ -46,33 +48,33 @@ elseif (EMSCRIPTEN)
   )
 elseif(MSVC)
   # For MSVC builds
-  list(APPEND PLATFORM_ARGS --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-  set(CSOUND_EXECUTABLE_PATH ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/csound)
+  list(APPEND PLATFORM_ARGS --opcode7dir64=$<TARGET_FILE_DIR:csound-bin>)
+  set(CSOUND_EXECUTABLE_PATH $<TARGET_FILE:csound-bin>)
   add_custom_target(csdtests
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --csound-executable=${CSOUND_EXECUTABLE_PATH}
       ${PLATFORM_ARGS}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
   )
   # Verbose variant target
   add_custom_target(csdtests-verbose
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CSOUND_EXECUTABLE_PATH}
-      --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+      --opcode7dir64=$<TARGET_FILE_DIR:csound-bin>
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
   )
 else()
   # Default for Unix-like systems (Linux, macOS)
   list(APPEND PLATFORM_ARGS --opcode7dir64=${CMAKE_BINARY_DIR})
   add_custom_target(csdtests
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
   )
   # Verbose variant target
   add_custom_target(csdtests-verbose
-      ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --opcode7dir64=${CMAKE_BINARY_DIR}

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -32,7 +32,7 @@ if(Python3_Interpreter_FOUND)
     )
   elseif (EMSCRIPTEN)
     # For Emscripten with Node.js runtime
-    list(APPEND PLATFORM_ARGS --runtime-environment=${EMSDK_NODE} --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    list(APPEND PLATFORM_ARGS --runtime-environment=${EMSDK_NODE} --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
     add_custom_target(csdtests
       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
@@ -44,7 +44,7 @@ if(Python3_Interpreter_FOUND)
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --runtime-environment=${EMSDK_NODE}
-      --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+      --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
     )
   elseif(MSVC)

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -6,80 +6,84 @@
 #   make csdtests         - Run CSD tests normally (non-verbose)
 #   make csdtests-verbose - Run CSD tests with verbose output
 
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 COMPONENTS Interpreter QUIET)
 
-# Build the common test arguments
-set(COMMON_TEST_ARGS --csound-executable=${CMAKE_BINARY_DIR}/csound --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
+if(Python3_Interpreter_FOUND)
+  # Build the common test arguments
+  set(COMMON_TEST_ARGS --csound-executable=${CMAKE_BINARY_DIR}/csound --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
 
-# Platform-specific csdtests targets
-if (MINGW)
-  # For MinGW with Wine runtime
-  list(APPEND PLATFORM_ARGS --runtime-environment=wine --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-  add_custom_target(csdtests
-    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+  # Platform-specific csdtests targets
+  if (MINGW)
+    # For MinGW with Wine runtime
+    list(APPEND PLATFORM_ARGS --runtime-environment=wine --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    add_custom_target(csdtests
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
-  )
-  # Verbose variant target
-  add_custom_target(csdtests-verbose
-    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    )
+    # Verbose variant target
+    add_custom_target(csdtests-verbose
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --runtime-environment=wine
       --opcode7dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
-  )
-elseif (EMSCRIPTEN)
-  # For Emscripten with Node.js runtime
-  list(APPEND PLATFORM_ARGS --runtime-environment=${EMSDK_NODE} --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-  add_custom_target(csdtests
-    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    )
+  elseif (EMSCRIPTEN)
+    # For Emscripten with Node.js runtime
+    list(APPEND PLATFORM_ARGS --runtime-environment=${EMSDK_NODE} --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    add_custom_target(csdtests
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
-  )
-  # Verbose variant target
-  add_custom_target(csdtests-verbose
-    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+    )
+    # Verbose variant target
+    add_custom_target(csdtests-verbose
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --runtime-environment=${EMSDK_NODE}
       --opcode6dir64=${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
-  )
-elseif(MSVC)
-  # For MSVC builds
-  list(APPEND PLATFORM_ARGS --opcode7dir64=$<TARGET_FILE_DIR:csound-bin>)
-  set(CSOUND_EXECUTABLE_PATH $<TARGET_FILE:csound-bin>)
-  add_custom_target(csdtests
+    )
+  elseif(MSVC)
+    # For MSVC builds
+    list(APPEND PLATFORM_ARGS --opcode7dir64=$<TARGET_FILE_DIR:csound-bin>)
+    set(CSOUND_EXECUTABLE_PATH $<TARGET_FILE:csound-bin>)
+    add_custom_target(csdtests
       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --csound-executable=${CSOUND_EXECUTABLE_PATH}
       ${PLATFORM_ARGS}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
-  )
-  # Verbose variant target
-  add_custom_target(csdtests-verbose
+    )
+    # Verbose variant target
+    add_custom_target(csdtests-verbose
       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CSOUND_EXECUTABLE_PATH}
       --opcode7dir64=$<TARGET_FILE_DIR:csound-bin>
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
-  )
-else()
-  # Default for Unix-like systems (Linux, macOS)
-  list(APPEND PLATFORM_ARGS --opcode7dir64=${CMAKE_BINARY_DIR})
-  add_custom_target(csdtests
+    )
+  else()
+    # Default for Unix-like systems (Linux, macOS)
+    list(APPEND PLATFORM_ARGS --opcode7dir64=${CMAKE_BINARY_DIR})
+    add_custom_target(csdtests
       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       ${COMMON_TEST_ARGS}
       ${PLATFORM_ARGS}
-  )
-  # Verbose variant target
-  add_custom_target(csdtests-verbose
+    )
+    # Verbose variant target
+    add_custom_target(csdtests-verbose
       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py
       --verbose
       --csound-executable=${CMAKE_BINARY_DIR}/csound
       --opcode7dir64=${CMAKE_BINARY_DIR}
       --source-dir=${CMAKE_CURRENT_SOURCE_DIR}
-  )
+    )
+  endif()
+else()
+  message(STATUS "Python3 not found; not creating commandline test targets.")
 endif()
 
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -636,7 +636,7 @@ def runTest():
         ["test_overload_selection.csd", "test wrong annotation case"],
         ["test_unschedule.csd", "test unscheduling events"],
         ["diskin_excess_channels.csd", "test sample accurate mode"],
-        ["test_async_diskin.csd", "test diskin in rt async mode"],        
+      ##  ["test_async_diskin.csd", "test diskin in rt async mode"],        
         ["test_midifile_ops.csd", "testing midifile opcodes"],
         ["test_csound_object.csd", "test Csound object opcodes"],
         ["test_true_false.csd", "testing true/false booleans"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -636,7 +636,7 @@ def runTest():
         ["test_overload_selection.csd", "test wrong annotation case"],
         ["test_unschedule.csd", "test unscheduling events"],
         ["diskin_excess_channels.csd", "test sample accurate mode"],
-      ##  ["test_async_diskin.csd", "test diskin in rt async mode"],        
+        ["test_async_diskin.csd", "test diskin in rt async mode"],        
         ["test_midifile_ops.csd", "testing midifile opcodes"],
         ["test_csound_object.csd", "test Csound object opcodes"],
         ["test_true_false.csd", "testing true/false booleans"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -636,6 +636,7 @@ def runTest():
         ["test_overload_selection.csd", "test wrong annotation case"],
         ["test_unschedule.csd", "test unscheduling events"],
         ["diskin_excess_channels.csd", "test sample accurate mode"],
+        ["test_async_diskin.csd", "test diskin in rt async mode"],        
         ["test_midifile_ops.csd", "testing midifile opcodes"],
         ["test_csound_object.csd", "test Csound object opcodes"],
         ["test_true_false.csd", "testing true/false booleans"],

--- a/tests/commandline/test_async_diskin.csd
+++ b/tests/commandline/test_async_diskin.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n --realtime
+</CsOptions>
+<CsInstruments>
+nchnls = 2
+
+instr 1
+a1 diskin2 "fox.wav"
+   out a1
+endin
+
+
+</CsInstruments>
+<CsScore>
+i1 0 4
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_dbap.csd
+++ b/tests/commandline/test_dbap.csd
@@ -96,6 +96,7 @@ endin
 // Center test
 instr 4
     source:k[] = [0, 0, 0]
+    tolerance:i = 0.000001
 
     lpos:i[][] = init(4, 3)
     lpos = [1, 45, 0, 1, 135, 0, 1, -45, 0, 1, -135, 0] // 3D
@@ -104,7 +105,7 @@ instr 4
     gains = dbapgains:k[](1, source, lpos, 3, 24.0)
 
     for g in gains do
-        if (g != 0.5) then
+        if (abs(g - 0.5) > tolerance) then
             printf("[FAIL] Center source test failed, gain should be 0.5 for each channel, got %f\n", 1, g)
             exitnowk(-1)
         endif

--- a/tests/commandline/test_dbap.csd
+++ b/tests/commandline/test_dbap.csd
@@ -105,7 +105,7 @@ instr 4
 
     for g in gains do
         if (g != 0.5) then
-            printf("[FAIL] Center source test failed, gain should be 0.5 for each channel\n", 1)
+            printf("[FAIL] Center source test failed, gain should be 0.5 for each channel, got %f\n", 1, g)
             exitnowk(-1)
         endif
     od


### PR DESCRIPTION
This PR improves the circular API by exposing the check space function, while keeping the new behaviour (write space increased by 1 sample to match reading space), adding unit and csd tests for this function and diskin async performance.

The new behaviour introduced in an earlier PR is such that write_space = size - read_space, whereas in the previous scheme we had write_space = size - read_space - 1, which turned out to be confusing for users. 