### PR TITLE
arrays: allow for initialising empty arrays

### DIFF
--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -49,11 +49,14 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
                                Str("Error: NULL size pointer for array initialization"));
     }
     int v = MYFLT2LRND(*p->isizes[i]);
-    if (UNLIKELY(v <= 0)) {
+    if (UNLIKELY(v < 0)) {
+      return csound->InitError(csound, "%s",
+                               Str("Error: sizes must be >= 0 for array initialization"));
+    }
+    if (UNLIKELY(v == 0)) {
       // Special-case for audio arrays: size 0 means use ksmps (first dimension only)
       if (!(isAudioArray && i == 0)) {
-        return csound->InitError(csound, "%s",
-                                 Str("Error: sizes must be > 0 for array initialization"));
+        continue;
       }
     }
   }
@@ -97,10 +100,11 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
                                                            p->h.insdshead);
     char *mem;
     arrayDat->arrayMemberSize = var->memBlockSize;
+    int32_t allocCount = size > 0 ? size : 1;
     arrayDat->data = csound->Calloc(csound,
-                                    arrayDat->allocated=var->memBlockSize*size);
+                                    arrayDat->allocated=var->memBlockSize*allocCount);
     mem = (char *) arrayDat->data;
-    for (i=0; i < size; i++) {
+    for (i=0; i < allocCount; i++) {
       var->initializeVariableMemory(csound, var,
                                     (MYFLT*)(mem+i*var->memBlockSize));
     }
@@ -296,6 +300,10 @@ int32_t array_set(CSOUND* csound, ARRAY_SET *p)
     int needInfer = 0;
     for (int32_t j = 0; j < dat->dimensions; j++) {
       if (dat->sizes[j] <= 0) { needInfer = 1; break; }
+    }
+    if (needInfer && dat->data != NULL && dat->dimensions == 1 &&
+        dat->sizes[0] == 0) {
+      needInfer = 0;
     }
     if (needInfer) {
       if (dat->dimensions == 1 && dat->allocated > 0 && dat->arrayMemberSize > 0) {
@@ -500,7 +508,8 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     }
   }
   // Check if this is a struct array that needs auto-sizing before bounds checking
-  if (dat->dimensions > 0 && dat->sizes != NULL && dat->arrayType && dat->arrayType->userDefinedType) {
+  if (dat->data == NULL && dat->dimensions > 0 && dat->sizes != NULL &&
+      dat->arrayType && dat->arrayType->userDefinedType) {
     int needsAutoSizing = 0;
     for (int32_t j = 0; j < dat->dimensions; j++) {
       if (dat->sizes[j] <= 0) {
@@ -526,6 +535,10 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     int needInfer = 0;
     for (int32_t j = 0; j < dat->dimensions; j++) {
       if (dat->sizes[j] <= 0) { needInfer = 1; break; }
+    }
+    if (needInfer && dat->data != NULL && dat->dimensions == 1 &&
+        dat->sizes[0] == 0) {
+      needInfer = 0;
     }
     if (needInfer) {
       if (dat->dimensions == 1 && dat->allocated > 0 && dat->arrayMemberSize > 0) {

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -26,6 +26,13 @@
 #include "csound_orc_semantics.h"
 #include "csound_standard_types.h"
 
+static int32_t is_intentionally_empty_array(const ARRAYDAT *dat)
+{
+  return dat != NULL && dat->data != NULL && dat->dimensions == 1 &&
+         dat->sizes != NULL && dat->sizes[0] == 0 &&
+         dat->arrayMemberSize > 0 &&
+         dat->allocated == (size_t) dat->arrayMemberSize;
+}
 
 int32_t array_init(CSOUND *csound, ARRAYINIT *p)
 {
@@ -301,8 +308,7 @@ int32_t array_set(CSOUND* csound, ARRAY_SET *p)
     for (int32_t j = 0; j < dat->dimensions; j++) {
       if (dat->sizes[j] <= 0) { needInfer = 1; break; }
     }
-    if (needInfer && dat->data != NULL && dat->dimensions == 1 &&
-        dat->sizes[0] == 0) {
+    if (needInfer && is_intentionally_empty_array(dat)) {
       needInfer = 0;
     }
     if (needInfer) {
@@ -508,7 +514,8 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     }
   }
   // Check if this is a struct array that needs auto-sizing before bounds checking
-  if (dat->data == NULL && dat->dimensions > 0 && dat->sizes != NULL &&
+  if (dat->dimensions > 0 && dat->sizes != NULL &&
+      !is_intentionally_empty_array(dat) &&
       dat->arrayType && dat->arrayType->userDefinedType) {
     int needsAutoSizing = 0;
     for (int32_t j = 0; j < dat->dimensions; j++) {
@@ -536,8 +543,7 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     for (int32_t j = 0; j < dat->dimensions; j++) {
       if (dat->sizes[j] <= 0) { needInfer = 1; break; }
     }
-    if (needInfer && dat->data != NULL && dat->dimensions == 1 &&
-        dat->sizes[0] == 0) {
+    if (needInfer && is_intentionally_empty_array(dat)) {
       needInfer = 0;
     }
     if (needInfer) {

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -62,9 +62,14 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
     }
     if (UNLIKELY(v == 0)) {
       // Special-case for audio arrays: size 0 means use ksmps (first dimension only)
-      if (!(isAudioArray && i == 0)) {
+      if (isAudioArray && i == 0) {
         continue;
       }
+      if (inArgCount == 1) {
+        continue;
+      }
+      return csound->InitError(csound, "%s",
+                               Str("Error: zero-size array initialization is only supported for 1-D arrays"));
     }
   }
 

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -58,7 +58,8 @@ static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx
           return;
         }
         p->arrayMemberSize = var->memBlockSize;
-        ss = (size_t)p->arrayMemberSize * (size_t)size;
+        int32_t allocCount = size > 0 ? size : 1;
+        ss = (size_t)p->arrayMemberSize * (size_t)allocCount;
         p->data = (MYFLT*)csound->Calloc(csound, ss);
         p->allocated = ss;
         // Initialize struct elements if user-defined type
@@ -67,14 +68,14 @@ static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx
           size_t blockSize = (size_t)var->memBlockSize;
           // Batch process struct arrays
           int32_t i = 0;
-          for (; i + 3 < size; i += 4) {
+          for (; i + 3 < allocCount; i += 4) {
             var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
             var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 1) * blockSize));
             var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 2) * blockSize));
             var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 3) * blockSize));
           }
           // The second loop only handles the remainder elements (0-3 elements at most)
-          for (; i < size; i++) {
+          for (; i < allocCount; i++) {
             var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
           }
           csound->Free(csound, var);
@@ -140,7 +141,8 @@ static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
         return;
       }
       p->arrayMemberSize = var->memBlockSize;
-      size_t bytes = (size_t)p->arrayMemberSize * (size_t)elemCount;
+      uint32_t allocCount = elemCount > 0 ? elemCount : 1;
+      size_t bytes = (size_t)p->arrayMemberSize * (size_t)allocCount;
       p->data = (MYFLT*)csound->Calloc(csound, bytes);
       p->allocated = bytes;
       // Initialize struct elements if it's UDT
@@ -149,14 +151,14 @@ static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
         size_t blockSize = (size_t)var->memBlockSize;
         // Batch process arrays
         uint32_t i = 0;
-        for (; i + 3 < elemCount; i += 4) {
+        for (; i + 3 < allocCount; i += 4) {
           var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
           var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 1) * blockSize));
           var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 2) * blockSize));
           var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 3) * blockSize));
         }
         // The second loop only handles the remainder elements (0-3 elements at most)
