### PR TITLE
refactor: append to tree/parser helper functions

### DIFF
--- a/Engine/csound_orc.y
+++ b/Engine/csound_orc.y
@@ -171,7 +171,7 @@
 
 #define namedInstrFlag csound->parserNamedInstrFlag
 
-    extern TREE* append_to_tree(CSOUND * csound, TREE *first, TREE *newlast);
+    extern TREE* parser_append(CSOUND * csound, TREE *first, TREE *newlast);
     extern int csound_orclex(TREE**, CSOUND *, void *);
     extern void print_tree(CSOUND *, char *msg, TREE *);
     extern TREE* constant_fold(CSOUND *, TREE *);
@@ -210,7 +210,7 @@ orcfile : root_statement_list
 
 
 root_statement_list : root_statement_list root_statement
-                      { $$ = append_to_tree(csound, $1, $2); }
+                      { $$ = parser_append(csound, $1, $2); }
                     | root_statement
                     ;
 
@@ -228,9 +228,9 @@ struct_definition : STRUCT_TOKEN identifier struct_arg_list
                   ;
 
 struct_arg_list : struct_arg_list ',' struct_arg
-                { $$ = append_to_tree(csound, $1, $3); }
+                { $$ = parser_append(csound, $1, $3); }
                 | struct_arg_list ',' NEWLINE struct_arg
-                 { $$ = append_to_tree(csound, $1, $4); }
+                 { $$ = parser_append(csound, $1, $4); }
                 | struct_arg
                 ;
 
@@ -255,7 +255,7 @@ instr_definition : INSTR_TOKEN instr_id_list NEWLINE
 
 
 instr_id_list : instr_id_list ',' instr_id
-                  { $$ = append_to_tree(csound, $1, $3); }
+                  { $$ = parser_append(csound, $1, $3); }
               | instr_id  { csp_orc_sa_instr_add_tree(csound, $1);
                     add_instr_variable(csound, $1);
                 }
@@ -347,7 +347,7 @@ udo_out_arg_list : '(' out_type_list ')'
              ;
 
 out_type_list : out_type_list ',' out_type
-              { $$ = append_to_tree(csound, $1, $3); }
+              { $$ = parser_append(csound, $1, $3); }
              | out_type
              ;
 
@@ -440,7 +440,7 @@ function_call : typed_identifierb expr_list ')'
 
 statement_list : statement_list statement
                 {
-                    $$ = append_to_tree(csound, (TREE *)$1, (TREE *)$2);
+                    $$ = parser_append(csound, (TREE *)$1, (TREE *)$2);
                 }
                 | statement
                 | {
@@ -669,9 +669,9 @@ declare_definition : DECLARE_TOKEN identifier udo_arg_list ':' udo_out_arg_list 
 
 /* Expressions */
 expr_list : expr_list ',' expr
-              { $$ = append_to_tree(csound, $1, $3); }
+              { $$ = parser_append(csound, $1, $3); }
          | expr_list ',' NEWLINE expr
-              { $$ = append_to_tree(csound, $1, $4); }
+              { $$ = parser_append(csound, $1, $4); }
          | expr
          ;
 
@@ -700,52 +700,52 @@ expr    : function_call
 gen_array : '[' expr S_ELIPSIS2 expr_list  ']' {
             $$ = make_leaf(csound, LINE,LOCN, T_FUNCTION, make_token(csound, "genarray", NULL));
             $$->right = $2;
-            append_to_tree(csound, $$->right, $4);
+            parser_append(csound, $$->right, $4);
              }
 
 slice_array :
           identifier '[' expr ':' expr_list  ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right, $3);
-            append_to_tree(csound, $$->right, $5);
+            $$->right = parser_append(csound, $$->right, $3);
+            parser_append(csound, $$->right, $5);
            }
            |
            identifier '[' ':' expr_list  ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right,
+            $$->right = parser_append(csound, $$->right,
                                        make_leaf(csound,LINE,LOCN, T_IDENT,
                                                  make_int(csound, "0", NULL)));
-            append_to_tree(csound, $$->right, $4);
+            parser_append(csound, $$->right, $4);
            }
            |
            identifier '[' expr ':' ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right, $3);
+            $$->right = parser_append(csound, $$->right, $3);
            }
           |
           expr '[' expr ':' expr_list  ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right, $3);
-            append_to_tree(csound, $$->right, $5);
+            $$->right = parser_append(csound, $$->right, $3);
+            parser_append(csound, $$->right, $5);
            }
            |
            expr '[' ':' expr_list  ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right,
+            $$->right = parser_append(csound, $$->right,
                                        make_leaf(csound,LINE,LOCN, T_IDENT,
                                                  make_int(csound, "0", NULL)));
-            append_to_tree(csound, $$->right, $4);
+            parser_append(csound, $$->right, $4);
            }
            |
            expr '[' expr ':' ']' {
             $$ = make_leaf(csound,LINE,LOCN, T_FUNCTION, make_token(csound, "slicearray", NULL));
             $$->right = $1;
-            $$->right = append_to_tree(csound, $$->right, $3);
+            $$->right = parser_append(csound, $$->right, $3);
            }
 
 
