### PR TITLE
Add linux portable build (no dependencies)

### DIFF
--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -61,6 +61,7 @@ jobs:
       LIBOPUS_VERSION:     "1.4"
       LIBFLAC_VERSION:     "1.4.3"
       LIBSNDFILE_VERSION:  "1.2.2"
+      LIBLO_VERSION:       "0.31"
 
     steps:
       # ------------------------------------------------------------------ #
@@ -112,6 +113,7 @@ jobs:
             -opus${{ env.LIBOPUS_VERSION }}
             -flac${{ env.LIBFLAC_VERSION }}
             -sndfile${{ env.LIBSNDFILE_VERSION }}
+            -lo${{ env.LIBLO_VERSION }}
             -v1
 
       # --- libogg (required by libvorbis and libFLAC) -------------------- #
@@ -230,6 +232,25 @@ jobs:
           mv "${DEPS_PREFIX}/lib/libsndfile_merged.a" "${DEPS_PREFIX}/lib/libsndfile.a"
           echo "Merged archive size: $(du -sh ${DEPS_PREFIX}/lib/libsndfile.a)"
 
+      # --- liblo (OSC library – provides lo::lo / liblo target) ----------- #
+      - name: Build static liblo
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://github.com/radarsat1/liblo/releases/download/${LIBLO_VERSION}/liblo-${LIBLO_VERSION}.tar.gz" \
+            | tar -xz -C /tmp
+          cmake \
+            -B /tmp/lo-build \
+            -S "/tmp/liblo-${LIBLO_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTS=OFF
+          cmake --build /tmp/lo-build -j"$(nproc)"
+          cmake --install /tmp/lo-build
+
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #
       # ------------------------------------------------------------------ #
@@ -242,6 +263,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            -DUSE_LIBLO=ON \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \
             -DUSE_PORTMIDI=ON \
@@ -267,8 +289,14 @@ jobs:
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
-          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
 
+          echo "════════════════════════════════════════════════════"
+          echo "  Full build tree – all shared libraries"
+          echo "════════════════════════════════════════════════════"
+          find build -name '*.so*' | sort
+
+          echo ""
           echo "════════════════════════════════════════════════════"
           echo "  csound binary"
           echo "════════════════════════════════════════════════════"
@@ -289,7 +317,7 @@ jobs:
           echo "  libcsound.so (codec chain must be statically"
           echo "  absorbed; no sndfile/FLAC/vorbis/opus .so deps)"
           echo "════════════════════════════════════════════════════"
-          LIBCSOUND=$(find build -maxdepth 2 -name 'libcsound*.so*' | head -1)
+          LIBCSOUND=$(find build -name 'libcsound*.so' | head -1)
           ldd "$LIBCSOUND"
 
           echo ""
@@ -304,15 +332,9 @@ jobs:
 
           echo ""
           echo "════════════════════════════════════════════════════"
-          echo "  Audio backend plugins"
-          echo "  (libasound / libjack / libportmidi expected here)"
+          echo "  Plugin shared libraries (all non-core .so files)"
           echo "════════════════════════════════════════════════════"
-          find build \( \
-            -name 'librtalsa.so'        \
-            -o -name 'librtjack.so'     \
-            -o -name 'librtpa.so' \
-            -o -name 'libpmidi.so'  \
-          \) | while read -r plugin; do
+          find build -name '*.so' ! -name 'libcsound*' | sort | while read -r plugin; do
             echo ""
             echo "--- $plugin ---"
             ldd "$plugin"
@@ -331,13 +353,48 @@ jobs:
         run: |
           mkdir -p dist/plugins
           cp build/csound dist/
-          find build -maxdepth 2 -name 'libcsound*.so*' -exec cp {} dist/ \;
-          find build \( \
-            -name 'librtalsa.so'        \
-            -o -name 'librtjack.so'     \
-            -o -name 'librtpa.so' \
-            -o -name 'libpmidi.so'  \
-          \) -exec cp {} dist/plugins/ \;
+
+          # Core library (real file + versioned symlinks)
+          find build -name 'libcsound*.so*' -exec cp -P {} dist/ \;
+
+          # Every .so that is not the core library is a plugin.
+          find build -name '*.so' ! -name 'libcsound*' \
+            -exec cp {} dist/plugins/ \;
+
+          echo ""
+          echo "Collected plugins:"
+          ls dist/plugins/
+
+          # Warn about any expected plugins that are missing.
+          EXPECTED="libVosim libafilters libambicode1 libampmidid libarrayops
+            libarrays libbabo libbformdec2 libbilbar libbuchla libcellular
+            libcompress libcontrol libcounter libcpumeter libcrossfm libdate
+            libdoppler libemugens libeqfil libexciter libfareygen libfareyseq
+            libfractalnoise libframebuffer libftest libftsamplebank libgammatone
+            libgendy libgrain4 libharmon libhrtfearly libhrtferX libhrtfopcodes
+            libhrtfreverb libipmidi libjoystick liblfsr libliveconv libloscilx
+            liblufs libminmax libmixer libmodmatrix libmp3in libnewgabops
+            libosc libpadsynth_gen libpan2 libpartikkel libpaulstretch
+            libphisem libphysmod libpinker libpitchtrack libplaterev libpmidi
+            libpvlock libpvoc libpvsopcodes libpvsops libquadbezier librtalsa
+            librtjack librtpw libsc_noise libscansyn libscoreline libscugens
+            libselect libsequencer libserial libsfont libshape
+            libsignalflowgraph libsockrecv libsocksend libspectra
+            libsquinewave libstdopcodes libstdutil libsterrain libsystem_call
+            libtabaudio libtabsum libtrigEnvSegs libugakbari liburandom
+            libvaops libvbap libwpfilters libzak"
+          MISSING=""
+          for name in $EXPECTED; do
+            if [ ! -f "dist/plugins/${name}.so" ]; then
+              MISSING="${MISSING} ${name}.so"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "WARNING – expected plugins not found in build output:"
+            for m in $MISSING; do echo "  $m"; done
+          else
+            echo "All expected plugins present."
+          fi
 
       - name: Upload artefacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           # Pull in the full history so version tags resolve correctly.
           fetch-depth: 0
+          ref: "develop"
 
       # ------------------------------------------------------------------ #
       # 3. Build a static libsndfile with zero external codec deps          #
