### PR TITLE
fix: handle struct array member copy without segfault

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -101,8 +101,12 @@ char *create_out_arg(CSOUND *csound, char* outype, int32_t argCount,
         snprintf(s, 16, "#%c%d[]", type[1], argCount);
         add_array_arg(csound, s,  NULL, 1, typeTable);
       } else { // type[]
+        size_t typeLen = strlen(type);
+        char *baseType = (typeLen >= 2) ? cs_strndup(csound, type, typeLen - 2)
+                                        : csoundStrdup(csound, type);
         snprintf(s, 16, "#%c%d[]", type[0], argCount);
-        add_array_arg(csound, s,  type, 1, typeTable);
+        add_array_arg(csound, s,  baseType, 1, typeTable);
+        csound->Free(csound, baseType);
       }
     }
     else {

--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -189,14 +189,27 @@ static void array_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
        and shared-ownership bugs; alias is non-owning (allocated=0).
        This check is done BEFORE any allocations to prevent memory leaks. */
     if (aSrc && aSrc->arrayType && aSrc->arrayType->userDefinedType) {
-        /* Free any existing destination storage before creating alias */
-        if (aDest->sizes != NULL) {
+        if (aDest->sizes == aSrc->sizes && aDest->data == aSrc->data) {
+            aDest->arrayMemberSize = aSrc->arrayMemberSize;
+            aDest->dimensions      = aSrc->dimensions;
+            aDest->arrayType       = aSrc->arrayType;
+            aDest->allocated       = 0;
+            return;
+        }
+
+        /* Free only owned destination storage before creating an alias. */
+        if (aDest->allocated > 0) {
+            if (aDest->sizes != NULL) {
+                cs->Free(cs, aDest->sizes);
+                aDest->sizes = NULL;
+            }
+            if (aDest->data != NULL) {
+                cs->Free(cs, aDest->data);
+                aDest->data = NULL;
+            }
+        } else if (aDest->data == NULL && aDest->sizes != NULL) {
             cs->Free(cs, aDest->sizes);
             aDest->sizes = NULL;
-        }
-        if (aDest->data != NULL) {
-            cs->Free(cs, aDest->data);
-            aDest->data = NULL;
         }
 
         /* Shallow alias for arrays of structs - non-owning reference */

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -561,6 +561,11 @@ int32_t copy_var_generic_init(CSOUND *csound, void *p)
             return copy_var_generic(csound, p);
         }
         ARRAYDAT *srcArr = (ARRAYDAT *)assign->a;
+        if (srcArr->arrayType && srcArr->arrayType->userDefinedType) {
+            assign->h.perf = copy_var_no_op;
+            copy_var_generic(csound, p);
+            return OK;
+        }
         // If the destination really is an array, make it like the source.
         if (csoundGetTypeForArg(dstArr) == &CS_VAR_TYPE_ARRAY) {
             tabinit_like(csound, dstArr, (ARRAYDAT *)srcArr);

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -3424,19 +3424,25 @@ int32_t tabcopy(CSOUND *csound, TABCPY *p)
 {
   int32_t i, arrayTotalSize, memMyfltSize;
 
-
-
   if (UNLIKELY(p->src->data==NULL) || p->src->dimensions <= 0 )
     return csound->InitError(csound, "%s", Str("array-variable not initialised"));
   if (UNLIKELY(p->dst->dimensions > 0 &&
                p->src->dimensions != p->dst->dimensions))
     return csound->InitError(csound, "%s",
                              Str("array-variable dimensions do not match"));
+  if (p->dst->arrayType == NULL)
+    p->dst->arrayType = p->src->arrayType;
   if (UNLIKELY(p->src->arrayType != p->dst->arrayType))
     return csound->InitError(csound, "%s",
                              Str("array-variable types do not match"));
 
   if (p->src == p->dst) return OK;
+
+  if (p->src->arrayType && p->src->arrayType->userDefinedType) {
+    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                                p->dst, p->src, p->h.insdshead);
+    return OK;
+  }
 
   arrayTotalSize = get_array_total_size(p->src);
   memMyfltSize = p->src->arrayMemberSize / sizeof(MYFLT);
@@ -3481,6 +3487,15 @@ int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
   if (p->dst->arrayType == NULL)
     p->dst->arrayType = p->src->arrayType;
 
+  if (p->src->arrayType && p->src->arrayType->userDefinedType) {
+    if (UNLIKELY(p->src->arrayType != p->dst->arrayType))
+      return csound->InitError(csound, "%s",
+                               Str("array-variable types do not match"));
+    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                                p->dst, p->src, p->h.insdshead);
+    return OK;
+  }
+
   // Propagate dimensions and sizes so downstream ops can rely on them
   if (p->src->dimensions > 0) {
     int32_t dim = p->src->dimensions;
@@ -3508,11 +3523,19 @@ int32_t tabcopyk(CSOUND *csound, TABCPY *p)
                p->src->dimensions != p->dst->dimensions))
     return csound->PerfError(csound,&(p->h), "%s",
                              Str("array-variable dimensions do not match"));
+  if (p->dst->arrayType == NULL)
+    p->dst->arrayType = p->src->arrayType;
   if (UNLIKELY(p->src->arrayType != p->dst->arrayType))
     return csound->PerfError(csound, &(p->h), "%s",
                              Str("array-variable types do not match"));
 
   if (p->src == p->dst) return OK;
+
+  if (p->src->arrayType && p->src->arrayType->userDefinedType) {
+    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                                p->dst, p->src, p->h.insdshead);
+    return OK;
+  }
 
   arrayTotalSize = get_array_total_size(p->src);
   memMyfltSize = p->src->arrayMemberSize / sizeof(MYFLT);

