### PR TITLE
Fix inverted yield callback throttle

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -301,7 +301,7 @@ int32_t start_engine(CSOUND *csound)
 
     csound->evt_poll_cnt    = 0;
     csound->evt_poll_maxcnt =
-      (int)(250.0 /(double) csound->ekr); /* VL this was wrong: kr/250 originally */
+      (int)((double) csound->ekr / 250.0);
 
     /* open MIDI output (moved here from argdecode) */
     if (O->Midioutname != NULL && O->Midioutname[0] == (char) '\0')

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -1,4 +1,6 @@
-#include "csound.h"
+#define __BUILDING_LIBCSOUND
+
+#include "csoundCore.h"
 #include "csound_graph_display.h"
 #include <stdio.h>
 #include "gtest/gtest.h"
@@ -71,4 +73,23 @@ TEST_F (EngineTests, testScoreRewind)
       ;
     csoundRewindScore(csound);
     ASSERT_TRUE(csoundPerformKsmps(csound) == 0); 
+}
+
+TEST_F (EngineTests, testEventPollCounterUsesControlRate)
+{
+    csoundSetOption(csound, "-n");
+    csoundSetOption(csound, "-d");
+    csoundEventString(csound, "i 1 0 1\n", 0);
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 48000
+      ksmps = 64
+      nchnls = 1
+      0dbfs = 1
+      instr 1
+      endin
+    )", 0), CSOUND_SUCCESS);
+
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    ASSERT_DOUBLE_EQ(csound->ekr, 750.0);
+    ASSERT_EQ(csound->evt_poll_maxcnt, 3);
 }


### PR DESCRIPTION
## Summary

This fixes the event poll throttle calculation so it matches the intended rate.

The old formula used:

```c
250.0 / ekr
```

At a normal control rate, for example `ekr = 750`, that becomes `0` after integer truncation. That means the counter reload value is zero, so the throttle does not actually space out polling work.

The new formula uses:

```c
ekr / 250.0
```

So with `ekr = 750`, the counter reload value becomes `3`, which matches the goal of polling at about 250 times per second instead of every k-cycle.

## Why this matters

This code sits in the performance setup path and controls how often event polling work is allowed to run.

A throttle counter should answer: “how many k-cycles should pass before the next poll?” Since `ekr` is the number of k-cycles per second, we divide `ekr` by `250` to get the spacing between polls.

For `ekr = 750`:

```text
750 k-cycles/sec / 250 polls/sec = 3 k-cycles per poll
```

The previous calculation asked the opposite question, so normal rates rounded down to zero.

## Testing

Added a GoogleTest regression on `develop` that:

- creates a Csound instance
- sets `sr = 48000` and `ksmps = 64`
- starts the engine
- confirms `ekr = 750`
- confirms `evt_poll_maxcnt = 3`

Verified locally with:

```sh
ninja -C build unittests
./build/tests/c/unittests --gtest_filter=EngineTests.testEventPollCounterUsesControlRate
```