@@ -172,7 +173,7 @@ jobs:
           echo "Checking for unexpected external libs..."
           UNEXPECTED=$(ldd build/csound | \
             grep -v -E \
-              'linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so' \
+              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libcsound64\.so\.7\.0\libdl\.so|libpthread\.so|librt\.so' \
             || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "ERROR: unexpected runtime dependencies found:"
@@ -180,6 +181,25 @@ jobs:
             exit 1
           fi
           echo "OK – only glibc-family libraries present."
+
+          echo "════════════════════════════════════════"
+          echo "  Dynamic deps of the libcsound "
+          echo "════════════════════════════════════════"
+          ldd build/libcsound64.so*
+  
+          echo ""
+          echo "Checking for unexpected external libs..."
+          UNEXPECTED=$(ldd build/csound | \
+            grep -v -E \
+              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so' \
+            || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "ERROR: unexpected runtime dependencies found:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          echo "OK – only glibc-family libraries present."
+
 
           echo ""
           echo "════════════════════════════════════════"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -39,6 +39,7 @@ on:
       - develop
       - main
       - testbuild
+      
   pull_request:
     branches:
       - develop
@@ -214,6 +215,29 @@ jobs:
           cmake --build /tmp/sndfile-build -j"$(nproc)"
           cmake --install /tmp/sndfile-build
 
+          # Merge all codec static archives into libsndfile.a.
+          #
+          # CMake puts CMAKE_SHARED_LINKER_FLAGS before the target libraries
+          # in the link command, so any codec -l flags we add there are
+          # processed before -lsndfile and get discarded by the linker before
+          # it knows they are needed.  Merging everything into one archive
+          # sidesteps the ordering problem entirely: the single libsndfile.a
+          # that CMake's SndFile target already links contains all symbols.
+          cat > /tmp/merge.mri << MRIEOF
+CREATE ${DEPS_PREFIX}/lib/libsndfile_merged.a
+ADDLIB ${DEPS_PREFIX}/lib/libsndfile.a
+ADDLIB ${DEPS_PREFIX}/lib/libFLAC.a
+ADDLIB ${DEPS_PREFIX}/lib/libvorbisenc.a
+ADDLIB ${DEPS_PREFIX}/lib/libvorbis.a
+ADDLIB ${DEPS_PREFIX}/lib/libogg.a
+ADDLIB ${DEPS_PREFIX}/lib/libopus.a
+SAVE
+END
+MRIEOF
+          ar -M < /tmp/merge.mri
+          mv "${DEPS_PREFIX}/lib/libsndfile_merged.a" "${DEPS_PREFIX}/lib/libsndfile.a"
+          echo "Merged archive size: $(du -sh ${DEPS_PREFIX}/lib/libsndfile.a)"
+
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #
       # ------------------------------------------------------------------ #
@@ -225,7 +249,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++ -L${DEPS_PREFIX}/lib -Wl,--start-group -lFLAC -lvorbisenc -lvorbis -lopus -logg -Wl,--end-group" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \
             -DUSE_PORTMIDI=ON \
@@ -238,8 +262,7 @@ jobs:
             -DINSTALL_PYTHON_INTERFACE=OFF \
             -DBUILD_LUA_INTERFACE=OFF \
             -DBUILD_CSBEATS=OFF \
-            -DBUILD_TESTS=OFF \
-            -DBUILD_UTILITIES=OFF
+            -DBUILD_TESTS=OFF
 
       # ------------------------------------------------------------------ #
       # 5. Compile                                                           #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -162,30 +162,17 @@ jobs:
           cmake --install /tmp/sndfile-build
 
       # libsndfile 1.2.x writes Vorbis::vorbisenc and Opus::opus into its
-      # installed SndFileTargets.cmake even when those libs were not found,
-      # which causes any downstream find_package(SndFile) to fail.
-      # Strip them unconditionally so the fix also applies when DEPS_PREFIX
-      # is restored from the Actions cache (where the broken file would
-      # otherwise be reused without re-running the build step above).
-      - name: Patch libsndfile CMake targets (remove unfound Vorbis / Opus deps)
+      # installed SndFileTargets.cmake even when those libs were not found.
+      # sed-patching the file is fragile because the exact formatting varies.
+      # The reliable fix is to remove the entire cmake package config dir so
+      # that find_package(SndFile) falls back to pkg-config, whose .pc file
+      # is generated correctly and only lists libs that were actually linked.
+      # Runs unconditionally so a cached (broken) DEPS_PREFIX is also fixed.
+      - name: Remove libsndfile CMake config (force pkg-config fallback)
         run: |
-          TARGETS="${DEPS_PREFIX}/lib/cmake/SndFile/SndFileTargets.cmake"
-          if [ ! -f "$TARGETS" ]; then
-            echo "ERROR: $TARGETS not found"
-            exit 1
-          fi
-          echo "Before patch:"
-          grep -E "Vorbis|Opus" "$TARGETS" || echo "  (none found)"
-          sed -i \
-            -e 's/Vorbis::vorbisenc;//g' \
-            -e 's/;Vorbis::vorbisenc//g' \
-            -e 's/Opus::opus;//g' \
-            -e 's/;Opus::opus//g' \
-            "$TARGETS"
-          echo "After patch:"
-          grep -E "Vorbis|Opus" "$TARGETS" \
-            && { echo "ERROR: entries still present"; exit 1; } \
-            || echo "  OK - entries removed"
+          rm -rf "${DEPS_PREFIX}/lib/cmake/SndFile"
+          echo "Removed cmake config. Remaining sndfile pkg-config:"
+          cat "${DEPS_PREFIX}/lib/pkgconfig/sndfile.pc"
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.DEPS_PREFIX }}
-          key: static-deps-ubuntu20-ogg${{ env.LIBOGG_VERSION }}-flac${{ env.LIBFLAC_VERSION }}-sndfile${{ env.LIBSNDFILE_VERSION }}-v1
+          key: static-deps-ubuntu20-ogg${{ env.LIBOGG_VERSION }}-flac${{ env.LIBFLAC_VERSION }}-sndfile${{ env.LIBSNDFILE_VERSION }}-v2
 
       - name: Build static libogg
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
@@ -138,7 +138,7 @@ jobs:
           cmake --build /tmp/flac-build -j"$(nproc)"
           cmake --install /tmp/flac-build
 
-      - name: Build static libsndfile (FLAC enabled, no Vorbis / MPEG)
+      - name: Build static libsndfile (FLAC enabled, Vorbis / Opus / MPEG disabled)
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
@@ -156,7 +156,9 @@ jobs:
             -DBUILD_EXAMPLES=OFF \
             -DBUILD_TESTING=OFF \
             -DENABLE_EXTERNAL_LIBS=ON \
-            -DENABLE_MPEG=OFF
+            -DENABLE_MPEG=OFF \
+            -DENABLE_VORBIS=OFF \
+            -DENABLE_OPUS=OFF
           cmake --build /tmp/sndfile-build -j"$(nproc)"
           cmake --install /tmp/sndfile-build
 

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -223,17 +223,9 @@ jobs:
           # it knows they are needed.  Merging everything into one archive
           # sidesteps the ordering problem entirely: the single libsndfile.a
           # that CMake's SndFile target already links contains all symbols.
-          cat > /tmp/merge.mri << MRIEOF
-CREATE ${DEPS_PREFIX}/lib/libsndfile_merged.a
-ADDLIB ${DEPS_PREFIX}/lib/libsndfile.a
-ADDLIB ${DEPS_PREFIX}/lib/libFLAC.a
-ADDLIB ${DEPS_PREFIX}/lib/libvorbisenc.a
-ADDLIB ${DEPS_PREFIX}/lib/libvorbis.a
-ADDLIB ${DEPS_PREFIX}/lib/libogg.a
-ADDLIB ${DEPS_PREFIX}/lib/libopus.a
-SAVE
-END
-MRIEOF
+          D="${DEPS_PREFIX}/lib"
+          printf 'CREATE %s/libsndfile_merged.a\nADDLIB %s/libsndfile.a\nADDLIB %s/libFLAC.a\nADDLIB %s/libvorbisenc.a\nADDLIB %s/libvorbis.a\nADDLIB %s/libogg.a\nADDLIB %s/libopus.a\nSAVE\nEND\n' \
+            "$D" "$D" "$D" "$D" "$D" "$D" "$D" > /tmp/merge.mri
           ar -M < /tmp/merge.mri
           mv "${DEPS_PREFIX}/lib/libsndfile_merged.a" "${DEPS_PREFIX}/lib/libsndfile.a"
           echo "Merged archive size: $(du -sh ${DEPS_PREFIX}/lib/libsndfile.a)"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -1,31 +1,35 @@
 # linux_minimal.yml
 #
 # Builds a Csound binary for Linux with ALSA, JACK, and PortMidi audio
-# back-ends enabled, and libsndfile compiled with FLAC support.
+# back-ends enabled, and libsndfile compiled with FLAC, Vorbis, and Opus
+# support.
 #
 # Dependency strategy
 # -------------------
 #   Core binary & libcsound.so
 #     Only glibc-family runtime deps (libc, libm, libdl, libpthread).
-#     The codec chain libogg → libFLAC → libsndfile is compiled from
-#     source as static PIC libraries and linked directly into libcsound.so,
-#     so none of them appear as shared-library requirements.
-#     libgcc_s / libstdc++ are also baked in via -static-libgcc /
-#     -static-libstdc++.
+#     The full codec chain is compiled from source as static PIC libraries
+#     and linked directly into libcsound.so:
+#
+#       libogg  ──┬──► libvorbis  ──┐
+#                 │                  ├──► libsndfile ──► libcsound.so
+#                 └──► libFLAC   ──┘
+#       libopus ──────────────────────────────────────► libcsound.so
+#
+#     libgcc_s / libstdc++ are also baked in via
+#     -static-libgcc / -static-libstdc++.
 #
 #   Audio backend plugins  (rtalsa.so, rtjack.so, *portmidi*.so …)
-#     Csound loads RT and MIDI modules as plugins at runtime, so their
-#     external deps are isolated to those plugin .so files and never
-#     affect the core binary.  The three audio libraries are installed
-#     from Ubuntu 20.04 packages:
-#       libasound2-dev   →  rtalsa plugin
-#       libjack-jackd2-dev → rtjack plugin
-#       libportmidi-dev  →  portmidi MIDI plugin
+#     Csound loads RT and MIDI modules as plugins at runtime.  Their
+#     external deps are isolated to those plugin .so files:
+#       libasound2-dev     →  rtalsa plugin
+#       libjack-jackd2-dev →  rtjack plugin
+#       libportmidi-dev    →  portmidi MIDI plugin
 #
 # Distribution compatibility
 # --------------------------
