### PR TITLE
Allow typed struct declarations to use default initialization

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -383,6 +383,18 @@ opcall  : identifier NEWLINE
             $2->left = $1;
             $2->right = $3;
           }
+        | out_arg_list identifier NEWLINE
+          { $$ = make_leaf(csound, LINE,LOCN, T_OPCALL, NULL);
+            if ($2->value != NULL && $2->value->lexeme != NULL &&
+                strcmp($2->value->lexeme, "init") == 0) {
+              $$->left = $2;
+              $2->type = T_OPCALL;
+              $2->left = $1;
+            } else {
+              $$->left = $1;
+              $$->right = $2;
+            }
+          }
         | out_arg_list_array expr_list NEWLINE
           { $$ = make_leaf(csound, LINE,LOCN, T_OPCALL, NULL);
             $$->left = $1;
@@ -399,6 +411,18 @@ opcall  : identifier NEWLINE
             $2->type = T_OPCALL;
             $2->left = $1;
             $2->right = $3;
+          }
+        | out_arg_list_array identifier NEWLINE
+          { $$ = make_leaf(csound, LINE,LOCN, T_OPCALL, NULL);
+            if ($2->value != NULL && $2->value->lexeme != NULL &&
+                strcmp($2->value->lexeme, "init") == 0) {
+              $$->left = $2;
+              $2->type = T_OPCALL;
+              $2->left = $1;
+            } else {
+              $$->left = $1;
+              $$->right = $2;
+            }
           }
         | function_call NEWLINE
           { $$ = $1; }

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3104,10 +3104,14 @@ int32_t initStructVar(CSOUND* csound, void* p) {
   CS_STRUCT_VAR* structVar = (CS_STRUCT_VAR*)init->out;
   CS_TYPE* type = csoundGetTypeForArg(init->out);
   int32_t len = cs_cons_length(type->members);
+  int32_t incnt = (int32_t)init->h.optext->t.inArgCount;
   int32_t i;
   if(csoundGetDebug(csound) & DEBUG_SEMANTICS) {
      csound->Message(csound, "Initializing Struct...\n");
      csound->Message(csound, "Struct Type: %s\n", type->varTypeName);
+  }
+  if (incnt == 0) {
+    return CSOUND_SUCCESS;
   }
   for (i = 0; i < len; i++) {
     CS_VAR_MEM* mem = structVar->members[i];
@@ -3407,6 +3411,10 @@ int32_t add_struct_definition(CSOUND* csound, TREE* structDefTree) {
     member = member->next;
   }
   temp[index] = 0;
+  oentry.intypes = csoundStrdup(csound, "");
+  csoundAppendOpcodes(csound, &oentry, 1);
+  oentry.opname = csoundStrdup(csound, oentry.opname);
+  oentry.outypes = csoundStrdup(csound, oentry.outypes);
   oentry.intypes = csoundStrdup(csound, temp);
   csoundAppendOpcodes(csound, &oentry, 1);
   return 1;
@@ -3818,6 +3826,17 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
         }
       }
       break;
+    }
+
+    case T_TYPED_IDENT: {
+      TREE *next = current->next;
+
+      add_args(csound, current, typeTable);
+      if (previous != NULL) {
+        previous->next = next;
+      }
+      current = next;
+      continue;
     }
 
     case BREAK_TOKEN: {

--- a/tests/commandline/structs/test_single_member_init.csd
+++ b/tests/commandline/structs/test_single_member_init.csd
@@ -11,6 +11,8 @@ nchnls = 1
 
 ; Test single-member struct initialization
 struct User name:S
+struct Point x:i, y:i
+struct Label name:S, value:i
 
 instr 1
   ; This should now work with the fix
@@ -25,9 +27,36 @@ instr 1
   prints "Single-member struct initialization test passed!\n"
 endin
 
+instr 2
+  globalPoint@global:Point init
+  point0:Point init
+  label0:Label init
+
+  if (globalPoint.x != 0 || globalPoint.y != 0) then
+    prints "Default global point initialization failed: x=%d y=%d\n", \
+      globalPoint.x, globalPoint.y
+    exitnow 1
+  endif
+
+  if (point0.x != 0 || point0.y != 0) then
+    prints "Default point initialization failed: x=%d y=%d\n", \
+      point0.x, point0.y
+    exitnow 1
+  endif
+
+  if (strcmp(label0.name, "") != 0 || label0.value != 0) then
+    prints "Default label initialization failed: name='%s' value=%d\n", \
+      label0.name, label0.value
+    exitnow 1
+  endif
+
+  prints "Default struct initialization test passed!\n"
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 0.1
+i 2 0 0.1
 e
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/structs/test_struct_init_partial_member_fails.csd
+++ b/tests/commandline/structs/test_struct_init_partial_member_fails.csd
@@ -1,0 +1,23 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+struct Point x:i, y:i
+
+instr 1
+  point:Point init 7
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -788,6 +788,11 @@ def runTest():
             "nested struct-array member reads inside boolean expression args",
         ],
         [
+            "structs/test_struct_init_partial_member_fails.csd",
+            "fail when struct init provides only some members",
+            "fail",
+        ],
+        [
             "structs/test_string_array_direct_member_index.csd",
             "direct indexing of a string-array struct member",
         ],
@@ -856,7 +861,7 @@ def runTest():
     tests += maxallocTests
     tests += pfieldTests
     tests += mkirTests
-   
+
     output = ""
 
     retVals = []


### PR DESCRIPTION
This PR allows a typed struct variable to be declared without calling its `init`
opcode explicitly. This is already needed and partially implemented when doing recursive declarations of structs. But there's a bug in it.

Before this change, this did not compile:

```csound
struct Point x:i, y:i

instr 1
  point:Point
endin
```

That was awkward because Csound already knows how to create initialized storage
for struct values. Numeric members start at `0`, string members start as empty
strings, and nested member storage is initialized by the type system.

The fix adds parser and semantic support for bare typed declarations. The
declaration creates the variable and then does not emit an opcode call. Runtime
storage initialization still happens through the existing variable-pool
initialization path.

This does not make struct constructor arguments optional. Required members are
still required when using `init`:

```csound
struct Point x:i, y:i

instr 1
  point:Point init 7
endin
```

That still fails, because `y:i` is not optional. This keeps constructor behavior
strict while allowing declared typed storage to have a canonical default value.
