### PR TITLE
Fixing removed function in iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+xcuserdata
+
 # Intermediate object files
 *.o
 *.os

--- a/iOS/Csound-for-iOS/Csound-iOS-ObjC-Examples/CsoundObj/classes/CsoundObj.m
+++ b/iOS/Csound-for-iOS/Csound-iOS-ObjC-Examples/CsoundObj/classes/CsoundObj.m
@@ -458,7 +458,11 @@ OSStatus  Csound_Render(void *inRefCon,
     [self notifyListenersOfCompletion];
   }
 }
-int csoundGetOutputBufferSize(CSOUND *);
+
+static int csoundGetOutputBufferSize(CSOUND *){
+    const OPARMS *parms = csoundGetParams(csound);
+    return parms->outbufsamps;
+}
 
 - (void)runCsound:(NSString *)csdFilePath
 {


### PR DESCRIPTION
Made CsoundGetOutputBuffer local as it was removed from the API.