-#   The job runs inside an ubuntu:20.04 container (glibc 2.31).
-#   Binaries work on Ubuntu 20+, Debian 11+, Fedora 33+, RHEL 9+, etc.
+#   Built inside ubuntu:20.04 container (glibc 2.31).
+#   Runs on Ubuntu 20+, Debian 11+, Fedora 33+, RHEL 9+, etc.
 
 name: linux_minimal
 
@@ -51,10 +55,12 @@ jobs:
 
     env:
       DEBIAN_FRONTEND: noninteractive
-      DEPS_PREFIX:        /opt/static-deps
-      LIBOGG_VERSION:     "1.3.5"
-      LIBFLAC_VERSION:    "1.4.3"
-      LIBSNDFILE_VERSION: "1.2.2"
+      DEPS_PREFIX:         /opt/static-deps
+      LIBOGG_VERSION:      "1.3.5"
+      LIBVORBIS_VERSION:   "1.3.7"
+      LIBOPUS_VERSION:     "1.4"
+      LIBFLAC_VERSION:     "1.4.3"
+      LIBSNDFILE_VERSION:  "1.2.2"
 
     steps:
       # ------------------------------------------------------------------ #
@@ -86,20 +92,29 @@ jobs:
           fetch-depth: 0
 
       # ------------------------------------------------------------------ #
-      # 3. Static codec chain: libogg → libFLAC → libsndfile                #
+      # 3. Static codec chain                                                #
       #                                                                      #
-      # All three are built as static PIC libraries under $DEPS_PREFIX.     #
-      # CMake finds them via CMAKE_PREFIX_PATH and links them into           #
-      # libcsound.so, so the shared library has no codec .so deps at        #
-      # runtime.                                                             #
+      # Csound's own CMakeLists.txt creates a "sndfile" interface target    #
+      # that unconditionally requires Vorbis::vorbisenc and Opus::opus,     #
+      # so those CMake targets must exist at configure time regardless of   #
+      # whether we personally want Vorbis/Opus support.  Building the full  #
+      # chain also lets libsndfile link them in cleanly.                    #
       # ------------------------------------------------------------------ #
-      - name: Cache static codec chain (libogg + libFLAC + libsndfile)
+      - name: Cache static codec chain
         id: cache-static-deps
         uses: actions/cache@v4
         with:
           path: ${{ env.DEPS_PREFIX }}
-          key: static-deps-ubuntu20-ogg${{ env.LIBOGG_VERSION }}-flac${{ env.LIBFLAC_VERSION }}-sndfile${{ env.LIBSNDFILE_VERSION }}-v2
+          key: |
+            static-deps-ubuntu20
+            -ogg${{ env.LIBOGG_VERSION }}
+            -vorbis${{ env.LIBVORBIS_VERSION }}
+            -opus${{ env.LIBOPUS_VERSION }}
+            -flac${{ env.LIBFLAC_VERSION }}
+            -sndfile${{ env.LIBSNDFILE_VERSION }}
+            -v1
 
+      # --- libogg (required by libvorbis and libFLAC) -------------------- #
       - name: Build static libogg
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
@@ -117,7 +132,45 @@ jobs:
           cmake --build /tmp/ogg-build -j"$(nproc)"
           cmake --install /tmp/ogg-build
 
-      - name: Build static libFLAC (with Ogg support)
+      # --- libvorbis (provides Vorbis::vorbisenc target) ----------------- #
+      - name: Build static libvorbis
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://downloads.xiph.org/releases/vorbis/libvorbis-${LIBVORBIS_VERSION}.tar.gz" \
+            | tar -xz -C /tmp
+          cmake \
+            -B /tmp/vorbis-build \
+            -S "/tmp/libvorbis-${LIBVORBIS_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake --build /tmp/vorbis-build -j"$(nproc)"
+          cmake --install /tmp/vorbis-build
+
+      # --- libopus (provides Opus::opus target) -------------------------- #
+      - name: Build static libopus
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://downloads.xiph.org/releases/opus/opus-${LIBOPUS_VERSION}.tar.gz" \
+            | tar -xz -C /tmp
+          cmake \
+            -B /tmp/opus-build \
+            -S "/tmp/opus-${LIBOPUS_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DOPUS_BUILD_PROGRAMS=OFF \
+            -DOPUS_BUILD_TESTING=OFF
+          cmake --build /tmp/opus-build -j"$(nproc)"
+          cmake --install /tmp/opus-build
+
+      # --- libFLAC (with Ogg support) ------------------------------------ #
+      - name: Build static libFLAC
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
@@ -139,7 +192,8 @@ jobs:
           cmake --build /tmp/flac-build -j"$(nproc)"
           cmake --install /tmp/flac-build
 
-      - name: Build static libsndfile (FLAC enabled, MPEG disabled)
+      # --- libsndfile (FLAC + Vorbis + Opus; no MPEG) -------------------- #
+      - name: Build static libsndfile
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
@@ -160,19 +214,6 @@ jobs:
             -DENABLE_MPEG=OFF
           cmake --build /tmp/sndfile-build -j"$(nproc)"
           cmake --install /tmp/sndfile-build
-
-      # libsndfile 1.2.x writes Vorbis::vorbisenc and Opus::opus into its
-      # installed SndFileTargets.cmake even when those libs were not found.
-      # sed-patching the file is fragile because the exact formatting varies.
-      # The reliable fix is to remove the entire cmake package config dir so
-      # that find_package(SndFile) falls back to pkg-config, whose .pc file
-      # is generated correctly and only lists libs that were actually linked.
-      # Runs unconditionally so a cached (broken) DEPS_PREFIX is also fixed.
-      - name: Remove libsndfile CMake config (force pkg-config fallback)
-        run: |
-          rm -rf "${DEPS_PREFIX}/lib/cmake/SndFile"
-          echo "Removed cmake config. Remaining sndfile pkg-config:"
-          cat "${DEPS_PREFIX}/lib/pkgconfig/sndfile.pc"
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #
@@ -208,9 +249,6 @@ jobs:
 
       # ------------------------------------------------------------------ #
       # 6. Verify runtime dependencies                                       #
-      #                                                                      #
-      # The core binary and libcsound.so must have only glibc-family deps.  #
-      # The audio backend plugins are allowed their respective audio libs.   #
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
@@ -233,8 +271,8 @@ jobs:
 
           echo ""
           echo "════════════════════════════════════════════════════"
-          echo "  libcsound.so (core library – codec chain must be"
-          echo "  statically absorbed; no sndfile/FLAC/ogg .so deps)"
+          echo "  libcsound.so (codec chain must be statically"
+          echo "  absorbed; no sndfile/FLAC/vorbis/opus .so deps)"
           echo "════════════════════════════════════════════════════"
           LIBCSOUND=$(find build -maxdepth 2 -name 'libcsound*.so*' | head -1)
           ldd "$LIBCSOUND"
@@ -255,8 +293,8 @@ jobs:
           echo "  (libasound / libjack / libportmidi expected here)"
           echo "════════════════════════════════════════════════════"
           find build \( \
-            -name 'rtalsa.so'      \
-            -o -name 'rtjack.so'   \
+            -name 'rtalsa.so'        \
+            -o -name 'rtjack.so'     \
             -o -name '*portmidi*.so' \
             -o -name '*pm_midi*.so'  \
           \) | while read -r plugin; do

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -308,10 +308,10 @@ jobs:
           echo "  (libasound / libjack / libportmidi expected here)"
           echo "════════════════════════════════════════════════════"
           find build \( \
-            -name 'rtalsa.so'        \
-            -o -name 'rtjack.so'     \
-            -o -name '*portmidi*.so' \
-            -o -name '*pm_midi*.so'  \
+            -name 'librtalsa.so'        \
+            -o -name 'librtjack.so'     \
+            -o -name 'librtpa.so' \
+            -o -name 'libpmidi.so'  \
           \) | while read -r plugin; do
             echo ""
             echo "--- $plugin ---"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -249,7 +249,7 @@ jobs:
             --disable-shared \
             --disable-examples \
             --disable-tools \
-            --disable-docs \
+            --disable-doc \
             CFLAGS="-fPIC -O2"
           make -j"$(nproc)"
           make install

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -118,7 +118,7 @@ jobs:
 
       # --- libogg (required by libvorbis and libFLAC) -------------------- #
       - name: Build static libogg
