### PR TITLE
fix(structs): incorrect type inference in nested struct conditions

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -38,6 +38,12 @@ static TREE *create_boolean_expression(CSOUND*, TREE*, int32_t,  uint64_t,
                                        TYPE_TABLE*);
 static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
                                TYPE_TABLE*);
+static int32_t struct_expr_has_array_root(TREE* structExpr);
+TREE* expand_struct_array_member_read(CSOUND* csound,
+                                      TREE* structExpr,
+                                      int32_t line,
+                                      uint64_t locn,
+                                      TYPE_TABLE* typeTable);
 static TREE *create_synthetic_label(CSOUND *csound, int32 count);
 
 TREE* tree_tail(TREE* node) {
@@ -464,25 +470,34 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   current = root->left;
   newArgList = NULL;
   while (current != NULL) {
-    if (is_expression_node(current)) {
-      TREE* newArg;
-      TREE* temp = current->next;
+    TREE* newArg;
+    TREE* temp = current->next;
 
-      current->next = NULL;
+    current->next = NULL;
+    if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
+      TREE* expanded = expand_struct_array_member_read(csound, current,
+                                                       line, locn, typeTable);
+      if (expanded != NULL) {
+        anchor = append_to_tree(csound, anchor, expanded);
+        last = tree_tail(anchor);
+        newArg = create_ans_token(csound, last->left->value->lexeme);
+        newArgList = append_to_tree(csound, newArgList, newArg);
+      }
+      else {
+        newArgList = append_to_tree(csound, newArgList, current);
+      }
+    }
+    else if (is_expression_node(current)) {
       anchor = append_to_tree(csound, anchor,
                             create_expression(csound, current, line, locn,
                                               typeTable));
       last = tree_tail(anchor);
       newArg = create_ans_token(csound, last->left->value->lexeme);
       newArgList = append_to_tree(csound, newArgList, newArg);
-      current = temp;
     } else {
-      TREE* temp;
       newArgList = append_to_tree(csound, newArgList, current);
-      temp = current->next;
-      current->next = NULL;
-      current = temp;
     }
+    current = temp;
 
   }
   root->left = newArgList;
@@ -490,11 +505,24 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   current = root->right;
   newArgList = NULL;
   while (current != NULL) {
-    if (is_expression_node(current)) {
-      TREE* newArg;
-      TREE* temp = current->next;
+    TREE* newArg;
+    TREE* temp = current->next;
 
-      current->next = NULL;
+    current->next = NULL;
+    if (current->type == STRUCT_EXPR && struct_expr_has_array_root(current)) {
+      TREE* expanded = expand_struct_array_member_read(csound, current,
+                                                       line, locn, typeTable);
+      if (expanded != NULL) {
+        anchor = append_to_tree(csound, anchor, expanded);
+        last = tree_tail(anchor);
+        newArg = create_ans_token(csound, last->left->value->lexeme);
+        newArgList = append_to_tree(csound, newArgList, newArg);
+      }
+      else {
+        newArgList = append_to_tree(csound, newArgList, current);
+      }
+    }
+    else if (is_expression_node(current)) {
       anchor = append_to_tree(csound, anchor,
                             create_expression(csound, current, line,
                                               locn, typeTable));
@@ -502,15 +530,11 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
 
       newArg = create_ans_token(csound, last->left->value->lexeme);
       newArgList = append_to_tree(csound, newArgList, newArg);
-      current = temp;
     }
     else {
-      TREE* temp;
       newArgList = append_to_tree(csound, newArgList, current);
-      temp = current->next;
-      current->next = NULL;
-      current = temp;
     }
+    current = temp;
   }
   root->right = newArgList;
 
@@ -1464,6 +1488,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   int32_t i;
   const char* memberType;
   const char* outType;
+  char* arrayMemberType = NULL;
   char* outArg;
 
   if (!resolve_struct_array_member_path(csound, structExpr, typeTable, &path)) {
@@ -1492,10 +1517,21 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
     currentStructArg = nextStructArg;
   }
 
-  memberType = path.memberVars[path.memberCount - 1]->varType->varTypeName;
-  outType = memberType;
-  if (path.hasKRateIndex && memberType[0] == 'i' && memberType[1] == '\0') {
-    outType = "k";
+  if (path.memberVars[path.memberCount - 1]->varType == &CS_VAR_TYPE_ARRAY) {
+    arrayMemberType = create_array_arg_type(csound,
+                                            path.memberVars[path.memberCount - 1]);
+    if (arrayMemberType == NULL) {
+      csound->Free(csound, currentStructArg);
+      return NULL;
+    }
+    outType = arrayMemberType;
+  }
+  else {
+    memberType = path.memberVars[path.memberCount - 1]->varType->varTypeName;
+    outType = memberType;
+    if (path.hasKRateIndex && memberType[0] == 'i' && memberType[1] == '\0') {
+      outType = "k";
+    }
   }
 
   outArg = create_out_arg(csound, (char*)outType,
@@ -1506,6 +1542,9 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                              path.memberIndices[path.memberCount - 1]));
 
   csound->Free(csound, currentStructArg);
+  if (arrayMemberType != NULL) {
+    csound->Free(csound, arrayMemberType);
+  }
   csound->Free(csound, outArg);
   return readOps;
 }

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2106,7 +2106,7 @@ char *check_optional_type(CSOUND *csound, char *name) {
 void add_arg(CSOUND* csound, char* varName, char* annotation,
              TYPE_TABLE* typeTable, TREE* tree) {
 
-  const CS_TYPE* type;
+  const CS_TYPE* type = NULL;
   CS_VARIABLE* var;
   char *t = csoundStrdup(csound, varName);
   char *lvarName = csoundStrdup(csound, varName); // local copy
@@ -2194,7 +2194,11 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
 
       t = lvarName;
 
-      if (*t == '#') t++;
+      int32_t isSynthetic = 0;
+      if (*t == '#') {
+        isSynthetic = 1;
+        t++;
+      }
       if (*t == 'g') pool = typeTable->globalPool;
       if (*t == 'g') t++;
 
@@ -2214,10 +2218,22 @@ void add_arg(CSOUND* csound, char* varName, char* annotation,
         varInit.dimensions = dimensions;
         varInit.type =  varType;
         typeArg = &varInit;
+      } else if (isSynthetic) {
+        char *syntheticType = csoundStrdup(csound, t);
+        char *end = syntheticType + strlen(syntheticType);
+        while (end > syntheticType && isdigit((unsigned char) end[-1])) {
+          *--end = '\0';
+        }
+        if (strlen(syntheticType) > 1) {
+          type = csoundGetTypeWithVarTypeName(csound->typePool, syntheticType);
+        }
+        csound->Free(csound, syntheticType);
       }
 
-      argLetter[0] = *t;
-      type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
+      if (type == NULL) {
+        argLetter[0] = *t;
+        type = csoundGetTypeWithVarTypeName(csound->typePool, argLetter);
+      }
     }
     var = csoundCreateVariable(csound, csound->typePool,
 				 type, lvarName, typeArg);

--- a/H/csound_orc_semantics.h
+++ b/H/csound_orc_semantics.h
@@ -36,6 +36,7 @@
 
 char *strip_extension(CSOUND *csound, const char *s);
 char* get_arg_type2(CSOUND* csound, TREE* tree, TYPE_TABLE* typeTable);
+char* create_array_arg_type(CSOUND* csound, CS_VARIABLE* arrayVar);
 
 void print_tree(CSOUND *, char *, TREE *);
 OENTRIES* find_opcode2(CSOUND*, char*);

--- a/tests/commandline/structs/test_struct_array_nested_condition_arg.csd
+++ b/tests/commandline/structs/test_struct_array_nested_condition_arg.csd
@@ -1,0 +1,31 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+struct Item label:S, children:Item[]
+
+instr 1
+  none:Item[] init 0
+  grand:Item init "grand", none
+
+  grandkids:Item[] init 1
+  child:Item init "child", grandkids
+  child.children[0] = grand
+
+  kids:Item[] init 1
+  root:Item init "root", kids
+  root.children[0] = child
+
+  if (strcmp(root.children[0].children[0].label, "grand") != 0) then
+    prints "nested condition failed\n"
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -784,6 +784,10 @@ def runTest():
             "direct indexing of recursive struct-array members",
         ],
         [
+            "structs/test_struct_array_nested_condition_arg.csd",
+            "nested struct-array member reads inside boolean expression args",
+        ],
+        [
             "structs/test_string_array_direct_member_index.csd",
             "direct indexing of a string-array struct member",
         ],


### PR DESCRIPTION
This fixes a type-inference and lowering gap for nested struct-array member reads when they appear inside expressions, such as function-call arguments in conditions.

Csound already handled simpler struct-array paths such as assigning to `holder.values[0]` and reading `holder.values[0].value` in direct contexts. The missing case was when a nested path had to be used as part of another expression:

  ```csound
  if (strcmp(root.children[0].children[0].label, "grand") != 0) then
  ```