### PR TITLE
setting UDO recursion depth limits

### DIFF
--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1218,6 +1218,25 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   if (tp == NULL)
     return csound->InitError(csound, Str("Cannot find instr %d (UDO %s)\n"),
                              instno, inm->name);
+
+  if(csound->oparms->recursion_depth > 0
+     && inm->recurse_depth == 0) {
+    // set top frame jump for recursion depth exception
+    if (setjmp(inm->udojmp) != 0) {
+      return csound->InitError(csound,
+                               "error: UDO %s max recursion depth %d reached",
+                               inm->name, csound->oparms->recursion_depth);
+    }
+  }
+
+   inm->recurse_depth++;
+   if(csound->oparms->recursion_depth > 0 &&
+      inm->recurse_depth >
+      csound->oparms->recursion_depth) {
+     // exit gracefully from here back to top frame
+     longjmp(inm->udojmp, CSOUND_ERROR);
+   }
+  
   if (!p->ip) {
     /* search for already allocated, but not active instance */
     /* if none was found, allocate a new instance */
@@ -1270,8 +1289,6 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   lcurip->onedkr = CS_ONEDKR;
   lcurip->onedksmps = CS_ONEDKSMPS;
   lcurip->kicvt = CS_KICVT;
-
-
 
   /* VL 13-12-13 */
   /* this sets ksmps and kr local variables */
@@ -1485,6 +1502,7 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
    if (UNLIKELY(csound->oparms->odebug))
     csound->Message(csound, "EXTRATIM=> cur(%p): %d, parent(%p): %d\n",
                     lcurip, lcurip->xtratim, parent_ip, parent_ip->xtratim);
+   inm->recurse_depth = 0;
   return OK;
 }
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1223,12 +1223,13 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
      && inm->recurse_depth == 0) {
     // set top frame jump for recursion depth exception
     if (setjmp(inm->udojmp) != 0) {
+      inm->recurse_depth = 0;
       return csound->InitError(csound,
                                "error: UDO %s max recursion depth %d reached",
                                inm->name, csound->oparms->recursion_depth);
     }
   }
-
+   // increment recursion depth count
    inm->recurse_depth++;
    if(csound->oparms->recursion_depth > 0 &&
       inm->recurse_depth >
@@ -1380,13 +1381,16 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
       err = (*csound->ids->init)(csound, csound->ids);
     csound->ids = csound->ids->nxti;
   }
+  // following init pass, decrement recursion depth count
+  inm->recurse_depth--;
 
   if(err) return err;
   if(inm->passByRef) {
     pbr_sync_pass_through_outputs(csound, p, lcurip);
     pbr_writeback_pass_through_inputs(csound, p, lcurip);
   }