-        # if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://downloads.xiph.org/releases/ogg/libogg-${LIBOGG_VERSION}.tar.gz" \
@@ -237,7 +237,7 @@ jobs:
       # a shared lib regardless of BUILD_SHARED_LIBS.  Use autotools instead,
       # which has reliable --disable-shared and --prefix support.
       - name: Build static liblo
-        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        # if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/radarsat1/liblo/releases/download/${LIBLO_VERSION}/liblo-${LIBLO_VERSION}.tar.gz" \

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -241,7 +241,7 @@ jobs:
             | tar -xz -C /tmp
           cmake \
             -B /tmp/lo-build \
-            -S "/tmp/liblo-${LIBLO_VERSION}" \
+            -S "/tmp/liblo-${LIBLO_VERSION}/cmake" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
             -DBUILD_SHARED_LIBS=OFF \

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -289,7 +289,7 @@ jobs:
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
-          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'
 
           echo "════════════════════════════════════════════════════"
           echo "  Full build tree – all shared libraries"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -35,6 +35,7 @@ on:
       - develop
       - main
       - testbuild
+      
   pull_request:
     branches:
       - develop
@@ -138,7 +139,7 @@ jobs:
           cmake --build /tmp/flac-build -j"$(nproc)"
           cmake --install /tmp/flac-build
 
-      - name: Build static libsndfile (FLAC enabled, Vorbis / Opus / MPEG disabled)
+      - name: Build static libsndfile (FLAC enabled, MPEG disabled)
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
@@ -156,11 +157,35 @@ jobs:
             -DBUILD_EXAMPLES=OFF \
             -DBUILD_TESTING=OFF \
             -DENABLE_EXTERNAL_LIBS=ON \
-            -DENABLE_MPEG=OFF \
-            -DENABLE_VORBIS=OFF \
-            -DENABLE_OPUS=OFF
+            -DENABLE_MPEG=OFF
           cmake --build /tmp/sndfile-build -j"$(nproc)"
           cmake --install /tmp/sndfile-build
+
+      # libsndfile 1.2.x writes Vorbis::vorbisenc and Opus::opus into its
+      # installed SndFileTargets.cmake even when those libs were not found,
+      # which causes any downstream find_package(SndFile) to fail.
+      # Strip them unconditionally so the fix also applies when DEPS_PREFIX
+      # is restored from the Actions cache (where the broken file would
+      # otherwise be reused without re-running the build step above).
+      - name: Patch libsndfile CMake targets (remove unfound Vorbis / Opus deps)
+        run: |
+          TARGETS="${DEPS_PREFIX}/lib/cmake/SndFile/SndFileTargets.cmake"
+          if [ ! -f "$TARGETS" ]; then
+            echo "ERROR: $TARGETS not found"
+            exit 1
+          fi
+          echo "Before patch:"
+          grep -E "Vorbis|Opus" "$TARGETS" || echo "  (none found)"
+          sed -i \
+            -e 's/Vorbis::vorbisenc;//g' \
+            -e 's/;Vorbis::vorbisenc//g' \
+            -e 's/Opus::opus;//g' \
+            -e 's/;Opus::opus//g' \
+            "$TARGETS"
+          echo "After patch:"
+          grep -E "Vorbis|Opus" "$TARGETS" \
+            && { echo "ERROR: entries still present"; exit 1; } \
+            || echo "  OK - entries removed"
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -185,7 +185,7 @@ jobs:
           echo "════════════════════════════════════════"
           echo "  Dynamic deps of the libcsound "
           echo "════════════════════════════════════════"
-          ldd build/libcsound64.so*
+          ldd build/libcsound64.so.7.0
   
           echo ""
           echo "Checking for unexpected external libs..."
@@ -193,9 +193,9 @@ jobs:
             grep -v -E \
               'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so' \
             || true)
-          if [ -n "$UNEXPECTED" ]; then
+          if [ -n "$UNEXPECTED2" ]; then
             echo "ERROR: unexpected runtime dependencies found:"
