### PR TITLE
Fix string-array struct member indexing in expression arguments

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -462,14 +462,16 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   while (current != NULL) {
     if (is_expression_node(current)) {
       TREE* newArg;
+      TREE* temp = current->next;
 
+      current->next = NULL;
       anchor = append_to_tree(csound, anchor,
                             create_expression(csound, current, line, locn,
                                               typeTable));
       last = tree_tail(anchor);
       newArg = create_ans_token(csound, last->left->value->lexeme);
       newArgList = append_to_tree(csound, newArgList, newArg);
-      current = current->next;
+      current = temp;
     } else {
       TREE* temp;
       newArgList = append_to_tree(csound, newArgList, current);
@@ -486,7 +488,9 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   while (current != NULL) {
     if (is_expression_node(current)) {
       TREE* newArg;
+      TREE* temp = current->next;
 
+      current->next = NULL;
       anchor = append_to_tree(csound, anchor,
                             create_expression(csound, current, line,
                                               locn, typeTable));
@@ -494,7 +498,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
 
       newArg = create_ans_token(csound, last->left->value->lexeme);
       newArgList = append_to_tree(csound, newArgList, newArg);
-      current = current->next;
+      current = temp;
     }
     else {
       TREE* temp;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2515,6 +2515,29 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root,
     if (right->type == T_FUNCTION &&
         right->left == NULL &&
         right->next == NULL) {
+      char *outType = NULL;
+      TREE *arg = right->right;
+      int32_t hasExpressionArg = 0;
+
+      while (arg != NULL && !hasExpressionArg) {
+        hasExpressionArg = is_expression_node(arg) ||
+                           is_boolean_expression_node(arg);
+        arg = arg->next;
+      }
+
+      if (hasExpressionArg && tree_arg_list_count(root->left) == 1) {
+        char *leftName = root->left->value ? root->left->value->lexeme : NULL;
+
+        if (leftName != NULL && strchr("aikSKBbf", leftName[0]) != NULL &&
+            (outType = get_arg_type2(csound, right, typeTable)) != NULL) {
+          if (strlen(outType) == 1 && leftName[0] == outType[0]) {
+            csound->Free(csound, outType);
+            return root;
+          }
+          csound->Free(csound, outType);
+        }
+      }
+
       right->next = root->next;
       right->left = root->left;
       right->type = T_OPCALL;

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2504,6 +2504,38 @@ TREE* convert_unary_op_to_binary(CSOUND* csound, TREE* new_left, TREE* unary_op)
  * For further reference, please see the rule for statement and opcall in
  * Engine/csound_orc.y.
  */
+static char *get_assignment_lhs_type_hint(CSOUND *csound, TREE *left)
+{
+  if (left == NULL || left->value == NULL) {
+    return NULL;
+  }
+
+  if (left->value->optype != NULL) {
+    const char *type = convert_array_type_string(csound, left->value->optype);
+    char *ret = csoundStrdup(csound, type);
+    if (type != left->value->optype) {
+      csound->Free(csound, (void*)type);
+    }
+    return ret;
+  }
+
+  char *name = left->value->lexeme;
+  if (name == NULL) {
+    return NULL;
+  }
+  if (*name == '#') {
+    name++;
+  }
+  if (*name == 'g' && name[1] != '\0') {
+    name++;
+  }
+  if (strchr("aikSKBbf", *name) != NULL) {
+    char type[2] = {*name, '\0'};
+    return csoundStrdup(csound, type);
+  }
+  return NULL;
+}
+
 TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root,
                                   TYPE_TABLE* typeTable) {
   int32_t leftCount, rightCount;
@@ -2526,15 +2558,19 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root,
       }
 
       if (hasExpressionArg && tree_arg_list_count(root->left) == 1) {
-        char *leftName = root->left->value ? root->left->value->lexeme : NULL;
+        char *leftType = get_assignment_lhs_type_hint(csound, root->left);
 
-        if (leftName != NULL && strchr("aikSKBbf", leftName[0]) != NULL &&
+        if (leftType != NULL && strlen(leftType) == 1 &&
             (outType = get_arg_type2(csound, right, typeTable)) != NULL) {
-          if (strlen(outType) == 1 && leftName[0] == outType[0]) {
+          if (!strcmp(leftType, outType)) {
+            csound->Free(csound, leftType);
             csound->Free(csound, outType);
             return root;
           }
           csound->Free(csound, outType);
+        }
+        if (leftType != NULL) {
+          csound->Free(csound, leftType);
         }
       }
 

--- a/tests/commandline/structs/test_string_array_direct_member_index.csd
+++ b/tests/commandline/structs/test_string_array_direct_member_index.csd
@@ -23,6 +23,9 @@ instr 1
   assert(strcmp(holder.keys[0], "alpha") == 0)
   assert(strcmp(holder.keys[1], "beta") == 0)
 
+  result:i = strcmp(holder.keys[0], "alpha")
+  assert(result == 0)
+
   prints "String-array direct member index test passed\n"
 endin
 

--- a/tests/commandline/structs/test_string_array_direct_member_index.csd
+++ b/tests/commandline/structs/test_string_array_direct_member_index.csd
@@ -1,0 +1,34 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+#include "../libassert.orc"
+
+struct Holder keys:S[], length:i
+
+instr 1
+  keys:S[] init 2
+  keys[0] = "alpha"
+  keys[1] = "beta"
+
+  holder:Holder init keys, 2
+
+  assert(strcmp(holder.keys[0], "alpha") == 0)
+  assert(strcmp(holder.keys[1], "beta") == 0)
+
+  prints "String-array direct member index test passed\n"
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/structs/test_struct_array_member_with_scalar.csd
+++ b/tests/commandline/structs/test_struct_array_member_with_scalar.csd
@@ -1,0 +1,42 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+#include "../libassert.orc"
+
+struct Box value:i
+struct Holder items:Box[], length:i
+
+instr 1
+  boxes:Box[] init 2
+
+  first:Box init 10
+  second:Box init 20
+  boxes[0] = first
+  boxes[1] = second
+
+  holder:Holder init boxes, 2
+
+  copied:Box[] = holder.items
+
+  assertEquals(holder.length, 2)
+  assertEquals(lenarray:i(copied), 2)
+  assertEquals(copied[0].value, 10)
+  assertEquals(copied[1].value, 20)
+
+  prints "Struct-array member with scalar test passed\n"
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -765,6 +765,14 @@ def runTest():
             "structs/test_struct_array_member_copy_fail.csd",
             "copying struct-array member out of a struct",
         ],
+        [
+            "structs/test_struct_array_member_with_scalar.csd",
+            "copying a struct-array member containing scalar fields",
+        ],
+        [
+            "structs/test_string_array_direct_member_index.csd",
+            "direct indexing of a string-array struct member",
+        ],
         ["test_exitnowk.csd", "perf-time exitnow opcode"],
         ["test_udt_channel.csd", "testing user-defined type channel"],
         ["test_udt_chan_no_match.csd", "testing unmatched udt channel", 1],


### PR DESCRIPTION
This fixes a compiler issue with expressions like:

```csound
strcmp(holder.keys[0], "alpha")
```

Here `holder.keys` is a string array stored inside a struct. Reading one element should produce a single string. Instead, the expression lowering code accidentally kept the next argument attached while lowering `holder.keys[0]`. That made the compiler see both `holder.keys[0]` and `"alpha"` together and infer a temporary type like `SS`, which is not a valid single temporary variable type.

The fix detaches each expression argument from its sibling list before lowering it. This makes each argument lower independently, so `holder.keys[0]` becomes one string temporary as intended.

There is also a small guard in assignment conversion. It preserves existing opcode-call behavior for multi-output and special opcodes like `pan2` and `schedule`, while still allowing simple expression assignments such as `iok = strcmp(...)` to be handled as expressions.

Two focused CSD tests were added: one for direct indexing of a string-array struct member, and one to keep existing struct-array member copying behavior covered.