-        for (; i < elemCount; i++) {
+        for (; i < allocCount; i++) {
           var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
         }
       }

--- a/tests/commandline/arrays/test_arrays_zero_dimension_fail.csd
+++ b/tests/commandline/arrays/test_arrays_zero_dimension_fail.csd
@@ -1,0 +1,15 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+instr 1
+  nums:i[][] init 0, 2
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/arrays/test_empty_array_init.csd
+++ b/tests/commandline/arrays/test_empty_array_init.csd
@@ -1,0 +1,43 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+struct Box value:i
+
+instr 1
+  nums:i[] init 0
+  names:S[] init 0
+  boxes:Box[] init 0
+
+  if (lenarray(nums) != 0 || lenarray(names) != 0 || lenarray(boxes) != 0) then
+    prints "Empty array lengths failed: nums=%d names=%d boxes=%d\n", \
+      lenarray(nums), lenarray(names), lenarray(boxes)
+    exitnow(1)
+  endif
+
+  nums init 1
+  names init 1
+
+  nums[0] = 42
+  names[0] = "flute"
+
+  if (lenarray(nums) != 1 || nums[0] != 42) then
+    prints "Empty numeric array resize failed: len=%d value=%d\n", \
+      lenarray(nums), nums[0]
+    exitnow(1)
+  endif
+
+  if (lenarray(names) != 1 || strcmp(names[0], "flute") != 0) then
+    prints "Empty string array resize failed: len=%d value='%s'\n", \
+      lenarray(names), names[0]
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/arrays/test_empty_array_init.csd
+++ b/tests/commandline/arrays/test_empty_array_init.csd
@@ -19,9 +19,12 @@ instr 1
 
   nums init 1
   names init 1
