### PR TITLE
Remove unused event poll counters

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -299,10 +299,6 @@ int32_t start_engine(CSOUND *csound)
     if (UNLIKELY(init0(csound) != 0))
       csoundDie(csound, Str("header init errors"));
 
-    csound->evt_poll_cnt    = 0;
-    csound->evt_poll_maxcnt =
-      (int)(250.0 /(double) csound->ekr); /* VL this was wrong: kr/250 originally */
-
     /* open MIDI output (moved here from argdecode) */
     if (O->Midioutname != NULL && O->Midioutname[0] == (char) '\0')
       O->Midioutname = NULL;

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -828,8 +828,6 @@ static const CSOUND cenviron_ = {
   1,              /*  csoundIsScorePending_ */
   0,              /*  advanceCnt          */
   0,              /*  initonly            */
-  0,              /*  evt_poll_cnt        */
-  0,              /*  evt_poll_maxcnt     */
   0, 0, 0,        /*  Mforcdecs, Mxtroffs, MTrkend */
   NULL,           /*  opcodeInfo  */
   NULL,           /*  flist               */
@@ -2389,4 +2387,3 @@ MYFLT csoundSetReleaseLengthSeconds(void *p, MYFLT n) {
   return ((MYFLT)((OPDS *)p)->insdshead->xtratim *
           ((OPDS *)p)->insdshead->csound->onedkr);
 }
-

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1622,8 +1622,6 @@ struct CSOUND_ {
   int32_t csoundIsScorePending_;
   int64_t advanceCnt;
   int32_t initonly;
-  int32_t evt_poll_cnt;
-  int32_t evt_poll_maxcnt;
   int32_t Mforcdecs, Mxtroffs, MTrkend;
   OPCODINFO *opcodeInfo;
   FUNC **flist;


### PR DESCRIPTION
This removes the old `evt_poll_cnt` and `evt_poll_maxcnt` fields from the engine state.

These counters used to control how often `csoundYield()` was called from the old k-cycle performance loop. On `develop`, that yield path is gone, and the current `kperf()` implementation no longer reads these counters.

So instead of fixing the old throttle formula, this PR removes the dead state entirely.