### PR TITLE
Fix: udo passbyref xin xout collision

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -900,7 +900,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -G x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
+        run: cmake -B build -S . -A x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -88,10 +88,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -523,10 +523,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -748,10 +748,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -785,10 +785,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -824,10 +824,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -960,10 +960,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -1037,10 +1037,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -1083,10 +1083,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -1154,10 +1154,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -1207,7 +1207,7 @@ jobs:
           submodules: true
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/check-pr-label
         with:
           label: release
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}          
 
   linux_build:
     name: Linux/Ubuntu build (apt-get)
@@ -877,6 +877,19 @@ jobs:
     env:
       CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
+      - name: Resolve VC Redist Directory Dynamically
+        shell: pwsh
+        run: |
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $redistPath = Get-ChildItem -Path "$vsPath\VC\Redist\MSVC\x64\Microsoft.VC*.CRT" | Select-Object -First 1 -ExpandProperty FullName
+    
+          if (-not $redistPath) {
+            Write-Error "Could not find the VC Redist directory on this runner."
+            exit 1
+            }
+          echo "Resolved VCREDIST_CRT_DIR to: $redistPath"
+          "VCREDIST_CRT_DIR=$redistPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+          
       - name: Checkout Source Code
         uses: actions/checkout@v5
         with:
@@ -954,6 +967,18 @@ jobs:
     env:
       CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
+      - name: Resolve VC Redist Directory Dynamically
+        shell: pwsh
+        run: |
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $redistPath = Get-ChildItem -Path "$vsPath\VC\Redist\MSVC\x64\Microsoft.VC*.CRT" | Select-Object -First 1 -ExpandProperty FullName
+    
+          if (-not $redistPath) {
+            Write-Error "Could not find the VC Redist directory on this runner."
+            exit 1
+            }
+          echo "Resolved VCREDIST_CRT_DIR to: $redistPath"
+          "VCREDIST_CRT_DIR=$redistPath" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout Source Code
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -900,7 +900,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -G "Visual Studio 17 2022" -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
+        run: cmake -B build -S . -G x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -977,7 +977,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -G "Visual Studio 17 2022" -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
+        run: cmake -B build -S . -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -883,10 +883,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      - uses: lukka/get-cmake@v3.29.0
+      - uses: lukka/get-cmake@v4.3.3
 
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -900,7 +900,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
+        run: cmake -B build -S . -G "Visual Studio 17 2022" -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -977,7 +977,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
+        run: cmake -B build -S . -G "Visual Studio 17 2022" -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -918,10 +918,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x64_github.iss
 
       - name: Upload installer
@@ -997,10 +997,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x86_github.iss
 
       - name: Upload installer

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -877,20 +877,6 @@ jobs:
     env:
       CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
-      - name: Resolve VC Redist Directory Dynamically
-        shell: pwsh
-        run: |
-          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $crtFolder = Get-ChildItem -Path "$vsPath\VC\Redist" -Filter "Microsoft.VC*.CRT" -Recurse -Directory | 
-                     Where-Object { $_.FullName -match 'x64' } | 
-                     Select-Object -First 1
-          if (-not $redistPath) {
-            Write-Error "Could not find the VC Redist directory on this runner."
-            exit 1
-            }
-          echo "Resolved VCREDIST_CRT_DIR to: $redistPath"
-          "VCREDIST_CRT_DIR=$redistPath" | Out-File -FilePath $env:GITHUB_ENV -Append
-          
       - name: Checkout Source Code
         uses: actions/checkout@v5
         with:
@@ -914,7 +900,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
+        run: cmake -B build -S . -G "Visual Studio 18 2026" -A x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -933,10 +919,22 @@ jobs:
         shell: powershell
         run: |
           $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $redistVersion = Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.OpenMP"
