### PR TITLE
Fix direct indexing of recursive struct array members

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -98,13 +98,17 @@ char *create_out_arg(CSOUND *csound, char* outype, int32_t argCount,
     char *type = remove_type_quoting(csound, outype);
     if (find_brace(type)) {
       if(*type == '[') { // [type]
-        snprintf(s, 16, "#%c%d[]", type[1], argCount);
-        add_array_arg(csound, s,  NULL, 1, typeTable);
+        size_t typeLen = strlen(type);
+        char *baseType = (typeLen >= 3) ? cs_strndup(csound, type + 1, typeLen - 2)
+                                        : csoundStrdup(csound, type);
+        snprintf(s, 256, "#%s%d[]", baseType, argCount);
+        add_array_arg(csound, s, baseType, 1, typeTable);
+        csound->Free(csound, baseType);
       } else { // type[]
         size_t typeLen = strlen(type);
         char *baseType = (typeLen >= 2) ? cs_strndup(csound, type, typeLen - 2)
                                         : csoundStrdup(csound, type);
-        snprintf(s, 16, "#%c%d[]", type[0], argCount);
+        snprintf(s, 256, "#%s%d[]", baseType, argCount);
         add_array_arg(csound, s,  baseType, 1, typeTable);
         csound->Free(csound, baseType);
       }
@@ -659,9 +663,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
 
       // Handle struct member access or other complex left expressions
       if (array_target_missing_lexeme(root)) {
-        // This could be a struct member access - delegate to get_arg_string_from_tree
-        // Note: get_arg_string_from_tree returns the element type for T_ARRAY nodes
-        char* elementType = get_arg_string_from_tree(csound, root, typeTable);
+        char* elementType = get_arg_type2(csound, root, typeTable);
         if (elementType == NULL) {
           return NULL;
         }

--- a/tests/commandline/structs/test_recursive_struct_member_array_direct_index.csd
+++ b/tests/commandline/structs/test_recursive_struct_member_array_direct_index.csd
@@ -1,0 +1,110 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+struct InstrumentNote pitch:i
+struct InstrumentShelf names:S[], notes:InstrumentNote[], length:i, hasParent:i, parent:InstrumentShelf[]
+
+opcode MakeNote(pitch:i):InstrumentNote
+  note:InstrumentNote init pitch
+  xout note
+endop
+
+opcode MakeRootShelf():InstrumentShelf
+  names:S[] init 1
+  notes:InstrumentNote[] init 1
+  parent:InstrumentShelf[] init 1
+  shelf:InstrumentShelf init names, notes, 0, 0, parent
+  xout shelf
+endop
+
+opcode MakeChildShelf(parentShelf:InstrumentShelf):InstrumentShelf
+  names:S[] init 1
+  notes:InstrumentNote[] init 1
+  parent:InstrumentShelf[] init 1
+  parent[0] = parentShelf
+  shelf:InstrumentShelf init names, notes, 0, 1, parent
+  xout shelf
+endop
+
+opcode FindInstrument(shelf:InstrumentShelf, name:S):i
+  index:i = 0
+  found:i = -1
+  names:S[] = shelf.names
+
+  while (index < shelf.length && found == -1) do
+    if (strcmp(names[index], name) == 0) then
+      found = index
+    endif
+    index += 1
+  od
+
+  xout found
+endop
+
+opcode StoreInstrument(shelf:InstrumentShelf, name:S, note:InstrumentNote):InstrumentShelf
+  index = FindInstrument(shelf, name)
+
+  if (index >= 0) then
+    shelf.notes[index] = note
+  else
+    newLength:i = shelf.length + 1
+    names:S[] init newLength
+    notes:InstrumentNote[] init newLength
+
+    copyIndex:i = 0
+    while (copyIndex < shelf.length) do
+      names[copyIndex] = shelf.names[copyIndex]
+      notes[copyIndex] = shelf.notes[copyIndex]
+      copyIndex += 1
+    od
+
+    names[shelf.length] = name
+    notes[shelf.length] = note
+    shelf.names = names
+    shelf.notes = notes
+    shelf.length = newLength
+  endif
+
+  xout shelf
+endop
+
+opcode LookupInstrument(shelf:InstrumentShelf, name:S):InstrumentNote
+  index = FindInstrument(shelf, name)
+
+  if (index >= 0) then
+    note:InstrumentNote = shelf.notes[index]
+  elseif (shelf.hasParent == 1) then
+    note = LookupInstrument(shelf.parent[0], name)
+  else
+    note = MakeNote(-999)
+  endif
+
+  xout note
+endop
+
+instr 1
+  winds:InstrumentShelf = MakeRootShelf()
+  winds = StoreInstrument(winds, "flute", MakeNote(72))
+
+  pit:InstrumentShelf = MakeChildShelf(winds)
+  pit = StoreInstrument(pit, "timpani", MakeNote(43))
+
+  flute:InstrumentNote = LookupInstrument(pit, "flute")
+  timpani:InstrumentNote = LookupInstrument(pit, "timpani")
+  missing:InstrumentNote = LookupInstrument(pit, "contrabassoon")
+
+  prints "flute=%d timpani=%d missing=%d\n", flute.pitch, timpani.pitch, missing.pitch
+
+  if (flute.pitch != 72 || timpani.pitch != 43 || missing.pitch != -999) then
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -774,6 +774,10 @@ def runTest():
             "assigning into a struct-array member inside a struct",
         ],
         [
+            "structs/test_recursive_struct_member_array_direct_index.csd",
+            "direct indexing of recursive struct-array members",
+        ],
+        [
             "structs/test_string_array_direct_member_index.csd",
             "direct indexing of a string-array struct member",
         ],


### PR DESCRIPTION
While testing recursive structs, I ran into another compiler edge case: indexing an array field directly from a recursive struct could fail even though the same code worked if the array field was first copied into a local variable.

For example, a struct can own an array of its own type, and code like this should be valid:

```csound
note = LookupInstrument(shelf.parent[0], name)
```

Before this change, that path could lose part of the element type while lowering the expression. The compiler then created an invalid temporary variable with no real type, which surfaced as an internal error like:

```text
cannot create variable #EnvS3: NULL type
```

The fix keeps the full array element type when creating temporary array values, including user-defined struct types. It also asks for the type of the single array expression being lowered, instead of accidentally including sibling function arguments in the type string.

This preserves existing behavior for normal arrays and struct arrays, but makes direct indexing behave the same as the local-variable workaround. A new regression test uses a small orchestra instrument lookup example with recursive shelves to cover direct reads, writes, and parent lookup through a recursive struct array field.