-            echo "$UNEXPECTED"
+            echo "$UNEXPECTED2"
             exit 1
           fi
           echo "OK – only glibc-family libraries present."

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -173,7 +173,7 @@ jobs:
           echo "Checking for unexpected external libs..."
           UNEXPECTED=$(ldd build/csound | \
             grep -v -E \
-              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libcsound64\.so\.7\.0\libdl\.so|libpthread\.so|librt\.so' \
+              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libcsound64\.so\.7\.0|libdl\.so|libpthread\.so|librt\.so' \
             || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "ERROR: unexpected runtime dependencies found:"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -307,7 +307,7 @@ jobs:
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
-          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'
 
           echo "════════════════════════════════════════════════════"
           echo "  Full build tree – all shared libraries"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -1,0 +1,204 @@
+# linux_minimal.yml
+#
+# Builds a self-contained Csound binary for Linux.
+#
+# Goals
+# -----
+#   • No shared-library dependencies at runtime beyond the standard glibc
+#     family (libc, libm, libdl, libpthread).  All other libraries
+#     (libsndfile, libgcc_s, libstdc++) are linked statically.
+#   • Broad distribution compatibility: the binary is compiled inside an
+#     ubuntu:20.04 container (glibc 2.31), so it runs unchanged on any
+#     distro that ships glibc 2.31 or later – Ubuntu 20+, Debian 11+,
+#     Fedora 33+, RHEL 9+, openSUSE Leap 15.3+, etc.
+#   • No audio back-end is compiled in (ALSA / PortAudio / JACK /
+#     PulseAudio), so the binary is useful for offline / batch / embedded
+#     use-cases where an audio daemon is not available.
+#
+# How it works
+# ------------
+#   1. Spin up an ubuntu:20.04 Docker container on the GitHub runner.
+#   2. Build libsndfile from source as a static PIC library with no
+#      external codec dependencies (no Ogg/FLAC/Opus/MPEG).
+#   3. Configure Csound with every optional external dependency disabled;
+#      point CMake at the static libsndfile.
+#   4. Link with -static-libgcc / -static-libstdc++ to avoid runtime
+#      libgcc_s.so / libstdc++.so requirements.
+#   5. Verify that ldd reports only glibc-family libraries, then upload
+#      the binary and shared library as workflow artefacts.
+
+name: linux_minimal
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Linux – minimal (libc only)
+    runs-on: ubuntu-22.04
+
+    # Use an ubuntu:20.04 container so the produced binary targets
+    # glibc 2.31, giving broad compatibility across modern distributions.
+    container:
+      image: ubuntu:20.04
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      # Where we install the static libsndfile we build ourselves.
+      SNDFILE_PREFIX: /opt/sndfile-static
+      LIBSNDFILE_VERSION: "1.2.2"
+
+    steps:
+      # ------------------------------------------------------------------ #
+      # 1. Toolchain                                                         #
+      # ------------------------------------------------------------------ #
+      - name: Install build toolchain
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            cmake \
+            curl \
+            flex \
+            bison \
+            git \
+            xz-utils \
+            pkg-config
+
+      # ------------------------------------------------------------------ #
+      # 2. Source checkout                                                   #
+      # ------------------------------------------------------------------ #
+      - name: Checkout Csound
+        uses: actions/checkout@v4
+        with:
+          # Pull in the full history so version tags resolve correctly.
+          fetch-depth: 0
+
+      # ------------------------------------------------------------------ #
+      # 3. Build a static libsndfile with zero external codec deps          #
+      # ------------------------------------------------------------------ #
+      - name: Cache static libsndfile
+        id: cache-sndfile
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SNDFILE_PREFIX }}
+          key: sndfile-${{ env.LIBSNDFILE_VERSION }}-ubuntu20-static-v1
+
+      - name: Download & build static libsndfile
+        if: steps.cache-sndfile.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://github.com/libsndfile/libsndfile/releases/download/${LIBSNDFILE_VERSION}/libsndfile-${LIBSNDFILE_VERSION}.tar.xz" \
+            | tar -xJ -C /tmp
+
+          cmake \
+            -B /tmp/sndfile-build \
+            -S "/tmp/libsndfile-${LIBSNDFILE_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${SNDFILE_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DBUILD_PROGRAMS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTING=OFF \
+            -DENABLE_EXTERNAL_LIBS=OFF \
+            -DENABLE_MPEG=OFF
+
+          cmake --build /tmp/sndfile-build -j"$(nproc)"
+          cmake --install /tmp/sndfile-build
+
+      # ------------------------------------------------------------------ #
+      # 4. Configure Csound                                                  #
+      # ------------------------------------------------------------------ #
+      - name: Configure Csound (minimal – no external runtime deps)
+        env:
+          PKG_CONFIG_PATH: "${{ env.SNDFILE_PREFIX }}/lib/pkgconfig"
+        run: |
+          cmake -B build -S . \
+            -DCMAKE_BUILD_TYPE=Release \
+            \
+            `# Point CMake's find_package / pkg-config at our static sndfile` \
+            -DCMAKE_PREFIX_PATH="${SNDFILE_PREFIX}" \
+            \
+            `# Link the C++ runtime and GCC support library statically so` \
+            `# libgcc_s.so and libstdc++.so are not required at runtime.` \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            \
+            `# Disable every optional audio back-end.` \
+            -DUSE_ALSA=OFF \
+            -DUSE_PORTAUDIO=OFF \
+            -DUSE_PORTMIDI=OFF \
+            -DUSE_JACK=OFF \
+            -DUSE_PULSEAUDIO=OFF \
+            \
+            `# Disable GUI, language bindings, and optional sub-projects.` \
+            -DUSE_FLTK=OFF \
+            -DBUILD_VIRTUAL_KEYBOARD=OFF \
+            -DBUILD_JAVA_INTERFACE=OFF \
+            -DBUILD_PYTHON_INTERFACE=OFF \
+            -DINSTALL_PYTHON_INTERFACE=OFF \
+            -DBUILD_LUA_INTERFACE=OFF \
+            -DBUILD_CSBEATS=OFF \
+            \
+            `# Tests require CUnit which is an external dep; skip them.` \
+            -DBUILD_TESTS=OFF
+
+      # ------------------------------------------------------------------ #
+      # 5. Compile                                                           #
+      # ------------------------------------------------------------------ #
+      - name: Build Csound
+        run: cmake --build build -j"$(nproc)"
+
+      # ------------------------------------------------------------------ #
+      # 6. Verify runtime dependencies                                       #
+      # ------------------------------------------------------------------ #
+      - name: Verify binary runtime dependencies
+        run: |
+          echo "════════════════════════════════════════"
+          echo "  Dynamic deps of the csound executable "
+          echo "════════════════════════════════════════"
+          ldd build/csound
+
+          echo ""
+          echo "Checking for unexpected external libs..."
+          UNEXPECTED=$(ldd build/csound | \
+            grep -v -E \
+              'linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so' \
+            || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "ERROR: unexpected runtime dependencies found:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          echo "OK – only glibc-family libraries present."
+
+          echo ""
+          echo "════════════════════════════════════════"
+          echo "  Csound version"
+          echo "════════════════════════════════════════"
+          build/csound --version || true
+
+      # ------------------------------------------------------------------ #
+      # 7. Upload artefacts                                                  #
+      # ------------------------------------------------------------------ #
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: csound-linux-minimal-x86_64
+          # Collect the main binary and the core shared library.
+          # Plugins (*.so in sub-dirs) are omitted because they would
+          # require the caller to also have their indirect deps available.
+          path: |
+            build/csound
+            build/libcsound*.so*
+          if-no-files-found: error
+          

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -238,7 +238,8 @@ jobs:
             -DINSTALL_PYTHON_INTERFACE=OFF \
             -DBUILD_LUA_INTERFACE=OFF \
             -DBUILD_CSBEATS=OFF \
-            -DBUILD_TESTS=OFF
+            -DBUILD_TESTS=OFF \
+            -DBUILD_UTILITIES=OFF
 
       # ------------------------------------------------------------------ #
       # 5. Compile                                                           #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -232,24 +232,45 @@ jobs:
           mv "${DEPS_PREFIX}/lib/libsndfile_merged.a" "${DEPS_PREFIX}/lib/libsndfile.a"
           echo "Merged archive size: $(du -sh ${DEPS_PREFIX}/lib/libsndfile.a)"
 
-      # --- liblo (OSC library – provides lo::lo / liblo target) ----------- #
+      # --- liblo (OSC library) -------------------------------------------- #
+      # liblo's cmake subdirectory ignores CMAKE_INSTALL_PREFIX and builds
+      # a shared lib regardless of BUILD_SHARED_LIBS.  Use autotools instead,
+      # which has reliable --disable-shared and --prefix support.
       - name: Build static liblo
         if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/radarsat1/liblo/releases/download/${LIBLO_VERSION}/liblo-${LIBLO_VERSION}.tar.gz" \
             | tar -xz -C /tmp
-          cmake \
-            -B /tmp/lo-build \
-            -S "/tmp/liblo-${LIBLO_VERSION}/cmake" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DBUILD_EXAMPLES=OFF \
-            -DBUILD_TESTS=OFF
-          cmake --build /tmp/lo-build -j"$(nproc)"
-          cmake --install /tmp/lo-build
+          cd "/tmp/liblo-${LIBLO_VERSION}"
+          ./configure \
+            --prefix="${DEPS_PREFIX}" \
+            --enable-static \
+            --disable-shared \
+            --disable-examples \
+            --disable-tools \
+            CFLAGS="-fPIC -O2"
+          make -j"$(nproc)"
+          make install
+
+      # # --- liblo (OSC library – provides lo::lo / liblo target) ----------- #
+      # - name: Build static liblo
+      #   if: steps.cache-static-deps.outputs.cache-hit != 'true'
+      #   run: |
+      #     curl -fsSL \
+      #       "https://github.com/radarsat1/liblo/releases/download/${LIBLO_VERSION}/liblo-${LIBLO_VERSION}.tar.gz" \
+      #       | tar -xz -C /tmp
+      #     cmake \
+      #       -B /tmp/lo-build \
+      #       -S "/tmp/liblo-${LIBLO_VERSION}/cmake" \
+      #       -DCMAKE_BUILD_TYPE=Release \
+      #       -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+      #       -DBUILD_SHARED_LIBS=OFF \
+      #       -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      #       -DBUILD_EXAMPLES=OFF \
+      #       -DBUILD_TESTS=OFF
+      #     cmake --build /tmp/lo-build -j"$(nproc)"
+      #     cmake --install /tmp/lo-build
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -267,7 +267,7 @@ jobs:
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
-          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'
 
           echo "════════════════════════════════════════════════════"
           echo "  csound binary"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -333,10 +333,10 @@ jobs:
           cp build/csound dist/
           find build -maxdepth 2 -name 'libcsound*.so*' -exec cp {} dist/ \;
           find build \( \
-            -name 'rtalsa.so'        \
-            -o -name 'rtjack.so'     \
-            -o -name '*portmidi*.so' \
-            -o -name '*pm_midi*.so'  \
+            -name 'librtalsa.so'        \
+            -o -name 'librtjack.so'     \
+            -o -name 'librtpa.so' \
+            -o -name 'libpmidi.so'  \
           \) -exec cp {} dist/plugins/ \;
 
       - name: Upload artefacts

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -118,7 +118,7 @@ jobs:
 
       # --- libogg (required by libvorbis and libFLAC) -------------------- #
       - name: Build static libogg
-        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        # if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://downloads.xiph.org/releases/ogg/libogg-${LIBOGG_VERSION}.tar.gz" \

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -61,7 +61,7 @@ jobs:
       LIBOPUS_VERSION:     "1.4"
       LIBFLAC_VERSION:     "1.4.3"
       LIBSNDFILE_VERSION:  "1.2.2"
-      LIBLO_VERSION:       "0.31"
+      LIBLO_VERSION:       "0.35"
 
     steps:
       # ------------------------------------------------------------------ #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -34,6 +34,7 @@ on:
     branches:
       - develop
       - main
+      - testbuild
   pull_request:
     branches:
       - develop

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -7,24 +7,23 @@
 # Dependency strategy
 # -------------------
 #   Core binary & libcsound.so
-#     Only glibc-family runtime deps (libc, libm, libdl, libpthread).
+#     Only glibc-family runtime deps (libc, libm, libmvec, libdl, libpthread).
+#     
 #     The full codec chain is compiled from source as static PIC libraries
 #     and linked directly into libcsound.so:
 #
-#       libogg  ──┬──► libvorbis  ──┐
-#                 │                  ├──► libsndfile ──► libcsound.so
-#                 └──► libFLAC   ──┘
-#       libopus ──────────────────────────────────────► libcsound.so
-#
+#       libogg, libvorbis -> libsndfile -> libcsound.so
+#       libFLAC           -> libsndfile -> libcsound.so
+#       libopus                         -> libcsound.so
+# 
 #     libgcc_s / libstdc++ are also baked in via
 #     -static-libgcc / -static-libstdc++.
 #
-#   Audio backend plugins  (rtalsa.so, rtjack.so, *portmidi*.so …)
-#     Csound loads RT and MIDI modules as plugins at runtime.  Their
-#     external deps are isolated to those plugin .so files:
-#       libasound2-dev     →  rtalsa plugin
-#       libjack-jackd2-dev →  rtjack plugin
-#       libportmidi-dev    →  portmidi MIDI plugin
+#   Audio backend plugins  (rtalsa.so, rtjack.so, *portmidi*.so …):
+#   Here we use the system's libraries, as available.
+# 
+#   At the moment portaudio is not included since csound has 
+#   already great support for jack, pipewire and ALSA.
 #
 # Distribution compatibility
 # --------------------------
@@ -64,9 +63,6 @@ jobs:
       LIBLO_VERSION:       "0.35"
 
     steps:
-      # ------------------------------------------------------------------ #
-      # 1. Toolchain + audio back-end dev packages                          #
-      # ------------------------------------------------------------------ #
       - name: Install build toolchain and audio backend headers
         run: |
           apt-get update -qq
@@ -84,23 +80,16 @@ jobs:
             libjack-jackd2-dev \
             libportmidi-dev
 
-      # ------------------------------------------------------------------ #
-      # 2. Source checkout                                                   #
-      # ------------------------------------------------------------------ #
       - name: Checkout Csound
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # ------------------------------------------------------------------ #
-      # 3. Static codec chain                                                #
-      #                                                                      #
-      # Csound's own CMakeLists.txt creates a "sndfile" interface target    #
-      # that unconditionally requires Vorbis::vorbisenc and Opus::opus,     #
-      # so those CMake targets must exist at configure time regardless of   #
-      # whether we personally want Vorbis/Opus support.  Building the full  #
-      # chain also lets libsndfile link them in cleanly.                    #
-      # ------------------------------------------------------------------ #
+      # Csound's own CMakeLists.txt creates a "sndfile" interface target   
+      # that requires Vorbis::vorbisenc and Opus::opus,     
+      # so those CMake targets must exist at configure time regardless of   
+      # whether we want Vorbis/Opus support. They are not hard to get built
+      # se we include them and add those formats for libsndfile  
       - name: Cache static codec chain
         id: cache-static-deps
         uses: actions/cache@v4
@@ -232,9 +221,8 @@ jobs:
           mv "${DEPS_PREFIX}/lib/libsndfile_merged.a" "${DEPS_PREFIX}/lib/libsndfile.a"
           echo "Merged archive size: $(du -sh ${DEPS_PREFIX}/lib/libsndfile.a)"
 
-      # --- liblo (OSC library) -------------------------------------------- #
-      # liblo's cmake subdirectory ignores CMAKE_INSTALL_PREFIX and builds
-      # a shared lib regardless of BUILD_SHARED_LIBS.  Use autotools instead,
+      # liblo's cmake subdirectory seems to ignore CMAKE_INSTALL_PREFIX and builds
+      # a shared lib regardless of BUILD_SHARED_LIBS. Use autotools instead,
       # which has reliable --disable-shared and --prefix support.
       - name: Build static liblo
         # if: steps.cache-static-deps.outputs.cache-hit != 'true'
@@ -256,10 +244,9 @@ jobs:
 
       # Libtool sometimes installs a shared lib even with --disable-shared,
       # and Csound's cmake will prefer the .so over our .a if it finds one
-      # anywhere on the library search path.  Running in a container, we can
+      # anywhere on the library search path. Running in a container, we can
       # simply remove every shared liblo from the system so the linker has
-      # no choice but to use our liblo.a.  This step is unconditional so it
-      # also cleans up after a cache restore.
+      # no choice but to use our liblo.a.
       - name: Remove shared liblo (enforce static linking into libosc.so)
         run: |
           echo "Removing any shared liblo libraries from the system..."
@@ -269,9 +256,6 @@ jobs:
           echo "Shared liblo remaining (expect none):"
           find / -xdev -name 'liblo.so*' 2>/dev/null && echo "FAIL" || echo "OK"
 
-      # ------------------------------------------------------------------ #
-      # 4. Configure Csound                                                  #
-      # ------------------------------------------------------------------ #
       - name: Configure Csound
         env:
           PKG_CONFIG_PATH: "${{ env.DEPS_PREFIX }}/lib/pkgconfig"
@@ -297,15 +281,9 @@ jobs:
             -DBUILD_CSBEATS=OFF \
             -DBUILD_TESTS=OFF
 
-      # ------------------------------------------------------------------ #
-      # 5. Compile                                                           #
-      # ------------------------------------------------------------------ #
       - name: Build Csound
         run: cmake --build build -j"$(nproc)"
 
-      # ------------------------------------------------------------------ #
-      # 6. Verify runtime dependencies                                       #
-      # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
           GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -253,24 +253,20 @@ jobs:
           make -j"$(nproc)"
           make install
 
-      # # --- liblo (OSC library – provides lo::lo / liblo target) ----------- #
-      # - name: Build static liblo
-      #   if: steps.cache-static-deps.outputs.cache-hit != 'true'
-      #   run: |
-      #     curl -fsSL \
-      #       "https://github.com/radarsat1/liblo/releases/download/${LIBLO_VERSION}/liblo-${LIBLO_VERSION}.tar.gz" \
-      #       | tar -xz -C /tmp
-      #     cmake \
-      #       -B /tmp/lo-build \
-      #       -S "/tmp/liblo-${LIBLO_VERSION}/cmake" \
-      #       -DCMAKE_BUILD_TYPE=Release \
-      #       -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
-      #       -DBUILD_SHARED_LIBS=OFF \
-      #       -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-      #       -DBUILD_EXAMPLES=OFF \
-      #       -DBUILD_TESTS=OFF
-      #     cmake --build /tmp/lo-build -j"$(nproc)"
-      #     cmake --install /tmp/lo-build
+      # Libtool sometimes installs a shared lib even with --disable-shared,
+      # and Csound's cmake will prefer the .so over our .a if it finds one
+      # anywhere on the library search path.  Running in a container, we can
+      # simply remove every shared liblo from the system so the linker has
+      # no choice but to use our liblo.a.  This step is unconditional so it
+      # also cleans up after a cache restore.
+      - name: Remove shared liblo (enforce static linking into libosc.so)
+        run: |
+          echo "Removing any shared liblo libraries from the system..."
+          find / -xdev -name 'liblo.so*' -delete 2>/dev/null || true
+          echo "Static liblo in DEPS_PREFIX:"
+          ls -lh "${DEPS_PREFIX}/lib/liblo.a"
+          echo "Shared liblo remaining (expect none):"
+          find / -xdev -name 'liblo.so*' 2>/dev/null && echo "FAIL" || echo "OK"
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #
@@ -285,9 +281,6 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DUSE_LIBLO=ON \
-            -DBUILD_PLUGINS=ON \
-            -DBUILD_DEPRECATED_OPCODES=OFF \
-            -DBUILD_OSC_OPCODES=ON \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \
             -DUSE_PORTMIDI=ON \
@@ -300,7 +293,8 @@ jobs:
             -DINSTALL_PYTHON_INTERFACE=OFF \
             -DBUILD_LUA_INTERFACE=OFF \
             -DBUILD_CSBEATS=OFF \
-            -DBUILD_TESTS=OFF 
+            -DBUILD_TESTS=OFF
+
       # ------------------------------------------------------------------ #
       # 5. Compile                                                           #
       # ------------------------------------------------------------------ #
@@ -312,7 +306,7 @@ jobs:
       # ------------------------------------------------------------------ #
       - name: Verify runtime dependencies
         run: |
-          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so'
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
 
           echo "════════════════════════════════════════════════════"
           echo "  Full build tree – all shared libraries"

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -39,7 +39,6 @@ on:
       - develop
       - main
       - testbuild
-      
   pull_request:
     branches:
       - develop
@@ -226,7 +225,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++ -L${DEPS_PREFIX}/lib -Wl,--start-group -lFLAC -lvorbisenc -lvorbis -lopus -logg -Wl,--end-group" \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \
             -DUSE_PORTMIDI=ON \

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -264,6 +264,9 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DUSE_LIBLO=ON \
+            -DBUILD_PLUGINS=ON \
+            -DBUILD_DEPRECATED_OPCODES=OFF \
+            -DBUILD_OSC_OPCODES=ON \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \
             -DUSE_PORTMIDI=ON \
@@ -276,8 +279,7 @@ jobs:
             -DINSTALL_PYTHON_INTERFACE=OFF \
             -DBUILD_LUA_INTERFACE=OFF \
             -DBUILD_CSBEATS=OFF \
-            -DBUILD_TESTS=OFF
-
+            -DBUILD_TESTS=OFF 
       # ------------------------------------------------------------------ #
       # 5. Compile                                                           #
       # ------------------------------------------------------------------ #

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -33,7 +33,7 @@ on:
   push:
     branches:
       - develop
-      - main
+      - testbuild
   pull_request:
     branches:
       - develop

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -281,6 +281,7 @@ jobs:
             -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            -DBUILD_PLUGINS=ON \
             -DUSE_LIBLO=ON \
             -DUSE_ALSA=ON \
             -DUSE_JACK=ON \

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -1,31 +1,31 @@
 # linux_minimal.yml
 #
-# Builds a self-contained Csound binary for Linux.
+# Builds a Csound binary for Linux with ALSA, JACK, and PortMidi audio
+# back-ends enabled, and libsndfile compiled with FLAC support.
 #
-# Goals
-# -----
-#   • No shared-library dependencies at runtime beyond the standard glibc
-#     family (libc, libm, libdl, libpthread).  All other libraries
-#     (libsndfile, libgcc_s, libstdc++) are linked statically.
-#   • Broad distribution compatibility: the binary is compiled inside an
-#     ubuntu:20.04 container (glibc 2.31), so it runs unchanged on any
-#     distro that ships glibc 2.31 or later – Ubuntu 20+, Debian 11+,
-#     Fedora 33+, RHEL 9+, openSUSE Leap 15.3+, etc.
-#   • No audio back-end is compiled in (ALSA / PortAudio / JACK /
-#     PulseAudio), so the binary is useful for offline / batch / embedded
-#     use-cases where an audio daemon is not available.
+# Dependency strategy
+# -------------------
+#   Core binary & libcsound.so
+#     Only glibc-family runtime deps (libc, libm, libdl, libpthread).
+#     The codec chain libogg → libFLAC → libsndfile is compiled from
+#     source as static PIC libraries and linked directly into libcsound.so,
+#     so none of them appear as shared-library requirements.
+#     libgcc_s / libstdc++ are also baked in via -static-libgcc /
+#     -static-libstdc++.
 #
-# How it works
-# ------------
-#   1. Spin up an ubuntu:20.04 Docker container on the GitHub runner.
-#   2. Build libsndfile from source as a static PIC library with no
-#      external codec dependencies (no Ogg/FLAC/Opus/MPEG).
-#   3. Configure Csound with every optional external dependency disabled;
-#      point CMake at the static libsndfile.
-#   4. Link with -static-libgcc / -static-libstdc++ to avoid runtime
-#      libgcc_s.so / libstdc++.so requirements.
-#   5. Verify that ldd reports only glibc-family libraries, then upload
-#      the binary and shared library as workflow artefacts.
+#   Audio backend plugins  (rtalsa.so, rtjack.so, *portmidi*.so …)
+#     Csound loads RT and MIDI modules as plugins at runtime, so their
+#     external deps are isolated to those plugin .so files and never
+#     affect the core binary.  The three audio libraries are installed
+#     from Ubuntu 20.04 packages:
+#       libasound2-dev   →  rtalsa plugin
+#       libjack-jackd2-dev → rtjack plugin
+#       libportmidi-dev  →  portmidi MIDI plugin
+#
+# Distribution compatibility
+# --------------------------
+#   The job runs inside an ubuntu:20.04 container (glibc 2.31).
+#   Binaries work on Ubuntu 20+, Debian 11+, Fedora 33+, RHEL 9+, etc.
 
 name: linux_minimal
 
@@ -33,7 +33,7 @@ on:
   push:
     branches:
       - develop
-      - testbuild
+      - main
   pull_request:
     branches:
       - develop
@@ -41,25 +41,24 @@ on:
 
 jobs:
   build:
-    name: Linux – minimal (libc only)
+    name: Linux – ALSA + JACK + PortMidi (libc-only core)
     runs-on: ubuntu-22.04
 
-    # Use an ubuntu:20.04 container so the produced binary targets
-    # glibc 2.31, giving broad compatibility across modern distributions.
     container:
       image: ubuntu:20.04
 
     env:
       DEBIAN_FRONTEND: noninteractive
-      # Where we install the static libsndfile we build ourselves.
-      SNDFILE_PREFIX: /opt/sndfile-static
+      DEPS_PREFIX:        /opt/static-deps
+      LIBOGG_VERSION:     "1.3.5"
+      LIBFLAC_VERSION:    "1.4.3"
       LIBSNDFILE_VERSION: "1.2.2"
 
     steps:
       # ------------------------------------------------------------------ #
-      # 1. Toolchain                                                         #
+      # 1. Toolchain + audio back-end dev packages                          #
       # ------------------------------------------------------------------ #
-      - name: Install build toolchain
+      - name: Install build toolchain and audio backend headers
         run: |
           apt-get update -qq
           apt-get install -y --no-install-recommends \
@@ -70,8 +69,11 @@ jobs:
             flex \
             bison \
             git \
+            pkg-config \
             xz-utils \
-            pkg-config
+            libasound2-dev \
+            libjack-jackd2-dev \
+            libportmidi-dev
 
       # ------------------------------------------------------------------ #
       # 2. Source checkout                                                   #
@@ -79,69 +81,101 @@ jobs:
       - name: Checkout Csound
         uses: actions/checkout@v4
         with:
-          # Pull in the full history so version tags resolve correctly.
           fetch-depth: 0
-          ref: "develop"
 
       # ------------------------------------------------------------------ #
-      # 3. Build a static libsndfile with zero external codec deps          #
+      # 3. Static codec chain: libogg → libFLAC → libsndfile                #
+      #                                                                      #
+      # All three are built as static PIC libraries under $DEPS_PREFIX.     #
+      # CMake finds them via CMAKE_PREFIX_PATH and links them into           #
+      # libcsound.so, so the shared library has no codec .so deps at        #
+      # runtime.                                                             #
       # ------------------------------------------------------------------ #
-      - name: Cache static libsndfile
-        id: cache-sndfile
+      - name: Cache static codec chain (libogg + libFLAC + libsndfile)
+        id: cache-static-deps
         uses: actions/cache@v4
         with:
-          path: ${{ env.SNDFILE_PREFIX }}
-          key: sndfile-${{ env.LIBSNDFILE_VERSION }}-ubuntu20-static-v1
+          path: ${{ env.DEPS_PREFIX }}
+          key: static-deps-ubuntu20-ogg${{ env.LIBOGG_VERSION }}-flac${{ env.LIBFLAC_VERSION }}-sndfile${{ env.LIBSNDFILE_VERSION }}-v1
 
-      - name: Download & build static libsndfile
-        if: steps.cache-sndfile.outputs.cache-hit != 'true'
+      - name: Build static libogg
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://downloads.xiph.org/releases/ogg/libogg-${LIBOGG_VERSION}.tar.gz" \
+            | tar -xz -C /tmp
+          cmake \
+            -B /tmp/ogg-build \
+            -S "/tmp/libogg-${LIBOGG_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DINSTALL_DOCS=OFF
+          cmake --build /tmp/ogg-build -j"$(nproc)"
+          cmake --install /tmp/ogg-build
+
+      - name: Build static libFLAC (with Ogg support)
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            "https://downloads.xiph.org/releases/flac/flac-${LIBFLAC_VERSION}.tar.xz" \
+            | tar -xJ -C /tmp
+          cmake \
+            -B /tmp/flac-build \
+            -S "/tmp/flac-${LIBFLAC_VERSION}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DWITH_OGG=ON \
+            -DBUILD_DOCS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTING=OFF \
+            -DINSTALL_MANPAGES=OFF
+          cmake --build /tmp/flac-build -j"$(nproc)"
+          cmake --install /tmp/flac-build
+
+      - name: Build static libsndfile (FLAC enabled, no Vorbis / MPEG)
+        if: steps.cache-static-deps.outputs.cache-hit != 'true'
         run: |
           curl -fsSL \
             "https://github.com/libsndfile/libsndfile/releases/download/${LIBSNDFILE_VERSION}/libsndfile-${LIBSNDFILE_VERSION}.tar.xz" \
             | tar -xJ -C /tmp
-
           cmake \
             -B /tmp/sndfile-build \
             -S "/tmp/libsndfile-${LIBSNDFILE_VERSION}" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="${SNDFILE_PREFIX}" \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DBUILD_PROGRAMS=OFF \
             -DBUILD_EXAMPLES=OFF \
             -DBUILD_TESTING=OFF \
-            -DENABLE_EXTERNAL_LIBS=OFF \
+            -DENABLE_EXTERNAL_LIBS=ON \
             -DENABLE_MPEG=OFF
-
           cmake --build /tmp/sndfile-build -j"$(nproc)"
           cmake --install /tmp/sndfile-build
 
       # ------------------------------------------------------------------ #
       # 4. Configure Csound                                                  #
       # ------------------------------------------------------------------ #
-      - name: Configure Csound (minimal – no external runtime deps)
+      - name: Configure Csound
         env:
-          PKG_CONFIG_PATH: "${{ env.SNDFILE_PREFIX }}/lib/pkgconfig"
+          PKG_CONFIG_PATH: "${{ env.DEPS_PREFIX }}/lib/pkgconfig"
         run: |
           cmake -B build -S . \
             -DCMAKE_BUILD_TYPE=Release \
-            \
-            `# Point CMake's find_package / pkg-config at our static sndfile` \
-            -DCMAKE_PREFIX_PATH="${SNDFILE_PREFIX}" \
-            \
-            `# Link the C++ runtime and GCC support library statically so` \
-            `# libgcc_s.so and libstdc++.so are not required at runtime.` \
+            -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}" \
             -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
             -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