+          $redistVersion = (Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt").Trim()
+          $redistRoot = "$vsPath\VC\Redist\MSVC\$redistVersion\x64"
+          function Get-RedistDir($component) {
+            $dir = Get-ChildItem -Path $redistRoot -Directory -Filter "Microsoft.VC*.$component" | Select-Object -First 1
+            if (-not $dir) {
+              Write-Error "Could not find Microsoft.VC*.$component under $redistRoot"
+              exit 1
+            }
+            return $dir.FullName
+          }
+          $Env:VCREDIST_CRT_DIR = (Get-RedistDir "CRT")
+          $Env:VCREDIST_CXXAMP_DIR = (Get-RedistDir "CXXAMP")
+          $Env:VCREDIST_OPENMP_DIR = (Get-RedistDir "OpenMP")
+          echo "Resolved VCREDIST_CRT_DIR to: $Env:VCREDIST_CRT_DIR"
+          echo "Resolved VCREDIST_CXXAMP_DIR to: $Env:VCREDIST_CXXAMP_DIR"
+          echo "Resolved VCREDIST_OPENMP_DIR to: $Env:VCREDIST_OPENMP_DIR"
           iscc /o. installer\\windows\\csound7_x64_github.iss
 
       - name: Upload installer
@@ -992,7 +990,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -G "Visual Studio 17 2022" -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
+        run: cmake -B build -S . -G "Visual Studio 18 2026" -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -1013,10 +1011,22 @@ jobs:
         shell: powershell
         run: |
           $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $redistVersion = Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.OpenMP"
+          $redistVersion = (Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt").Trim()
+          $redistRoot = "$vsPath\VC\Redist\MSVC\$redistVersion\x86"
+          function Get-RedistDir($component) {
+            $dir = Get-ChildItem -Path $redistRoot -Directory -Filter "Microsoft.VC*.$component" | Select-Object -First 1
+            if (-not $dir) {
+              Write-Error "Could not find Microsoft.VC*.$component under $redistRoot"
+              exit 1
+            }
+            return $dir.FullName
+          }
+          $Env:VCREDIST_CRT_DIR = (Get-RedistDir "CRT")
+          $Env:VCREDIST_CXXAMP_DIR = (Get-RedistDir "CXXAMP")
+          $Env:VCREDIST_OPENMP_DIR = (Get-RedistDir "OpenMP")
+          echo "Resolved VCREDIST_CRT_DIR to: $Env:VCREDIST_CRT_DIR"
+          echo "Resolved VCREDIST_CXXAMP_DIR to: $Env:VCREDIST_CXXAMP_DIR"
+          echo "Resolved VCREDIST_OPENMP_DIR to: $Env:VCREDIST_OPENMP_DIR"
           iscc /o. installer\\windows\\csound7_x86_github.iss
 
       - name: Upload installer

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -918,10 +918,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x64_github.iss
 
       - name: Upload installer
@@ -997,10 +997,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x86_github.iss
 
       - name: Upload installer

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -914,7 +914,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -A x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
+        run: cmake -B build -S . -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -932,10 +932,11 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $redistVersion = Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x64\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x64_github.iss
 
       - name: Upload installer
@@ -968,19 +969,6 @@ jobs:
     env:
       CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
-      - name: Resolve VC Redist Directory Dynamically
-        shell: pwsh
-        run: |
-          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $crtFolder = Get-ChildItem -Path "$vsPath\VC\Redist" -Filter "Microsoft.VC*.CRT" -Recurse -Directory | 
-                     Where-Object { $_.FullName -match 'x64' } | 
-                     Select-Object -First 1
-          if (-not $redistPath) {
-            Write-Error "Could not find the VC Redist directory on this runner."
-            exit 1
-            }
-          echo "Resolved VCREDIST_CRT_DIR to: $redistPath"
-          "VCREDIST_CRT_DIR=$redistPath" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout Source Code
         uses: actions/checkout@v5
         with:
@@ -1004,7 +992,7 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure build
-        run: cmake -B build -S . -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
+        run: cmake -B build -S . -G "Visual Studio 17 2022" -A Win32 -DBUILD_TESTS=1 -DUSE_VCPKG=1 -DCUSTOM_CMAKE="./platform/windows/Custom-vs-x86.cmake"
 
       - name: Build Csound
         run: cmake --build build --config Release
@@ -1024,10 +1012,11 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $redistVersion = Get-Content "$vsPath\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="$vsPath\VC\Redist\MSVC\$redistVersion\x86\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x86_github.iss
 
       - name: Upload installer

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -918,10 +918,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x64\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x64_github.iss
 
       - name: Upload installer
@@ -997,10 +997,10 @@ jobs:
 #        if: github.ref == 'refs/heads/develop'
         shell: powershell
         run: |
-          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
-          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
-          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
-          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
+          $Env:RedistVersion=Get-Content "C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+          $Env:VCREDIST_CRT_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CRT"
+          $Env:VCREDIST_CXXAMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.CXXAMP"
+          $Env:VCREDIST_OPENMP_DIR="C:\Program Files\Microsoft Visual Studio\2026\Enterprise\VC\Redist\MSVC\${Env:RedistVersion}\x86\Microsoft.VC143.OpenMP"
           iscc /o. installer\\windows\\csound7_x86_github.iss
 
       - name: Upload installer

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -881,8 +881,9 @@ jobs:
         shell: pwsh
         run: |
           $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $redistPath = Get-ChildItem -Path "$vsPath\VC\Redist\MSVC\x64\Microsoft.VC*.CRT" | Select-Object -First 1 -ExpandProperty FullName
-    
+          $crtFolder = Get-ChildItem -Path "$vsPath\VC\Redist" -Filter "Microsoft.VC*.CRT" -Recurse -Directory | 
+                     Where-Object { $_.FullName -match 'x64' } | 
+                     Select-Object -First 1
           if (-not $redistPath) {
             Write-Error "Could not find the VC Redist directory on this runner."
             exit 1
@@ -971,8 +972,9 @@ jobs:
         shell: pwsh
         run: |
           $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $redistPath = Get-ChildItem -Path "$vsPath\VC\Redist\MSVC\x64\Microsoft.VC*.CRT" | Select-Object -First 1 -ExpandProperty FullName
-    
+          $crtFolder = Get-ChildItem -Path "$vsPath\VC\Redist" -Filter "Microsoft.VC*.CRT" -Recurse -Directory | 
+                     Where-Object { $_.FullName -match 'x64' } | 
+                     Select-Object -First 1
           if (-not $redistPath) {
             Write-Error "Could not find the VC Redist directory on this runner."
             exit 1

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1112,8 +1112,6 @@ static void deact(CSOUND *csound, INSDS *ip)
         p->cvt_out[k] = NULL; // clear pointer
       }
 
-    csoundRestoreUserOpcodeArgpp(csound, p);
-
     deact(csound, p->ip);     /* deactivate */
     p->ip = NULL;
     /* IV - Oct 26 2002: set perf routine to "not initialised" */

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -53,9 +53,6 @@ static int32_t count_args(const char *args) {
   return count;
 }
 
-/* Forward declaration from insert.c */
-extern void csoundReinitInstrumentArgpp(CSOUND *csound, INSDS *ip);
-
 static inline void rewire_argpp(CSOUND *csound, OPDS *chain, int32_t index,
                                 MYFLT *argPtr, const char *structPath);
 static MYFLT *pbr_resolve_struct_target(CSOUND *csound, MYFLT *argPtr,
@@ -76,9 +73,9 @@ typedef struct pbr_plan_builder {
   PBR_REWIRE_ENTRY *perf_entries;
   int32_t perf_count;
   int32_t perf_capacity;
-  PBR_REWIRE_ENTRY *xout_entries;
-  int32_t xout_count;
-  int32_t xout_capacity;
+  PBR_SEED_ENTRY   *seed_entries;
+  int32_t seed_count;
+  int32_t seed_capacity;
 } PBR_PLAN_BUILDER;
 
 static size_t pbr_name_key_length(const char *var_name) {
@@ -149,6 +146,19 @@ static char *pbr_dup_struct_path(CSOUND *csound,
   return path_len > 0 ? cs_strndup(csound, struct_path, path_len) : NULL;
 }
 
+static int32_t pbr_arg_has_struct_path(const ARG *arg, const char *raw_name) {
+  if (arg != NULL && arg->structPath != NULL && arg->structPath[0] != '\0') {
+    return 1;
+  }
+
+  if (raw_name != NULL) {
+    const char *dot = strchr(raw_name, '.');
+    return dot != NULL && dot[1] != '\0';
+  }
+
+  return 0;
+}
+
 static int32_t pbr_alias_find(const PBR_ALIAS_ENTRY *aliases,
                               int32_t alias_count,
                               const char *name) {
@@ -159,7 +169,7 @@ static int32_t pbr_alias_find(const PBR_ALIAS_ENTRY *aliases,
   }
 
   for (i = 0; i < alias_count; i++) {
-    if (pbr_names_match(aliases[i].name, name)) {
+    if (strcmp(aliases[i].name, name) == 0) {
       return i;
     }
   }
@@ -167,9 +177,27 @@ static int32_t pbr_alias_find(const PBR_ALIAS_ENTRY *aliases,
   return -1;
 }
 
-static int32_t pbr_alias_lookup(const PBR_ALIAS_ENTRY *aliases,
-                                int32_t alias_count,
-                                const char *var_name) {
+static int32_t pbr_alias_lookup_exact(const PBR_ALIAS_ENTRY *aliases,
+                                      int32_t alias_count,
+                                      const char *var_name) {
+  int32_t i;
+
+  if (var_name == NULL) {
+    return -1;
+  }
+
+  for (i = 0; i < alias_count; i++) {
+    if (strcmp(aliases[i].name, var_name) == 0) {
+      return aliases[i].ar_index;
+    }
+  }
+
+  return -1;
+}
+
+static int32_t pbr_alias_lookup_base(const PBR_ALIAS_ENTRY *aliases,
+                                     int32_t alias_count,
+                                     const char *var_name) {
   int32_t i;
 
   if (var_name == NULL) {
@@ -183,6 +211,45 @@ static int32_t pbr_alias_lookup(const PBR_ALIAS_ENTRY *aliases,
   }
 
   return -1;
+}
+
+static int32_t pbr_alias_lookup(const PBR_ALIAS_ENTRY *aliases,
+                                int32_t alias_count,
+                                const char *var_name) {
+  int32_t ar_index = pbr_alias_lookup_exact(aliases, alias_count, var_name);
+  return ar_index >= 0 ? ar_index :
+    pbr_alias_lookup_base(aliases, alias_count, var_name);
+}
+
+static int32_t pbr_lookup_arg_alias(const PBR_PLAN_BUILDER *builder,
+                                    const char *arg_name,
+                                    const char *raw_name) {
+  int32_t ar_index = pbr_alias_lookup_exact(builder->aliases,
+                                            builder->alias_count,
+                                            raw_name);
+  if (ar_index >= 0) {
+    return ar_index;
+  }
+
+  if (arg_name != raw_name) {
+    ar_index = pbr_alias_lookup_exact(builder->aliases,
+                                      builder->alias_count,
+                                      arg_name);
+    if (ar_index >= 0) {
+      return ar_index;
+    }
+  }
+
+  ar_index = pbr_alias_lookup_base(builder->aliases,
+                                   builder->alias_count,
+                                   raw_name);
+  if (ar_index >= 0) {
+    return ar_index;
+  }
+
+  return arg_name != raw_name ?
+    pbr_alias_lookup_base(builder->aliases, builder->alias_count, arg_name) :
+    -1;
 }
 
 static int32_t pbr_ensure_alias_capacity(CSOUND *csound,
@@ -297,6 +364,46 @@ static int32_t pbr_append_entry(CSOUND *csound,
   return OK;
 }
 
+static int32_t pbr_append_seed(CSOUND *csound,
+                               PBR_SEED_ENTRY **entries,
+                               int32_t *count,
+                               int32_t *capacity,
+                               int32_t output_ar_index,
+                               int32_t input_ar_index,
+                               const ARG *input_arg,
+                               const char *input_raw_name) {
+  PBR_SEED_ENTRY *entry;
+
+  if (*count >= *capacity) {
+    int32_t new_capacity = *capacity > 0 ? *capacity * 2 : 8;
+    PBR_SEED_ENTRY *grown;
+    while (new_capacity <= *count) {
+      new_capacity *= 2;
+    }
+    grown = *entries == NULL ?
+      (PBR_SEED_ENTRY *)csound->Malloc(csound,
+                                       (size_t)new_capacity *
+                                       sizeof(PBR_SEED_ENTRY)) :
+      (PBR_SEED_ENTRY *)csound->ReAlloc(csound, *entries,
+                                        (size_t)new_capacity *
+                                        sizeof(PBR_SEED_ENTRY));
+    if (grown == NULL) {
+      return NOTOK;
+    }
+    *entries = grown;
+    *capacity = new_capacity;
+  }
+
+  entry = &((*entries)[*count]);
+  entry->output_ar_index = output_ar_index;
+  entry->input_ar_index = input_ar_index;
+  entry->input_struct_path = pbr_dup_struct_path(csound, input_arg,
+                                                 input_raw_name);
+  (*count)++;
+
+  return OK;
+}
+
 static int32_t pbr_can_rewire_xout_source(const char *raw_name) {
   if (raw_name == NULL) {
     return 0;
@@ -363,10 +470,26 @@ static void pbr_collect_io_aliases(CSOUND *csound,
         }
       }
 
-      if (source_ar_index >= udoinfo->outchns) {
-        pbr_append_entry(csound, &builder->xout_entries, &builder->xout_count,
-                         &builder->xout_capacity, xout_opcode_mem_offset, i,
-                         source_ar_index, xout_arg, raw_name);
+      if (source_ar_index >= (int32_t)udoinfo->outchns) {
+        /* Pass-through: xout reads from a xin-aliased variable.
+           Redirect the alias to the output slot so internal opcodes write to
+           the caller's output pointer (like a native opcode's output field),
+           and record a seed entry so the output is initialised from the input
+           value before the internal chain runs. */
+        if (pbr_arg_has_struct_path(xout_arg, raw_name)) {
+          pbr_add_alias(csound, builder, raw_name, i);
+          if (resolved_name != raw_name && strchr(resolved_name, '.') != NULL) {
+            pbr_add_alias(csound, builder, resolved_name, i);
+          }
+        } else {
+          pbr_add_alias(csound, builder, resolved_name, i);
+          if (resolved_name != raw_name) {
+            pbr_add_alias(csound, builder, raw_name, i);
+          }
+        }
+        pbr_append_seed(csound, &builder->seed_entries, &builder->seed_count,
+                        &builder->seed_capacity, i, source_ar_index,
+                        xout_arg, raw_name);
         continue;
       }
 
@@ -399,7 +522,7 @@ static void pbr_collect_rewire_entries(CSOUND *csound,
       break;
     }
 
-    if (strcmp(opname, "xin") == 0 || strcmp(opname, "xout") == 0) {
+    if (strcmp(opname, "xin") == 0) {
       continue;
     }
 
@@ -410,14 +533,8 @@ static void pbr_collect_rewire_entries(CSOUND *csound,
       for (i = 0; i < ttp->outlist->count;
            i++, arg = arg != NULL ? arg->next : NULL) {
         const char *arg_name = pbr_get_arg_name(arg, ttp->outlist->arg[i]);
-        int32_t ar_index = pbr_alias_lookup(builder->aliases,
-                                            builder->alias_count,
-                                            arg_name);
-        if (ar_index < 0 && arg_name != ttp->outlist->arg[i]) {
-          ar_index = pbr_alias_lookup(builder->aliases,
-                                      builder->alias_count,
-                                      ttp->outlist->arg[i]);
-        }
+        int32_t ar_index = pbr_lookup_arg_alias(builder, arg_name,
+                                                ttp->outlist->arg[i]);
         if (ar_index < 0) {
           continue;
         }
@@ -443,14 +560,8 @@ static void pbr_collect_rewire_entries(CSOUND *csound,
       for (i = 0; i < ttp->inlist->count;
            i++, arg = arg != NULL ? arg->next : NULL) {
         const char *arg_name = pbr_get_arg_name(arg, ttp->inlist->arg[i]);
-        int32_t ar_index = pbr_alias_lookup(builder->aliases,
-                                            builder->alias_count,
-                                            arg_name);
-        if (ar_index < 0 && arg_name != ttp->inlist->arg[i]) {
-          ar_index = pbr_alias_lookup(builder->aliases,
-                                      builder->alias_count,
-                                      ttp->inlist->arg[i]);
-        }
+        int32_t ar_index = pbr_lookup_arg_alias(builder, arg_name,
+                                                ttp->inlist->arg[i]);
         if (ar_index < 0) {
           continue;
         }
@@ -488,6 +599,22 @@ static void pbr_free_entries(CSOUND *csound,
   csound->Free(csound, entries);
 }
 
+static void pbr_free_seed_entries(CSOUND *csound,
+                                  PBR_SEED_ENTRY *entries,
+                                  int32_t entry_count) {
+  int32_t i;
+
+  if (entries == NULL) {
+    return;
+  }
+
+  for (i = 0; i < entry_count; i++) {
+    csound->Free(csound, entries[i].input_struct_path);
+  }
+
+  csound->Free(csound, entries);
+}
+
 static void pbr_free_plan(CSOUND *csound, PBR_REWIRE_PLAN *plan) {
   if (plan == NULL) {
     return;
@@ -495,7 +622,7 @@ static void pbr_free_plan(CSOUND *csound, PBR_REWIRE_PLAN *plan) {
 
   pbr_free_entries(csound, plan->init_entries, plan->init_count);
   pbr_free_entries(csound, plan->perf_entries, plan->perf_count);
-  pbr_free_entries(csound, plan->xout_entries, plan->xout_count);
+  pbr_free_seed_entries(csound, plan->seed_entries, plan->seed_count);
   csound->Free(csound, plan);
 }
 
@@ -558,89 +685,105 @@ static void pbr_apply_entries(CSOUND *csound,
   }
 }
 
-static int32_t pbr_get_opcode_arg_count(OPDS *chain) {
-  OENTRY *ep;
+static void pbr_copy_value(CSOUND *csound, MYFLT *dst, MYFLT *src, INSDS *ctx) {
+  CS_TYPE *dst_type;
+  CS_TYPE *src_type;
 
-  if (chain == NULL || chain->optext == NULL || chain->optext->t.oentry == NULL) {
-    return 0;
-  }
-
-  ep = chain->optext->t.oentry;
-  if (ep->useropinfo != NULL) {
-    OPCODINFO *useropinfo = (OPCODINFO *)ep->useropinfo;
-    return useropinfo->outchns + useropinfo->inchns;
-  }
-
-  return count_args(ep->outypes) + count_args(ep->intypes);
-}
-
-static MYFLT **pbr_get_arg_slot(OPDS *chain, int32_t index) {
-  OENTRY *ep;
-
-  if (chain == NULL || chain->optext == NULL || chain->optext->t.oentry == NULL ||
-      index < 0) {
-    return NULL;
-  }
-
-  ep = chain->optext->t.oentry;
-  if (ep->useropinfo == NULL) {
-    return (MYFLT **)((char *)chain + sizeof(OPDS) + index * sizeof(void *));
-  }
-
-  return &(((UOPCODE *)chain)->ar[index]);
-}
-
-static void pbr_rewire_caller_chain_aliases(CSOUND *csound,
-                                            OPDS *chain,
-                                            MYFLT *old_ptr,
-                                            MYFLT *new_ptr,
-                                            int32_t perf_chain) {
-  while (chain != NULL) {
-    int32_t arg_count = pbr_get_opcode_arg_count(chain);
-    int32_t i;
-
-    for (i = 0; i < arg_count; i++) {
-      MYFLT **slot = pbr_get_arg_slot(chain, i);
-      if (slot != NULL && *slot == old_ptr) {
-        rewire_argpp(csound, chain, i, new_ptr, NULL);
-      }
-    }
-
-    chain = perf_chain ? chain->nxtp : chain->nxti;
-  }
-}
-
-static void pbr_alias_xout_entries_in_caller(CSOUND *csound,
-                                             UOPCODE *p,
-                                             const PBR_REWIRE_ENTRY *entries,
-                                             int32_t entry_count) {
-  /* Direct xout of a caller-backed source has no internal destination slot to
-     rewire, so later caller opcode args are rewritten to the source pointer.
-     The caller argpp layout is restored when the UDO instance is deactivated. */
-  int32_t i;
-
-  if (p == NULL || p->parent_ip == NULL) {
+  if (dst == NULL || src == NULL || dst == src) {
     return;
   }
 
-  for (i = 0; i < entry_count; i++) {
-    const PBR_REWIRE_ENTRY *entry = &entries[i];
+  dst_type = csoundGetTypeForArg(dst);
+  src_type = csoundGetTypeForArg(src);
+  if (dst_type != NULL && dst_type->copyValue != NULL) {
+    dst_type->copyValue(csound, dst_type, dst, src, ctx);
+  } else if (src_type != NULL && src_type->copyValue != NULL) {
+    src_type->copyValue(csound, src_type, dst, src, ctx);
+  } else {
+    *dst = *src;
+  }
+}
+
+static int32_t pbr_is_readonly_source(MYFLT *src) {
+  CS_TYPE *src_type = src != NULL ? csoundGetTypeForArg(src) : NULL;
+  return src_type == &CS_VAR_TYPE_C || src_type == &CS_VAR_TYPE_P;
+}
+
+static void pbr_seed_pass_through_outputs(CSOUND *csound,
+                                          UOPCODE *p,
+                                          INSDS *ctx) {
+  OPCODINFO *udoinfo;
+  PBR_REWIRE_PLAN *plan;
+  int32_t max_ar_index;
+  int32_t i;
+
+  if (p == NULL || p->buf == NULL || p->buf->opcode_info == NULL) {
+    return;
+  }
+
+  udoinfo = p->buf->opcode_info;
+  plan = udoinfo->pbr_plan;
+  if (plan == NULL || plan->seed_entries == NULL) {
+    return;
+  }
+
+  max_ar_index = udoinfo->outchns + udoinfo->inchns;
+  for (i = 0; i < plan->seed_count; i++) {
+    const PBR_SEED_ENTRY *entry = &plan->seed_entries[i];
     MYFLT *dst;
     MYFLT *src;
 
-    if (entry->arg_index < 0 || entry->ar_index < 0) {
+    if (entry->output_ar_index < 0 || entry->output_ar_index >= max_ar_index ||
+        entry->input_ar_index < 0 || entry->input_ar_index >= max_ar_index) {
       continue;
     }
 
-    dst = p->ar[entry->arg_index];
-    src = pbr_resolve_struct_target(csound, p->ar[entry->ar_index],
-                                    entry->structPath);
-    if (dst == NULL || src == NULL || dst == src) {
+    dst = p->ar[entry->output_ar_index];
+    src = pbr_resolve_struct_target(csound, p->ar[entry->input_ar_index],
+                                    entry->input_struct_path);
+    pbr_copy_value(csound, dst, src, ctx);
+  }
+}
+
+static void pbr_writeback_pass_through_inputs(CSOUND *csound,
+                                              UOPCODE *p,
+                                              INSDS *ctx) {
+  OPCODINFO *udoinfo;
+  PBR_REWIRE_PLAN *plan;
+  int32_t max_ar_index;
+  int32_t i;
+
+  if (p == NULL || p->buf == NULL || p->buf->opcode_info == NULL) {
+    return;
+  }
+
+  udoinfo = p->buf->opcode_info;
+  plan = udoinfo->pbr_plan;
+  if (plan == NULL || plan->seed_entries == NULL) {
+    return;
+  }
+
+  max_ar_index = udoinfo->outchns + udoinfo->inchns;
+  for (i = 0; i < plan->seed_count; i++) {
+    const PBR_SEED_ENTRY *entry = &plan->seed_entries[i];
+    MYFLT *dst;
+    MYFLT *src;
+    MYFLT *input_base;
+
+    if (entry->output_ar_index < 0 || entry->output_ar_index >= max_ar_index ||
+        entry->input_ar_index < 0 || entry->input_ar_index >= max_ar_index) {
       continue;
     }
 
-    pbr_rewire_caller_chain_aliases(csound, p->h.nxti, dst, src, 0);
-    pbr_rewire_caller_chain_aliases(csound, p->h.nxtp, dst, src, 1);
+    input_base = p->ar[entry->input_ar_index];
+    if (pbr_is_readonly_source(input_base)) {
+      continue;
+    }
+
+    dst = pbr_resolve_struct_target(csound, input_base,
+                                    entry->input_struct_path);
+    src = p->ar[entry->output_ar_index];
+    pbr_copy_value(csound, dst, src, ctx);
   }
 }
 
@@ -698,10 +841,10 @@ void csoundBuildUserOpcodeRewirePlan(CSOUND *csound, OPCODINFO *udoinfo) {
 
   plan->init_count = builder.init_count;
   plan->perf_count = builder.perf_count;
-  plan->xout_count = builder.xout_count;
+  plan->seed_count = builder.seed_count;
   plan->init_entries = builder.init_entries;
   plan->perf_entries = builder.perf_entries;
-  plan->xout_entries = builder.xout_entries;
+  plan->seed_entries = builder.seed_entries;
 
   csound->Free(csound, builder.aliases);
 }
@@ -826,10 +969,11 @@ static MYFLT *pbr_resolve_struct_target(CSOUND *csound, MYFLT *argPtr,
 
 /* Wire UDO internals to caller storage for pass-by-reference.
  *
- * Inputs are mapped directly to caller argument locations. Outputs written by
- * internal opcodes are rewired to caller output storage. Direct xout reads from
- * caller-backed inputs or struct members are handled separately by rewriting
- * later caller opcode args to the same source pointer.
+ * Internal opcodes that reference xin/xout-aliased variables are rewired to
+ * point directly at the caller's argument storage, like native opcode output
+ * pointers.  For xin->xout pass-through variables, the alias is directed to
+ * the caller's output slot and the output is seeded with the input value so
+ * that internal operations start from the correct initial value.
  */
 static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
   OPCODINFO *udoinfo = (OPCODINFO*) p->h.optext->t.oentry->useropinfo;
@@ -840,10 +984,18 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
     return;
   }
 
+  /* Rewire internal opcodes to point at caller storage.  For pass-through
+     variables (xin->xout same name), the alias now points at the output slot
+     so internal writes go to the caller's output variable. */
   pbr_apply_entries(csound, p, lcurip->nxti, op_mem_start,
                     plan->init_entries, plan->init_count);
   pbr_apply_entries(csound, p, lcurip->nxtp, op_mem_start,
                     plan->perf_entries, plan->perf_count);
+
+  /* Seed pass-through outputs before the internal chain runs.  Constants and
+     other immutable inputs stay protected because writes happen to the output
+     scratch slot first; mutable inputs are written back after the chain. */
+  pbr_seed_pass_through_outputs(csound, p, lcurip);
 }
 
 /*
@@ -1042,11 +1194,6 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
 
   if(inm->passByRef) {
     handle_pass_by_ref(csound, p, lcurip);
-    if (inm->pbr_plan != NULL && inm->pbr_plan->xout_count > 0) {
-      pbr_alias_xout_entries_in_caller(csound, p,
-                                       inm->pbr_plan->xout_entries,
-                                       inm->pbr_plan->xout_count);
-    }
   }
 
   /* Initialize the UDO */
@@ -1067,11 +1214,14 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   }
 
   if(err) return err;
+  if(inm->passByRef) {
+    pbr_writeback_pass_through_inputs(csound, p, lcurip);
+  }
   csound->mode = 0;  ATOMIC_SET(p->ip->init_done, 1);
 
   /* After init chain completes, materialise UDO outputs only for pass-by-copy.
      In pass-by-ref mode, internal outputs are already rewired to caller storage
-     and direct xout aliases have already been propagated into the caller chain. */
+     and direct pass-through outputs have already been written back. */
   if (!inm->passByRef) {
     OPCOD_IOBUFS *buf_local = p->buf;
     OPCODINFO *inm_local = buf_local->opcode_info;
@@ -1726,9 +1876,10 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
     return OK;
   p->ip->spin = p->parent_ip->spin;
   p->ip->spout = p->parent_ip->spout;
+  pbr_seed_pass_through_outputs(csound, p, p->ip);
   p->ip->kcounter++;  /* kcount should be incremented BEFORE perf */
   if (UNLIKELY(!(CS_PDS = (OPDS*) (p->ip->nxtp))))
-    goto endop; /* no perf code */
+    goto writeback; /* no perf code */
 
   /* IV - Nov 16 2002: update release flag */
   p->ip->relesing = p->parent_ip->relesing;
@@ -1751,6 +1902,9 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
            && (CS_PDS = CS_PDS->nxtp));
   }
 
+ writeback:
+  pbr_writeback_pass_through_inputs(csound, p, p->ip);
+
  endop:
   /* restore globals */
   CS_PDS = saved_pds;
@@ -1763,23 +1917,6 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
   return OK;
 }
 
-void csoundRestoreUserOpcodeArgpp(CSOUND *csound, UOPCODE *p)
-{
-  OPCODINFO *udoinfo;
-  PBR_REWIRE_PLAN *plan;
-
-  if (p == NULL || p->parent_ip == NULL || p->buf == NULL) {
-    return;
-  }
-
-  udoinfo = p->buf->opcode_info;
-  plan = udoinfo != NULL ? udoinfo->pbr_plan : NULL;
-  if (plan == NULL || plan->xout_count == 0) {
-    return;
-  }
-
-  csoundReinitInstrumentArgpp(csound, p->parent_ip);
-}
 
 /*
   This opcode sets the local ksmps for an instrument

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -914,6 +914,30 @@ static void pbr_writeback_pass_through_inputs(CSOUND *csound,
       continue;
     }
 
+    /* Skip writeback when the caller's input variable is also bound to one
+       of the UDO's output slots.  In that case the output was already
+       materialised by xout/sync and writing the work value back would
+       overwrite it.  This covers the #2061 scenario where the input is
+       aliased to a non-pass-through output position. */
+    {
+      int32_t j;
+      int32_t skip = 0;
+      for (j = 0; j < udoinfo->outchns; j++) {
+        if (j == entry->work_ar_index) {
+          /* The work output slot is where the pass-through value is
+             redirected; that alias is intentional, not a collision. */
+          continue;
+        }
+        if (p->ar[j] == input_base) {
+          skip = 1;
+          break;
+        }
+      }
+      if (skip) {
+        continue;
+      }
+    }
+
     dst = pbr_resolve_struct_target(csound, input_base,
                                     entry->input_struct_path);
     src = p->ar[entry->work_ar_index];

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -121,11 +121,11 @@ static const char *pbr_get_arg_name(const ARG *arg, const char *raw_name) {
   return raw_name;
 }
 
-static char *pbr_dup_struct_path(CSOUND *csound,
-                                 const ARG *arg,
-                                 const char *raw_name) {
+static const char *pbr_get_struct_path(const ARG *arg,
+                                       const char *raw_name,
+                                       size_t *path_len) {
   const char *struct_path = arg != NULL ? arg->structPath : NULL;
-  size_t path_len = 0;
+  size_t len = 0;
 
   if ((struct_path == NULL || *struct_path == '\0') && raw_name != NULL) {
     const char *dot = strchr(raw_name, '.');
@@ -135,28 +135,54 @@ static char *pbr_dup_struct_path(CSOUND *csound,
   }
 
   if (struct_path == NULL || *struct_path == '\0') {
+    if (path_len != NULL) {
+      *path_len = 0;
+    }
     return NULL;
   }
 
-  while (struct_path[path_len] != '\0' && struct_path[path_len] != ':' &&
-         struct_path[path_len] != '@' && struct_path[path_len] != '[') {
-    path_len++;
+  while (struct_path[len] != '\0' && struct_path[len] != ':' &&
+         struct_path[len] != '@' && struct_path[len] != '[') {
+    len++;
   }
 
-  return path_len > 0 ? cs_strndup(csound, struct_path, path_len) : NULL;
+  if (path_len != NULL) {
+    *path_len = len;
+  }
+
+  return len > 0 ? struct_path : NULL;
+}
+
+static char *pbr_dup_struct_path(CSOUND *csound,
+                                 const ARG *arg,
+                                 const char *raw_name) {
+  size_t path_len = 0;
+  const char *struct_path = pbr_get_struct_path(arg, raw_name, &path_len);
+
+  return struct_path != NULL ? cs_strndup(csound, struct_path, path_len) : NULL;
 }
 
 static int32_t pbr_arg_has_struct_path(const ARG *arg, const char *raw_name) {
-  if (arg != NULL && arg->structPath != NULL && arg->structPath[0] != '\0') {
-    return 1;
+  size_t path_len = 0;
+  return pbr_get_struct_path(arg, raw_name, &path_len) != NULL && path_len > 0;
+}
+
+static int32_t pbr_struct_paths_match(const char *stored_path,
+                                      const ARG *arg,
+                                      const char *raw_name) {
+  size_t path_len = 0;
+  const char *struct_path = pbr_get_struct_path(arg, raw_name, &path_len);
+
+  if (struct_path == NULL) {
+    return stored_path == NULL || *stored_path == '\0';
   }
 
-  if (raw_name != NULL) {
-    const char *dot = strchr(raw_name, '.');
-    return dot != NULL && dot[1] != '\0';
+  if (stored_path == NULL) {
+    return 0;
   }
 
-  return 0;
+  return strlen(stored_path) == path_len &&
+    strncmp(stored_path, struct_path, path_len) == 0;
 }
 
 static int32_t pbr_alias_find(const PBR_ALIAS_ENTRY *aliases,
@@ -370,6 +396,7 @@ static int32_t pbr_append_seed(CSOUND *csound,
                                int32_t *capacity,
                                int32_t output_ar_index,
                                int32_t input_ar_index,
+                               int32_t work_ar_index,
                                const ARG *input_arg,
                                const char *input_raw_name) {
   PBR_SEED_ENTRY *entry;
@@ -397,11 +424,31 @@ static int32_t pbr_append_seed(CSOUND *csound,
   entry = &((*entries)[*count]);
   entry->output_ar_index = output_ar_index;
   entry->input_ar_index = input_ar_index;
+  entry->work_ar_index = work_ar_index;
   entry->input_struct_path = pbr_dup_struct_path(csound, input_arg,
                                                  input_raw_name);
   (*count)++;
 
   return OK;
+}
+
+static int32_t pbr_find_seed_work_output(const PBR_SEED_ENTRY *entries,
+                                         int32_t entry_count,
+                                         int32_t input_ar_index,
+                                         const ARG *input_arg,
+                                         const char *input_raw_name) {
+  int32_t i;
+
+  for (i = 0; i < entry_count; i++) {
+    const PBR_SEED_ENTRY *entry = &entries[i];
+    if (entry->input_ar_index == input_ar_index &&
+        pbr_struct_paths_match(entry->input_struct_path,
+                               input_arg, input_raw_name)) {
+      return entry->work_ar_index;
+    }
+  }
+
+  return -1;
 }
 
 static int32_t pbr_can_rewire_xout_source(const char *raw_name) {
@@ -410,6 +457,50 @@ static int32_t pbr_can_rewire_xout_source(const char *raw_name) {
   }
 
   return strchr(raw_name, '[') == NULL && strchr(raw_name, '@') == NULL;
+}
+
+/* xout processing rewrites aliases to output slots.  Query the original xin
+   declaration so duplicate pass-through detection is not affected by earlier
+   xout entries mutating the alias table. */
+static int32_t pbr_lookup_xin_alias(OPCODINFO *udoinfo,
+                                    OPTXT *xin_optxt,
+                                    const char *var_name) {
+  int32_t exact_pass;
+
+  if (udoinfo == NULL || xin_optxt == NULL || udoinfo->in_arg_pool == NULL ||
+      xin_optxt->t.outlist == NULL || var_name == NULL) {
+    return -1;
+  }
+
+  for (exact_pass = 1; exact_pass >= 0; exact_pass--) {
+    CS_VARIABLE *param = udoinfo->in_arg_pool->head;
+    ARG *xin_arg = xin_optxt->t.outArgs;
+    ARGLST *xin_outlist = xin_optxt->t.outlist;
+    int32_t i;
+
+    for (i = 0; i < udoinfo->inchns && i < xin_outlist->count && param != NULL;
+         i++, param = param->next,
+         xin_arg = xin_arg != NULL ? xin_arg->next : NULL) {
+      int32_t ar_index = udoinfo->outchns + i;
+      const char *xin_varname = xin_outlist->arg[i];
+      const char *resolved_name = pbr_get_arg_name(xin_arg, xin_varname);
+      const char *names[3] = { xin_varname, resolved_name, param->varName };
+      int32_t j;
+
+      for (j = 0; j < 3; j++) {
+        const char *candidate = names[j];
+        if (candidate == NULL) {
+          continue;
+        }
+        if (exact_pass ? strcmp(candidate, var_name) == 0 :
+            pbr_names_match(candidate, var_name)) {
+          return ar_index;
+        }
+      }
+    }
+  }
+
+  return -1;
 }
 
 static void pbr_collect_io_aliases(CSOUND *csound,
@@ -460,36 +551,41 @@ static void pbr_collect_io_aliases(CSOUND *csound,
       int32_t source_ar_index = -1;
 
       if (pbr_can_rewire_xout_source(raw_name)) {
-        source_ar_index = pbr_alias_lookup(builder->aliases,
-                                           builder->alias_count,
-                                           resolved_name);
+        source_ar_index = pbr_lookup_xin_alias(udoinfo, xin_optxt,
+                                               resolved_name);
         if (source_ar_index < 0 && resolved_name != raw_name) {
-          source_ar_index = pbr_alias_lookup(builder->aliases,
-                                             builder->alias_count,
-                                             raw_name);
+          source_ar_index = pbr_lookup_xin_alias(udoinfo, xin_optxt,
+                                                 raw_name);
         }
       }
 
       if (source_ar_index >= (int32_t)udoinfo->outchns) {
+        int32_t work_ar_index =
+          pbr_find_seed_work_output(builder->seed_entries, builder->seed_count,
+                                    source_ar_index, xout_arg, raw_name);
         /* Pass-through: xout reads from a xin-aliased variable.
            Redirect the alias to the output slot so internal opcodes write to
            the caller's output pointer (like a native opcode's output field),
            and record a seed entry so the output is initialised from the input
-           value before the internal chain runs. */
-        if (pbr_arg_has_struct_path(xout_arg, raw_name)) {
-          pbr_add_alias(csound, builder, raw_name, i);
-          if (resolved_name != raw_name && strchr(resolved_name, '.') != NULL) {
-            pbr_add_alias(csound, builder, resolved_name, i);
-          }
-        } else {
-          pbr_add_alias(csound, builder, resolved_name, i);
-          if (resolved_name != raw_name) {
+           value before the internal chain runs.  Duplicate pass-through xouts
+           share the first output slot as their mutable work value. */
+        if (work_ar_index < 0) {
+          work_ar_index = i;
+          if (pbr_arg_has_struct_path(xout_arg, raw_name)) {
             pbr_add_alias(csound, builder, raw_name, i);
+            if (resolved_name != raw_name && strchr(resolved_name, '.') != NULL) {
+              pbr_add_alias(csound, builder, resolved_name, i);
+            }
+          } else {
+            pbr_add_alias(csound, builder, resolved_name, i);
+            if (resolved_name != raw_name) {
+              pbr_add_alias(csound, builder, raw_name, i);
+            }
           }
         }
         pbr_append_seed(csound, &builder->seed_entries, &builder->seed_count,
                         &builder->seed_capacity, i, source_ar_index,
-                        xout_arg, raw_name);
+                        work_ar_index, xout_arg, raw_name);
         continue;
       }
 
@@ -745,6 +841,43 @@ static void pbr_seed_pass_through_outputs(CSOUND *csound,
   }
 }
 
+static void pbr_sync_pass_through_outputs(CSOUND *csound,
+                                          UOPCODE *p,
+                                          INSDS *ctx) {
+  OPCODINFO *udoinfo;
+  PBR_REWIRE_PLAN *plan;
+  int32_t max_ar_index;
+  int32_t i;
+
+  if (p == NULL || p->buf == NULL || p->buf->opcode_info == NULL) {
+    return;
+  }
+
+  udoinfo = p->buf->opcode_info;
+  plan = udoinfo->pbr_plan;
+  if (plan == NULL || plan->seed_entries == NULL) {
+    return;
+  }
+
+  max_ar_index = udoinfo->outchns + udoinfo->inchns;
+  for (i = 0; i < plan->seed_count; i++) {
+    const PBR_SEED_ENTRY *entry = &plan->seed_entries[i];
+    MYFLT *dst;
+    MYFLT *src;
+
+    /* Fan the final work value out to duplicate xout positions. */
+    if (entry->output_ar_index < 0 || entry->output_ar_index >= max_ar_index ||
+        entry->work_ar_index < 0 || entry->work_ar_index >= max_ar_index ||
+        entry->output_ar_index == entry->work_ar_index) {
+      continue;
+    }
+
+    dst = p->ar[entry->output_ar_index];
+    src = p->ar[entry->work_ar_index];
+    pbr_copy_value(csound, dst, src, ctx);
+  }
+}
+
 static void pbr_writeback_pass_through_inputs(CSOUND *csound,
                                               UOPCODE *p,
                                               INSDS *ctx) {
@@ -771,7 +904,8 @@ static void pbr_writeback_pass_through_inputs(CSOUND *csound,
     MYFLT *input_base;
 
     if (entry->output_ar_index < 0 || entry->output_ar_index >= max_ar_index ||
-        entry->input_ar_index < 0 || entry->input_ar_index >= max_ar_index) {
+        entry->input_ar_index < 0 || entry->input_ar_index >= max_ar_index ||
+        entry->work_ar_index < 0 || entry->work_ar_index >= max_ar_index) {
       continue;
     }
 
@@ -782,7 +916,7 @@ static void pbr_writeback_pass_through_inputs(CSOUND *csound,
 
     dst = pbr_resolve_struct_target(csound, input_base,
                                     entry->input_struct_path);
-    src = p->ar[entry->output_ar_index];
+    src = p->ar[entry->work_ar_index];
     pbr_copy_value(csound, dst, src, ctx);
   }
 }
@@ -1215,6 +1349,7 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
 
   if(err) return err;
   if(inm->passByRef) {
+    pbr_sync_pass_through_outputs(csound, p, lcurip);
     pbr_writeback_pass_through_inputs(csound, p, lcurip);
   }
   csound->mode = 0;  ATOMIC_SET(p->ip->init_done, 1);
@@ -1903,6 +2038,7 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
   }
 
  writeback:
+  pbr_sync_pass_through_outputs(csound, p, p->ip);
   pbr_writeback_pass_through_inputs(csound, p, p->ip);
 
  endop:

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -176,8 +176,9 @@ extern "C" {
   } PBR_REWIRE_ENTRY;
 
   typedef struct pbr_seed_entry {
-    int32_t output_ar_index;   /* output slot (ar[0..outchns-1]) to write into */
-    int32_t input_ar_index;    /* input slot  (ar[outchns..outchns+inchns-1]) to read from */
+    int32_t output_ar_index;   /* xout position to materialise */
+    int32_t input_ar_index;    /* xin slot to seed from and write back to */
+    int32_t work_ar_index;     /* canonical mutable output slot; duplicates share it */
     char    *input_struct_path;
   } PBR_SEED_ENTRY;
 

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -175,13 +175,19 @@ extern "C" {
     char    *structPath;
   } PBR_REWIRE_ENTRY;
 
+  typedef struct pbr_seed_entry {
+    int32_t output_ar_index;   /* output slot (ar[0..outchns-1]) to write into */
+    int32_t input_ar_index;    /* input slot  (ar[outchns..outchns+inchns-1]) to read from */
+    char    *input_struct_path;
+  } PBR_SEED_ENTRY;
+
   typedef struct pbr_rewire_plan {
     int32_t init_count;
     int32_t perf_count;
-    int32_t xout_count;
+    int32_t seed_count;
     PBR_REWIRE_ENTRY *init_entries;
     PBR_REWIRE_ENTRY *perf_entries;
-    PBR_REWIRE_ENTRY *xout_entries;
+    PBR_SEED_ENTRY   *seed_entries;
   } PBR_REWIRE_PLAN;
 
   typedef struct opcodinfo {

--- a/H/udo.h
+++ b/H/udo.h
@@ -112,7 +112,6 @@ int32_t useropcdset(CSOUND *, UOPCODE *p);
 int32_t useropcd_local_ksmps(CSOUND *, UOPCODE*);
 int32_t useropcd_pass_by_copy(CSOUND *, UOPCODE*);
 int32_t useropcd_pass_by_ref(CSOUND *, UOPCODE *);
-void csoundRestoreUserOpcodeArgpp(CSOUND *, UOPCODE *);
 void csoundBuildUserOpcodeRewirePlan(CSOUND *, OPCODINFO *);
 void csoundFreeOpcodeInfoChain(CSOUND *);
 

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -60,6 +60,15 @@ opcode readStructMember(var:TestStruct2515):i
 endop
 
 
+// UDO that modifies its input in-place and returns it via xout.
+// Tests pass-by-reference with constant inputs: xout of a xin variable
+// should not corrupt the global constant pool.
+opcode incrAndReturn(ival):i
+    ival += 1
+    xout ival
+endop
+
+
 instr 1
     iv = 33
     iv2 = 77
@@ -157,16 +166,36 @@ endin
 ; schedule("SoundTest", 0, 4)
 
 
+instr 10
+// Test incrAndReturn with a literal constant: should not corrupt
+// the global constant pool and should produce the correct result.
+val:i = incrAndReturn(1)
+assertEquals(val,2)
+print val
+// Test with a variable to verify pass-through still works.
+val:i = incrAndReturn(val)
+assertEquals(val,3)
+print val
+// Test distinct input/output variables: the input should still be modified
+// by pass-by-reference, while the output receives the returned value.
+src:i = 5
+dst:i = incrAndReturn(src)
+assertEquals(src,6)
+assertEquals(dst,6)
+print src, dst
+endin
+
+
 </CsInstruments>
 <CsScore>
 i1 0 1
 i2 0 1
 i3 0 1
 i4 0 1
+i10 0 1
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25
 
 </CsScore>
 </CsoundSynthesizer>
-

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -76,6 +76,28 @@ opcode mixedPassExpr(ival):(i,i)
 endop
 
 
+// repeated pass-through outputs share the same mutable UDO value.
+opcode duplicatePass(ival):(i,i)
+    ival += 1
+    xout ival, ival
+endop
+
+
+// repeated k-rate pass-through outputs across perf cycles.
+opcode duplicatePassK(kval):(k,k)
+    kval += 1
+    xout kval, kval
+endop
+
+
+// repeated array pass-through outputs exercise typed copyValue fan-out.
+opcode duplicateArrayPass(iArr[]):(i[],i[])
+    iArr[0] += 1
+    iArr[1] += 2
+    xout iArr, iArr
+endop
+
+
 opcode readStructMember(var:TestStruct2515):i
     xout var.var1
 endop
@@ -309,6 +331,48 @@ assertEquals(iVal, 5)
 endin
 
 
+instr 27
+// duplicate pass-through outputs should both materialise the final value.
+src:i = 4
+out1:i, out2:i = duplicatePass(src)
+assertEquals(src, 5)
+assertEquals(out1, 5)
+assertEquals(out2, 5)
+endin
+
+
+instr 28
+// duplicate k-rate outputs should sync each perf cycle.
+kSrc init 4
+kOut1, kOut2 = duplicatePassK(kSrc)
+if (timeinstk() == 1) then
+    if (kSrc != 5 || kOut1 != 5 || kOut2 != 5) then
+        printks "ERROR: duplicatePassK cycle 1 kSrc=%g kOut1=%g kOut2=%g\n", 0, kSrc, kOut1, kOut2
+        exitnowk(-1)
+    endif
+endif
+if (timeinstk() == 2) then
+    if (kSrc != 6 || kOut1 != 6 || kOut2 != 6) then
+        printks "ERROR: duplicatePassK cycle 2 kSrc=%g kOut1=%g kOut2=%g\n", 0, kSrc, kOut1, kOut2
+        exitnowk(-1)
+    endif
+endif
+endin
+
+
+instr 29
+// duplicate array outputs should copy the final work array to both outputs.
+iArr[] fillarray 3, 4
+iOut1[], iOut2[] = duplicateArrayPass(iArr)
+assertEquals(iArr[0], 4)
+assertEquals(iArr[1], 6)
+assertEquals(iOut1[0], 4)
+assertEquals(iOut1[1], 6)
+assertEquals(iOut2[0], 4)
+assertEquals(iOut2[1], 6)
+endin
+
+
 opcode sound(iamp, ifreq):a
     aout = oscili(iamp, ifreq)
     if(ifreq < sr/2) then
@@ -366,6 +430,9 @@ i23 0 0.1
 i24 0 1
 i25 0 1
 i26 0 1
+i27 0 1
+i28 0 0.01
+i29 0 1
 i10 0 1 7
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -50,12 +50,40 @@ opcode incrK(kval):void
 endop
 
 
+// k-rate direct pass-through; += 0 ensures a perf-time body.
+opcode passK(kval):k
+    kval += 0
+    xout kval
+endop
+
+
+// k-rate pass-through with source mutation and return.
+opcode incrAndReturnK(kval):k
+    kval += 1
+    xout kval
+endop
+
+
 opcode incrExpr(ival):(i,i)
     xout ival + 1, ival + 2
 endop
 
 
+// mixed xin pass-through and expression xout.
+opcode mixedPassExpr(ival):(i,i)
+    ival += 1
+    xout ival, ival + 1
+endop
+
+
 opcode readStructMember(var:TestStruct2515):i
+    xout var.var1
+endop
+
+
+// struct member pass-through with source writeback.
+opcode incrStructMemberReturn(var:TestStruct2515):i
+    var.var1 += 2
     xout var.var1
 endop
 
@@ -66,6 +94,27 @@ endop
 opcode incrAndReturn(ival):i
     ival += 1
     xout ival
+endop
+
+
+// array pass-through with source writeback.
+opcode incrArrayReturn(iArr[]):i[]
+    iArr[0] += 10
+    iArr[1] += 20
+    xout iArr
+endop
+
+
+// array element xout is not a pass-through alias.
+opcode firstArrayValue(iArr[]):i
+    xout iArr[0]
+endop
+
+
+// audio block pass-through with source writeback.
+opcode scaleAudio(aSig):a
+    aSig *= 0.5
+    xout aSig
 endop
 
 
@@ -149,6 +198,117 @@ instr 4
 endin
 
 
+instr 20
+// k-rate input mutation across perf cycles.
+kVal init 10
+incrK(kVal)
+if (timeinstk() == 1) then
+    if (kVal != 13) then
+        printks "ERROR: incrK cycle 1 kVal=%g\n", 0, kVal
+        exitnowk(-1)
+    endif
+endif
+if (timeinstk() == 2) then
+    if (kVal != 16) then
+        printks "ERROR: incrK cycle 2 kVal=%g\n", 0, kVal
+        exitnowk(-1)
+    endif
+endif
+endin
+
+
+instr 21
+// k-rate pass-through seed and mutable source writeback.
+kSrc init 5
+kOut = incrAndReturnK(kSrc)
+if (timeinstk() == 1) then
+    if (kSrc != 6 || kOut != 6) then
+        printks "ERROR: incrAndReturnK cycle 1 kSrc=%g kOut=%g\n", 0, kSrc, kOut
+        exitnowk(-1)
+    endif
+endif
+if (timeinstk() == 2) then
+    if (kSrc != 7 || kOut != 7) then
+        printks "ERROR: incrAndReturnK cycle 2 kSrc=%g kOut=%g\n", 0, kSrc, kOut
+        exitnowk(-1)
+    endif
+endif
+endin
+
+
+instr 22
+// k-rate direct pass-through follows changing source values.
+kSrc init 8
+kOut = passK(kSrc)
+if (timeinstk() == 1) then
+    if (kOut != 8) then
+        printks "ERROR: passK cycle 1 kSrc=%g kOut=%g\n", 0, kSrc, kOut
+        exitnowk(-1)
+    endif
+endif
+kSrc += 1
+if (timeinstk() == 2) then
+    if (kOut != 9) then
+        printks "ERROR: passK cycle 2 kSrc=%g kOut=%g\n", 0, kSrc, kOut
+        exitnowk(-1)
+    endif
+endif
+endin
+
+
+instr 23
+// audio pass-through copies full blocks and writes back source.
+aSrc init 0.5
+aOut = scaleAudio(aSrc)
+kSrc downsamp aSrc
+kOut downsamp aOut
+if (timeinstk() > 0) then
+    if (abs(kSrc - 0.25) > 0.000001) then
+        printks "ERROR: scaleAudio source kSrc=%g\n", 0, kSrc
+        exitnowk(-1)
+    endif
+    if (abs(kOut - 0.25) > 0.000001) then
+        printks "ERROR: scaleAudio output kOut=%g\n", 0, kOut
+        exitnowk(-1)
+    endif
+    turnoff
+endif
+endin
+
+
+instr 24
+// array pass-through xout and array element xout.
+iArr[] fillarray 1, 2
+iOut[] = incrArrayReturn(iArr)
+assertEquals(iArr[0], 11)
+assertEquals(iArr[1], 22)
+assertEquals(iOut[0], 11)
+assertEquals(iOut[1], 22)
+iElem = firstArrayValue(iOut)
+assertEquals(iElem, 11)
+endin
+
+
+instr 25
+// mixed pass-through and expression outputs.
+src:i = 10
+pass:i, expr:i = mixedPassExpr(src)
+assertEquals(src, 11)
+assertEquals(pass, 11)
+assertEquals(expr, 12)
+endin
+
+
+instr 26
+// struct member xout writes back only that member.
+ts:TestStruct2515 init 3, 4
+iVal = incrStructMemberReturn(ts)
+assertEquals(ts.var1, 5)
+assertEquals(ts.var2, 4)
+assertEquals(iVal, 5)
+endin
+
+
 opcode sound(iamp, ifreq):a
     aout = oscili(iamp, ifreq)
     if(ifreq < sr/2) then
@@ -183,6 +343,13 @@ dst:i = incrAndReturn(src)
 assertEquals(src,6)
 assertEquals(dst,6)
 print src, dst
+// Test p-field input: return value changes, p-field remains read-only.
+pval:i = incrAndReturn(p4)
+assertEquals(pval,8)
+assertEquals(p4,7)
+pval2:i = incrAndReturn(p4)
+assertEquals(pval2,8)
+assertEquals(p4,7)
 endin
 
 
@@ -192,7 +359,14 @@ i1 0 1
 i2 0 1
 i3 0 1
 i4 0 1
-i10 0 1
+i20 0 0.01
+i21 0 0.01
+i22 0 0.01
+i23 0 0.1
+i24 0 1
+i25 0 1
+i26 0 1
+i10 0 1 7
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -417,6 +417,86 @@ assertEquals(p4,7)
 endin
 
 
+// ============================================================
+// Issue #2061: pass-by-ref with multiple UDO outputs was broken
+// when input and output variable names differed, or when the input
+// aliased the second output instead of the first.
+// https://github.com/csound/csound/issues/2061
+// ============================================================
+
+// The exact opcode from issue #2061: one pass-through + one expression
+opcode Test2061K(var:k):(k,k)
+    b:k = var * 2
+    xout var, b
+endop
+
+// i-rate variant to check if the issue is wider than k-rate
+opcode Test2061I(var:i):(i,i)
+    b:i = var * 2
+    xout var, b
+endop
+
+
+// Scenario 1 from #2061: different input/output variable names
+// k0 = 1; k1, k2 = Test(k0) -> should give k1==1, k2==2
+instr 30
+    k0 init 1
+    k1, k2 Test2061K k0
+    if (timeinstk() == 1) then
+        if (k1 != 1 || k2 != 2) then
+            printks "ERROR: #2061 scenario 1 k1=%g k2=%g (expected 1, 2)\n", 0, k1, k2
+            exitnowk(-1)
+        endif
+    endif
+endin
+
+
+// Scenario 2 from #2061: input reused as first output
+// k1 = 1; k1, k2 = Test(k1) -> should give k1==1, k2==2
+instr 31
+    k1 init 1
+    k1, k2 Test2061K k1
+    if (timeinstk() == 1) then
+        if (k1 != 1 || k2 != 2) then
+            printks "ERROR: #2061 scenario 2 k1=%g k2=%g (expected 1, 2)\n", 0, k1, k2
+            exitnowk(-1)
+        endif
+    endif
+endin
+
+
+// Scenario 3 from #2061: input reused as second output (swapped)
+// k1 = 1; k2, k1 = Test(k1) -> should give k2==1, k1==2
+instr 32
+    k1 init 1
+    k2, k1 Test2061K k1
+    if (timeinstk() == 1) then
+        if (k2 != 1 || k1 != 2) then
+            printks "ERROR: #2061 scenario 3 k2=%g k1=%g (expected 1, 2)\n", 0, k2, k1
+            exitnowk(-1)
+        endif
+    endif
+endin
+
+
+// i-rate variant of scenario 1
+instr 33
+    i0 = 1
+    i1, i2 = Test2061I(i0)
+    assertEquals(i1, 1)
+    assertEquals(i2, 2)
+endin
+
+
+// i-rate variant of scenario 3 (swapped outputs)
+instr 34
+    i1 = 1
+    i2, i1 = Test2061I(i1)
+    assertEquals(i2, 1)
+    assertEquals(i1, 2)
+endin
+
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -434,6 +514,11 @@ i27 0 1
 i28 0 0.01
 i29 0 1
 i10 0 1 7
+i30 0 0.01
+i31 0 0.01
+i32 0 0.01
+i33 0 1
+i34 0 1
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25


### PR DESCRIPTION
Did work with AI Assistance (GPT5.5 and Opus 4.6) to implement a fix to issues related to xin/xout collisions. Has different mechanism than #2548 and should match UDO processing more closely with native C opcodes. Generated summary below:


## Summary

Fixes new-style UDO pass-by-reference handling when a `xin`-backed variable is returned directly through `xout`.

The implementation now treats direct `xin -> xout` pass-through values like native opcode output storage: the UDO output slot is seeded from the input before init/perf execution, internal UDO opcodes operate on that output-backed working value, and mutable inputs are written back after the UDO chain runs. Read-only sources such as constants and p-fields are not written back, so literal constants are no longer corrupted.

Additional regression coverage was added for constants, p-fields, k-rate and audio pass-through, arrays, struct members, mixed pass-through/expression outputs, and duplicate pass-through outputs.

## Difference from #2548

[PR #2548](https://github.com/csound/csound/pull/2548) fixed the immediate constant corruption by detecting constant-backed `xin` arguments and special-casing the existing pass-by-ref rewiring path.

This PR uses a broader model instead: it removes the caller-chain alias rewrite for direct `xout` pass-through and routes UDO-local pass-through work through the declared output slot, matching native C opcode input/output pointer behavior more closely. Constants and p-fields are protected as a consequence of the general seed/writeback model rather than by a constant-only exception.

## Testing

- `build/csound --nosound tests/commandline/udo/pass_by_ref.csd`
- `ctest --output-on-failure -j4`
- `cmake --build build --target csdtests`