--- a/OOps/structs.c
+++ b/OOps/structs.c
@@ -624,9 +624,13 @@ int32_t struct_init(CSOUND *csound, STRUCT_INIT *p)
       return csound->PerfError(csound, &(p->h), "Struct member %d is NULL", i);
     }
 
-    // For now, assume all members are scalars (MYFLT)
-    // In a full implementation, we'd need to handle different member types
-    member->value = *p->args[i];
+    if (member->varType && member->varType->copyValue) {
+      member->varType->copyValue(csound, member->varType,
+                                 (void*)&member->value, (void*)p->args[i],
+                                 p->h.insdshead);
+    } else {
+      member->value = *p->args[i];
+    }
   }
 
   return OK;

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -28,6 +28,15 @@ typedef struct {
     MYFLT   *r, *a;
 } AEVAL;
 
+static inline CS_VARIABLE *array_element_create_variable(CSOUND *csound,
+                                                         const CS_TYPE *arrayType,
+                                                         INSDS *ctx)
+{
+    void *typeArg = (arrayType && arrayType->userDefinedType)
+                      ? (void *)arrayType : NULL;
+    return arrayType->createVariable(csound, typeArg, ctx);
+}
+
 static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx)
 {
     size_t ss;
@@ -43,7 +52,11 @@ static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx
           csound->Die(csound, "tabinit: arrayType is NULL");
           return;
         }
-        CS_VARIABLE* var = p->arrayType->createVariable(csound, NULL, ctx);
+        CS_VARIABLE* var = array_element_create_variable(csound, p->arrayType, ctx);
+        if (UNLIKELY(var == NULL)) {
+          csound->Die(csound, "tabinit: could not create array element variable");
+          return;
+        }
         p->arrayMemberSize = var->memBlockSize;
         ss = (size_t)p->arrayMemberSize * (size_t)size;
         p->data = (MYFLT*)csound->Calloc(csound, ss);
@@ -73,7 +86,7 @@ static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx
         p->allocated = ss;
         // Initialize only the newly added struct elements if it's UDT
         if (p->arrayType && p->arrayType->userDefinedType) {
-          CS_VARIABLE* var2 = p->arrayType->createVariable(csound, NULL, ctx);
+          CS_VARIABLE* var2 = array_element_create_variable(csound, p->arrayType, ctx);
           if (var2 && var2->initializeVariableMemory) {
             char *base = (char*)p->data;
             size_t blockSize = (size_t)var2->memBlockSize;
@@ -121,7 +134,11 @@ static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
                          ? (int32_t)(p->allocated / (size_t)p->arrayMemberSize)
                          : 0;
     if (p->data == NULL) {
-      CS_VARIABLE* var = p->arrayType->createVariable(csound, NULL, NULL);
+      CS_VARIABLE* var = array_element_create_variable(csound, p->arrayType, NULL);
+      if (UNLIKELY(var == NULL)) {
+        csound->Die(csound, "tabinit_like: could not create array element variable");
+        return;
+      }
       p->arrayMemberSize = var->memBlockSize;
       size_t bytes = (size_t)p->arrayMemberSize * (size_t)elemCount;
       p->data = (MYFLT*)csound->Calloc(csound, bytes);
@@ -153,7 +170,7 @@ static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
         p->allocated = bytes;
         // Initialize only the newly added struct elements if it's UDT
         if (p->arrayType && p->arrayType->userDefinedType) {
-          CS_VARIABLE* var2 = p->arrayType->createVariable(csound, NULL, NULL);
+          CS_VARIABLE* var2 = array_element_create_variable(csound, p->arrayType, NULL);
           if (var2 && var2->initializeVariableMemory) {
             char *base = (char*)p->data;
             size_t blockSize = (size_t)var2->memBlockSize;

--- a/tests/commandline/structs/test_struct_array_member_copy_fail.csd
+++ b/tests/commandline/structs/test_struct_array_member_copy_fail.csd
@@ -1,0 +1,42 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+#include "../libassert.orc"
+
+struct Box value:i
+struct Holder items:Box[]
+
+instr 1
+  boxes:Box[] init 2
+
+  first:Box init 10
+  second:Box init 20
+  boxes[0] = first
+  boxes[1] = second
+
+  holder:Holder init boxes
+
+  ; This is the operation that failed
+  copied:Box[] = holder.items
+
+  assertEquals(lenarray:i(copied), 2)
+  assertEquals(copied[0].value, 10)
+  assertEquals(copied[1].value, 20)
+
+  prints "Struct-array member copy test passed\n"
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -761,6 +761,10 @@ def runTest():
             "structs/test_struct_array_k_index_member_access.csd",
             "test k-rate index member access on struct array elements",
         ],
+        [
+            "structs/test_struct_array_member_copy_fail.csd",
+            "copying struct-array member out of a struct",
+        ],
         ["test_exitnowk.csd", "perf-time exitnow opcode"],
         ["test_udt_channel.csd", "testing user-defined type channel"],
         ["test_udt_chan_no_match.csd", "testing unmatched udt channel", 1],


### PR DESCRIPTION
Fixes a crash when copying an array of structs out of a struct member.

  Example:

  holder:Holder init boxes
  copied:Box[] = holder.items

  What was wrong:

  - Csound tried to create struct array elements without passing the struct type, so it could crash.
  - The copy also happened too late for i-time checks, so copied values could still be 0.
  - A later cleanup path could free memory it did not own.

  What changed:

  - Struct array elements now get created with the right type.
  - Struct arrays are copied during init when needed.
  - Struct array aliases now avoid double-free cleanup.
  - Added the failing CSD to the commandline tests as a normal passing test.