@@ -759,7 +759,7 @@ static_array : '[' expr_list ']' {
 */
 array_expr :  array_expr '[' expr ']'
           {
-            append_to_tree(csound, $1->right, $3);
+            parser_append(csound, $1->right, $3);
             $$ = $1;
           }
           | identifier '[' expr ']'
@@ -928,7 +928,7 @@ binary_expr : expr '+' optnewline expr   { $$ = make_node(csound, LINE,LOCN, '+'
 
 
 out_arg_list : out_arg_list ',' out_arg
-              { $$ = append_to_tree(csound, $1, $3); }
+              { $$ = parser_append(csound, $1, $3); }
              | out_arg
              ;
 
@@ -939,12 +939,12 @@ out_arg : identifier
         ;
 
 out_arg_list_array : out_arg_list_array ',' array_expr
-              { $$ = append_to_tree(csound, $1, $3); }
+              { $$ = parser_append(csound, $1, $3); }
              | array_expr
              ;
 
 array_identifier: array_identifier '[' ']' {
-            append_to_tree(csound, $1->right,
+            parser_append(csound, $1->right,
                            make_leaf(csound, LINE, LOCN, '[', make_token(csound, "[", NULL)));
             $$ = $1;
           }

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -477,9 +477,15 @@ static TREE *expand_expression_arg_list(CSOUND *csound, TREE *current,
     if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
       expanded = expand_struct_array_member_read(csound, current, line,
                                                  locn, typeTable);
+      if (expanded == NULL) {
+        return NULL;
+      }
     }
     else if (is_expression_node(current)) {
       expanded = create_expression(csound, current, line, locn, typeTable);
+      if (expanded == NULL) {
+        return NULL;
+      }
     }
 
     if (expanded != NULL) {
@@ -504,6 +510,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
 {
   char op[80], *outarg = NULL;
   TREE *anchor = NULL;
+  TREE *expandedArgs;
   TREE *opTree;
   OENTRIES* opentries;
   CS_VARIABLE* var;
@@ -512,10 +519,22 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   if (root->type=='?') return create_cond_expression(csound, root, line,
                                                      locn, typeTable);
   memset(op, 0, 80);
-  root->left = expand_expression_arg_list(csound, root->left, &anchor,
-                                          line, locn, typeTable);
-  root->right = expand_expression_arg_list(csound, root->right, &anchor,
-                                           line, locn, typeTable);
+  if (root->left != NULL) {
+    expandedArgs = expand_expression_arg_list(csound, root->left, &anchor,
+                                              line, locn, typeTable);
+    if (expandedArgs == NULL) {
+      return NULL;
+    }
+    root->left = expandedArgs;
+  }
+  if (root->right != NULL) {
+    expandedArgs = expand_expression_arg_list(csound, root->right, &anchor,
+                                              line, locn, typeTable);
+    if (expandedArgs == NULL) {
+      return NULL;
+    }
+    root->right = expandedArgs;
+  }
 
   switch(root->type) {
   case '+':

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -57,13 +57,29 @@ static TREE* tree_tail(TREE* node) {
   return t;
 }
 
+/* Append node to the end of head's sibling (->next) list and return
+   the (possibly new) head; either argument may be NULL.  Walks the
+   list from head on every call, so for a chain of consecutive appends
+   prefer tree_append_at() with a saved tail cursor. */
 TREE* tree_append(TREE *head, TREE *node) {
+  if (node == NULL) {
+    return head;
+  }
   TREE *tail = tree_tail(head);
   if (tail == NULL) {
     return node;
   }
   tail->next = node;
   return head;
+}
+
+/* Attach node at a known tail and return the new tail.  Unlike
+   tree_append() this never re-walks the list from its head, so a chain
+   of consecutive appends stays O(total length): keep the returned tail
+   and feed it to the next call. */
+static TREE* tree_append_at(TREE *tail, TREE *node) {
+  tail->next = node;
+  return tree_tail(node);
 }
 
 char *remove_type_quoting(CSOUND *csound, const char *outype) {
@@ -405,16 +421,16 @@ static TREE *create_cond_expression(CSOUND *csound,
     D->left = create_ans_token(csound, right); D->right = d;
     d = D;
   }
-  b = tree_append(b, d);
-  b = tree_append(b, create_simple_goto_token(csound, L2, type==2?0:type));
-  b = tree_append(b, create_synthetic_label(csound, ln1));
-  b = tree_append(b, c);
-  b = tree_append(b, create_synthetic_label(csound, ln2));
-
-  last = create_opcode_token(csound, csoundStrdup(csound, eq));
+  /* last is the tail of b here; chain via tree_append_at so no node is
+     walked twice */
+  last = tree_append_at(last, d);
+  last = tree_append_at(last, create_simple_goto_token(csound, L2, type==2?0:type));
+  last = tree_append_at(last, create_synthetic_label(csound, ln1));
+  last = tree_append_at(last, c);
+  last = tree_append_at(last, create_synthetic_label(csound, ln2));
+  last = tree_append_at(last, create_opcode_token(csound, csoundStrdup(csound, eq)));
   last->left = create_ans_token(csound, right);
   last->right = create_ans_token(csound, right);
-  b = tree_append(b, last);
   return b;
 }
 
@@ -445,6 +461,39 @@ static char* create_out_arg_for_expression(CSOUND* csound, char* op, TREE* left,
                         typeTable->localPool->synthArgCount++, typeTable);
 }
 
+static TREE *expand_expression_arg_list(CSOUND *csound, TREE *current,
+                                        TREE **anchor, int32_t line,
+                                        uint64_t locn,
+                                        TYPE_TABLE *typeTable)
+{
+  TREE *newArgList = NULL;
+
+  while (current != NULL) {
+    TREE *expanded = NULL;
+    TREE *newArg = current;
+    TREE *next = current->next;
+
+    current->next = NULL;
+    if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
+      expanded = expand_struct_array_member_read(csound, current, line,
+                                                 locn, typeTable);
+    }
+    else if (is_expression_node(current)) {
+      expanded = create_expression(csound, current, line, locn, typeTable);
+    }
+
+    if (expanded != NULL) {
+      *anchor = tree_append(*anchor, expanded);
+      expanded = tree_tail(*anchor);
+      newArg = create_ans_token(csound, expanded->left->value->lexeme);
+    }
+    newArgList = tree_append(newArgList, newArg);
+    current = next;
+  }
+
+  return newArgList;
+}
+
 /**
  * Create a chain of Opcode (OPTXT) text from the AST node given. Called from
  * create_opcode when an expression node has been found as an argument
@@ -454,8 +503,8 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
                                TYPE_TABLE* typeTable)
 {
   char op[80], *outarg = NULL;
-  TREE *anchor = NULL, *last;
-  TREE * opTree, *current, *newArgList;
+  TREE *anchor = NULL;
+  TREE *opTree;
   OENTRIES* opentries;
   CS_VARIABLE* var;
 
@@ -463,76 +512,10 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   if (root->type=='?') return create_cond_expression(csound, root, line,
                                                      locn, typeTable);
   memset(op, 0, 80);
-  current = root->left;
-  newArgList = NULL;
-  while (current != NULL) {
-    TREE* newArg;
-    TREE* temp = current->next;
-
-    current->next = NULL;
-    if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
-      TREE* expanded = expand_struct_array_member_read(csound, current,
-                                                       line, locn, typeTable);
-      if (expanded != NULL) {
-        anchor = tree_append(anchor, expanded);
-        last = tree_tail(anchor);
-        newArg = create_ans_token(csound, last->left->value->lexeme);
-        newArgList = tree_append(newArgList, newArg);
-      }
-      else {
-        newArgList = tree_append(newArgList, current);
-      }
-    }
-    else if (is_expression_node(current)) {
-      anchor = tree_append(anchor,
-                            create_expression(csound, current, line, locn,
-                                              typeTable));
-      last = tree_tail(anchor);
-      newArg = create_ans_token(csound, last->left->value->lexeme);
-      newArgList = tree_append(newArgList, newArg);
-    } else {
-      newArgList = tree_append(newArgList, current);
-    }
-    current = temp;
-
-  }
-  root->left = newArgList;
-
-  current = root->right;
-  newArgList = NULL;
-  while (current != NULL) {
-    TREE* newArg;
-    TREE* temp = current->next;
-
-    current->next = NULL;
-    if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
-      TREE* expanded = expand_struct_array_member_read(csound, current,
-                                                       line, locn, typeTable);
-      if (expanded != NULL) {
-        anchor = tree_append(anchor, expanded);
-        last = tree_tail(anchor);
-        newArg = create_ans_token(csound, last->left->value->lexeme);
-        newArgList = tree_append(newArgList, newArg);
-      }
-      else {
-        newArgList = tree_append(newArgList, current);
-      }
-    }
-    else if (is_expression_node(current)) {
-      anchor = tree_append(anchor,
-                            create_expression(csound, current, line,
-                                              locn, typeTable));
-      last = tree_tail(anchor);
-
-      newArg = create_ans_token(csound, last->left->value->lexeme);
-      newArgList = tree_append(newArgList, newArg);
-    }
-    else {
-      newArgList = tree_append(newArgList, current);
-    }
-    current = temp;
-  }
-  root->right = newArgList;
+  root->left = expand_expression_arg_list(csound, root->left, &anchor,
+                                          line, locn, typeTable);
+  root->right = expand_expression_arg_list(csound, root->right, &anchor,
+                                           line, locn, typeTable);
 
   switch(root->type) {
   case '+':
@@ -706,7 +689,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
         synterr(csound,
                 Str("create_expression: unable to find array sub-type "
                     "for var %s line %d\n"),
-                varBaseName, current->line);
+                varBaseName, line);
         return NULL;
       } else {
         // Check if it's an array

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -46,7 +46,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                                       TYPE_TABLE* typeTable);
 static TREE *create_synthetic_label(CSOUND *csound, int32 count);
 
-TREE* tree_tail(TREE* node) {
+static TREE* tree_tail(TREE* node) {
   TREE* t = node;
   if (t == NULL) {
     return NULL;
@@ -55,6 +55,15 @@ TREE* tree_tail(TREE* node) {
     t = t->next;
   }
   return t;
+}
+
+TREE* tree_append(TREE *head, TREE *node) {
+  TREE *tail = tree_tail(head);
+  if (tail == NULL) {
+    return node;
+  }
+  tail->next = node;
+  return head;
 }
 
 char *remove_type_quoting(CSOUND *csound, const char *outype) {
@@ -345,10 +354,7 @@ static TREE *create_cond_expression(CSOUND *csound,
   right  = get_arg_type2(csound, d, typeTable);
   if (left[0]=='c') left[0] = 'i';
   if (right[0]=='c') right[0] = 'i';
-  last = b;
-  while (last->next != NULL) {
-    last = last->next;
-  }
+  last = tree_tail(b);
 
   if(last->left == NULL) {
     csound->Message(csound,
@@ -399,26 +405,16 @@ static TREE *create_cond_expression(CSOUND *csound,
     D->left = create_ans_token(csound, right); D->right = d;
     d = D;
   }
-  last = b;
-  while (last->next != NULL) {
-    last = last->next;
-  }
-  last->next = d;
-  while (last->next != NULL) last = last->next;
-  //Last is now last assignment
-  last->next = create_simple_goto_token(csound, L2, type==2?0:type);
-  while (last->next != NULL) last = last->next;
-  last->next = create_synthetic_label(csound,ln1);
-  while (last->next != NULL) last = last->next;
+  b = tree_append(b, d);
+  b = tree_append(b, create_simple_goto_token(csound, L2, type==2?0:type));
+  b = tree_append(b, create_synthetic_label(csound, ln1));
+  b = tree_append(b, c);
+  b = tree_append(b, create_synthetic_label(csound, ln2));
 
-  last->next = c;
-  while (last->next != NULL) last = last->next;
-  while (last->next != NULL) last = last->next;
-  last->next = create_synthetic_label(csound,ln2);
-  while (last->next != NULL) last = last->next;
-  last->next = create_opcode_token(csound, csoundStrdup(csound, eq));
-  last->next->left = create_ans_token(csound, right);
-  last->next->right = create_ans_token(csound, right);
+  last = create_opcode_token(csound, csoundStrdup(csound, eq));
+  last->left = create_ans_token(csound, right);
+  last->right = create_ans_token(csound, right);
+  b = tree_append(b, last);
   return b;
 }
 
@@ -478,24 +474,24 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       TREE* expanded = expand_struct_array_member_read(csound, current,
                                                        line, locn, typeTable);
       if (expanded != NULL) {
-        anchor = append_to_tree(csound, anchor, expanded);
+        anchor = tree_append(anchor, expanded);
         last = tree_tail(anchor);
         newArg = create_ans_token(csound, last->left->value->lexeme);
-        newArgList = append_to_tree(csound, newArgList, newArg);
+        newArgList = tree_append(newArgList, newArg);
       }
       else {
-        newArgList = append_to_tree(csound, newArgList, current);
+        newArgList = tree_append(newArgList, current);
       }
     }
     else if (is_expression_node(current)) {
-      anchor = append_to_tree(csound, anchor,
+      anchor = tree_append(anchor,
                             create_expression(csound, current, line, locn,
                                               typeTable));
       last = tree_tail(anchor);
       newArg = create_ans_token(csound, last->left->value->lexeme);
-      newArgList = append_to_tree(csound, newArgList, newArg);
+      newArgList = tree_append(newArgList, newArg);
     } else {
-      newArgList = append_to_tree(csound, newArgList, current);
+      newArgList = tree_append(newArgList, current);
     }
     current = temp;
 
@@ -513,26 +509,26 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       TREE* expanded = expand_struct_array_member_read(csound, current,
                                                        line, locn, typeTable);
       if (expanded != NULL) {
-        anchor = append_to_tree(csound, anchor, expanded);
+        anchor = tree_append(anchor, expanded);
         last = tree_tail(anchor);
         newArg = create_ans_token(csound, last->left->value->lexeme);
-        newArgList = append_to_tree(csound, newArgList, newArg);
+        newArgList = tree_append(newArgList, newArg);
       }
       else {
-        newArgList = append_to_tree(csound, newArgList, current);
+        newArgList = tree_append(newArgList, current);
       }
     }
     else if (is_expression_node(current)) {
-      anchor = append_to_tree(csound, anchor,
+      anchor = tree_append(anchor,
                             create_expression(csound, current, line,
                                               locn, typeTable));
       last = tree_tail(anchor);
 
       newArg = create_ans_token(csound, last->left->value->lexeme);
-      newArgList = append_to_tree(csound, newArgList, newArg);
+      newArgList = tree_append(newArgList, newArg);
     }
     else {
-      newArgList = append_to_tree(csound, newArgList, current);
+      newArgList = tree_append(newArgList, current);
     }
     current = temp;
   }
@@ -785,11 +781,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
     anchor = opTree;
   }
   else {
-    last = anchor;
-    while (last->next != NULL) {
-      last = last->next;
-    }
-    last->next = opTree;
+    anchor = tree_append(anchor, opTree);
   }
   csound->Free(csound, outarg);
   return anchor;
@@ -812,10 +804,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
   if (is_boolean_expression_node(root->left)) {
     anchor = create_boolean_expression(csound, root->left,
                                        line, locn, typeTable);
-    last = anchor;
-    while (last->next != NULL) {
-      last = last->next;
-    }
+    last = tree_tail(anchor);
     /* TODO - Free memory of old left node
        freetree */
     root->left = create_ans_token(csound, last->left->value->lexeme);
@@ -824,10 +813,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
 
     /* TODO - Free memory of old left node
        freetree */
-    last = anchor;
-    while (last->next != NULL) {
-      last = last->next;
-    }
+    last = tree_tail(anchor);
     root->left = create_ans_token(csound, last->left->value->lexeme);
   }
 
@@ -841,21 +827,12 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
       anchor = newRight;
     }
     else {
-      last = anchor;
-      while (last->next != NULL) {
-        last = last->next;
-      }
-      last->next = newRight;
+      anchor = tree_append(anchor, newRight);
     }
-    last = newRight;
-
-    while (last->next != NULL) {
-      last = last->next;
-    }
+    last = tree_tail(newRight);
     /* TODO - Free only the replaced right wrapper node/token here;
        do not recursively delete children since they are reused. */
-    root->right = append_to_tree(csound,
-                                 create_ans_token(csound,
+    root->right = tree_append(create_ans_token(csound,
                                                   last->left->value->lexeme),
                                  remaining);
   }
@@ -869,22 +846,13 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
       anchor = newRight;
     }
     else {
-      last = anchor;
-      while (last->next != NULL) {
-        last = last->next;
-      }
-      last->next = newRight;
+      anchor = tree_append(anchor, newRight);
     }
-    last = newRight;
-
-    while (last->next != NULL) {
-      last = last->next;
-    }
+    last = tree_tail(newRight);
 
     // VL need to append any arguments following
     // the new expression
-    root->right = append_to_tree(csound,
-                                 create_ans_token(csound,
+    root->right = tree_append(create_ans_token(csound,
                                                   last->left->value->lexeme),
                                  remaining);
     /* TODO - Free only the replaced right wrapper node/token here;
@@ -981,11 +949,7 @@ static TREE *create_boolean_expression(CSOUND *csound, TREE *root,
     anchor = opTree;
   }
   else {
-    last = anchor;
-    while (last->next != NULL) {
-      last = last->next;
-    }
-    last->next = opTree;
+    anchor = tree_append(anchor, opTree);
   }
   csound->Free(csound, outarg);
   csound->Free(csound, op);
@@ -1419,7 +1383,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
                                   typeTable->localPool->synthArgCount++,
                                   typeTable);
   assignmentOps =
-    append_to_tree(csound, assignmentOps,
+    tree_append(assignmentOps,
                    create_struct_array_get_call(csound, current->line,
                                                 current->locn,
                                                 structTemps[0],
@@ -1431,7 +1395,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
                                         typeTable->localPool->synthArgCount++,
                                         typeTable);
     assignmentOps =
-      append_to_tree(csound, assignmentOps,
+      tree_append(assignmentOps,
                      create_struct_member_get_call(csound, current->line,
                                                    current->locn,
                                                    structTemps[i + 1],
@@ -1440,7 +1404,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
   }
 
   assignmentOps =
-    append_to_tree(csound, assignmentOps,
+    tree_append(assignmentOps,
                    create_struct_member_set_call(csound, current->line,
                                                  current->locn,
                                                  structTemps[path.memberCount - 1],
@@ -1449,14 +1413,14 @@ int expand_struct_array_member_assignment(CSOUND* csound,
 
   for (i = path.memberCount - 2; i >= 0; i--) {
     assignmentOps =
-      append_to_tree(csound, assignmentOps,
+      tree_append(assignmentOps,
                      create_struct_member_set_from_ident_call(
                        csound, current->line, current->locn,
                        structTemps[i], path.memberIndices[i], structTemps[i + 1]));
   }
 
   assignmentOps =
-    append_to_tree(csound, assignmentOps,
+    tree_append(assignmentOps,
                    create_struct_array_set_call(csound, current->line,
                                                 current->locn,
                                                 path.arrayExpr,
@@ -1466,7 +1430,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
     csound->Free(csound, structTemps[i]);
   }
 
-  *anchor = append_to_tree(csound, *anchor, assignmentOps);
+  *anchor = tree_append(*anchor, assignmentOps);
   return 1;
 }
 
@@ -1499,7 +1463,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                                     path.rootStructType->varTypeName,
                                     typeTable->localPool->synthArgCount++,
                                     typeTable);
-  readOps = append_to_tree(csound, readOps,
+  readOps = tree_append(readOps,
                            create_struct_array_get_call(csound, line, locn,
                                                         currentStructArg,
                                                         path.arrayExpr));
@@ -1509,7 +1473,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                                          path.memberVars[i]->varType->varTypeName,
                                          typeTable->localPool->synthArgCount++,
                                          typeTable);
-    readOps = append_to_tree(csound, readOps,
+    readOps = tree_append(readOps,
                              create_struct_member_get_call(
                                csound, line, locn, nextStructArg,
                                currentStructArg, path.memberIndices[i]));
@@ -1536,7 +1500,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
 
   outArg = create_out_arg(csound, (char*)outType,
                           typeTable->localPool->synthArgCount++, typeTable);
-  readOps = append_to_tree(csound, readOps,
+  readOps = tree_append(readOps,
                            create_struct_member_get_call(
                              csound, line, locn, outArg, currentStructArg,
                              path.memberIndices[path.memberCount - 1]));
@@ -1579,7 +1543,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       TREE* expanded = expand_struct_array_member_read(csound, currentArg,
                                                        currentArg->line, currentArg->locn, typeTable);
       if (expanded) {
-        anchor = append_to_tree(csound, anchor, expanded);
+        anchor = tree_append(anchor, expanded);
         last = tree_tail(anchor);
         char* newArg = last->left->value->lexeme;
         newArgTree = create_ans_token(csound, newArg);
@@ -1626,7 +1590,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       csound->Free(csound, currentArg);
 
       /* Set as anchor if necessary */
-      anchor = append_to_tree(csound, anchor, expressionNodes);
+      anchor = tree_append(anchor, expressionNodes);
 
       /* reconnect into chain */
       last = tree_tail(expressionNodes);
@@ -1655,7 +1619,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
     currentArg = currentArg->next;
   }
 
-  anchor = append_to_tree(csound, anchor, current);
+  anchor = tree_append(anchor, current);
 
 
   // handle LHS expressions (i.e. array-set's)
@@ -1752,7 +1716,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
       arraySet->right->next->next =
         currentArg->right; // TODO - check if this handles expressions
 
-      anchor = append_to_tree(csound, anchor, arraySet);
+      anchor = tree_append(anchor, arraySet);
       currentArg = temp;
 
     }
@@ -1762,7 +1726,7 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
 
   handle_optional_args(csound, current);
   collapse_last_assigment(csound, anchor, typeTable);
-  append_to_tree(csound, anchor, originalNext);
+  tree_append(anchor, originalNext);
   return anchor;
 }
 
@@ -1789,7 +1753,7 @@ TREE* expand_if_statement(CSOUND* csound,
                                 right->locn, typeTable);
 
 
-    anchor = append_to_tree(csound, anchor, expressionNodes);
+    anchor = tree_append(anchor, expressionNodes);
 
     /* reconnect into chain */
     last = tree_tail(expressionNodes);
@@ -1823,7 +1787,7 @@ TREE* expand_if_statement(CSOUND* csound,
       tempRight = ifBlockCurrent->right;
 
       if (ifBlockCurrent->type == ELSE_TOKEN) {
-        append_to_tree(csound, anchor, tempRight);
+        tree_append(anchor, tempRight);
         break;
       }
 
@@ -1832,7 +1796,7 @@ TREE* expand_if_statement(CSOUND* csound,
                                   tempLeft->line, tempLeft->locn,
                                   typeTable);
 
-      anchor = append_to_tree(csound, anchor, expressionNodes);
+      anchor = tree_append(anchor, expressionNodes);
 
       last = tree_tail(expressionNodes);
 
@@ -1868,7 +1832,7 @@ TREE* expand_if_statement(CSOUND* csound,
           );
         }
         gotoToken->next = statements;
-        anchor = append_to_tree(csound, anchor, gotoToken);
+        anchor = tree_append(anchor, gotoToken);
 
         /* relinking */
         last = tree_tail(last);
@@ -1882,12 +1846,12 @@ TREE* expand_if_statement(CSOUND* csound,
           if (UNLIKELY(csoundGetDebug(csound) & DEBUG_EXPRESSIONS))
             csound->Message(csound, "Creating simple goto token\n");
 
-          append_to_tree(csound, last, gotoEndLabelToken);
+          tree_append(last, gotoEndLabelToken);
 
           gotoEndLabelToken->next = labelEnd;
         }
         else {
-          append_to_tree(csound, last, labelEnd);
+          tree_append(last, labelEnd);
         }
 
         ifBlockCurrent = tempRight->next;
@@ -1897,14 +1861,14 @@ TREE* expand_if_statement(CSOUND* csound,
     if (endLabelCounter > 0) {
       TREE *endLabel = create_synthetic_label(csound,
                                               endLabelCounter);
-      anchor = append_to_tree(csound, anchor, endLabel);
+      anchor = tree_append(anchor, endLabel);
 
       typeTable->labelList = cs_cons(csound,
                                      csoundStrdup(csound,
                                                endLabel->value->lexeme),
                                      typeTable->labelList);
     }
-    anchor = append_to_tree(csound, anchor, current->next);
+    anchor = tree_append(anchor, current->next);
   }
   else {
     csound->Message(csound,
@@ -2001,7 +1965,7 @@ TREE* expand_switch_statement(
         if (gotoChainTail == NULL) {
           gotoChainTail = gotoChainTailAnchor;
         } else {
-          append_to_tree(csound, gotoChainTail, gotoChainTailAnchor);
+          tree_append(gotoChainTail, gotoChainTailAnchor);
         }
 
         TREE* caseArg = caseNode->left;
@@ -2013,7 +1977,7 @@ TREE* expand_switch_statement(
             }
           } else {
             gotoChainHeadAnchor = create_cgoto_node(csound, isPerfRate);
-            append_to_tree(csound, gotoChainHead, gotoChainHeadAnchor);
+            tree_append(gotoChainHead, gotoChainHeadAnchor);
           }
 
           gotoChainHeadAnchor->right = create_equality_statement(
@@ -2027,10 +1991,8 @@ TREE* expand_switch_statement(
         }
 
         if (caseNode->right != NULL) {
-          gotoChainTailAnchor = append_to_tree(csound, gotoChainTailAnchor, caseNode->right);
-          gotoChainTailAnchor = append_to_tree(
-            csound,
-            gotoChainTailAnchor,
+          gotoChainTailAnchor = tree_append(gotoChainTailAnchor, caseNode->right);
+          gotoChainTailAnchor = tree_append(gotoChainTailAnchor,
             copy_node(csound, endGoto)
           );
           hasTrailingEmptyCases = 0;
@@ -2039,9 +2001,7 @@ TREE* expand_switch_statement(
         }
     } else if (caseNode->type == DEFAULT_TOKEN && gotoChainHeadDefaultCase == NULL) {
       if (hasTrailingEmptyCases) {
-        gotoChainTailAnchor = append_to_tree(
-          csound,
-          gotoChainTailAnchor,
+        gotoChainTailAnchor = tree_append(gotoChainTailAnchor,
           copy_node(csound, endGoto)
         );
         hasTrailingEmptyCases = 0;
@@ -2056,7 +2016,7 @@ TREE* expand_switch_statement(
       gotoChainHeadDefaultCase->right = defaultCaseLabel;
       if (caseNode->right != NULL) {
         defaultCaseBody = caseNode->right;
-        append_to_tree(csound, defaultCaseBody, copy_node(csound, endGoto));
+        tree_append(defaultCaseBody, copy_node(csound, endGoto));
       } else {
         defaultCaseBody = copy_node(csound, endGoto);
       }
@@ -2071,19 +2031,13 @@ TREE* expand_switch_statement(
   }
 
   if (gotoChainHeadDefaultCase != NULL) {
-    gotoChainHeadAnchor = append_to_tree(
-      csound,
-      gotoChainHeadAnchor,
+    gotoChainHeadAnchor = tree_append(gotoChainHeadAnchor,
       gotoChainHeadDefaultCase
     );
-    gotoChainTailAnchor = append_to_tree(
-      csound,
-      gotoChainTailAnchor,
+    gotoChainTailAnchor = tree_append(gotoChainTailAnchor,
       copy_node(csound, defaultCaseLabel)
     );
-    gotoChainTailAnchor = append_to_tree(
-      csound,
-      gotoChainTailAnchor,
+    gotoChainTailAnchor = tree_append(gotoChainTailAnchor,
       defaultCaseBody
     );
     if (gotoChainTail == NULL) {
@@ -2092,24 +2046,18 @@ TREE* expand_switch_statement(
   }
 
   if (gotoChainHeadDefaultCase == NULL) {
-    gotoChainHeadAnchor = append_to_tree(
-      csound,
-      gotoChainHeadAnchor,
+    gotoChainHeadAnchor = tree_append(gotoChainHeadAnchor,
       endGoto
     );
   }
 
-  gotoChainHeadAnchor = append_to_tree(
-    csound,
-    gotoChainHeadAnchor,
+  gotoChainHeadAnchor = tree_append(gotoChainHeadAnchor,
     gotoChainTail
   );
-  append_to_tree(
-    csound,
-    gotoChainHeadAnchor,
+  tree_append(gotoChainHeadAnchor,
     copy_node(csound, endLabel)
   );
-  append_to_tree(csound, gotoChainHeadAnchor, originalNext);
+  tree_append(gotoChainHeadAnchor, originalNext);
 
   return gotoChainHead != NULL ? gotoChainHead : gotoChainHeadAnchor;
 }
@@ -2151,7 +2099,7 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
       current->locn,
       typeTable
     );
-    anchor = append_to_tree(csound, anchor, expressionNodes);
+    anchor = tree_append(anchor, expressionNodes);
     last = tree_tail(anchor);
   }
 
@@ -2177,7 +2125,7 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
   gotoToken->right->next = labelEnd;
 
 
-  last = append_to_tree(csound, last, gotoToken);
+  last = tree_append(last, gotoToken);
   last = tree_tail(last);
 
 
@@ -2190,7 +2138,7 @@ TREE* expand_until_statement(CSOUND* csound, TREE* current,
                                                      topLabel,
                                                      (gotoType==1 ? 0 : 1));
 
-  append_to_tree(csound, last, gotoTopLabelToken);
+  tree_append(last, gotoTopLabelToken);
   gotoTopLabelToken->next = labelEnd;
 
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -4016,40 +4016,22 @@ void do_baktrace(CSOUND *csound, uint64_t files)
 }
 
 /**
- * Appends TREE * node to TREE * node using ->next field in struct; walks
- * down  list to append at end; checks for NULL's and returns
- * appropriate nodes
+ * Grammar-rule variant of tree_append() (csound_orc_expressions.c):
+ * the same sibling-list append, but additionally treats an
+ * uninitialized `first` node as an empty list.
+ * HACK - This occurs for rules like in topstatement where the left hand
+ * topstatement the first time around is not initialized to anything
+ * useful; the number 400 is arbitrary, chosen as it seemed to be a
+ * value higher than all the type numbers that were being printed out.
+ * Only use this from parser rules; everywhere else use tree_append().
  */
-TREE* append_to_tree(CSOUND * csound, TREE *first, TREE *newlast)
+TREE* parser_append(CSOUND * csound, TREE *first, TREE *newlast)
 {
   IGN(csound);
-  TREE *current;
-  if (first == NULL) {
+  if (first != NULL && (first->type > 400 || first->type < 0)) {
     return newlast;
   }
-
-  if (newlast == NULL) {
-    return first;
-  }
-
-  /* HACK - Checks to see if first node is uninitialized (sort of)
-   * This occurs for rules like in topstatement where the left hand
-   * topstatement the first time around is not initialized to anything
-   * useful; the number 400 is arbitrary, chosen as it seemed to be a
-   * value higher than all the type numbers that were being printed out
-   */
-  if (first->type > 400 || first-> type < 0) {
-    return newlast;
-  }
-
-  current = first;
-  while (current->next != NULL) {
-    current = current->next;
-  }
-
-  current->next = newlast;
-
-  return first;
+  return tree_append(first, newlast);
 }
 
 
@@ -4579,23 +4561,20 @@ void handle_optional_args(CSOUND *csound, TREE *l)
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
                            make_int(csound, "0", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
         case 'P':
         case 'p':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
                            make_int(csound, "1", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
         case 'q':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
                            make_int(csound, "10", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
 
         case 'V':
@@ -4603,23 +4582,20 @@ void handle_optional_args(CSOUND *csound, TREE *l)
           temp = make_leaf(csound, l->line, l->locn, NUMBER_TOKEN,
                            make_num(csound, ".5", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
         case 'h':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
                            make_int(csound, "127", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
         case 'J':
         case 'j':
           temp = make_leaf(csound, l->line, l->locn, INTEGER_TOKEN,
                            make_int(csound, "-1", NULL));
           temp->markup = &SYNTHESIZED_ARG;
-          if (l->right==NULL) l->right = temp;
-          else append_to_tree(csound, l->right, temp);
+          l->right = tree_append(l->right, temp);
           break;
         case 'M':
         case 'N':

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3913,14 +3913,8 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
             anchor = anchor_expansion;
           }
 
-          // Find the end of the expansion chain and link to current->next
-          TREE* last = anchor_expansion;
-          while (last && last->next) {
-            last = last->next;
-          }
-          if (last) {
-            last->next = current->next;
-          }
+          // Reconnect the expansion to the remaining statements.
+          tree_append(anchor_expansion, current->next);
 
           current = anchor_expansion;
           continue;
@@ -4015,20 +4009,23 @@ void do_baktrace(CSOUND *csound, uint64_t files)
 
 }
 
+/* HACK - a TREE type outside this range marks an uninitialized node.
+ * This occurs for rules like in topstatement where the left hand
+ * topstatement the first time around is not initialized to anything
+ * useful; the bound 400 is arbitrary, chosen as it seemed to be a
+ * value higher than all the type numbers that were being printed out. */
+#define TREE_TYPE_IS_UNINITIALIZED(t) ((t)->type > 400 || (t)->type < 0)
+
 /**
  * Grammar-rule variant of tree_append() (csound_orc_expressions.c):
  * the same sibling-list append, but additionally treats an
  * uninitialized `first` node as an empty list.
- * HACK - This occurs for rules like in topstatement where the left hand
- * topstatement the first time around is not initialized to anything
- * useful; the number 400 is arbitrary, chosen as it seemed to be a
- * value higher than all the type numbers that were being printed out.
  * Only use this from parser rules; everywhere else use tree_append().
  */
 TREE* parser_append(CSOUND * csound, TREE *first, TREE *newlast)
 {
   IGN(csound);
-  if (first != NULL && (first->type > 400 || first->type < 0)) {
+  if (first != NULL && TREE_TYPE_IS_UNINITIALIZED(first)) {
     return newlast;
   }
   return tree_append(first, newlast);

--- a/H/csound_orc_expressions.h
+++ b/H/csound_orc_expressions.h
@@ -46,6 +46,7 @@ int32_t is_expression_node(TREE *node);
 int32_t is_boolean_expression_node(TREE *node);
 int32_t is_statement_expansion_required(TREE* root);
 void handle_optional_args(CSOUND *csound, TREE *l);
+TREE* tree_append(TREE *head, TREE *node);
 TREE* expand_if_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable);
 TREE* expand_until_statement(CSOUND* csound, TREE* current,
                              TYPE_TABLE* typeTable, int32_t, LOOP_JUMP_TARGETS* targets);

--- a/H/csound_orc_semantics.h
+++ b/H/csound_orc_semantics.h
@@ -49,7 +49,8 @@ char* convert_external_to_internal(CSOUND* csound, char* arg);
 int32_t check_out_args(CSOUND* csound, char* outArgsFound, char* opOutArgs);
 void handle_optional_args(CSOUND *, TREE *);
 char* resolve_opcode_get_outarg(CSOUND* , OENTRIES* , char*);
-TREE* append_to_tree(CSOUND * csound, TREE *first, TREE *newlast);
+/* grammar-rule variant of tree_append(); only for use in parser rules */
+TREE* parser_append(CSOUND * csound, TREE *first, TREE *newlast);
 void add_arg(CSOUND* csound, char* varName, char* annotation,
 	     TYPE_TABLE* typeTable, TREE *tree);
 void add_array_arg(CSOUND* csound, char* varName, char* annotation,

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -124,6 +124,16 @@ TEST_F (OrcCompileTests, testCompile)
     }
 }
 
+TEST_F (OrcCompileTests, testNestedExpressionFailurePropagates)
+{
+    const char *instrument =
+        "instr 1\n"
+        "  iresult = abs(missing[0] + 1)\n"
+        "endin\n";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
 TEST_F (OrcCompileTests, testReuse)
 {
     int32_t result;


### PR DESCRIPTION
a very repetitive pattern that we repeat often is appending TREE node at end of chain of siblings. Problem is we already have a helper function with a similar name, so to disambiguate better between the two I renamed it to parser_append and made a good use of tree_append, reducing LOC and improving readability.