### PR TITLE
Move realtime async compile merge off the audio thread

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -1137,7 +1137,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install mingw-w64-i686-dev gcc-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64-tools
+          sudo apt-get install mingw-w64-i686-dev gcc-mingw-w64-i686 g++-mingw-w64-i686 mingw-w64-tools flex bison
 
       - name: Use posix mingw for 32-bit
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,6 +782,11 @@ else()
 endif()
 
 # Flex/Bison for the new parser
+if(WIN32)
+    find_program(FLEX_EXECUTABLE NAMES flex win_flex win_flex.exe)
+    find_program(BISON_EXECUTABLE NAMES bison win_bison win_bison.exe)
+endif()
+
 find_package(FLEX)
 find_package(BISON)
 

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -53,8 +53,8 @@ static int32_t named_instr_alloc(CSOUND *csound, char *s, INSTRTXT *ip, int32 in
                                  ENGINE_STATE *engineState, int32_t merge);
 
 MYFLT initialise_io(CSOUND *csound);
-void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE *t,
-                         OPDS *ids);
+int32_t merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE *t,
+                            OPDS *ids);
 OENTRY* find_opcode(CSOUND*, char*);
 void sanitize(CSOUND *csound);
 
@@ -2115,7 +2115,14 @@ int32_t csound_compile_tree(CSOUND *csound, TREE *root, int32_t async)
       if (!csound->oparms->realtime)
         csoundUnlockMutex(csound->API_lock);
     } else {
-      merge_state_enqueue(csound, engineState, typeTable, ids);
+      if (UNLIKELY(merge_state_enqueue(csound, engineState,
+                                       typeTable, ids) != CSOUND_SUCCESS)) {
+        csound->ErrorMsg(csound, "%s", Str("cannot merge compiled orchestra: "
+                                           "realtime allocation queue is full\n"));
+        enginestate_free(csound, engineState);
+        free_typetable(csound, typeTable);
+        return CSOUND_ERROR;
+      }
     }
   } else {
     /* now add the instruments with names, assigning them fake instr numbers */

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2115,11 +2115,7 @@ int32_t csound_compile_tree(CSOUND *csound, TREE *root, int32_t async)
       if (!csound->oparms->realtime)
         csoundUnlockMutex(csound->API_lock);
     } else {
-      if (csound->oparms->realtime)
-        csoundSpinLock(&csound->alloc_spinlock);
       merge_state_enqueue(csound, engineState, typeTable, ids);
-      if (csound->oparms->realtime)
-        csoundSpinUnLock(&csound->alloc_spinlock);
     }
   } else {
     /* now add the instruments with names, assigning them fake instr numbers */

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1790,6 +1790,19 @@ static char *node2string(int32_t type) {
   }
 }
 
+static void merge_engine_state(CSOUND *csound, ENGINE_STATE *engineState,
+                               TYPE_TABLE *typetable) {
+  enginestate_merge(csound, engineState);
+  enginestate_free(csound, engineState);
+  free_typetable(csound, typetable);
+}
+
+static void run_merged_global_init(CSOUND *csound, OPDS *ids) {
+  /* run global i-time code */
+  init0(csound);
+  csound->ids = ids;
+}
+
 /** Merge and Dispose of engine state and type table,
     and run global i-time code
 */
@@ -1797,12 +1810,22 @@ void merge_state(CSOUND *csound, ENGINE_STATE *engineState,
                  TYPE_TABLE *typetable, OPDS *ids) {
   if (csound->init_pass_threadlock)
     csoundLockMutex(csound->init_pass_threadlock);
-  enginestate_merge(csound, engineState);
-  enginestate_free(csound, engineState);
-  free_typetable(csound, typetable);
-  /* run global i-time code */
-  init0(csound);
-  csound->ids = ids;
+  merge_engine_state(csound, engineState, typetable);
+  run_merged_global_init(csound, ids);
+  if (csound->init_pass_threadlock)
+    csoundUnlockMutex(csound->init_pass_threadlock);
+}
+
+void merge_state_realtime(CSOUND *csound, ENGINE_STATE *engineState,
+                          TYPE_TABLE *typetable, OPDS *ids) {
+  if (csound->init_pass_threadlock)
+    csoundLockMutex(csound->init_pass_threadlock);
+  /* Global i-time opcodes may allocate, so this lock must end before init0. */
+  csoundSpinLock(&csound->alloc_spinlock);
+  named_instr_assign_numbers(csound, engineState);
+  merge_engine_state(csound, engineState, typetable);
+  csoundSpinUnLock(&csound->alloc_spinlock);
+  run_merged_global_init(csound, ids);
   if (csound->init_pass_threadlock)
     csoundUnlockMutex(csound->init_pass_threadlock);
 }

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -1820,11 +1820,12 @@ void merge_state_realtime(CSOUND *csound, ENGINE_STATE *engineState,
                           TYPE_TABLE *typetable, OPDS *ids) {
   if (csound->init_pass_threadlock)
     csoundLockMutex(csound->init_pass_threadlock);
-  /* Global i-time opcodes may allocate, so this lock must end before init0. */
+  /* Keep the init-lock-before-allocation-lock order used by realtime init. */
   csoundSpinLock(&csound->alloc_spinlock);
   named_instr_assign_numbers(csound, engineState);
   merge_engine_state(csound, engineState, typetable);
   csoundSpinUnLock(&csound->alloc_spinlock);
+  /* Global i-time opcodes may acquire the allocation lock themselves. */
   run_merged_global_init(csound, ids);
   if (csound->init_pass_threadlock)
     csoundUnlockMutex(csound->init_pass_threadlock);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -418,7 +418,7 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp) {
     data.insno = insno;
     data.blk =  *newevtp;
     data.type = 0;
-    return alloc_queue_enqueue(csound, &data) == CSOUND_SUCCESS ? 0 : 1;
+    return alloc_queue_enqueue(csound, &data);
   }
   else return insert(csound, insno, newevtp);
 }