-            \
-            `# Disable every optional audio back-end.` \
-            -DUSE_ALSA=OFF \
+            -DUSE_ALSA=ON \
+            -DUSE_JACK=ON \
+            -DUSE_PORTMIDI=ON \
             -DUSE_PORTAUDIO=OFF \
-            -DUSE_PORTMIDI=OFF \
-            -DUSE_JACK=OFF \
             -DUSE_PULSEAUDIO=OFF \
-            \
-            `# Disable GUI, language bindings, and optional sub-projects.` \
             -DUSE_FLTK=OFF \
             -DBUILD_VIRTUAL_KEYBOARD=OFF \
             -DBUILD_JAVA_INTERFACE=OFF \
@@ -149,8 +183,6 @@ jobs:
             -DINSTALL_PYTHON_INTERFACE=OFF \
             -DBUILD_LUA_INTERFACE=OFF \
             -DBUILD_CSBEATS=OFF \
-            \
-            `# Tests require CUnit which is an external dep; skip them.` \
             -DBUILD_TESTS=OFF
 
       # ------------------------------------------------------------------ #
@@ -161,64 +193,87 @@ jobs:
 
       # ------------------------------------------------------------------ #
       # 6. Verify runtime dependencies                                       #
+      #                                                                      #
+      # The core binary and libcsound.so must have only glibc-family deps.  #
+      # The audio backend plugins are allowed their respective audio libs.   #
       # ------------------------------------------------------------------ #
