### PR TITLE
Fix assignment into struct-owned arrays of structs

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1660,16 +1660,22 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
           if (var->subType) {
             // Generic array, use subType (element type)
             outType = csoundStrdup(csound, var->subType->varTypeName);
-          } else if (var->dimensions > 0 || var->varType == &CS_VAR_TYPE_ARRAY) {
-            // Generic array with dimensions
-            outType = csoundStrdup(csound, var->subType->varTypeName);
           } else if (var->varType == &CS_VAR_TYPE_A) {
             outType = csoundStrdup(csound, "k");
+          } else if (var->varType == &CS_VAR_TYPE_ARRAY) {
+            synterr(csound,
+                    Str("expand_statement: unable to find array sub-type "
+                        "for var %s line %d\n"),
+                    varBaseName, current->line);
+            return NULL;
           } else {
             // Typed array like k[], varType is the element type
             outType = csoundStrdup(csound, var->varType->varTypeName);
           }
-          arrayElementIsStruct = var->subType && var->subType->userDefinedType;
+          arrayElementIsStruct =
+            (var->subType && var->subType->userDefinedType) ||
+            (var->subType == NULL && var->varType &&
+             var->varType->userDefinedType);
         }
       }
 

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -658,8 +658,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       char* outype;
 
       // Handle struct member access or other complex left expressions