+  boxes init 1
 
+  box:Box init 64
   nums[0] = 42
   names[0] = "flute"
+  boxes[0] = box
 
   if (lenarray(nums) != 1 || nums[0] != 42) then
     prints "Empty numeric array resize failed: len=%d value=%d\n", \
@@ -32,6 +35,12 @@ instr 1
   if (lenarray(names) != 1 || strcmp(names[0], "flute") != 0) then
     prints "Empty string array resize failed: len=%d value='%s'\n", \
       lenarray(names), names[0]
+    exitnow(1)
+  endif
+
+  if (lenarray(boxes) != 1 || boxes[0].value != 64) then
+    prints "Empty struct array resize failed: len=%d value=%d\n", \
+      lenarray(boxes), boxes[0].value
     exitnow(1)
   endif
 endin

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -510,6 +510,11 @@ def runTest():
             "test expected failure with negative dimension size and array",
             1,
         ],
+        [
+            "arrays/test_arrays_zero_dimension_fail.csd",
+            "test expected failure with zero dimension in multi-dimensional array",
+            1,
+        ],
         ["test_iarr_operators.csd", "test i[] operators"],
         ["test_booleans.csd", "tests using boolean data-types"],
         ["test_boolean_function.csd", "test boolean function in conditionals"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -702,6 +702,7 @@ def runTest():
         ["arrays/arrays_for_loop.csd", "tests for loops over array types"],
         ["arrays/test_redef_fail.csd", "fail on redefinition of variable by array", 1],
         ["arrays/array_copy.csd", "test for =.generic copy on k-rate only"],
+        ["arrays/test_empty_array_init.csd", "test zero-length array initialization"],
         ["complex_array_test.csd", "testing complex array ops"],
         ["test_array_channels.csd", "testing bus channels holding arrays"],
         ["fft_array_test.csd", "testing complex fft array ops"],


### PR DESCRIPTION
tabinit already allows this, looking at the code, it looks to me more like a bug than intentional. There are definitely use cases for empty arrays, unused placeholders is one example.

EDIT: this PR only makes this possible for 1D arrays, not multi-dimensional, as 0 has a separate meaning. We could support 0 length arrays for multi-dim arrays, but for now, this is good enough start.