-      - name: Verify binary runtime dependencies
+      - name: Verify runtime dependencies
         run: |
-          echo "════════════════════════════════════════"
-          echo "  Dynamic deps of the csound executable "
-          echo "════════════════════════════════════════"
+          GLIBC_ONLY='linux-vdso|ld-linux|libc\.so|libm\.so|libdl\.so|libpthread\.so|librt\.so'
+
+          echo "════════════════════════════════════════════════════"
+          echo "  csound binary"
+          echo "════════════════════════════════════════════════════"
           ldd build/csound
 
           echo ""
-          echo "Checking for unexpected external libs..."
-          UNEXPECTED=$(ldd build/csound | \
-            grep -v -E \
-              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libcsound64\.so\.7\.0|libdl\.so|libpthread\.so|librt\.so' \
-            || true)
+          echo "Asserting csound binary has only glibc-family deps..."
+          UNEXPECTED=$(ldd build/csound | grep -Ev "($GLIBC_ONLY|libcsound)" || true)
           if [ -n "$UNEXPECTED" ]; then
-            echo "ERROR: unexpected runtime dependencies found:"
+            echo "FAIL – unexpected runtime dependencies in csound binary:"
             echo "$UNEXPECTED"
             exit 1
           fi
-          echo "OK – only glibc-family libraries present."
+          echo "OK"
 
-          echo "════════════════════════════════════════"
-          echo "  Dynamic deps of the libcsound "
-          echo "════════════════════════════════════════"
-          ldd build/libcsound64.so.7.0
-  
           echo ""
-          echo "Checking for unexpected external libs..."
-          UNEXPECTED=$(ldd build/csound | \
-            grep -v -E \
-              'linux-vdso|ld-linux|libc\.so|libm\.so|libmvec\.so|libdl\.so|libpthread\.so|librt\.so' \
-            || true)
-          if [ -n "$UNEXPECTED2" ]; then
-            echo "ERROR: unexpected runtime dependencies found:"
-            echo "$UNEXPECTED2"
+          echo "════════════════════════════════════════════════════"
+          echo "  libcsound.so (core library – codec chain must be"
+          echo "  statically absorbed; no sndfile/FLAC/ogg .so deps)"
+          echo "════════════════════════════════════════════════════"
+          LIBCSOUND=$(find build -maxdepth 2 -name 'libcsound*.so*' | head -1)
+          ldd "$LIBCSOUND"
+
+          echo ""
+          echo "Asserting libcsound.so has only glibc-family deps..."
+          UNEXPECTED=$(ldd "$LIBCSOUND" | grep -Ev "($GLIBC_ONLY)" || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "FAIL – unexpected runtime dependencies in libcsound.so:"
+            echo "$UNEXPECTED"
             exit 1
           fi
-          echo "OK – only glibc-family libraries present."
-
+          echo "OK"
 
           echo ""
-          echo "════════════════════════════════════════"
+          echo "════════════════════════════════════════════════════"
+          echo "  Audio backend plugins"
+          echo "  (libasound / libjack / libportmidi expected here)"
+          echo "════════════════════════════════════════════════════"
+          find build \( \
+            -name 'rtalsa.so'      \
+            -o -name 'rtjack.so'   \
+            -o -name '*portmidi*.so' \
+            -o -name '*pm_midi*.so'  \
+          \) | while read -r plugin; do
+            echo ""
+            echo "--- $plugin ---"
+            ldd "$plugin"
+          done
+
+          echo ""
+          echo "════════════════════════════════════════════════════"
           echo "  Csound version"
-          echo "════════════════════════════════════════"
+          echo "════════════════════════════════════════════════════"
           build/csound --version || true
 
       # ------------------------------------------------------------------ #
       # 7. Upload artefacts                                                  #
       # ------------------------------------------------------------------ #
+      - name: Collect artefacts
+        run: |
+          mkdir -p dist/plugins
+          cp build/csound dist/
+          find build -maxdepth 2 -name 'libcsound*.so*' -exec cp {} dist/ \;
+          find build \( \
+            -name 'rtalsa.so'        \
+            -o -name 'rtjack.so'     \
+            -o -name '*portmidi*.so' \
+            -o -name '*pm_midi*.so'  \
+          \) -exec cp {} dist/plugins/ \;
+
       - name: Upload artefacts
         uses: actions/upload-artifact@v4
         with:
           name: csound-linux-minimal-x86_64
-          # Collect the main binary and the core shared library.
-          # Plugins (*.so in sub-dirs) are omitted because they would
-          # require the caller to also have their indirect deps available.
-          path: |
-            build/csound
-            build/libcsound*.so*
+          path: dist/
           if-no-files-found: error
-          

--- a/.github/workflows/linux_minimal.yml
+++ b/.github/workflows/linux_minimal.yml
@@ -249,6 +249,7 @@ jobs:
             --disable-shared \
             --disable-examples \
             --disable-tools \
+            --disable-docs \
             CFLAGS="-fPIC -O2"
           make -j"$(nproc)"
           make install


### PR DESCRIPTION
This PR adds a minimal csound 7 build for linux without any external dependencies. It builds a static libsndfile and liblo and generates an artifact with the csound executable, libcsound and all plugins which run without the need of being installed. The user is required to set OPCODE7DIR64 to point to the distributed plugins directory. The resulting binary and libcsound.so is able to load external plugins and correctly loads the system libraries needed if available (alsa, jack). In particular it does not include portaudio since csound itself has native support for linux backends. 