### PR TITLE
Fix for diskin2 async race condition

### DIFF
--- a/H/diskin2.h
+++ b/H/diskin2.h
@@ -30,7 +30,7 @@
 #define POS_FRAC_SCALE  0x10000000
 #define POS_FRAC_MASK   0x0FFFFFFF
 
-typedef struct {
+typedef struct diskin2 {
     OPDS    h;
     MYFLT   *out[DISKIN2_MAXCHN];
     MYFLT   *iFileCode;
@@ -74,10 +74,12 @@ typedef struct {
     MYFLT   aOut_bufsize;
     void    *cb;
     int32_t     async;
-  MYFLT     transpose;
+    MYFLT     transpose;
+    CSOUND *csound;
+    struct diskin2  *nxt;
 } DISKIN2;
 
-typedef struct {
+typedef struct diskin2_array {
     OPDS    h;
     ARRAYDAT *aOut;
     MYFLT   *iFileCode;
@@ -118,6 +120,8 @@ typedef struct {
   MYFLT aOut_bufsize;
   void *cb;
   int32_t  async;
+  CSOUND *csound;
+  struct diskin2_array *nxt;
 } DISKIN2_ARRAY;
 
 int32_t diskin2_init(CSOUND *csound, DISKIN2 *p);

--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -31,6 +31,12 @@ typedef struct _circular_buffer {
   spin_lock_t lock;
 } circular_buffer;
 
+int32_t csoundCircularBufferGetSize(CSOUND *csound, void *p) {
+  (void) csound;
+  if(p == NULL) return 0;
+  return ((circular_buffer *)p)->numelem;
+}
+
 void *csoundCreateCircularBuffer(CSOUND *csound, int32_t numelem, int32_t elemsize){
     circular_buffer *p;
     if ((p = (circular_buffer *)

--- a/InOut/circularbuffer.c
+++ b/InOut/circularbuffer.c
@@ -31,11 +31,19 @@ typedef struct _circular_buffer {
   spin_lock_t lock;
 } circular_buffer;
 
-int32_t csoundCircularBufferGetSize(CSOUND *csound, void *p) {
+int32_t csoundGetSizeCircularBuffer(CSOUND *csound, void *p) {
   (void) csound;
   if(p == NULL) return 0;
-  return ((circular_buffer *)p)->numelem;
+  return ((circular_buffer *)p)->numelem-1; // minus one to match requested size
 }
+
+int32_t csoundGetElementSizeCircularBuffer(CSOUND *csound, void *p) {
+  (void) csound;
+  if(p == NULL) return 0;
+  return ((circular_buffer *)p)->elemsize;
+}
+
+
 
 void *csoundCreateCircularBuffer(CSOUND *csound, int32_t numelem, int32_t elemsize){
     circular_buffer *p;

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -291,6 +291,7 @@ int32_t soundin(CSOUND *csound, DISKIN2 *p){
 
 static uintptr_t diskin_io_thread(void *p);
 static int32_t diskin2_cleanup(CSOUND *csound, void *p);
+int32_t csoundCircularBufferGetSize(CSOUND *csound, void *p); 
 
 static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
 {
@@ -412,13 +413,16 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
   if (csound->oparms->realtime==1 && p->fforceSync==0) {
     DISKIN2  **top, *current;
     p->csound = csound;
+    int32_t numelem =  p->bufSize*p->nChannels;
+    
      /* circular buffer is allocated once per opcode
         instance and will be freed by csoundReset
+        we also make sure size is compatible
       */
-    if(p->cb == NULL) {
+    if(p->cb == NULL ||
+       csoundCircularBufferGetSize(csound,p->cb)) {
        p->cb = csound->CreateCircularBuffer(csound,
-                                    p->bufSize*p->nChannels,
-                                             sizeof(MYFLT));
+                                    numelem, sizeof(MYFLT));
     }
 
    if (UNLIKELY(p->cb == NULL)) {
@@ -1534,7 +1538,17 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
     if (csound->oparms->realtime==1 && p->fforceSync==0){
       DISKIN2_ARRAY **top, *current;
       p->csound = csound;
-
+    int32_t numelem =  p->bufSize*p->nChannels;
+    
+     /* circular buffer is allocated once per opcode
+        instance and will be freed by csoundReset
+        we also make sure size is compatible
+      */
+    if(p->cb == NULL ||
+       csoundCircularBufferGetSize(csound,p->cb)) {
+       p->cb = csound->CreateCircularBuffer(csound,
+                                    numelem, sizeof(MYFLT));
+    }
       // create circular buffer if not already created
       // freed on CsoundReset()
       if(p->cb == NULL) {

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -412,12 +412,23 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
   p->buf = (MYFLT*) (p->auxData.auxp);
   p->prvBuf = (MYFLT*) p->buf + (int32_t)n;
   memset(p->buf, 0, n*sizeof(MYFLT));
-  // create circular buffer, on fail set mode to synchronous
-  if (csound->oparms->realtime==1 && p->fforceSync==0 &&
-      (p->cb = csound->CreateCircularBuffer(csound,
-                                            p->bufSize*p->nChannels,
-                                            sizeof(MYFLT))) != NULL){
+  
+  if (csound->oparms->realtime==1 && p->fforceSync==0) {
     DISKIN_INST **top, *current;
+     /* circular buffer is allocated once per opcode
+        instance and will be freed by csoundReset
+      */
+    if(p->cb == NULL) {
+       p->cb = csound->CreateCircularBuffer(csound,
+                                    p->bufSize*p->nChannels,
+                                             sizeof(MYFLT));
+    }
+
+   if (UNLIKELY(p->cb == NULL)) {
+     return csound->InitError(csound, "%s",
+                              Str("diskin2: failed to allocate circular buffer"));
+   }
+
 #ifndef __EMSCRIPTEN__
     int32_t *start;
 #endif
@@ -454,10 +465,11 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
         while(current->nxt != NULL) { /* find next empty slot in chain */
           current = current->nxt;
         }
+        /* DISKIN_INST memory will be freed on csoundReset() */
         current->nxt = (DISKIN_INST *) csound->Calloc(csound,
                                                       sizeof(DISKIN_INST));
         current = current->nxt;
-      }
+    }
     current->csound = csound;
     current->diskin = p;
     current->nxt = NULL;
@@ -544,11 +556,7 @@ int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
       csound->DestroyGlobalVariable(csound, "DISKIN_INST");
     }
 #endif
-    csound->Free(csound, current);
-    csound->DestroyCircularBuffer(csound, ((DISKIN2 *)p)->cb);
-    ((DISKIN2 *)p)->cb = NULL;
   }
-
   return OK;
 }
 
@@ -757,7 +765,7 @@ int32_t diskin2_perf_synchronous(CSOUND *csound, DISKIN2 *p)
 }
 
 
-int32_t diskin_file_read(CSOUND *csound, DISKIN2 *p)
+void diskin_file_read(CSOUND *csound, DISKIN2 *p)
 {
     /* nsmps is bufsize in frames */
     int32_t nsmps = csound->CheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
@@ -769,10 +777,10 @@ int32_t diskin_file_read(CSOUND *csound, DISKIN2 *p)
     MYFLT   *aOut = (MYFLT *)p->aOut_buf; /* needs to be allocated */
     MYFLT transpose = p->transpose;
 
-    if (UNLIKELY(p->fdch.fd == NULL) ) goto file_error;
+    if (UNLIKELY(p->fdch.fd == NULL) ) return;
     if (!p->initDone && !p->SkipInit) {
-      return csound->PerfError(csound, &(p->h),
-                               Str("diskin2: not initialised"));
+      csound->ErrorMsg(csound, Str("diskin2: not initialised"));
+      return;
     }
     if (transpose != p->prv_kTranspose) {
       double  f;
@@ -940,10 +948,6 @@ int32_t diskin_file_read(CSOUND *csound, DISKIN2 *p)
         mc += lc;
       } while(nc && *start);
     }
-    return OK;
- file_error:
-    csound->ErrorMsg(csound, Str("diskin2: file descriptor closed or invalid\n"));
-    return NOTOK;
 }
 
 
@@ -985,17 +989,18 @@ int32_t diskin2_perf_asynchronous(CSOUND *csound, DISKIN2 *p)
 
 
 uintptr_t diskin_io_thread(void *p){
-    DISKIN_INST *current = (DISKIN_INST *) p;
-    int32_t wakeup =
+  DISKIN_INST *current = (DISKIN_INST *) p;
+  CSOUND *csound = current->csound;
+  int32_t wakeup =
       1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
-    int32_t *start =
+  int32_t *start =
       current->csound->QueryGlobalVariable(current->csound,"DISKIN_THREAD_START");
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
-    while(*start){
-      current = (DISKIN_INST *) p;
+   while(*start){
       csoundSleep(wakeup > 0 ? wakeup : 1);
-      while(current != NULL){
-        diskin_file_read(current->csound, current->diskin);
+      current = (DISKIN_INST *) p;
+      while(current){
+        diskin_file_read(csound, current->diskin);
         current = current->nxt;
       }
     }
@@ -1014,8 +1019,7 @@ int32_t diskin2_perf(CSOUND *csound, DISKIN2 *p) {
 
 static CS_NOINLINE void diskin2_read_buffer_array(CSOUND *csound,
                                                   DISKIN2_ARRAY *p,
-                                                  int32_t bufReadPos)
-{
+                                                  int32_t bufReadPos) {
     MYFLT   *tmp;
     int32_t nsmps;
     int32_t i;
@@ -1102,8 +1106,7 @@ static inline void diskin2_file_pos_inc_array(DISKIN2_ARRAY *p, int32_t *ndx)
 
 static inline void diskin2_get_sample_array(CSOUND *csound,
                                             DISKIN2_ARRAY *p, int32_t fPos,
-                                            int32_t n, MYFLT scl)
-{
+                                            int32_t n, MYFLT scl) {
     int32_t  bufPos, i;
     int32_t ksmps = CS_KSMPS;
     MYFLT *aOut = (MYFLT *) p->aOut->data;
@@ -1194,35 +1197,11 @@ int32_t diskin2_async_deinit_array(CSOUND *csound,  DISKIN2_ARRAY *p){
       csound->DestroyGlobalVariable(csound, "DISKIN_INST_ARRAY");
     }
 #endif
-
-    csound->Free(csound, current);
-    csound->DestroyCircularBuffer(csound, ((DISKIN2_ARRAY *)p)->cb);
   }
     return OK;
 }
-int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p);
 
-uintptr_t diskin_io_thread_array(void *p){
-    DISKIN_INST *current = (DISKIN_INST *) p;
-    int32_t wakeup =
-      1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
-    int32_t *start =
-      current->csound->QueryGlobalVariable(current->csound,
-                                           "DISKIN_THREAD_START_ARRAY");
-    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
-    while(*start){
-      current = (DISKIN_INST *) p;
-      csoundSleep(wakeup > 0 ? wakeup : 1);
-      while(current != NULL){
-        diskin_file_read_array(current->csound, (DISKIN2_ARRAY *)current->diskin);
-        current = current->nxt;
-      }
-    }
-    return 0;
-}
-
-int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
-{
+void diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p) {
     /* nsmps is bufsize in frames */
     int32_t nsmps = csound->CheckCircularBuffer(csound, p->cb, 1)/p->nChannels;
     int32_t i, nn;
@@ -1232,10 +1211,10 @@ int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
     int32_t     wsized2, warp;
     MYFLT  *aOut = (MYFLT *)p->aOut_buf; /* needs to be allocated */
 
-    if (UNLIKELY(p->fdch.fd == NULL) ) goto file_error;
+    if (UNLIKELY(p->fdch.fd == NULL) ) return;
     if (!p->initDone && !p->SkipInit) {
-      return csound->PerfError(csound, &(p->h),
-                               Str("diskin2: not initialised"));
+      csound->ErrorMsg(csound, Str("diskin2: not initialised"));
+      return;
     }
     if (*(p->kTranspose) != p->prv_kTranspose) {
       double  f;
@@ -1402,18 +1381,30 @@ int32_t diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p)
         mc += lc;
       } while(nc && *start);
     }
-    return OK;
- file_error:
-    csound->ErrorMsg(csound, Str("diskin2: file descriptor closed or invalid\n"));
-    return NOTOK;
+}
+
+uintptr_t diskin_io_thread_array(void *p){
+    DISKIN_INST *current = (DISKIN_INST *) p;
+    int32_t wakeup =
+      1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
+    int32_t *start =
+      current->csound->QueryGlobalVariable(current->csound,
+                                           "DISKIN_THREAD_START_ARRAY");
+    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+    while(*start){
+      current = (DISKIN_INST *) p;
+      csoundSleep(wakeup > 0 ? wakeup : 1);
+      while(current != NULL){
+        diskin_file_read_array(current->csound, (DISKIN2_ARRAY *)current->diskin);
+        current = current->nxt;
+      }
+    }
+    return 0;
 }
 
 
-
-
 static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
-                                  int32_t stringname)
-{
+                                  int32_t stringname){
     double  pos;
     char    name[1024];
     void    *fd;
@@ -1544,12 +1535,21 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
 
     memset(p->buf, 0, n*sizeof(MYFLT));
 
-    // create circular buffer, on fail set mode to synchronous
-    if (csound->oparms->realtime==1 && p->fforceSync==0 &&
-        (p->cb = csound->CreateCircularBuffer(csound,
-                                              p->bufSize*p->nChannels,
-                                              sizeof(MYFLT))) != NULL){
+
+    if (csound->oparms->realtime==1 && p->fforceSync==0){
       DISKIN_INST **top, *current;
+
+      // create circular buffer if not already created
+      // freed on CsoundReset()
+      if(p->cb == NULL) {
+        p->cb = csound->CreateCircularBuffer(csound,
+                                              p->bufSize*p->nChannels,
+                                             sizeof(MYFLT));
+      }
+      if(p->cb == NULL) {
+        return csound->InitError(csound, "could not allocate circular buffer\n");
+      }
+      
 #ifndef __EMSCRIPTEN__
       int32_t *start;
 #endif
@@ -1589,6 +1589,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
           while(current->nxt != NULL) { /* find next empty slot in chain */
             current = current->nxt;
           }
+          // This is freed on CsoundReset()
           current->nxt =
             (DISKIN_INST *) csound->Calloc(csound, sizeof(DISKIN_INST));
           current = current->nxt;
@@ -1601,7 +1602,6 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
       if (*(start =
             csound->QueryGlobalVariable(csound,
                                         "DISKIN_THREAD_START_ARRAY")) == 0) {
-        uintptr_t diskin_io_thread_array(void *p);
         void **thread = csound->QueryGlobalVariable(csound,
                                                        "DISKIN_PTHREAD_ARRAY");
         *start = 1;

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -1,7 +1,7 @@
 /*
   diskin2.c:
 
-  Copyright (C) 2005 Istvan Varga
+  Copyright (C) 2005 Istvan Varga, (C) 2013 - 2026 V Lazzarini
 
   This file is part of Csound.
 
@@ -290,8 +290,7 @@ int32_t soundin(CSOUND *csound, DISKIN2 *p){
 }
 
 static uintptr_t diskin_io_thread(void *p);
-static int32_t diskin2_cleanup(CSOUND *csound, void *p);
-int32_t csoundCircularBufferGetSize(CSOUND *csound, void *p); 
+static int32_t diskin2_cleanup(CSOUND *csound, void *p); 
 
 static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
 {
@@ -420,7 +419,7 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
         we also make sure size is compatible
       */
     if(p->cb == NULL ||
-       csoundCircularBufferGetSize(csound,p->cb)) {
+       csound->GetSizeCircularBuffer(csound,p->cb) < numelem) {
        p->cb = csound->CreateCircularBuffer(csound,
                                     numelem, sizeof(MYFLT));
     }
@@ -1544,7 +1543,7 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
         we also make sure size is compatible
       */
     if(p->cb == NULL ||
-       csoundCircularBufferGetSize(csound,p->cb)) {
+       csound->GetSizeCircularBuffer(csound,p->cb) < numelem) {
        p->cb = csound->CreateCircularBuffer(csound,
                                     numelem, sizeof(MYFLT));
     }

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -20,18 +20,13 @@
   Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
 */
 
+
 #include "csoundCore.h"
 #include "soundfile.h"
 #include "soundio.h"
 #include "diskin2.h"
 #include <math.h>
 #include <inttypes.h>
-
-typedef struct DISKIN_INST_ {
-  CSOUND *csound;
-  DISKIN2 *diskin;
-  struct DISKIN_INST_ *nxt;
-} DISKIN_INST;
 
 
 static CS_NOINLINE void diskin2_read_buffer(CSOUND *csound,
@@ -294,7 +289,8 @@ int32_t soundin(CSOUND *csound, DISKIN2 *p){
     return ret;
 }
 
-uintptr_t diskin_io_thread(void *p);
+static uintptr_t diskin_io_thread(void *p);
+static int32_t diskin2_cleanup(CSOUND *csound, void *p);
 
 static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
 {
@@ -414,7 +410,8 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
   memset(p->buf, 0, n*sizeof(MYFLT));
   
   if (csound->oparms->realtime==1 && p->fforceSync==0) {
-    DISKIN_INST **top, *current;
+    DISKIN2  **top, *current;
+    p->csound = csound;
      /* circular buffer is allocated once per opcode
         instance and will be freed by csoundReset
       */
@@ -440,7 +437,7 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
       csound->AuxAlloc(csound, (int32_t) n, &(p->auxData2));
     p->aOut_buf = (MYFLT *) (p->auxData2.auxp);
     memset(p->aOut_buf, 0, n);
-    top = (DISKIN_INST **)csound->QueryGlobalVariable(csound, "DISKIN_INST");
+    top = (DISKIN2 **)csound->QueryGlobalVariable(csound, "DISKIN_INST");
 
     // allocate audio data buffer for asynchr processing
     // this is used to copy interleaved data before output
@@ -450,9 +447,9 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
 
 #ifndef __EMSCRIPTEN__
     if (top == NULL){
-      csound->CreateGlobalVariable(csound, "DISKIN_INST", sizeof(DISKIN_INST *));
-      top = (DISKIN_INST **) csound->QueryGlobalVariable(csound, "DISKIN_INST");
-      *top = (DISKIN_INST *) csound->Calloc(csound, sizeof(DISKIN_INST));
+      csound->CreateGlobalVariable(csound, "DISKIN_INST", sizeof(DISKIN2 *));
+      top = (DISKIN2 **) csound->QueryGlobalVariable(csound, "DISKIN_INST");
+      *top = p;
       csound->CreateGlobalVariable(csound, "DISKIN_PTHREAD", sizeof(void**));
       csound->CreateGlobalVariable(csound,
                                    "DISKIN_THREAD_START", sizeof(int32_t));
@@ -466,19 +463,17 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
           current = current->nxt;
         }
         /* DISKIN_INST memory will be freed on csoundReset() */
-        current->nxt = (DISKIN_INST *) csound->Calloc(csound,
-                                                      sizeof(DISKIN_INST));
+        current->nxt = p;
         current = current->nxt;
     }
-    current->csound = csound;
-    current->diskin = p;
     current->nxt = NULL;
 
 #ifndef __EMSCRIPTEN__
-    if ( *(start = csound->QueryGlobalVariable(csound,
+    if(*(start = csound->QueryGlobalVariable(csound,
                                                "DISKIN_THREAD_START")) == 0) {
       void **thread = csound->QueryGlobalVariable(csound, "DISKIN_PTHREAD");
       *thread = csound->CreateThread(diskin_io_thread, *top);
+      printf("thread start\n");
       *start = 1;
     }
 #endif
@@ -526,25 +521,8 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
   return OK;
 }
 
-int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
-
-  if(p->async) { // deinit only needed in asybc MODE
-    DISKIN_INST **top, *current, *prv;
-    if ((top = (DISKIN_INST **)
-         csound->QueryGlobalVariable(csound, "DISKIN_INST")) == NULL)
-      return NOTOK;
-
-    current = *top;
-    prv = NULL;
-    while(current->diskin != (DISKIN2 *)p) {
-      prv = current;
-      current = current->nxt;
-    }
-    if (prv == NULL) *top = current->nxt;
-    else prv->nxt = current->nxt;
-
+static int32_t diskin2_cleanup(CSOUND *csound, void *p) {
 #ifndef __EMSCRIPTEN__
-    if (*top == NULL) {
       int32_t *start; void **pt;
       start = (int32_t *) csound->QueryGlobalVariable(csound,"DISKIN_THREAD_START");
       *start = 0;
@@ -554,8 +532,27 @@ int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
       csound->DestroyGlobalVariable(csound, "DISKIN_PTHREAD");
       csound->DestroyGlobalVariable(csound, "DISKIN_THREAD_START");
       csound->DestroyGlobalVariable(csound, "DISKIN_INST");
-    }
 #endif
+    return OK;
+}
+
+int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
+
+  if(p->async) { // deinit only needed in async mode
+    DISKIN2 **top, *current, *prv = NULL;
+    if ((top = (DISKIN2 **)
+         csound->QueryGlobalVariable(csound, "DISKIN_INST")) == NULL)
+      return NOTOK;
+    int i = 0;
+    current = *top;
+    while(current != (DISKIN2 *)p) {
+      prv = current;
+      current = current->nxt;      
+    }
+    if (prv == NULL) *top = current->nxt;
+    else prv->nxt = current->nxt;
+    if(*top == NULL)
+      diskin2_cleanup(csound,p);
   }
   return OK;
 }
@@ -988,19 +985,20 @@ int32_t diskin2_perf_asynchronous(CSOUND *csound, DISKIN2 *p)
 }
 
 
-uintptr_t diskin_io_thread(void *p){
-  DISKIN_INST *current = (DISKIN_INST *) p;
+static uintptr_t diskin_io_thread(void *p){
+  DISKIN2 *current = (DISKIN2 *) p;
   CSOUND *csound = current->csound;
   int32_t wakeup =
-      1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
+      1000*current->h.insdshead->ksmps/current->h.insdshead->esr;
   int32_t *start =
-      current->csound->QueryGlobalVariable(current->csound,"DISKIN_THREAD_START");
+     csound->QueryGlobalVariable(csound,"DISKIN_THREAD_START");
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
    while(*start){
       csoundSleep(wakeup > 0 ? wakeup : 1);
-      current = (DISKIN_INST *) p;
+      current = *((DISKIN2 **)
+                  csound->QueryGlobalVariable(csound, "DISKIN_INST"));
       while(current){
-        diskin_file_read(csound, current->diskin);
+        diskin_file_read(csound, current);
         current = current->nxt;
       }
     }
@@ -1012,10 +1010,6 @@ int32_t diskin2_perf(CSOUND *csound, DISKIN2 *p) {
     if (!p->async) return diskin2_perf_synchronous(csound, p);
     else return diskin2_perf_asynchronous(csound, p);
 }
-
-
-
-
 
 static CS_NOINLINE void diskin2_read_buffer_array(CSOUND *csound,
                                                   DISKIN2_ARRAY *p,
@@ -1170,13 +1164,13 @@ static inline void diskin2_get_sample_array(CSOUND *csound,
 int32_t diskin2_async_deinit_array(CSOUND *csound,  DISKIN2_ARRAY *p){
 
   if(p->async) {
-    DISKIN_INST **top, *current, *prv;
-    if ((top = (DISKIN_INST **)
+    DISKIN2_ARRAY  **top, *current, *prv;
+    if ((top = (DISKIN2_ARRAY **)
          csound->QueryGlobalVariable(csound, "DISKIN_INST_ARRAY")) == NULL)
       return NOTOK;
     current = *top;
     prv = NULL;
-    while(current->diskin != (DISKIN2 *)p) {
+    while(current != p) {
       prv = current;
       current = current->nxt;
     }
@@ -1190,7 +1184,7 @@ int32_t diskin2_async_deinit_array(CSOUND *csound,  DISKIN2_ARRAY *p){
                                                   "DISKIN_THREAD_START_ARRAY");
       *start = 0;
       pt = csound->QueryGlobalVariable(csound,"DISKIN_PTHREAD_ARRAY");
-      csound->Message(csound, "dealloc %p %d\n", start, *start);
+      //csound->Message(csound, "dealloc %p %d\n", start, *start);
       csound->JoinThread(*pt);
       csound->DestroyGlobalVariable(csound, "DISKIN_PTHREAD_ARRAY");
       csound->DestroyGlobalVariable(csound, "DISKIN_THREAD_START_ARRAY");
@@ -1384,18 +1378,19 @@ void diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p) {
 }
 
 uintptr_t diskin_io_thread_array(void *p){
-    DISKIN_INST *current = (DISKIN_INST *) p;
+    DISKIN2_ARRAY *current = (DISKIN2_ARRAY *) p;
+    CSOUND *csound = current->csound;
     int32_t wakeup =
-      1000*current->diskin->h.insdshead->ksmps/current->diskin->h.insdshead->esr;
+      1000*current->h.insdshead->ksmps/current->h.insdshead->esr;
     int32_t *start =
-      current->csound->QueryGlobalVariable(current->csound,
-                                           "DISKIN_THREAD_START_ARRAY");
+      csound->QueryGlobalVariable(csound, "DISKIN_THREAD_START_ARRAY");
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
     while(*start){
-      current = (DISKIN_INST *) p;
+      current = *((DISKIN2_ARRAY **)
+                  csound->QueryGlobalVariable(csound, "DISKIN_INST_ARRAY"));
       csoundSleep(wakeup > 0 ? wakeup : 1);
       while(current != NULL){
-        diskin_file_read_array(current->csound, (DISKIN2_ARRAY *)current->diskin);
+        diskin_file_read_array(csound, current);
         current = current->nxt;
       }
     }
@@ -1537,7 +1532,8 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
 
 
     if (csound->oparms->realtime==1 && p->fforceSync==0){
-      DISKIN_INST **top, *current;
+      DISKIN2_ARRAY **top, *current;
+      p->csound = csound;
 
       // create circular buffer if not already created
       // freed on CsoundReset()
@@ -1568,14 +1564,14 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
       if (n != (int32_t)p->audioData.size)
        csound->AuxAlloc(csound, (int32_t) n, &(p->audioData));
       top =
-        (DISKIN_INST **)csound->QueryGlobalVariable(csound, "DISKIN_INST_ARRAY");
+        (DISKIN2_ARRAY **)csound->QueryGlobalVariable(csound, "DISKIN_INST_ARRAY");
 #ifndef __EMSCRIPTEN__
       if (top == NULL){
         csound->CreateGlobalVariable(csound,
-                                     "DISKIN_INST_ARRAY", sizeof(DISKIN_INST *));
-        top = (DISKIN_INST **) csound->QueryGlobalVariable(csound,
+                                     "DISKIN_INST_ARRAY", sizeof(DISKIN2_ARRAY *));
+        top = (DISKIN2_ARRAY **) csound->QueryGlobalVariable(csound,
                                                            "DISKIN_INST_ARRAY");
-        *top = (DISKIN_INST *) csound->Calloc(csound, sizeof(DISKIN_INST));
+        *top = p;
         csound->CreateGlobalVariable(csound,
                                      "DISKIN_PTHREAD_ARRAY", sizeof(void**));
         csound->CreateGlobalVariable(csound,
@@ -1589,13 +1585,9 @@ static int32_t diskin2_init_array(CSOUND *csound, DISKIN2_ARRAY *p,
           while(current->nxt != NULL) { /* find next empty slot in chain */
             current = current->nxt;
           }
-          // This is freed on CsoundReset()
-          current->nxt =
-            (DISKIN_INST *) csound->Calloc(csound, sizeof(DISKIN_INST));
+          current->nxt = p;
           current = current->nxt;
         }
-      current->csound = csound;
-      current->diskin =  (DISKIN2 *) p;
       current->nxt = NULL;
 
 #ifndef __EMSCRIPTEN__

--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -477,7 +477,6 @@ static int32_t diskin2_init_(CSOUND *csound, DISKIN2 *p, int32_t stringname)
                                                "DISKIN_THREAD_START")) == 0) {
       void **thread = csound->QueryGlobalVariable(csound, "DISKIN_PTHREAD");
       *thread = csound->CreateThread(diskin_io_thread, *top);
-      printf("thread start\n");
       *start = 1;
     }
 #endif
@@ -549,7 +548,7 @@ int32_t diskin2_async_deinit(CSOUND *csound, DISKIN2 *p){
       return NOTOK;
     int i = 0;
     current = *top;
-    while(current != (DISKIN2 *)p) {
+    while(current != p) {
       prv = current;
       current = current->nxt;      
     }
@@ -1372,7 +1371,7 @@ void diskin_file_read_array(CSOUND *csound, DISKIN2_ARRAY *p) {
     {
       /* write to circular buffer */
       int32_t lc, mc=0, nc=nsmps*p->nChannels;
-      int32_t *start = csound->QueryGlobalVariable(csound,"DISKIN_THREAD_START");
+      int32_t *start = csound->QueryGlobalVariable(csound,"DISKIN_THREAD_START_ARRAY");
       do{
         lc = csound->WriteCircularBuffer(csound, p->cb, &aOut[mc], nc);
         nc -= lc;

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -509,6 +509,8 @@ static const CSOUND cenviron_ = {
     csoundWriteCircularBuffer,
     csoundCheckCircularBuffer,
     csoundPeekCircularBuffer,
+    csoundGetSizeCircularBuffer,
+    csoundGetElementSizeCircularBuffer,
     csoundFlushCircularBuffer,
     csoundDestroyCircularBuffer,
     /* File access */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1283,6 +1283,8 @@ struct CSOUND_ {
   int32_t (*WriteCircularBuffer)(CSOUND *, void *, const void *, int32_t);
   int32_t (*CheckCircularBuffer)(CSOUND *, void *, int32_t);
   int32_t (*PeekCircularBuffer)(CSOUND *, void *, void *, int32_t);
+  int32_t (*GetSizeCircularBuffer)(CSOUND *, void *);
+  int32_t (*GetElementSizeCircularBuffer)(CSOUND *, void *);  
   void (*FlushCircularBuffer)(CSOUND *, void *);
   void (*DestroyCircularBuffer)(CSOUND *, void *);
   /**@}*/

--- a/include/csound_circular_buffer.h
+++ b/include/csound_circular_buffer.h
@@ -93,6 +93,22 @@ extern "C" {
    */
   PUBLIC int32_t csoundCheckCircularBuffer(CSOUND *csound, void *p, int32_t flag);
 
+  /**
+   * Get the allocated number of items in a circular buffer
+   * @param csound This value is currently ignored.
+   * @param p pointer to an existing circular buffer
+   * @returns the number of elements allocated in the circular buffer
+   */
+  PUBLIC int32_t csoundGetSizeCircularBuffer(CSOUND *csound, void *p);
+
+  /**
+   * Get the allocated space for each item in a circular buffer
+   * @param csound This value is currently ignored.
+   * @param p pointer to an existing circular buffer
+   * @returns the size of each element in bytes
+   */
+  PUBLIC int32_t csoundGetElementSizeCircularBuffer(CSOUND *csound, void *p);
+  
   
   /**
    * Free circular buffer

--- a/tests/commandline/test_async_diskin.csd
+++ b/tests/commandline/test_async_diskin.csd
@@ -1,18 +1,30 @@
 <CsoundSynthesizer>
 <CsOptions>
--n --realtime
+-odac -+rtaudio=null --realtime
 </CsOptions>
 <CsInstruments>
-nchnls = 2
 
 instr 1
 a1 diskin2 "fox.wav"
-   out a1
+   out a1*0.1
+   schedule(1,0.1,1) 
+endin
+
+instr 2
+a1[] diskin2 "fox.wav"
+   out a1[0]*0.1
+   schedule(1,0.1,1) 
 endin
 
 
+instr 3
+ eventi("e",0,0)
+endin
+
 </CsInstruments>
 <CsScore>
-i1 0 4
+i1 0 1
+i2 0 1
+i3 1 0
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
A race condition leading to after-free access was detected by asan. This PR fixes the issue by simplifying the code and removing any premature deallocations, keeping it lock-free as required.

Closes #2575 

PS: a more stringent test was added.