-  csound->mode = 0;  ATOMIC_SET(p->ip->init_done, 1);
+  csound->mode = 0;
+  ATOMIC_SET(p->ip->init_done, 1);
 
   /* After init chain completes, materialise UDO outputs only for pass-by-copy.
      In pass-by-ref mode, internal outputs are already rewired to caller storage
@@ -1502,7 +1506,6 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
    if (UNLIKELY(csound->oparms->odebug))
     csound->Message(csound, "EXTRATIM=> cur(%p): %d, parent(%p): %d\n",
                     lcurip, lcurip->xtratim, parent_ip, parent_ip->xtratim);
-   inm->recurse_depth = 0;
   return OK;
 }
 

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -200,6 +200,8 @@ extern "C" {
     CS_VAR_POOL* out_arg_pool;
     CS_VAR_POOL* in_arg_pool;
     struct instr *ip;
+    int32_t recurse_depth;
+    jmp_buf udojmp;
     OENTRY *oentry;
     PBR_REWIRE_PLAN *pbr_plan;
     struct opcodinfo *prv;

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -348,7 +348,7 @@ static const char *longUsageList[] = {
     Str_noop("--run-unit-tests        enable assertion opcodes and report test failures"),
     Str_noop("                          (assertions are ignored by default)"),
     Str_noop("--error-deprecated      trigger compilation error on deprecated opcodes"),
-    Str_noop("--recursion-dept=n    set max UDO recursion depth to n"),
+    Str_noop("--recursion-depth=n    set max UDO recursion depth to n"),
     Str_noop("--help                  long help"),
     NULL};
 

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -348,6 +348,7 @@ static const char *longUsageList[] = {
     Str_noop("--run-unit-tests        enable assertion opcodes and report test failures"),
     Str_noop("                          (assertions are ignored by default)"),
     Str_noop("--error-deprecated      trigger compilation error on deprecated opcodes"),
+    Str_noop("--recursion-dept=n    set max UDO recursion depth to n"),
     Str_noop("--help                  long help"),
     NULL};
 
@@ -1235,9 +1236,7 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
     s += 14;
     O->kr_default = O->sr_default / atof(s);
     return 1;
-  }
-
-  else if (!(strcmp(s, "aft-zero"))) {
+  } else if (!(strcmp(s, "aft-zero"))) {
     csound->aftouch = 0;
     return 1;
   } else if (!(strncmp(s, "limiter=", 8))) {
@@ -1248,10 +1247,14 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
                        Str("Ignoring invalid limiter\n"));
       O->limiter = 0;
     }
-    return 1;
-
+   return 1;
   } else if (!(strcmp(s, "limiter"))) {
     O->limiter = 0.5;
+    return 1;
+  } else if (!(strncmp(s, "recursion-depth=", 16))) {
+    s += 16;
+    int32_t depth = atof(s);
+    O->recursion_depth = depth > 0 ? depth : 0;
     return 1;
   } else if (!(strcmp(s, "vbr"))) {
 #ifdef SNDFILE_MP3

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1022,7 +1022,9 @@ static const CSOUND cenviron_ = {
     0.0,           /*   limiter */
     DFLT_SR, DFLT_KR,  /* defaults */
     0,             /* mp3 mode */
-    0              /* instr redefinition flag */
+    0,             /* instr redefinition flag */
+    0,             /* deprecation error flag */
+    1000           /* MAX udo recursion depth */
   },
   {0, 0, {0}}, /* REMOT_BUF */
   NULL,           /* remoteGlobals        */

--- a/include/csound.h
+++ b/include/csound.h
@@ -283,6 +283,8 @@ extern "C" {
     int32_t     redef;
     /* error on deprecated opcodes */
     int32_t     error_deprecated;
+    /* UDO recursion depth */
+    int32_t     recursion_depth;
   } OPARMS;
 
   /**

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -790,6 +790,7 @@ def runTest():
             "test_udo_optional_after_instr.csd",
             "test new-style UDO optional args defined after instr",
         ],
+        ["test_udo_recursion.csd", "test for UDO recursion depth exception", 1]
     ]
 
     maxallocTests = [

--- a/tests/commandline/test_udo_recursion.csd
+++ b/tests/commandline/test_udo_recursion.csd
@@ -1,0 +1,42 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+0dbfs=1
+
+opcode Crashy():i
+  ikeepGoing = 1
+  while (ikeepGoing == 1) do
+    if (ikeepGoing == 1) then
+      xout -1
+    endif
+    ivalue = Crashy()
+  od
+  xout 0
+endop
+
+opcode RecurseOK(cnt:i):i
+  cnt += 1
+  while (cnt < 10) do
+    print cnt
+    xout RecurseOK(cnt)
+  od
+    xout 0
+endop
+
+instr 1
+  ivalue = Crashy()
+endin
+
+instr 2
+  ret:i = RecurseOK(0)
+  prints "carried on"
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 1
+i2 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR is a second attempt at handling stack exhaustion in infinite recursion UDO due to user error. Earlier attempt tried to check for stack exhaustion and exit gracefully but that proved to be difficult to catch as it could happen in different places.

This attempt is a second-best approach, it sets a hard limit for recursion depth in UDOs, which is controlled by the an engine parameter. Set to 1000 by default, this can be changed using the option `--recursion-depth=n`. If `n` is set to zero, the check is bypassed.

A test was added to check that an infinite recursion is caught while finite recursion passes.

Closes #2578 (hopefully).   