-      if (root->left == NULL || root->left->value == NULL ||
-          root->left->value->lexeme == NULL) {
+      if (array_target_missing_lexeme(root)) {
         // This could be a struct member access - delegate to get_arg_string_from_tree
         // Note: get_arg_string_from_tree returns the element type for T_ARRAY nodes
         char* elementType = get_arg_string_from_tree(csound, root, typeTable);
@@ -1633,8 +1632,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       CS_VARIABLE* var;
       int32_t arrayElementIsStruct = 0;
 
-      if (currentArg->left == NULL || currentArg->left->value == NULL ||
-          currentArg->left->value->lexeme == NULL) {
+      if (array_target_missing_lexeme(currentArg)) {
         const CS_TYPE* outCsType;
         outType = get_arg_type2(csound, currentArg, typeTable);
         if (outType == NULL) {

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1631,32 +1631,45 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
     if (currentArg->type == T_ARRAY) {
       char *outType;
       CS_VARIABLE* var;
+      int32_t arrayElementIsStruct = 0;
 
-      char *varBaseName = currentArg->left->value->lexeme;
-      // search for the array variable in all pools
-      var = find_var_from_pools(csound, varBaseName,
-                                varBaseName, typeTable);
-      if (var == NULL) {
-        synterr(csound,
-                Str("expand_statement: unable to find array sub-type "
-                    "for var %s line %d\n"),
-                varBaseName, current->line);
-        return NULL;
+      if (currentArg->left == NULL || currentArg->left->value == NULL ||
+          currentArg->left->value->lexeme == NULL) {
+        const CS_TYPE* outCsType;
+        outType = get_arg_type2(csound, currentArg, typeTable);
+        if (outType == NULL) {
+          return NULL;
+        }
+        outCsType = csoundGetTypeWithVarTypeName(csound->typePool, outType);
+        arrayElementIsStruct = outCsType != NULL && outCsType->userDefinedType;
       } else {
-        // Check if it's an array
-        // For LHS array assignment, the temporary variable should have the element type
-        // (e.g., "k" for k[], "S" for S[]) because it represents the value being assigned
-        if (var->subType) {
-          // Generic array, use subType (element type)
-          outType = strdup(var->subType->varTypeName);
-        } else if (var->dimensions > 0 || var->varType == &CS_VAR_TYPE_ARRAY) {
-          // Generic array with dimensions
-          outType = strdup(var->subType->varTypeName);
-        } else if (var->varType == &CS_VAR_TYPE_A) {
-          outType = strdup("k");
+        char *varBaseName = currentArg->left->value->lexeme;
+        // search for the array variable in all pools
+        var = find_var_from_pools(csound, varBaseName,
+                                  varBaseName, typeTable);
+        if (var == NULL) {
+          synterr(csound,
+                  Str("expand_statement: unable to find array sub-type "
+                      "for var %s line %d\n"),
+                  varBaseName, current->line);
+          return NULL;
         } else {
-          // Typed array like k[], varType is the element type
-          outType = strdup(var->varType->varTypeName);
+          // Check if it's an array
+          // For LHS array assignment, the temporary variable should have the element type
+          // (e.g., "k" for k[], "S" for S[]) because it represents the value being assigned
+          if (var->subType) {
+            // Generic array, use subType (element type)
+            outType = csoundStrdup(csound, var->subType->varTypeName);
+          } else if (var->dimensions > 0 || var->varType == &CS_VAR_TYPE_ARRAY) {
+            // Generic array with dimensions
+            outType = csoundStrdup(csound, var->subType->varTypeName);
+          } else if (var->varType == &CS_VAR_TYPE_A) {
+            outType = csoundStrdup(csound, "k");
+          } else {
+            // Typed array like k[], varType is the element type
+            outType = csoundStrdup(csound, var->varType->varTypeName);
+          }
+          arrayElementIsStruct = var->subType && var->subType->userDefinedType;
         }
       }
 
@@ -1665,7 +1678,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
                          create_out_arg(csound, outType,
                                         typeTable->localPool->synthArgCount++,
                                         typeTable));
-      free(outType);
+      csound->Free(csound, outType);
 
       if (previousArg == NULL) {
         current->left = temp;
@@ -1679,7 +1692,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       char* opcodeNameBase;
       if (init) {
         opcodeNameBase = "##array_init";
-      } else if (var->subType && var->subType->userDefinedType) {
+      } else if (arrayElementIsStruct) {
         opcodeNameBase = "##array_set_struct";
       } else {
         opcodeNameBase = "##array_set";

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -320,7 +320,12 @@ static char *resolve_struct_expr_type(CSOUND *csound, TREE *tree,
 
         char *elementType = NULL;
         int len = (int)strlen(structArrayType);
-        if (structArrayType[0] == ':') {
+        if (len >= 3 && structArrayType[0] == '[' &&
+            structArrayType[len - 1] == ']') {
+          elementType = csound->Malloc(csound, len - 1);
+          strncpy(elementType, structArrayType + 1, len - 2);
+          elementType[len - 2] = '\0';
+        } else if (structArrayType[0] == ':') {
           char *semicolon = strchr(structArrayType, ';');
           if (semicolon != NULL) {
             int typeNameLen = (int)(semicolon - structArrayType - 1);
@@ -2418,6 +2423,16 @@ int32_t add_args(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
       break;
 
     case T_ARRAY:
+
+      if (current->left == NULL || current->left->value == NULL ||
+          current->left->value->lexeme == NULL) {
+        char *arrayElementType = get_arg_type2(csound, current, typeTable);
+        if (arrayElementType == NULL) {
+          csound->LongJmp(csound, 1);
+        }
+        csound->Free(csound, arrayElementType);
+        break;
+      }
 
       varName = current->left->value->lexeme;
       // check if the array variable exists, it needs to be declared

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2424,8 +2424,7 @@ int32_t add_args(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable)
 
     case T_ARRAY:
 
-      if (current->left == NULL || current->left->value == NULL ||
-          current->left->value->lexeme == NULL) {
+      if (array_target_missing_lexeme(current)) {
         char *arrayElementType = get_arg_type2(csound, current, typeTable);
         if (arrayElementType == NULL) {
           csound->LongJmp(csound, 1);

--- a/H/csound_orc_expressions.h
+++ b/H/csound_orc_expressions.h
@@ -33,6 +33,12 @@ typedef struct {
     int32_t gotoType;
 } LOOP_JUMP_TARGETS;
 
+static inline int32_t array_target_missing_lexeme(TREE *arrayNode) {
+  return arrayNode == NULL || arrayNode->left == NULL ||
+         arrayNode->left->value == NULL ||
+         arrayNode->left->value->lexeme == NULL;
+}
+
 CONS_CELL* cs_cons(CSOUND* csound, void* val, CONS_CELL* cons);
 CONS_CELL* cs_cons_append(CONS_CELL* cons1, CONS_CELL* cons2);
 

--- a/tests/commandline/structs/test_struct_member_array_struct_set.csd
+++ b/tests/commandline/structs/test_struct_member_array_struct_set.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+#include "../libassert.orc"
+
+0dbfs = 1
+
+struct Item value:i
+struct Holder values:Item[]
+
+instr 1
+  values:Item[] init 1
+  holder:Holder init values
+  item:Item init 42
+
+  holder.values[0] = item
+
+  assertEquals(holder.values[0].value, 42)
+endin
+</CsInstruments>
+<CsScore>
+i1 0 0
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -770,6 +770,10 @@ def runTest():
             "copying a struct-array member containing scalar fields",
         ],
         [
+            "structs/test_struct_member_array_struct_set.csd",
+            "assigning into a struct-array member inside a struct",
+        ],
+        [
             "structs/test_string_array_direct_member_index.csd",
             "direct indexing of a string-array struct member",
         ],


### PR DESCRIPTION
Found my second struct-array compiler bug in one day. This one came from trying to assign directly into an array that lives inside a struct:

```csound
struct Item value:i
struct Holder values:Item[]

holder.values[0] = item
```

That shape crashed the compiler because the assignment path assumed the left-hand array target was always a plain identifier, like `values[0]`. For `holder.values[0]`, the array base is a struct expression instead, so the compiler ended up dereferencing missing identifier metadata.

This patch teaches the semantic and expression-lowering paths to handle that form explicitly. Struct-owned arrays now resolve their element type through the existing type resolver, and assignments choose `##array_set_struct` when the element type is user-defined.

While testing the write, the read side exposed a related type spelling issue: `holder.values[0].value` could produce the internal array type form `[:Item;]`, which was not recognized in one struct-expression path. That is handled here too.