@@ -772,7 +772,7 @@ int32_t insert_midi_event(CSOUND *csound, int32_t insno, MCHNBLK *chn,
     data.chn = chn;
     data.mep = *mep;
     data.type = 1;
-    return alloc_queue_enqueue(csound, &data) == CSOUND_SUCCESS ? 0 : 1;
+    return alloc_queue_enqueue(csound, &data);
   }
   else return insert_midi(csound, insno, chn, mep);
 

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -328,20 +328,24 @@ uintptr_t event_insert_thread(void *p) {
         case ALLOC_DATA_REINIT_PASS: {
           INSDS *ip = data.ip;
           OPDS *ids = data.ids;
+          int32_t error;
           csoundSpinLock(&csound->alloc_spinlock);
-          realtime_reinit_pass(csound, ip, ids);
+          error = realtime_reinit_pass(csound, ip, ids);
           csoundSpinUnLock(&csound->alloc_spinlock);
-          ATOMIC_SET(ip->init_done, 1);
+          if (error == 0)
+            ATOMIC_SET(ip->init_done, 1);
           break;
         }
 
         case ALLOC_DATA_INIT_PASS: {
           INSDS *ip = data.ip;
+          int32_t error;
           ATOMIC_SET(ip->init_done, 0);
           csoundSpinLock(&csound->alloc_spinlock);
-          realtime_init_pass(csound, ip);
+          error = realtime_init_pass(csound, ip);
           csoundSpinUnLock(&csound->alloc_spinlock);
-          ATOMIC_SET(ip->init_done, 1);
+          if (error == 0)
+            ATOMIC_SET(ip->init_done, 1);
           break;
         }
 

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -237,10 +237,7 @@ uintptr_t event_insert_thread(void *p) {
           ENGINE_STATE *engine_state = inst[rp].engine_state;
           TYPE_TABLE *type_table = inst[rp].type_table;
           OPDS *ids = inst[rp].ids;
-          csoundSpinLock(&csound->alloc_spinlock);
-          named_instr_assign_numbers(csound, engine_state);
-          merge_state(csound, engine_state, type_table, ids);
-          csoundSpinUnLock(&csound->alloc_spinlock);
+          merge_state_realtime(csound, engine_state, type_table, ids);
         }
         if (inst[rp].type == 3)  {
           INSDS *ip = inst[rp].ip;

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -45,6 +45,48 @@ static int32_t insert_midi(CSOUND *csound, int32_t insno, MCHNBLK *chn,
 static int32_t insert(CSOUND *csound, int32_t insno, EVTBLK *newevtp);
 static void maxalloc_turnoff(CSOUND *csound, int32_t insno);
 
+static void alloc_queue_lock(CSOUND *csound)
+{
+  if (csound->alloc_queue_mutex != NULL)
+    csoundLockMutex(csound->alloc_queue_mutex);
+  else
+    csoundSpinLock(&csound->alloc_queue_spinlock);
+}
+
+static void alloc_queue_unlock(CSOUND *csound)
+{
+  if (csound->alloc_queue_mutex != NULL)
+    csoundUnlockMutex(csound->alloc_queue_mutex);
+  else
+    csoundSpinUnLock(&csound->alloc_queue_spinlock);
+}
+
+int32_t alloc_queue_lock_init(CSOUND *csound)
+{
+  csound->alloc_queue_mutex = NULL;
+  csound->alloc_queue_items = 0;
+  csound->alloc_queue_wp = 0;
+#if CSOUND_SPINLOCK_AVAILABLE
+  if (csoundSpinLockInit(&csound->alloc_queue_spinlock) == CSOUND_SUCCESS)
+    return CSOUND_SUCCESS;
+#endif
+  csound->alloc_queue_mutex = csoundCreateMutex(0);
+  return csound->alloc_queue_mutex != NULL ? CSOUND_SUCCESS : CSOUND_ERROR;
+}
+
+void alloc_queue_lock_destroy(CSOUND *csound)
+{
+  if (csound->alloc_queue_mutex != NULL) {
+    csoundDestroyMutex(csound->alloc_queue_mutex);
+    csound->alloc_queue_mutex = NULL;
+  }
+#if defined(__GNUC__) && defined(HAVE_PTHREAD_SPIN_LOCK)
+  else {
+    pthread_spin_destroy(&csound->alloc_queue_spinlock);
+  }
+#endif
+}
+
 /* Reserve, fill, and publish a realtime allocation request. */
 int32_t alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data)
 {
@@ -54,17 +96,34 @@ int32_t alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data)
   if (UNLIKELY(csound->alloc_queue == NULL))
     return CSOUND_ERROR;
 
-  csoundSpinLock(&csound->alloc_queue_spinlock);
-  if (UNLIKELY(ATOMIC_GET(csound->alloc_queue_items) >= MAX_ALLOC_QUEUE)) {
+  alloc_queue_lock(csound);
+  if (UNLIKELY(csound->alloc_queue_items >= MAX_ALLOC_QUEUE)) {
     result = CSOUND_ERROR;
   }
   else {
     wp = csound->alloc_queue_wp;
     csound->alloc_queue[wp] = *data;
     csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
-    ATOMIC_INCR(csound->alloc_queue_items);
+    csound->alloc_queue_items++;
   }
-  csoundSpinUnLock(&csound->alloc_queue_spinlock);
+  alloc_queue_unlock(csound);
+  return result;
+}
+
+static int32_t alloc_queue_dequeue(CSOUND *csound, ALLOC_DATA *data,
+                                   unsigned long *readPosition)
+{
+  int32_t result = 0;
+
+  alloc_queue_lock(csound);
+  if (csound->alloc_queue_items > 0) {
+    *data = csound->alloc_queue[*readPosition];
+    *readPosition = *readPosition + 1 < MAX_ALLOC_QUEUE ?
+      *readPosition + 1 : 0;
+    csound->alloc_queue_items--;
+    result = 1;
+  }
+  alloc_queue_unlock(csound);
   return result;
 }
 
@@ -202,7 +261,6 @@ static int32_t reinit_pass(CSOUND *csound, INSDS *ip, OPDS *ids) {
  */
 uintptr_t event_insert_thread(void *p) {
   CSOUND *csound = (CSOUND *) p;
-  ALLOC_DATA *inst = csound->alloc_queue;
   float wakeup = (1000*csound->ksmps/csound->esr);
   unsigned long rp = 0, items, rpm = 0;
   message_string_queue_t *mess = NULL;
@@ -228,48 +286,56 @@ uintptr_t event_insert_thread(void *p) {
   }
 
   while(csound->event_insert_loop) {
-    // get the value of items_to_alloc
-    items = ATOMIC_GET(csound->alloc_queue_items);
-    if(items == 0)
-      csoundSleep((int32_t) ((int32_t) wakeup > 0 ? wakeup : 1));
-    else while(items) {
-        if (inst[rp].type == ALLOC_DATA_MERGE_STATE) {
-          ENGINE_STATE *engine_state = inst[rp].engine_state;
-          TYPE_TABLE *type_table = inst[rp].type_table;
-          OPDS *ids = inst[rp].ids;
+    ALLOC_DATA data;
+    uint32_t processed = 0;
+
+    while (processed < MAX_ALLOC_QUEUE &&
+           alloc_queue_dequeue(csound, &data, &rp)) {
+      switch (data.type) {
+        case ALLOC_DATA_MERGE_STATE: {
+          ENGINE_STATE *engine_state = data.engine_state;
+          TYPE_TABLE *type_table = data.type_table;
+          OPDS *ids = data.ids;
           merge_state_realtime(csound, engine_state, type_table, ids);
+          break;
         }
-        if (inst[rp].type == 3)  {
-          INSDS *ip = inst[rp].ip;
-          OPDS *ids = inst[rp].ids;
+
+        case ALLOC_DATA_REINIT_PASS: {
+          INSDS *ip = data.ip;
+          OPDS *ids = data.ids;
           csoundSpinLock(&csound->alloc_spinlock);
           reinit_pass(csound, ip, ids);
           csoundSpinUnLock(&csound->alloc_spinlock);
           ATOMIC_SET(ip->init_done, 1);
+          break;
         }
-        if (inst[rp].type == 2)  {
-          INSDS *ip = inst[rp].ip;
+
+        case ALLOC_DATA_INIT_PASS: {
+          INSDS *ip = data.ip;
           ATOMIC_SET(ip->init_done, 0);
           csoundSpinLock(&csound->alloc_spinlock);
           init_pass(csound, ip);
           csoundSpinUnLock(&csound->alloc_spinlock);
           ATOMIC_SET(ip->init_done, 1);
+          break;
         }
-        if(inst[rp].type == 1) {
+
+        case ALLOC_DATA_MIDI_EVENT:
           csoundSpinLock(&csound->alloc_spinlock);
-          insert_midi(csound, inst[rp].insno, inst[rp].chn, &inst[rp].mep);
+          insert_midi(csound, data.insno, data.chn, &data.mep);
           csoundSpinUnLock(&csound->alloc_spinlock);
-        }
-        if(inst[rp].type == 0)  {
+          break;
+
+        case ALLOC_DATA_SCORE_EVENT:
           csoundSpinLock(&csound->alloc_spinlock);
-          insert(csound, inst[rp].insno, &inst[rp].blk);
+          insert(csound, data.insno, &data.blk);
           csoundSpinUnLock(&csound->alloc_spinlock);
-        }
-        // decrement the value of items_to_alloc
-        ATOMIC_DECR(csound->alloc_queue_items);
-        items--;
-        rp = rp + 1 < MAX_ALLOC_QUEUE ? rp + 1 : 0;
+          break;
       }
+      processed++;
+    }
+    if(processed == 0)
+      csoundSleep((int32_t) ((int32_t) wakeup > 0 ? wakeup : 1));
     items = ATOMIC_GET(csound->message_string_queue_items);
     while(items) {
       if(mess != NULL)
@@ -414,7 +480,7 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp) {
     ALLOC_DATA data = { 0 };
     data.insno = insno;
     data.blk =  *newevtp;
-    data.type = 0;
+    data.type = ALLOC_DATA_SCORE_EVENT;
     return alloc_queue_enqueue(csound, &data);
   }
   else return insert(csound, insno, newevtp);
@@ -768,7 +834,7 @@ int32_t insert_midi_event(CSOUND *csound, int32_t insno, MCHNBLK *chn,
     data.insno = insno;
     data.chn = chn;
     data.mep = *mep;
-    data.type = 1;
+    data.type = ALLOC_DATA_MIDI_EVENT;
     return alloc_queue_enqueue(csound, &data);
   }
   else return insert_midi(csound, insno, chn, mep);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -256,6 +256,28 @@ static int32_t reinit_pass(CSOUND *csound, INSDS *ip, OPDS *ids) {
   return error;
 }
 
+static int32_t realtime_init_pass(CSOUND *csound, INSDS *ip)
+{
+  int32_t error;
+
+  /* Init opcodes may acquire alloc_spinlock; the init mutex remains held. */
+  csoundSpinUnLock(&csound->alloc_spinlock);
+  error = init_pass(csound, ip);
+  csoundSpinLock(&csound->alloc_spinlock);
+  return error;
+}
+
+static int32_t realtime_reinit_pass(CSOUND *csound, INSDS *ip, OPDS *ids)
+{
+  int32_t error;
+
+  /* Reinit has the same lock requirements as the initial pass. */
+  csoundSpinUnLock(&csound->alloc_spinlock);
+  error = reinit_pass(csound, ip, ids);
+  csoundSpinLock(&csound->alloc_spinlock);
+  return error;
+}
+
 /*
  * creates a thread to process instance allocations
  */
@@ -291,6 +313,9 @@ uintptr_t event_insert_thread(void *p) {
 
     while (processed < MAX_ALLOC_QUEUE &&
            alloc_queue_dequeue(csound, &data, &rp)) {
+      /* Keep the common lock order: init mutex, then allocation lock. */
+      if (csound->init_pass_threadlock)
+        csoundLockMutex(csound->init_pass_threadlock);
       switch (data.type) {
         case ALLOC_DATA_MERGE_STATE: {
           ENGINE_STATE *engine_state = data.engine_state;
@@ -304,7 +329,7 @@ uintptr_t event_insert_thread(void *p) {
           INSDS *ip = data.ip;
           OPDS *ids = data.ids;
           csoundSpinLock(&csound->alloc_spinlock);
-          reinit_pass(csound, ip, ids);
+          realtime_reinit_pass(csound, ip, ids);
           csoundSpinUnLock(&csound->alloc_spinlock);
           ATOMIC_SET(ip->init_done, 1);
           break;
@@ -314,7 +339,7 @@ uintptr_t event_insert_thread(void *p) {
           INSDS *ip = data.ip;
           ATOMIC_SET(ip->init_done, 0);
           csoundSpinLock(&csound->alloc_spinlock);
-          init_pass(csound, ip);
+          realtime_init_pass(csound, ip);
           csoundSpinUnLock(&csound->alloc_spinlock);
           ATOMIC_SET(ip->init_done, 1);
           break;
@@ -332,6 +357,8 @@ uintptr_t event_insert_thread(void *p) {
           csoundSpinUnLock(&csound->alloc_spinlock);
           break;
       }
+      if (csound->init_pass_threadlock)
+        csoundUnlockMutex(csound->init_pass_threadlock);
       processed++;
     }
     if(processed == 0)
@@ -757,7 +784,8 @@ static int32_t insert_new(CSOUND *csound, int32_t insno,
 
   // current event needs to be reset here
   csound->init_event = newevtp;
-  error = init_pass(csound, ip);
+  error = csound->oparms->realtime ? realtime_init_pass(csound, ip) :
+    init_pass(csound, ip);
   if(error == 0)
     ATOMIC_SET(ip->init_done, 1);
   if (UNLIKELY(csound->inerrcnt || ip->p3.value == FL(0.0))) {
@@ -1063,7 +1091,8 @@ int32_t insert_midi(CSOUND *csound, int32_t insno, MCHNBLK *chn, MEVENT *mep)
    }
   } else csound->init_event = NULL;
 
-  error = init_pass(csound, ip);
+  error = csound->oparms->realtime ? realtime_init_pass(csound, ip) :
+    init_pass(csound, ip);
   if(evt.p) csound->Free(csound, evt.p);
   csound->init_event = NULL;
   if(error == 0)

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -45,17 +45,27 @@ static int32_t insert_midi(CSOUND *csound, int32_t insno, MCHNBLK *chn,
 static int32_t insert(CSOUND *csound, int32_t insno, EVTBLK *newevtp);
 static void maxalloc_turnoff(CSOUND *csound, int32_t insno);
 
-/* Reserve, fill, and publish realtime allocation queue slots in producer order. */
-void alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data)
+/* Reserve, fill, and publish a realtime allocation request. */
+int32_t alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data)
 {
   unsigned long wp;
+  int32_t result = CSOUND_SUCCESS;
+
+  if (UNLIKELY(csound->alloc_queue == NULL))
+    return CSOUND_ERROR;
 
   csoundSpinLock(&csound->alloc_queue_spinlock);
-  wp = csound->alloc_queue_wp;
-  csound->alloc_queue[wp] = *data;
-  csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
-  ATOMIC_INCR(csound->alloc_queue_items);
+  if (UNLIKELY(ATOMIC_GET(csound->alloc_queue_items) >= MAX_ALLOC_QUEUE)) {
+    result = CSOUND_ERROR;
+  }
+  else {
+    wp = csound->alloc_queue_wp;
+    csound->alloc_queue[wp] = *data;
+    csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
+    ATOMIC_INCR(csound->alloc_queue_items);
+  }
   csoundSpinUnLock(&csound->alloc_queue_spinlock);
+  return result;
 }
 
 /* Helper function to get type string from argument without unsafe casting */
@@ -408,8 +418,7 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp) {
     data.insno = insno;
     data.blk =  *newevtp;
     data.type = 0;
-    alloc_queue_enqueue(csound, &data);
-    return 0;
+    return alloc_queue_enqueue(csound, &data) == CSOUND_SUCCESS ? 0 : 1;
   }
   else return insert(csound, insno, newevtp);
 }
@@ -763,8 +772,7 @@ int32_t insert_midi_event(CSOUND *csound, int32_t insno, MCHNBLK *chn,
     data.chn = chn;
     data.mep = *mep;
     data.type = 1;
-    alloc_queue_enqueue(csound, &data);
-    return 0;
+    return alloc_queue_enqueue(csound, &data) == CSOUND_SUCCESS ? 0 : 1;
   }
   else return insert_midi(csound, insno, chn, mep);
 

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -45,6 +45,19 @@ static int32_t insert_midi(CSOUND *csound, int32_t insno, MCHNBLK *chn,
 static int32_t insert(CSOUND *csound, int32_t insno, EVTBLK *newevtp);
 static void maxalloc_turnoff(CSOUND *csound, int32_t insno);
 
+/* Reserve, fill, and publish realtime allocation queue slots in producer order. */
+void alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data)
+{
+  unsigned long wp;
+
+  csoundSpinLock(&csound->alloc_queue_spinlock);
+  wp = csound->alloc_queue_wp;
+  csound->alloc_queue[wp] = *data;
+  csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
+  ATOMIC_INCR(csound->alloc_queue_items);
+  csoundSpinUnLock(&csound->alloc_queue_spinlock);
+}
+
 /* Helper function to get type string from argument without unsafe casting */
 static char* get_arg_type_from_arg(ARG *arg, CS_VARIABLE **var) {
     if (arg->type == ARG_CONSTANT) {
@@ -210,6 +223,15 @@ uintptr_t event_insert_thread(void *p) {
     if(items == 0)
       csoundSleep((int32_t) ((int32_t) wakeup > 0 ? wakeup : 1));
     else while(items) {
+        if (inst[rp].type == ALLOC_DATA_MERGE_STATE) {
+          ENGINE_STATE *engine_state = inst[rp].engine_state;
+          TYPE_TABLE *type_table = inst[rp].type_table;
+          OPDS *ids = inst[rp].ids;
+          csoundSpinLock(&csound->alloc_spinlock);
+          named_instr_assign_numbers(csound, engine_state);
+          merge_state(csound, engine_state, type_table, ids);
+          csoundSpinUnLock(&csound->alloc_spinlock);
+        }
         if (inst[rp].type == 3)  {
           INSDS *ip = inst[rp].ip;
           OPDS *ids = inst[rp].ids;
@@ -382,12 +404,11 @@ static void set_xtratim(CSOUND *csound, INSDS *ip)
 int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp) {
 
   if(csound->oparms->realtime) {
-    unsigned long wp = csound->alloc_queue_wp;
-    csound->alloc_queue[wp].insno = insno;
-    csound->alloc_queue[wp].blk =  *newevtp;
-    csound->alloc_queue[wp].type = 0;
-    csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
-    ATOMIC_INCR(csound->alloc_queue_items);
+    ALLOC_DATA data = { 0 };
+    data.insno = insno;
+    data.blk =  *newevtp;
+    data.type = 0;
+    alloc_queue_enqueue(csound, &data);
     return 0;
   }
   else return insert(csound, insno, newevtp);
@@ -737,13 +758,12 @@ int32_t insert_midi_event(CSOUND *csound, int32_t insno, MCHNBLK *chn,
                           MEVENT *mep) {
 
   if(csound->oparms->realtime) {
-    unsigned long wp = csound->alloc_queue_wp;
-    csound->alloc_queue[wp].insno = insno;
-    csound->alloc_queue[wp].chn = chn;
-    csound->alloc_queue[wp].mep = *mep;
-    csound->alloc_queue[wp].type = 1;
-    csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
-    ATOMIC_INCR(csound->alloc_queue_items);
+    ALLOC_DATA data = { 0 };
+    data.insno = insno;
+    data.chn = chn;
+    data.mep = *mep;
+    data.type = 1;
+    alloc_queue_enqueue(csound, &data);
     return 0;
   }
   else return insert_midi(csound, insno, chn, mep);

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -127,6 +127,67 @@ static int32_t alloc_queue_dequeue(CSOUND *csound, ALLOC_DATA *data,
   return result;
 }
 
+static size_t evtblk_strarg_size(const EVTBLK *src)
+{
+  char *end = src->strarg;
+  int32_t n = src->scnt;
+
+  if (end == NULL)
+    return 0;
+
+  if (n <= 0)
+    return strlen(end) + 1;
+
+  while (n--)
+    end += strlen(end) + 1;
+  return (size_t)(end - src->strarg);
+}
+
+static void free_queued_evtblk_pfields(CSOUND *csound, EVTBLK *evt)
+{
+  if (evt->p != NULL) {
+    csound->Free(csound, evt->p);
+    evt->p = NULL;
+  }
+}
+
+static void free_queued_evtblk(CSOUND *csound, EVTBLK *evt)
+{
+  free_queued_evtblk_pfields(csound, evt);
+  if (evt->strarg != NULL) {
+    csound->Free(csound, evt->strarg);
+    evt->strarg = NULL;
+  }
+}
+
+static int32_t copy_evtblk_for_queue(CSOUND *csound, EVTBLK *dst,
+                                     const EVTBLK *src)
+{
+  *dst = *src;
+  dst->p = NULL;
+  dst->strarg = NULL;
+
+  if (src->p != NULL && src->pcnt >= 0) {
+    size_t bytes = sizeof(MYFLT) * ((size_t)src->pcnt + 1U);
+    dst->p = (MYFLT *) csound->Malloc(csound, bytes);
+    if (UNLIKELY(dst->p == NULL))
+      return CSOUND_MEMORY;
+    memcpy(dst->p, src->p, bytes);
+  }
+
+  if (src->strarg != NULL) {
+    size_t bytes = evtblk_strarg_size(src);
+    dst->strarg = (char *) csound->Malloc(csound, bytes);
+    if (UNLIKELY(dst->strarg == NULL)) {
+      free_queued_evtblk(csound, dst);
+      return CSOUND_MEMORY;
+    }
+    memcpy(dst->strarg, src->strarg, bytes);
+  }
+
+  return CSOUND_SUCCESS;
+}
+
 /* Helper function to get type string from argument without unsafe casting */
 static char* get_arg_type_from_arg(ARG *arg, CS_VARIABLE **var) {
     if (arg->type == ARG_CONSTANT) {
@@ -356,10 +417,21 @@ uintptr_t event_insert_thread(void *p) {
           break;
 
         case ALLOC_DATA_SCORE_EVENT:
+        {
+          int32_t result;
           csoundSpinLock(&csound->alloc_spinlock);
-          insert(csound, data.insno, &data.blk);
+          result = insert(csound, data.insno, &data.blk);
           csoundSpinUnLock(&csound->alloc_spinlock);
+          if (result == 0) {
+            /* insert() copies p-fields, but keeps strarg for INSDS::strarg. */
+            free_queued_evtblk_pfields(csound, &data.blk);
+            data.blk.strarg = NULL;
+          }
+          else {
+            free_queued_evtblk(csound, &data.blk);
+          }
           break;
+        }
       }
       if (csound->init_pass_threadlock)
         csoundUnlockMutex(csound->init_pass_threadlock);
@@ -509,10 +581,16 @@ int32_t insert_event(CSOUND *csound, int32_t insno, EVTBLK *newevtp) {
 
   if(csound->oparms->realtime) {
     ALLOC_DATA data = { 0 };
+    int32_t result;
     data.insno = insno;
-    data.blk =  *newevtp;
     data.type = ALLOC_DATA_SCORE_EVENT;
-    return alloc_queue_enqueue(csound, &data);
+    result = copy_evtblk_for_queue(csound, &data.blk, newevtp);
+    if (UNLIKELY(result != CSOUND_SUCCESS))
+      return result;
+    result = alloc_queue_enqueue(csound, &data);
+    if (UNLIKELY(result != CSOUND_SUCCESS))
+      free_queued_evtblk(csound, &data.blk);
+    return result;
   }
   else return insert(csound, insno, newevtp);
 }

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -36,7 +36,8 @@
 #define SEGAMPS CS_AMPLMSG
 #define SORMSG  CS_RNGEMSG
 
-#ifdef HAVE_PTHREAD_SPIN_LOCK
+#if defined(HAVE_PTHREAD_SPIN_LOCK) || defined(MSVC) || defined(MACOSX) || \
+    (defined(__GNUC__) && defined(HAVE_ATOMIC_BUILTIN))
 #define RT_SPIN_TRYLOCK { int32_t trylock = CSOUND_SUCCESS; \
   if(csound->oparms->realtime)             \
     trylock = csoundSpinTryLock(&csound->alloc_spinlock);      \
@@ -45,7 +46,8 @@
 #define RT_SPIN_TRYLOCK csoundSpinLock(&csound->alloc_spinlock);
 #endif
 
-#ifdef HAVE_PTHREAD_SPIN_LOCK
+#if defined(HAVE_PTHREAD_SPIN_LOCK) || defined(MSVC) || defined(MACOSX) || \
+    (defined(__GNUC__) && defined(HAVE_ATOMIC_BUILTIN))
 #define RT_SPIN_UNLOCK \
   if(csound->oparms->realtime) \
     csoundSpinUnLock(&csound->alloc_spinlock); \

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -952,13 +952,22 @@ static void process_midi_event(CSOUND *csound, MEVENT *mep, MCHNBLK *chn)
   if (mep->type == NOTEON_TYPE && mep->dat2) {      /* midi note ON: */
     if (UNLIKELY((n = insert_midi_event(csound, insno, chn, mep)))) {
       /* alloc,init,activ */
+      char *name = csound->engineState.instrtxtp[insno]->insname;
       csound->ErrorMsg(csound,
                       Str("\t\t   T%7.3f - note deleted. "), csound->curp2);
-      if (n == CSOUND_ERROR)
-        csound->ErrorMsg(csound,
-                         Str("realtime allocation queue is full\n"));
+      if (n == CSOUND_ERROR) {
+        if (name)
+          csound->ErrorMsg(csound,
+                           Str("\nINIT ERROR in instr %s: note deleted "
+                               "(realtime allocation queue is full)\n"),
+                           name);
+        else
+          csound->ErrorMsg(csound,
+                           Str("\nINIT ERROR in instr %d: note deleted "
+                               "(realtime allocation queue is full)\n"),
+                           insno);
+      }
       else {
-        char *name = csound->engineState.instrtxtp[insno]->insname;
         if (name)
           csound->ErrorMsg(csound, Str("\nINIT ERROR in instr %s: note deleted (%d init errors)\n"),
                           name, n);

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -789,6 +789,18 @@ static CS_NOINLINE void print_score_error(CSOUND *p, int32_t rtEvt,
   p->perferrcnt++;
 }
 
+static const char *realtime_event_error_reason(int32_t status)
+{
+  switch (status) {
+  case CSOUND_ERROR:
+    return Str("realtime allocation queue is full");
+  case CSOUND_MEMORY:
+    return Str("out of memory while copying realtime event");
+  default:
+    return NULL;
+  }
+}
+
 static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
 {
   EVTBLK  *saved_currevent;
@@ -868,11 +880,19 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
       /* else alloc, init, activate */
       if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
         /* Use a consistent INIT ERROR prefix so frontends can parse it */
-        if (n == CSOUND_ERROR)
-          print_score_error(csound, rtEvt,
-                            Str("\nINIT ERROR in instr %d (%s): note "
-                                "deleted (realtime allocation queue is full)"),
-                            insno, evt->strarg);
+        if (n < 0) {
+          const char *reason = realtime_event_error_reason(n);
+          if (reason != NULL)
+            print_score_error(csound, rtEvt,
+                              Str("\nINIT ERROR in instr %d (%s): note "
+                                  "deleted (%s)"),
+                              insno, evt->strarg, reason);
+          else
+            print_score_error(csound, rtEvt,
+                              Str("\nINIT ERROR in instr %d (%s): note "
+                                  "deleted (realtime event failed with status %d)"),
+                              insno, evt->strarg, n);
+        }
         else
           print_score_error(csound, rtEvt,
                             Str("\nINIT ERROR in instr %d (%s): note "
@@ -906,11 +926,19 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
           evt->p[3] = evt->p3orig * (MYFLT) csound->ibeatTime/csound->esr;
         if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
           /* Use a consistent INIT ERROR prefix so frontends can parse it */
-          if (n == CSOUND_ERROR)
-            print_score_error(csound, rtEvt,
-                              Str("\nINIT ERROR in instr %d: note deleted "
-                                  "(realtime allocation queue is full)"),
-                              insno);
+          if (n < 0) {
+            const char *reason = realtime_event_error_reason(n);
+            if (reason != NULL)
+              print_score_error(csound, rtEvt,
+                                Str("\nINIT ERROR in instr %d: note deleted "
+                                    "(%s)"),
+                                insno, reason);
+            else
+              print_score_error(csound, rtEvt,
+                                Str("\nINIT ERROR in instr %d: note deleted "
+                                    "(realtime event failed with status %d)"),
+                                insno, n);
+          }
           else
             print_score_error(csound, rtEvt,
                               Str("\nINIT ERROR in instr %d: note deleted "
@@ -955,17 +983,32 @@ static void process_midi_event(CSOUND *csound, MEVENT *mep, MCHNBLK *chn)
       char *name = csound->engineState.instrtxtp[insno]->insname;
       csound->ErrorMsg(csound,
                       Str("\t\t   T%7.3f - note deleted. "), csound->curp2);
-      if (n == CSOUND_ERROR) {
-        if (name)
-          csound->ErrorMsg(csound,
-                           Str("\nINIT ERROR in instr %s: note deleted "
-                               "(realtime allocation queue is full)\n"),
-                           name);
-        else
-          csound->ErrorMsg(csound,
-                           Str("\nINIT ERROR in instr %d: note deleted "
-                               "(realtime allocation queue is full)\n"),
-                           insno);
+      if (n < 0) {
+        const char *reason = realtime_event_error_reason(n);
+        if (reason != NULL) {
+          if (name)
+            csound->ErrorMsg(csound,
+                             Str("\nINIT ERROR in instr %s: note deleted "
+                                 "(%s)\n"),
+                             name, reason);
+          else
+            csound->ErrorMsg(csound,
+                             Str("\nINIT ERROR in instr %d: note deleted "
+                                 "(%s)\n"),
+                             insno, reason);
+        }
+        else {
+          if (name)
+            csound->ErrorMsg(csound,
+                             Str("\nINIT ERROR in instr %s: note deleted "
+                                 "(realtime event failed with status %d)\n"),
+                             name, n);
+          else
+            csound->ErrorMsg(csound,
+                             Str("\nINIT ERROR in instr %d: note deleted "
+                                 "(realtime event failed with status %d)\n"),
+                             insno, n);
+        }
       }
       else {
         if (name)

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -833,10 +833,16 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
         evt->p[3] = evt->p3orig * (MYFLT) csound->ibeatTime/csound->esr;
       /* else alloc, init, activate */
       if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
-        /* Use a consistent INIT ERROR prefix so frontends can parse it */
-        print_score_error(csound, rtEvt,
-                        Str("\nINIT ERROR in instr %d (%s): note deleted (%d init errors)"),
-                        insno, evt->strarg, n);
+        if (n == CSOUND_ERROR)
+          print_score_error(csound, rtEvt,
+                            Str(" - note deleted. realtime allocation "
+                                "queue is full"));
+        else
+          /* Use a consistent INIT ERROR prefix so frontends can parse it */
+          print_score_error(csound, rtEvt,
+                            Str("\nINIT ERROR in instr %d (%s): note "
+                                "deleted (%d init errors)"),
+                            insno, evt->strarg, n);
       }
     }
     else {                                        /* IV - Oct 31 2002 */
@@ -864,11 +870,16 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
         if (csound->oparms->Beatmode && !rtEvt && evt->p3orig > FL(0.0))
           evt->p[3] = evt->p3orig * (MYFLT) csound->ibeatTime/csound->esr;
         if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
-          /* else alloc, init, activate */
-          /* Use a consistent INIT ERROR prefix so frontends can parse it */
-          print_score_error(csound, rtEvt,
-                          Str("\nINIT ERROR in instr %d: note deleted (%d init errors)"),
-                          insno, n);
+          if (n == CSOUND_ERROR)
+            print_score_error(csound, rtEvt,
+                              Str(" - note deleted. realtime allocation "
+                                  "queue is full"));
+          else
+            /* Use a consistent INIT ERROR prefix so frontends can parse it */
+            print_score_error(csound, rtEvt,
+                              Str("\nINIT ERROR in instr %d: note deleted "
+                                  "(%d init errors)"),
+                              insno, n);
         }
       }
     }
@@ -907,7 +918,10 @@ static void process_midi_event(CSOUND *csound, MEVENT *mep, MCHNBLK *chn)
       /* alloc,init,activ */
       csound->ErrorMsg(csound,
                       Str("\t\t   T%7.3f - note deleted. "), csound->curp2);
-      {
+      if (n == CSOUND_ERROR)
+        csound->ErrorMsg(csound,
+                         Str("realtime allocation queue is full\n"));
+      else {
         char *name = csound->engineState.instrtxtp[insno]->insname;
         if (name)
           csound->ErrorMsg(csound, Str("\nINIT ERROR in instr %s: note deleted (%d init errors)\n"),

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -327,7 +327,8 @@ int32_t start_engine(CSOUND *csound)
 
 #ifndef __EMSCRIPTEN__
     if (csound->oparms->realtime && csound->event_insert_loop == 0){
-      csound->init_pass_threadlock = csoundCreateMutex(0);
+      /* Init-time compile opcodes re-enter this lock while merging state. */
+      csound->init_pass_threadlock = csoundCreateMutex(1);
       csound->ErrorMsg(csound, "Initialising spinlock...\n");
       csoundSpinLockInit(&csound->alloc_queue_spinlock);
       csoundSpinLockInit(&csound->alloc_spinlock);

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -327,6 +327,7 @@ int32_t start_engine(CSOUND *csound)
     if (csound->oparms->realtime && csound->event_insert_loop == 0){
       csound->init_pass_threadlock = csoundCreateMutex(0);
       csound->ErrorMsg(csound, "Initialising spinlock...\n");
+      csoundSpinLockInit(&csound->alloc_queue_spinlock);
       csoundSpinLockInit(&csound->alloc_spinlock);
       csound->event_insert_loop = 1;
       csound->alloc_queue = (ALLOC_DATA *)

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -833,12 +833,13 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
         evt->p[3] = evt->p3orig * (MYFLT) csound->ibeatTime/csound->esr;
       /* else alloc, init, activate */
       if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
+        /* Use a consistent INIT ERROR prefix so frontends can parse it */
         if (n == CSOUND_ERROR)
           print_score_error(csound, rtEvt,
-                            Str(" - note deleted. realtime allocation "
-                                "queue is full"));
+                            Str("\nINIT ERROR in instr %d (%s): note "
+                                "deleted (realtime allocation queue is full)"),
+                            insno, evt->strarg);
         else
-          /* Use a consistent INIT ERROR prefix so frontends can parse it */
           print_score_error(csound, rtEvt,
                             Str("\nINIT ERROR in instr %d (%s): note "
                                 "deleted (%d init errors)"),
@@ -870,12 +871,13 @@ static int32_t process_score_event(CSOUND *csound, EVTBLK *evt, int32_t rtEvt)
         if (csound->oparms->Beatmode && !rtEvt && evt->p3orig > FL(0.0))
           evt->p[3] = evt->p3orig * (MYFLT) csound->ibeatTime/csound->esr;
         if (UNLIKELY((n = insert_event(csound, insno, evt)))) {
+          /* Use a consistent INIT ERROR prefix so frontends can parse it */
           if (n == CSOUND_ERROR)
             print_score_error(csound, rtEvt,
-                              Str(" - note deleted. realtime allocation "
-                                  "queue is full"));
+                              Str("\nINIT ERROR in instr %d: note deleted "
+                                  "(realtime allocation queue is full)"),
+                              insno);
           else
-            /* Use a consistent INIT ERROR prefix so frontends can parse it */
             print_score_error(csound, rtEvt,
                               Str("\nINIT ERROR in instr %d: note deleted "
                                   "(%d init errors)"),

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -36,8 +36,7 @@
 #define SEGAMPS CS_AMPLMSG
 #define SORMSG  CS_RNGEMSG
 
-#if defined(HAVE_PTHREAD_SPIN_LOCK) || defined(MSVC) || defined(MACOSX) || \
-    (defined(__GNUC__) && defined(HAVE_ATOMIC_BUILTIN))
+#if CSOUND_SPINLOCK_AVAILABLE
 #define RT_SPIN_TRYLOCK { int32_t trylock = CSOUND_SUCCESS; \
   if(csound->oparms->realtime)             \
     trylock = csoundSpinTryLock(&csound->alloc_spinlock);      \
@@ -46,8 +45,7 @@
 #define RT_SPIN_TRYLOCK csoundSpinLock(&csound->alloc_spinlock);
 #endif
 
-#if defined(HAVE_PTHREAD_SPIN_LOCK) || defined(MSVC) || defined(MACOSX) || \
-    (defined(__GNUC__) && defined(HAVE_ATOMIC_BUILTIN))
+#if CSOUND_SPINLOCK_AVAILABLE
 #define RT_SPIN_UNLOCK \
   if(csound->oparms->realtime) \
     csoundSpinUnLock(&csound->alloc_spinlock); \
@@ -329,15 +327,45 @@ int32_t start_engine(CSOUND *csound)
     if (csound->oparms->realtime && csound->event_insert_loop == 0){
       /* Init-time compile opcodes re-enter this lock while merging state. */
       csound->init_pass_threadlock = csoundCreateMutex(1);
-      csound->ErrorMsg(csound, "Initialising spinlock...\n");
-      csoundSpinLockInit(&csound->alloc_queue_spinlock);
+      if (UNLIKELY(csound->init_pass_threadlock == NULL)) {
+        csound->ErrorMsg(csound, "%s", Str("Failed to initialise realtime "
+                                             "init lock\n"));
+        return CSOUND_ERROR;
+      }
+      csound->ErrorMsg(csound, "Initialising realtime allocation queue...\n");
+      if (UNLIKELY(alloc_queue_lock_init(csound) != CSOUND_SUCCESS)) {
+        csound->ErrorMsg(csound, "%s", Str("Failed to initialise realtime "
+                                             "allocation queue lock\n"));
+        csoundDestroyMutex(csound->init_pass_threadlock);
+        csound->init_pass_threadlock = NULL;
+        return CSOUND_ERROR;
+      }
       csoundSpinLockInit(&csound->alloc_spinlock);
-      csound->event_insert_loop = 1;
       csound->alloc_queue = (ALLOC_DATA *)
         csound->Calloc(csound, sizeof(ALLOC_DATA)*MAX_ALLOC_QUEUE);
+      if (UNLIKELY(csound->alloc_queue == NULL)) {
+        csound->ErrorMsg(csound, "%s", Str("Failed to allocate realtime "
+                                             "allocation queue\n"));
+        alloc_queue_lock_destroy(csound);
+        csoundDestroyMutex(csound->init_pass_threadlock);
+        csound->init_pass_threadlock = NULL;
+        return CSOUND_MEMORY;
+      }
+      csound->event_insert_loop = 1;
       csound->event_insert_thread =
         csound->CreateThread(event_insert_thread,
                              (void*)csound);
+      if (UNLIKELY(csound->event_insert_thread == NULL)) {
+        csound->event_insert_loop = 0;
+        alloc_queue_lock_destroy(csound);
+        csoundDestroyMutex(csound->init_pass_threadlock);
+        csound->init_pass_threadlock = NULL;
+        csound->Free(csound, csound->alloc_queue);
+        csound->alloc_queue = NULL;
+        csound->ErrorMsg(csound, "%s", Str("Failed to start realtime "
+                                             "allocation queue thread\n"));
+        return CSOUND_ERROR;
+      }
       csound->ErrorMsg(csound, "Starting realtime mode queue: %p thread: %p\n",
                       csound->alloc_queue, csound->event_insert_thread );
     }
@@ -413,7 +441,13 @@ static void stop_event_insert_thread(CSOUND *csound)
     if (csound->event_insert_thread != NULL) {
       csound->event_insert_loop = 0;
       csound->JoinThread(csound->event_insert_thread);
+      alloc_queue_lock_destroy(csound);
+      csound->Free(csound, csound->alloc_queue);
+      csound->alloc_queue = NULL;
+      csound->alloc_queue_items = 0;
+      csound->alloc_queue_wp = 0;
       csoundDestroyMutex(csound->init_pass_threadlock);
+      csound->init_pass_threadlock = NULL;
       csound->event_insert_thread = 0;
     }
 }

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -233,6 +233,7 @@ extern "C" {
   } MODULE_INFO;
 
 #define MAX_ALLOC_QUEUE 1024
+#define ALLOC_DATA_MERGE_STATE 4
   typedef struct _alloc_data_ {
     int32_t type;
     int32_t insno;
@@ -241,6 +242,8 @@ extern "C" {
     MEVENT mep;
     INSDS *ip;
     OPDS *ids;
+    ENGINE_STATE *engine_state;
+    struct type_table *type_table;
   } ALLOC_DATA;
 
 #define MAX_MESSAGE_STR 1024

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -233,6 +233,10 @@ extern "C" {
   } MODULE_INFO;
 
 #define MAX_ALLOC_QUEUE 1024
+#define ALLOC_DATA_SCORE_EVENT 0
+#define ALLOC_DATA_MIDI_EVENT 1
+#define ALLOC_DATA_INIT_PASS 2
+#define ALLOC_DATA_REINIT_PASS 3
 #define ALLOC_DATA_MERGE_STATE 4
   typedef struct _alloc_data_ {
     int32_t type;

--- a/H/csound_orc_compile.h
+++ b/H/csound_orc_compile.h
@@ -42,4 +42,6 @@ int32_t query_reversewrite_opcode(CSOUND *csound, ORCTOKEN *o);
 void named_instr_assign_numbers(CSOUND *csound, ENGINE_STATE *engineState);
 void merge_state(CSOUND *csound, ENGINE_STATE *engineState,
                  TYPE_TABLE *typetable, OPDS *ids); 
+void merge_state_realtime(CSOUND *csound, ENGINE_STATE *engineState,
+                          TYPE_TABLE *typetable, OPDS *ids);
 #endif

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -85,7 +85,7 @@ extern "C" {
   void free_instr_var_memory(CSOUND* csound, INSDS* ip);
   int32_t init_instance(CSOUND *csound, INSDS *ip, EVTBLK *newevtp);
   int32_t instr_context_check(CSOUND *csound, INSDS *ip, INSDS *insdshead);
-  void alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data);
+  int32_t alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data);
   int32_t insert_midi_event(CSOUND *, int32_t,  MCHNBLK*, MEVENT*);
   int32_t insert_event(CSOUND *, int32_t,  EVTBLK*);
   void free_inactive_instances(CSOUND*);

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -87,6 +87,8 @@ extern "C" {
   int32_t instr_context_check(CSOUND *csound, INSDS *ip, INSDS *insdshead);
   int32_t alloc_queue_enqueue(CSOUND *csound,
                               const struct _alloc_data_ *data);
+  int32_t alloc_queue_lock_init(CSOUND *csound);
+  void alloc_queue_lock_destroy(CSOUND *csound);
   int32_t insert_midi_event(CSOUND *, int32_t,  MCHNBLK*, MEVENT*);
   int32_t insert_event(CSOUND *, int32_t,  EVTBLK*);
   void free_inactive_instances(CSOUND*);

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -27,6 +27,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+  typedef struct _alloc_data_ ALLOC_DATA;
   void *csoundMalloc(CSOUND *, size_t);
   void *csoundCalloc(CSOUND *, size_t);
   void *csoundCallocAligned(CSOUND *, size_t, size_t);  
@@ -84,6 +85,7 @@ extern "C" {
   void free_instr_var_memory(CSOUND* csound, INSDS* ip);
   int32_t init_instance(CSOUND *csound, INSDS *ip, EVTBLK *newevtp);
   int32_t instr_context_check(CSOUND *csound, INSDS *ip, INSDS *insdshead);
+  void alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data);
   int32_t insert_midi_event(CSOUND *, int32_t,  MCHNBLK*, MEVENT*);
   int32_t insert_event(CSOUND *, int32_t,  EVTBLK*);
   void free_inactive_instances(CSOUND*);

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -27,7 +27,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  typedef struct _alloc_data_ ALLOC_DATA;
+  struct _alloc_data_;
   void *csoundMalloc(CSOUND *, size_t);
   void *csoundCalloc(CSOUND *, size_t);
   void *csoundCallocAligned(CSOUND *, size_t, size_t);  
@@ -85,7 +85,8 @@ extern "C" {
   void free_instr_var_memory(CSOUND* csound, INSDS* ip);
   int32_t init_instance(CSOUND *csound, INSDS *ip, EVTBLK *newevtp);
   int32_t instr_context_check(CSOUND *csound, INSDS *ip, INSDS *insdshead);
-  int32_t alloc_queue_enqueue(CSOUND *csound, const ALLOC_DATA *data);
+  int32_t alloc_queue_enqueue(CSOUND *csound,
+                              const struct _alloc_data_ *data);
   int32_t insert_midi_event(CSOUND *, int32_t,  MCHNBLK*, MEVENT*);
   int32_t insert_event(CSOUND *, int32_t,  EVTBLK*);
   void free_inactive_instances(CSOUND*);

--- a/OOps/goto_ops.c
+++ b/OOps/goto_ops.c
@@ -113,14 +113,23 @@ int32_t reinit(CSOUND *csound, GOTO *p)
     csound->reinitflag = p->h.insdshead->reinitflag = 0;
   }
   else {
-    uint64_t wp = csound->alloc_queue_wp;
+    int32_t init_done = ATOMIC_GET(p->h.insdshead->init_done);
+    int32_t actflg = ATOMIC_GET8(p->h.insdshead->actflg);
+    ALLOC_DATA data = { 0 };
+
     ATOMIC_SET(p->h.insdshead->init_done, 0);
     ATOMIC_SET8(p->h.insdshead->actflg, 0);
-    csound->alloc_queue[wp].ip = p->h.insdshead;
-    csound->alloc_queue[wp].ids = p->lblblk->prvi;
-    csound->alloc_queue[wp].type = 3;
-    csound->alloc_queue_wp = wp + 1 < MAX_ALLOC_QUEUE ? wp + 1 : 0;
-    ATOMIC_INCR(csound->alloc_queue_items);
+    data.ip = p->h.insdshead;
+    data.ids = p->lblblk->prvi;
+    data.type = 3;
+
+    if (UNLIKELY(alloc_queue_enqueue(csound, &data) != CSOUND_SUCCESS)) {
+      ATOMIC_SET(p->h.insdshead->init_done, init_done);
+      ATOMIC_SET8(p->h.insdshead->actflg, actflg);
+      csound->reinitflag = p->h.insdshead->reinitflag = 0;
+      return csound->PerfError(csound, &p->h, "%s",
+                               Str("reinit: realtime allocation queue is full"));
+    }
     return NOTOK;
   }
   return OK;

--- a/OOps/goto_ops.c
+++ b/OOps/goto_ops.c
@@ -121,7 +121,7 @@ int32_t reinit(CSOUND *csound, GOTO *p)
     ATOMIC_SET8(p->h.insdshead->actflg, 0);
     data.ip = p->h.insdshead;
     data.ids = p->lblblk->prvi;
-    data.type = 3;
+    data.type = ALLOC_DATA_REINIT_PASS;
 
     if (UNLIKELY(alloc_queue_enqueue(csound, &data) != CSOUND_SUCCESS)) {
       ATOMIC_SET(p->h.insdshead->init_done, init_done);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1082,6 +1082,7 @@ static const CSOUND cenviron_ = {
   NULL,           /* alloc_queue */
   0,              /* alloc_queue_items */
   0,              /* alloc_queue_wp */
+  SPINLOCK_INIT,  /* alloc_queue_spinlock */
   SPINLOCK_INIT,  /* alloc_spinlock */
   NULL,           /* init_event */
   NULL,           /* message_string */

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1083,6 +1083,7 @@ static const CSOUND cenviron_ = {
   0,              /* alloc_queue_items */
   0,              /* alloc_queue_wp */
   SPINLOCK_INIT,  /* alloc_queue_spinlock */
+  NULL,           /* alloc_queue_mutex */
   SPINLOCK_INIT,  /* alloc_spinlock */
   NULL,           /* init_event */
   NULL,           /* message_string */

--- a/Top/threadsafe.c
+++ b/Top/threadsafe.c
@@ -95,6 +95,7 @@ void allocate_message_queue(CSOUND *csound) {
 }
 
 
+
 /* enqueue should be called by the relevant API function */
 void *message_enqueue(CSOUND *csound, int32_t message, char *args,
                       int32_t argsiz) {
@@ -308,6 +309,17 @@ void kill_instance_enqueue(CSOUND *csound, MYFLT instr, int32_t insno,
    csound_compile_tree() in csound_orc_compile.c
 */
 void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE* t, OPDS *ids) {
+  if (csound->oparms->realtime && csound->event_insert_loop &&
+      csound->alloc_queue != NULL) {
+    ALLOC_DATA data = { 0 };
+    data.engine_state = e;
+    data.type_table = t;
+    data.ids = ids;
+    data.type = ALLOC_DATA_MERGE_STATE;
+    alloc_queue_enqueue(csound, &data);
+    return;
+  }
+
   const int32_t argsize = ARG_ALIGN*3;
   char args[ARG_ALIGN*3];
   memcpy(args, &e, sizeof(ENGINE_STATE *));
@@ -428,6 +440,3 @@ void csound_table_copy_in(CSOUND *csound, int32_t table, const MYFLT *ptable) {
   if (csound->oparms->realtime)
     csoundUnlockMutex(csound->init_pass_threadlock);
 }
-
-
-

--- a/Top/threadsafe.c
+++ b/Top/threadsafe.c
@@ -308,7 +308,8 @@ void kill_instance_enqueue(CSOUND *csound, MYFLT instr, int32_t insno,
 /* this is to be called from
    csound_compile_tree() in csound_orc_compile.c
 */
-void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE* t, OPDS *ids) {
+int32_t merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e,
+                            TYPE_TABLE *t, OPDS *ids) {
   if (csound->oparms->realtime && csound->event_insert_loop &&
       csound->alloc_queue != NULL) {
     ALLOC_DATA data = { 0 };
@@ -316,8 +317,7 @@ void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE* t, OPDS *i
     data.type_table = t;
     data.ids = ids;
     data.type = ALLOC_DATA_MERGE_STATE;
-    alloc_queue_enqueue(csound, &data);
-    return;
+    return alloc_queue_enqueue(csound, &data);
   }
 
   const int32_t argsize = ARG_ALIGN*3;
@@ -326,6 +326,7 @@ void merge_state_enqueue(CSOUND *csound, ENGINE_STATE *e, TYPE_TABLE* t, OPDS *i
   memcpy(args+ARG_ALIGN, &t, sizeof(TYPE_TABLE *));
   memcpy(args+2*ARG_ALIGN, &ids, sizeof(OPDS *));
   message_enqueue(csound,MERGE_STATE, args, argsize);
+  return CSOUND_SUCCESS;
 }
 
 /** Async versions of the functions above

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1791,6 +1791,7 @@ struct CSOUND_ {
   ALLOC_DATA *alloc_queue;
   volatile unsigned long alloc_queue_items;
   unsigned long alloc_queue_wp;
+  spin_lock_t alloc_queue_spinlock;
   spin_lock_t alloc_spinlock;
   EVTBLK *init_event;
   char *message_string;

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1792,6 +1792,7 @@ struct CSOUND_ {
   volatile unsigned long alloc_queue_items;
   unsigned long alloc_queue_wp;
   spin_lock_t alloc_queue_spinlock;
+  void *alloc_queue_mutex;
   spin_lock_t alloc_spinlock;
   EVTBLK *init_event;
   char *message_string;

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -579,6 +579,14 @@ typedef int32_t spin_lock_t;
 #define SPINLOCK_INIT 0
 #endif
 
+#if defined(MSVC) || defined(MACOSX) || \
+    (defined(__GNUC__) && (defined(HAVE_PTHREAD_SPIN_LOCK) || \
+                           defined(HAVE_ATOMIC_BUILTIN)))
+#define CSOUND_SPINLOCK_AVAILABLE 1
+#else
+#define CSOUND_SPINLOCK_AVAILABLE 0
+#endif
+
 #if (defined(__MACH__) || defined(ANDROID) || defined(NACL) \
   || defined(__CYGWIN__) || defined(__HAIKU__))
 #include <pthread.h>

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -33,6 +33,9 @@ if(BUILD_TESTS)
         ugen_test.cpp
     )
 
+    set(unittests_CFLAGS ${libcsound_CFLAGS})
+    list(REMOVE_ITEM unittests_CFLAGS -D__BUILDING_LIBCSOUND)
+    target_compile_options(unittests PRIVATE ${unittests_CFLAGS})
     target_compile_features(unittests PUBLIC cxx_std_17)
 
     target_include_directories(${CSOUNDLIB} PRIVATE ${libcsound_private_include_dirs})

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -3,6 +3,7 @@
 #include "csound_graph_display.h"
 #include <algorithm>
 #include <atomic>
+#include <cstring>
 #include <stdio.h>
 #include <thread>
 #include <vector>
@@ -248,6 +249,56 @@ TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
 
     ATOMIC_SET(csound->alloc_queue_items, 0);
     csound->alloc_queue_wp = 0;
+    alloc_queue_lock_destroy(csound);
+    csound->Free(csound, csound->alloc_queue);
+    csound->alloc_queue = nullptr;
+}
+
+TEST_F (EngineTests, testRealtimeInsertEventCopiesQueuedEvtblk)
+{
+    csound->alloc_queue = static_cast<ALLOC_DATA *>(
+      csound->Calloc(csound, sizeof(ALLOC_DATA) * MAX_ALLOC_QUEUE));
+    ASSERT_NE(csound->alloc_queue, nullptr);
+    ASSERT_EQ(alloc_queue_lock_init(csound), CSOUND_SUCCESS);
+    ATOMIC_SET(csound->alloc_queue_items, 0);
+    csound->alloc_queue_wp = 0;
+
+    int32_t realtime = csound->oparms->realtime;
+    MYFLT pfields[] = { FL(0.0), FL(1.0), FL(0.0), FL(0.25) };
+    char strarg[] = "First\0Second";
+    EVTBLK event = { 0 };
+    event.opcod = 'i';
+    event.pcnt = 3;
+    event.p = pfields;
+    event.scnt = 2;
+    event.strarg = strarg;
+    csound->oparms->realtime = 1;
+
+    ASSERT_EQ(insert_event(csound, 1, &event), CSOUND_SUCCESS);
+    ASSERT_EQ(ATOMIC_GET(csound->alloc_queue_items), 1);
+
+    ALLOC_DATA *queued = &csound->alloc_queue[0];
+    ASSERT_EQ(queued->type, ALLOC_DATA_SCORE_EVENT);
+    ASSERT_EQ(queued->insno, 1);
+    ASSERT_NE(queued->blk.p, event.p);
+    ASSERT_NE(queued->blk.strarg, event.strarg);
+    ASSERT_EQ(queued->blk.pcnt, event.pcnt);
+    ASSERT_EQ(queued->blk.p[1], FL(1.0));
+    ASSERT_STREQ(queued->blk.strarg, "First");
+    ASSERT_STREQ(queued->blk.strarg + std::strlen("First") + 1, "Second");
+
+    pfields[1] = FL(99.0);
+    strarg[0] = 'X';
+    ASSERT_EQ(queued->blk.p[1], FL(1.0));
+    ASSERT_STREQ(queued->blk.strarg, "First");
+
+    csound->Free(csound, queued->blk.p);
+    csound->Free(csound, queued->blk.strarg);
+    queued->blk.p = nullptr;
+    queued->blk.strarg = nullptr;
+    ATOMIC_SET(csound->alloc_queue_items, 0);
+    csound->alloc_queue_wp = 0;
+    csound->oparms->realtime = realtime;
     alloc_queue_lock_destroy(csound);
     csound->Free(csound, csound->alloc_queue);
     csound->alloc_queue = nullptr;

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -218,7 +218,8 @@ TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
     for (int32_t i = 0; i < MAX_ALLOC_QUEUE; ++i) {
       ALLOC_DATA data = { 0 };
       data.insno = i + 1;
-      ASSERT_EQ(alloc_queue_enqueue(csound, &data), CSOUND_SUCCESS);
+      ASSERT_EQ(alloc_queue_enqueue(csound, &data), CSOUND_SUCCESS)
+        << "queue item " << i;
     }
 
     ASSERT_EQ(ATOMIC_GET(csound->alloc_queue_items), MAX_ALLOC_QUEUE);
@@ -232,6 +233,15 @@ TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
     ASSERT_EQ(ATOMIC_GET(csound->alloc_queue_items), MAX_ALLOC_QUEUE);
     ASSERT_EQ(csound->alloc_queue_wp, 0u);
     ASSERT_EQ(csound->alloc_queue[0].insno, 1);
+
+    int32_t realtime = csound->oparms->realtime;
+    EVTBLK event = { 0 };
+    MCHNBLK channel = { 0 };
+    MEVENT midi = { 0 };
+    csound->oparms->realtime = 1;
+    ASSERT_EQ(insert_event(csound, 1, &event), CSOUND_ERROR);
+    ASSERT_EQ(insert_midi_event(csound, 1, &channel, &midi), CSOUND_ERROR);
+    csound->oparms->realtime = realtime;
 
     ATOMIC_SET(csound->alloc_queue_items, 0);
     csound->alloc_queue_wp = 0;

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -1,7 +1,11 @@
 #define __BUILDING_LIBCSOUND
 #include "csoundCore.h"
 #include "csound_graph_display.h"
+#include <algorithm>
+#include <atomic>
 #include <stdio.h>
+#include <thread>
+#include <vector>
 #include "gtest/gtest.h"
 #include "time.h"
 
@@ -210,8 +214,7 @@ TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
     csound->alloc_queue = static_cast<ALLOC_DATA *>(
       csound->Calloc(csound, sizeof(ALLOC_DATA) * MAX_ALLOC_QUEUE));
     ASSERT_NE(csound->alloc_queue, nullptr);
-    ASSERT_EQ(csoundSpinLockInit(&csound->alloc_queue_spinlock),
-              CSOUND_SUCCESS);
+    ASSERT_EQ(alloc_queue_lock_init(csound), CSOUND_SUCCESS);
     ATOMIC_SET(csound->alloc_queue_items, 0);
     csound->alloc_queue_wp = 0;
 
@@ -245,6 +248,59 @@ TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
 
     ATOMIC_SET(csound->alloc_queue_items, 0);
     csound->alloc_queue_wp = 0;
+    alloc_queue_lock_destroy(csound);
+    csound->Free(csound, csound->alloc_queue);
+    csound->alloc_queue = nullptr;
+}
+
+TEST_F (EngineTests, testRealtimeAllocQueueMutexFallback)
+{
+    constexpr int32_t producerCount = 4;
+    constexpr int32_t itemsPerProducer = MAX_ALLOC_QUEUE / producerCount;
+    std::atomic<int32_t> failures {0};
+    std::atomic<int32_t> ready {0};
+    std::atomic<bool> start {false};
+    std::vector<std::thread> producers;
+
+    csound->alloc_queue = static_cast<ALLOC_DATA *>(
+      csound->Calloc(csound, sizeof(ALLOC_DATA) * MAX_ALLOC_QUEUE));
+    ASSERT_NE(csound->alloc_queue, nullptr);
+    csound->alloc_queue_mutex = csoundCreateMutex(0);
+    ASSERT_NE(csound->alloc_queue_mutex, nullptr);
+    csound->alloc_queue_items = 0;
+    csound->alloc_queue_wp = 0;
+
+    for (int32_t producer = 0; producer < producerCount; ++producer) {
+      producers.emplace_back([this, producer, &failures, &ready, &start]() {
+        ready++;
+        while (!start.load())
+          std::this_thread::yield();
+        for (int32_t index = 0; index < itemsPerProducer; ++index) {
+          ALLOC_DATA data = { 0 };
+          data.insno = producer * itemsPerProducer + index + 1;
+          if (alloc_queue_enqueue(csound, &data) != CSOUND_SUCCESS)
+            failures++;
+        }
+      });
+    }
+
+    while (ready.load() != producerCount)
+      std::this_thread::yield();
+    start = true;
+
+    for (auto &producer : producers)
+      producer.join();
+
+    ASSERT_EQ(failures.load(), 0);
+    ASSERT_EQ(csound->alloc_queue_items, MAX_ALLOC_QUEUE);
+    std::vector<int32_t> instrumentNumbers;
+    for (int32_t index = 0; index < MAX_ALLOC_QUEUE; ++index)
+      instrumentNumbers.push_back(csound->alloc_queue[index].insno);
+    std::sort(instrumentNumbers.begin(), instrumentNumbers.end());
+    for (int32_t index = 0; index < MAX_ALLOC_QUEUE; ++index)
+      ASSERT_EQ(instrumentNumbers[index], index + 1);
+
+    alloc_queue_lock_destroy(csound);
     csound->Free(csound, csound->alloc_queue);
     csound->alloc_queue = nullptr;
 }

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -195,7 +195,11 @@ TEST_F (EngineTests, testRealtimeAsyncCompileMergesOnEventThread)
       endin
     )", 1), CSOUND_SUCCESS);
 
-    csoundSleep(100);
+    int32_t insno = 0;
+    for (int32_t i = 0; i < 200 && insno <= 0; ++i) {
+      csoundSleep(10);
+      insno = csoundGetInstrNumber(csound, "AsyncMerged");
+    }
 
-    ASSERT_GT(csoundGetInstrNumber(csound, "AsyncMerged"), 0);
+    ASSERT_GT(insno, 0);
 }

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -260,8 +260,6 @@ TEST_F (EngineTests, testRealtimeInsertEventCopiesQueuedEvtblk)
       csound->Calloc(csound, sizeof(ALLOC_DATA) * MAX_ALLOC_QUEUE));
     ASSERT_NE(csound->alloc_queue, nullptr);
     ASSERT_EQ(alloc_queue_lock_init(csound), CSOUND_SUCCESS);
-    ATOMIC_SET(csound->alloc_queue_items, 0);
-    csound->alloc_queue_wp = 0;
 
     int32_t realtime = csound->oparms->realtime;
     MYFLT pfields[] = { FL(0.0), FL(1.0), FL(0.0), FL(0.25) };
@@ -280,6 +278,8 @@ TEST_F (EngineTests, testRealtimeInsertEventCopiesQueuedEvtblk)
     ALLOC_DATA *queued = &csound->alloc_queue[0];
     ASSERT_EQ(queued->type, ALLOC_DATA_SCORE_EVENT);
     ASSERT_EQ(queued->insno, 1);
+    ASSERT_NE(queued->blk.p, nullptr);
+    ASSERT_NE(queued->blk.strarg, nullptr);
     ASSERT_NE(queued->blk.p, event.p);
     ASSERT_NE(queued->blk.strarg, event.strarg);
     ASSERT_EQ(queued->blk.pcnt, event.pcnt);
@@ -296,8 +296,6 @@ TEST_F (EngineTests, testRealtimeInsertEventCopiesQueuedEvtblk)
     csound->Free(csound, queued->blk.strarg);
     queued->blk.p = nullptr;
     queued->blk.strarg = nullptr;
-    ATOMIC_SET(csound->alloc_queue_items, 0);
-    csound->alloc_queue_wp = 0;
     csound->oparms->realtime = realtime;
     alloc_queue_lock_destroy(csound);
     csound->Free(csound, csound->alloc_queue);

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -174,3 +174,28 @@ TEST_F (EngineTests, testEmptyCommandLineArgumentSeparator)
     ASSERT_EQ(csoundCompile(csound, 5, compileArguments), CSOUND_SUCCESS);
     ASSERT_EQ(csoundGetCommandLineArgCount(csound), 0);
 }
+
+TEST_F (EngineTests, testRealtimeAsyncCompileMergesOnEventThread)
+{
+    csoundSetOption(csound, "-n");
+    csoundSetOption(csound, "-d");
+    csoundSetOption(csound, "--realtime");
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 48000
+      ksmps = 64
+      nchnls = 1
+      0dbfs = 1
+      instr 1
+      endin
+    )", 0), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      instr AsyncMerged
+      endin
+    )", 1), CSOUND_SUCCESS);
+
+    csoundSleep(100);
+
+    ASSERT_GT(csoundGetInstrNumber(csound, "AsyncMerged"), 0);
+}

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -271,7 +271,7 @@ TEST_F (EngineTests, testRealtimeAllocQueueMutexFallback)
     csound->alloc_queue_wp = 0;
 
     for (int32_t producer = 0; producer < producerCount; ++producer) {
-      producers.emplace_back([this, producer, &failures, &ready, &start]() {
+      producers.emplace_back([this, producer, itemsPerProducer, &failures, &ready, &start]() {
         ready++;
         while (!start.load())
           std::this_thread::yield();

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -1,4 +1,5 @@
-#include "csound.h"
+#define __BUILDING_LIBCSOUND
+#include "csoundCore.h"
 #include "csound_graph_display.h"
 #include <stdio.h>
 #include "gtest/gtest.h"
@@ -202,4 +203,38 @@ TEST_F (EngineTests, testRealtimeAsyncCompileMergesOnEventThread)
     }
 
     ASSERT_GT(insno, 0);
+}
+
+TEST_F (EngineTests, testRealtimeAllocQueueRejectsOverflow)
+{
+    csound->alloc_queue = static_cast<ALLOC_DATA *>(
+      csound->Calloc(csound, sizeof(ALLOC_DATA) * MAX_ALLOC_QUEUE));
+    ASSERT_NE(csound->alloc_queue, nullptr);
+    ASSERT_EQ(csoundSpinLockInit(&csound->alloc_queue_spinlock),
+              CSOUND_SUCCESS);
+    ATOMIC_SET(csound->alloc_queue_items, 0);
+    csound->alloc_queue_wp = 0;
+
+    for (int32_t i = 0; i < MAX_ALLOC_QUEUE; ++i) {
+      ALLOC_DATA data = { 0 };
+      data.insno = i + 1;
+      ASSERT_EQ(alloc_queue_enqueue(csound, &data), CSOUND_SUCCESS);
+    }
+
+    ASSERT_EQ(ATOMIC_GET(csound->alloc_queue_items), MAX_ALLOC_QUEUE);
+    ASSERT_EQ(csound->alloc_queue_wp, 0u);
+    for (int32_t i = 0; i < MAX_ALLOC_QUEUE; ++i)
+      ASSERT_EQ(csound->alloc_queue[i].insno, i + 1);
+
+    ALLOC_DATA overflow = { 0 };
+    overflow.insno = MAX_ALLOC_QUEUE + 1;
+    ASSERT_EQ(alloc_queue_enqueue(csound, &overflow), CSOUND_ERROR);
+    ASSERT_EQ(ATOMIC_GET(csound->alloc_queue_items), MAX_ALLOC_QUEUE);
+    ASSERT_EQ(csound->alloc_queue_wp, 0u);
+    ASSERT_EQ(csound->alloc_queue[0].insno, 1);
+
+    ATOMIC_SET(csound->alloc_queue_items, 0);
+    csound->alloc_queue_wp = 0;
+    csound->Free(csound, csound->alloc_queue);
+    csound->alloc_queue = nullptr;
 }

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -8,6 +8,12 @@
 
 find_package(Python3 COMPONENTS Interpreter QUIET)
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_realtime_compile_opcodes.orc
+  ${CMAKE_CURRENT_BINARY_DIR}/test_realtime_compile_opcodes.orc
+  COPYONLY
+)
+
 if(Python3_Interpreter_FOUND)
   # Build the common test arguments
   set(COMMON_TEST_ARGS --csound-executable=${CMAKE_BINARY_DIR}/csound --source-dir=${CMAKE_CURRENT_SOURCE_DIR})
@@ -85,5 +91,4 @@ if(Python3_Interpreter_FOUND)
 else()
   message(STATUS "Python3 not found; not creating commandline test targets.")
 endif()
-
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -461,6 +461,10 @@ def runTest():
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],
+        [
+            "test_realtime_compile_opcodes.csd",
+            "test realtime init-thread compile opcodes",
+        ],
         ["test_global_struct_var.csd", "testing global structure var"],
         ["test_setscorepos.csd", "testing setscorepos and rewindscore"],
         ["test_instr0_call.csd", "testing ability to call instr 0"],

--- a/tests/commandline/test_realtime_compile_opcodes.csd
+++ b/tests/commandline/test_realtime_compile_opcodes.csd
@@ -1,0 +1,60 @@
+<CsoundSynthesizer>
+<CsOptions>
+-odac -+rtaudio=null -d --realtime
+</CsOptions>
+<CsInstruments>
+
+sr = 48000
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+
+giStringResult init 0
+giFileResult init 0
+
+instr 1
+  iStringStatus compilestr {{
+giStringResult = 1
+
+instr RealtimeCompiledString
+endin
+}}
+
+  if (iStringStatus != 0) then
+    prints "compilestr failed: status=%d\n", iStringStatus
+    exitnow(1)
+  endif
+
+  Scwd pwd
+  Sfile sprintf "%s/test_realtime_compile_opcodes.orc", Scwd
+  if (filevalid(Sfile) == 0) then
+    Sfile sprintf "%s/tests/commandline/test_realtime_compile_opcodes.orc", Scwd
+  endif
+  iFileStatus compileorc Sfile
+
+  if (iFileStatus != 0) then
+    prints "compileorc failed: status=%d\n", iFileStatus
+    exitnow(1)
+  endif
+
+  iStringInstr nstrnum "RealtimeCompiledString"
+  iFileInstr nstrnum "RealtimeCompiledFile"
+
+  if (iStringInstr <= 0 || iFileInstr <= 0) then
+    prints "compiled instruments unavailable: string=%d file=%d\n", \
+      iStringInstr, iFileInstr
+    exitnow(1)
+  endif
+
+  if (giStringResult != 1 || giFileResult != 1) then
+    prints "compiled global init did not run: string=%d file=%d\n", \
+      giStringResult, giFileResult
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_realtime_compile_opcodes.csd
+++ b/tests/commandline/test_realtime_compile_opcodes.csd
@@ -14,10 +14,12 @@ giFileResult init 0
 
 instr 1
   iStringStatus compilestr {{
-giStringResult = 1
-
 instr RealtimeCompiledString
 endin
+
+; Exercises alloc_spinlock acquisition from merged global i-time code.
+prealloc "RealtimeCompiledString", 1
+giStringResult = 1
 }}
 
   if (iStringStatus != 0) then

--- a/tests/commandline/test_realtime_compile_opcodes.orc
+++ b/tests/commandline/test_realtime_compile_opcodes.orc
@@ -1,0 +1,4 @@
+giFileResult = 1
+
+instr RealtimeCompiledFile
+endin


### PR DESCRIPTION
This moves the heavy async orchestra merge work out of the realtime audio callback path.

Before this change, realtime `csoundCompileOrc(..., async = 1)` queued a `MERGE_STATE` message. That message was later handled by `message_dequeue()`, which is called at the top of every k-cycle from `kperf()`.

That meant the audio thread could end up doing the full merge work before rendering the next block.

This PR routes realtime async merge work through the existing `event_insert_thread` instead. The audio thread no longer performs the full merge from `message_dequeue()` in realtime mode.