### PR TITLE
fix: BARE_METAL=ON + BUILD_STATIC_LIBRARY=ON generates duplicate libcsound.a, breaking Ninja on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1702,7 +1702,7 @@ endif()
 
 
 
-if(BUILD_STATIC_LIBRARY)
+if(BUILD_STATIC_LIBRARY AND NOT BARE_METAL)
     add_library(${CSOUNDLIB_STATIC} STATIC ${libcsound_static_SRCS})
     target_include_directories(${CSOUNDLIB_STATIC} PRIVATE ${libcsound_private_include_dirs})
     target_include_directories(${CSOUNDLIB_STATIC} PUBLIC ${libcsound_public_include_dirs})
@@ -1815,7 +1815,7 @@ if(WIN32 OR NOT IOS OR OSXCROSS_TARGET)
 endif()
 
 # export static library targets (only when BUILD_STATIC_LIBRARY is enabled)
-if(BUILD_STATIC_LIBRARY)
+if(BUILD_STATIC_LIBRARY AND NOT BARE_METAL)
     install(EXPORT CsoundStaticExports
         FILE "CsoundStaticTargets.cmake"
         NAMESPACE "Csound::"


### PR DESCRIPTION
Fixes #2553

When BARE_METAL=ON, the primary csound target is already built as STATIC, making BUILD_STATIC_LIBRARY redundant. Both targets resolve to libcsound.a, which GNU Make silently allows but Ninja rejects as a hard error.

Guard the static library add_library block and the standalone `install(EXPORT CsoundStaticExports)` block with `AND NOT BARE_METAL` so they are skipped when the primary library is already static.