### PR TITLE
fix(fgens): zero the FUNC header and release the buffers it owns

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -93,6 +93,18 @@ static int32_t GENUL(FGDATA *ff, FUNC *ftp)
     return csoundFtError(ff, Str("unknown GEN number"));
 }
 
+/* Releases a function table and the two buffers its header owns. csoundFree
+   ignores NULL, and args stays NULL until csoundFTCreate fills it in.
+   The caller must have already cleared csound->flist[fno]. */
+static void ftfree(CSOUND *csound, FUNC *ftp)
+{
+    if (ftp == NULL)
+      return;
+    csound->Free(csound, ftp->ftable);
+    csound->Free(csound, ftp->args);
+    csound->Free(csound, (void*) ftp);
+}
+
 /**
  * Create ftable using evtblk data, and store pointer to new table in *ftpp.
  * If mode is zero, a zero table number is ignored, otherwise a new table
@@ -139,7 +151,7 @@ int32_t csoundFTCreate(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp,
         return csoundFtError(&ff, Str("ftable does not exist"));
       }
       csound->flist[ff.fno] = NULL;
-      csound->Free(csound, (void*) ftp);
+      ftfree(csound, ftp);
       if (UNLIKELY(msg_enabled))
         csoundMessage(csound, Str("ftable %d now deleted\n"), ff.fno);
       return 0;
@@ -198,9 +210,8 @@ int32_t csoundFTCreate(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp,
       i = (*csound->gensub[genum])(&ff, NULL);
       ftp = csound->flist[ff.fno];
       if (i != 0) {
-        if(ftp != NULL)
-          csound->Free(csound, ftp);
         csound->flist[ff.fno] = NULL;
+        ftfree(csound, ftp);
         return -1;
       }
       ftp->sr = csound->esr;
@@ -251,7 +262,7 @@ int32_t csoundFTCreate(CSOUND *csound, FUNC **ftpp, const EVTBLK *evtblkp,
       csoundMessage(csound, Str("ftable %d:\n"), ff.fno);
     if ((*csound->gensub[genum])(&ff, ftp) != 0) {
       csound->flist[ff.fno] = NULL;
-      csound->Free(csound, ftp);
+      ftfree(csound, ftp);
       return -1;
     }
 
@@ -295,11 +306,11 @@ int32_t csoundFTAlloc(CSOUND *csound, int32_t tableNum,
         csound->flist[i] = NULL;            /* Clear new section            */
       csound->maxfnum = size;
     }
-    /* allocate space for table */
-    size = (int32_t) (len * (int32_t) sizeof(MYFLT));
+    /* allocate space for table: the header must be zeroed, csoundFTCreate
+       frees ftp->args before replacing it and would otherwise free garbage */
     ftp = csound->flist[tableNum];
     if (ftp == NULL) {
-      csound->flist[tableNum] = (FUNC*) csound->Malloc(csound, sizeof(FUNC));
+      csound->flist[tableNum] = (FUNC*) csound->Calloc(csound, sizeof(FUNC));
       csound->flist[tableNum]->ftable =
         (MYFLT*)csound->Malloc(csound, sizeof(MYFLT)*(len+1));
     }
@@ -311,14 +322,13 @@ int32_t csoundFTAlloc(CSOUND *csound, int32_t tableNum,
                                         "may find this disturbing"), tableNum);
       }
       csound->flist[tableNum] = NULL;
-      csound->Free(csound, ftp);
-      csound->flist[tableNum] = (FUNC*) csound->Malloc(csound, (size_t) size);
+      ftfree(csound, ftp);
+      csound->flist[tableNum] = (FUNC*) csound->Calloc(csound, sizeof(FUNC));
       csound->flist[tableNum]->ftable =
         (MYFLT*)csound->Malloc(csound, sizeof(MYFLT)*(len+1));
     }
     /* initialise table header */
     ftp = csound->flist[tableNum];
-    //memset((void*) ftp, 0, (size_t) ((char*) &(ftp->ftable) - (char*) ftp));
     ftp->flen = (int32) len;
     if (!(len & (len - 1))) {
       /* for power of two length: */
@@ -351,7 +361,7 @@ int32_t csoundFTFree(CSOUND *csound, int32_t tableNum)
     if (UNLIKELY(ftp == NULL))
       return -1;
     csound->flist[tableNum] = NULL;
-    csound->Free(csound, ftp);
+    ftfree(csound, ftp);
 
     return 0;
 }
@@ -2111,9 +2121,9 @@ static CS_NOINLINE FUNC *ftalloc(const FGDATA *ff)
     if (UNLIKELY(ftp != NULL)) {
       csound->Warning(csound, Str("replacing previous ftable %d"), ff->fno);
       if (ff->flen != (int32)ftp->flen) {       /* if redraw & diff len, */
-        csound->Free(csound, ftp->ftable);
-        csound->Free(csound, (void*) ftp);             /*   release old space   */
-        csound->flist[ff->fno] = ftp = NULL;
+        csound->flist[ff->fno] = NULL;
+        ftfree(csound, ftp);                          /*   release old space   */
+        ftp = NULL;
         if (UNLIKELY(csound->actanchor.nxtact != NULL)) { /*   & chk for danger */
           csound->Warning(csound, Str("ftable %d relocating due to size change"
                                       "\n         currently active instruments "
@@ -2123,6 +2133,8 @@ static CS_NOINLINE FUNC *ftalloc(const FGDATA *ff)
       else {
                                     /* else clear it to zero */
         MYFLT *tmp = ftp->ftable;
+        /* the memset below drops args on the floor: release it first */
+        csound->Free(csound, ftp->args);
         memset((void*) ftp->ftable, 0, sizeof(MYFLT)*(ff->flen+1));
         memset((void*) ftp, 0, sizeof(FUNC));
         ftp->ftable = tmp; /* restore table pointer */

--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -403,6 +403,18 @@ void delete_selected_rt_events(CSOUND *csound, MYFLT instr)
   //csound->OrcTrigEvts = NULL;
 }
 
+#ifndef __EMSCRIPTEN__
+static void stop_event_insert_thread(CSOUND *csound)
+{
+    if (csound->event_insert_thread != NULL) {
+      csound->event_insert_loop = 0;
+      csound->JoinThread(csound->event_insert_thread);
+      csoundDestroyMutex(csound->init_pass_threadlock);
+      csound->event_insert_thread = 0;
+    }
+}
+#endif
+
 static inline void cs_beep(CSOUND *csound)
 {
     csound->ErrorMsg(csound, Str("%c\tbeep!\n"), '\a');
@@ -435,6 +447,10 @@ int32_t csound_cleanup(CSOUND *csound)
     /* will not clean up more than once */
     csound->engineStatus &= ~(CS_STATE_CLN);
 
+#ifndef __EMSCRIPTEN__
+    stop_event_insert_thread(csound);
+#endif
+
     deactivate_all_notes(csound);
 
     if (csound->engineState.instrtxtp &&
@@ -443,15 +459,6 @@ int32_t csound_cleanup(CSOUND *csound)
         csound->engineState.instrtxtp[0]->instance->actflg)
       xturnoff_now(csound, csound->engineState.instrtxtp[0]->instance);
     delete_pending_rt_events(csound);
-
-#ifndef __EMSCRIPTEN__
-    if (csound->event_insert_loop == 1) {
-      csound->event_insert_loop = 0;
-      csound->JoinThread(csound->event_insert_thread);
-      csoundDestroyMutex(csound->init_pass_threadlock);
-      csound->event_insert_thread = 0;
-    }
-#endif
 
     while (csound->freeEvtNodes != NULL) {
       p = (void*) csound->freeEvtNodes;

--- a/Opcodes/ftgen.c
+++ b/Opcodes/ftgen.c
@@ -770,20 +770,32 @@ static int32_t getftargs(CSOUND *csound, FTARGS *p)
 
   argcnt = src->argcnt;
 
-  for (i = 1; i != argcnt; i++)
+  if (argcnt <= 1 || src->args == NULL) {
+    p->Scd->size = 1;
+    if (p->Scd->data == NULL) {
+      p->Scd->data = (char*) csound->Calloc(csound, 1);
+    }
+    else {
+      p->Scd->data = (char*) csound->ReAlloc(csound, p->Scd->data, 1);
+    }
+    p->Scd->data[0] = '\0';
+    return OK;
+  }
+
+  for (i = 1; i < argcnt; i++)
     strlen += snprintf(NULL, 0, "%g ", src->args[i]);
 
-  p->Scd->size = strlen;
+  p->Scd->size = strlen + 1;
 
   if (p->Scd->data == NULL) {
-    p->Scd->data = (char*) csound->Calloc(csound, strlen);
+    p->Scd->data = (char*) csound->Calloc(csound, strlen + 1);
   }
   else
-    p->Scd->data = (char*) csound->ReAlloc(csound, p->Scd->data, strlen);
+    p->Scd->data = (char*) csound->ReAlloc(csound, p->Scd->data, strlen + 1);
 
   {
-    char* curr = p->Scd->data, *const end = curr + strlen;
-    for (i = 1; curr != end && i != argcnt; i++) {
+    char* curr = p->Scd->data, *const end = curr + strlen + 1;
+    for (i = 1; curr != end && i < argcnt; i++) {
       curr += snprintf(curr, end-curr, "%g ", src->args[i]);
     }
   }

--- a/Opcodes/ftgen.c
+++ b/Opcodes/ftgen.c
@@ -245,6 +245,17 @@ static int32_t myInitError(CSOUND *csound, OPDS *p, const char *str, ...)
   return csound->InitError(csound, "%s",str);
 }
 
+static void ftload_copy_header(CSOUND *csound, FUNC *ftp,
+                               const FUNC *header, size_t size)
+{
+  MYFLT *ftable = ftp->ftable;
+  csound->Free(csound, ftp->args);
+  memcpy(ftp, header, size);
+  ftp->ftable = ftable;
+  ftp->args = NULL;
+  ftp->argcnt = 0;
+}
+
 static int32_t ftload_(CSOUND *csound, FTLOAD *p, int32_t istring)
 {
   MYFLT **argp = p->argums;
@@ -298,7 +309,8 @@ static int32_t ftload_(CSOUND *csound, FTLOAD *p, int32_t istring)
       // Do we need to check value of ftp->fflen? #27323
       if (ftp->flen > 0x40000000)
         return csound->InitError(csound,"%s", Str("table length too long"));
-      memcpy(ftp, &header, sizeof(FUNC) - sizeof(MYFLT*) - SSTRSIZ);
+      ftload_copy_header(csound, ftp, &header,
+                         sizeof(FUNC) - sizeof(MYFLT*) - SSTRSIZ);
       memset(ftp->ftable, 0, sizeof(MYFLT) * ((uint64_t) ftp->flen + 1));
       n = fread(ftp->ftable, sizeof(MYFLT), ftp->flen + 1l, file);
       if (UNLIKELY(n!=ftp->flen + 1)) goto err4;
@@ -434,7 +446,7 @@ static int32_t ftload_(CSOUND *csound, FTLOAD *p, int32_t istring)
       }
       ftp = ft_func(csound, &fno_f);
       if(ftp->ftable) {
-        memcpy(ftp, &header, sizeof(FUNC) - sizeof(MYFLT));
+        ftload_copy_header(csound, ftp, &header, sizeof(FUNC) - sizeof(MYFLT));
         memset(ftp->ftable, 0, sizeof(MYFLT) * (ftp->flen + 1));
       } else goto err;
         
@@ -523,10 +535,14 @@ static int32_t ftsave_(CSOUND *csound, FTLOAD *p, int32_t istring)
       FUNC *ftp;
       //csound->Message(csound, "saving table %f \n", **argp);
       if ( *argp && (ftp = csound->FTFind(csound, *argp)) != NULL) {
+        FUNC header = *ftp;
         MYFLT *table = ftp->ftable;
         int32 flen = ftp->flen;
         int32_t n;
-        n =  (int32_t) fwrite(ftp, sizeof(FUNC) - sizeof(MYFLT) - SSTRSIZ, 1, file);
+        header.args = NULL;
+        header.argcnt = 0;
+        header.ftable = NULL;
+        n =  (int32_t) fwrite(&header, sizeof(FUNC) - sizeof(MYFLT) - SSTRSIZ, 1, file);
         if (UNLIKELY(n!=1)) goto err4;
         n =  (int32_t) fwrite(table, sizeof(MYFLT), flen + 1, file);
         if (UNLIKELY(n!=flen + 1)) goto err4;

--- a/Opcodes/ftgen.c
+++ b/Opcodes/ftgen.c
@@ -785,16 +785,16 @@ static int32_t getftargs(CSOUND *csound, FTARGS *p)
   for (i = 1; i < argcnt; i++)
     strlen += snprintf(NULL, 0, "%g ", src->args[i]);
 
-  p->Scd->size = strlen + 1;
+  p->Scd->size = strlen;
 
   if (p->Scd->data == NULL) {
-    p->Scd->data = (char*) csound->Calloc(csound, strlen + 1);
+    p->Scd->data = (char*) csound->Calloc(csound, strlen);
   }
   else
-    p->Scd->data = (char*) csound->ReAlloc(csound, p->Scd->data, strlen + 1);
+    p->Scd->data = (char*) csound->ReAlloc(csound, p->Scd->data, strlen);
 
   {
-    char* curr = p->Scd->data, *const end = curr + strlen + 1;
+    char* curr = p->Scd->data, *const end = curr + strlen;
     for (i = 1; curr != end && i < argcnt; i++) {
       curr += snprintf(curr, end-curr, "%g ", src->args[i]);
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -452,6 +452,7 @@ def runTest():
         ["test_parse_error_udo_missing_arglist.csd", "expected failure: udo missing arg list", 1],
         ["test_gen49_defer.csd", "test GEN49 deferred length"],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
+        ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],
         ["test_global_struct_var.csd", "testing global structure var"],
         ["test_setscorepos.csd", "testing setscorepos and rewindscore"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -451,6 +451,7 @@ def runTest():
         ["test_parse_error_udo_missing_commas.csd", "expected failure: udo missing commas", 1],
         ["test_parse_error_udo_missing_arglist.csd", "expected failure: udo missing arg list", 1],
         ["test_gen49_defer.csd", "test GEN49 deferred length"],
+        ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],
         ["test_global_struct_var.csd", "testing global structure var"],
         ["test_setscorepos.csd", "testing setscorepos and rewindscore"],

--- a/tests/commandline/test_ftload_binary_args_ownership.csd
+++ b/tests/commandline/test_ftload_binary_args_ownership.csd
@@ -1,0 +1,44 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giSrc = ftgen(1, 0, 16, -2, 11, 22, 33, 44)
+giDst = ftgen(2, 0, 16, 2, 0)
+
+opcode AssertTableValue(ndx:i, fn:i, exptc:i):void
+  value:i = table:i(ndx, fn)
+  if value != exptc then
+    prints("ftload ownership: value mismatch at index %d, expected %d, got %f\n", ndx, exptc, value)
+    exitnow(-1)
+  endif
+endop
+
+instr 1
+  prints("ftload ownership: saving table 1\n")
+  ftsave("test_ftload_binary_args_ownership.ftsave", 0, 1)
+  prints("ftload ownership: loading table 1 as table 2\n")
+  ftload("test_ftload_binary_args_ownership.ftsave", 0, 2)
+
+  prints("ftload ownership: checking loaded table data\n")
+  AssertTableValue(0, 2, 11)
+  AssertTableValue(1, 2, 22)
+  AssertTableValue(2, 2, 33)
+  AssertTableValue(3, 2, 44)
+
+  prints("ftload ownership: freeing table 2\n")
+  ftfree(2, 0)
+  prints("ftload ownership: freeing table 1\n")
+  ftfree(1, 0)
+  prints("ftload ownership: passed\n")
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_getftargs_empty_after_ftload.csd
+++ b/tests/commandline/test_getftargs_empty_after_ftload.csd
@@ -1,0 +1,28 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giSrc = ftgen(1, 0, 16, -2, 1)
+giDst = ftgen(2, 0, 16, 2, 0)
+
+instr 1
+  ftsave("test_getftargs_empty_after_ftload.ftsave", 0, 1)
+  ftload("test_getftargs_empty_after_ftload.ftsave", 0, 2)
+  Sargs getftargs 2, 1
+
+  if strlen(Sargs) != 0 then
+    prints("getftargs: expected empty args after ftload, got '%s'\n", Sargs)
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Starting from a review of the stm opcode clocks #2587, this ended up uncovering what looks like a
long-standing memory bug in Engine/fgens.c.

`csoundFTAlloc()` allocated FUNC headers with Malloc, leaving fields such as `ftp->args`
uninitialized. Later, `csoundFTCreate()` could do:
```c
if (ftp->args != NULL) csound->Free(csound, ftp->args);
```
and attempt to free a pointer that was never written by Csound.
This showed up in Windows CI in the deferred `GEN49` path:

```text
Return Code: 3221226356  ->  0xC0000374  =  STATUS_HEAP_CORRUPTION
```
or, with a different heap layout:
```text
csound command: received signal 11
```
The output always stopped right after: 
`ftable 101`:
which places the crash inside the deferred-length ftgen.

Under AddressSanitizer, the pointer passed to `free()` had the malloc fill pattern:

```text
#0 csoundFree  memalloc.c
#1 ftgen_      ftgen.c

x[1] = 0xbebebebebebebebe
```
So the pointer was not valid-but-corrupted table memory; it was an uninitialized field in
the FUNC header.

## Fix

This patch:

- allocates FUNC headers with Calloc
- fixes the relocation branch of csoundFTAlloc(), which allocated len * sizeof(MYFLT) instead of sizeof(FUNC)
- adds ftfree() to release the FUNC header together with its owned ftable and args buffers
- releases args before ftalloc() clears a reused same-size FUNC header

## Verification

The original failing case now passes with Guard Malloc and filled allocations:

DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib MALLOC_FILL_SPACE=1 \
  ./csound tests/commandline/test_gen49_defer.csd

I also used targeted `.csd` reproducers for paths that are not covered by the normal suite:

- `csoundFTFree()` releasing table storage
- `ftalloc()` same-size replacement/reuse
- `ftalloc()` different-size relocation
- `csoundFTAlloc()` relocation via ftload

The leak was measurable. Creating and releasing thirty 8 MB tables changed from:

before: max RSS = 262 MB
after : max RSS =  31 MB

The targeted tests are included below for review/reproduction if useful.
<details>
<summary>Test 1: csoundFTFree leak check</summary>

<CsoundSynthesizer>
<CsOptions>
-n -m0
</CsOptions>
<CsInstruments>
sr=44100
ksmps=32
nchnls=1
0dbfs=1

instr 1
    fn:i = ftgen(1, 0, 1048576, 10, 1)
    ftfree(1, 0)
endin
</CsInstruments>
<CsScore>
r30
i 1 0 0.001
s
e
</CsScore>
</CsoundSynthesizer>
</details>
<details>
<summary>Test 2: ftalloc reuse/free/relocation paths</summary>

<CsoundSynthesizer>
<CsOptions>
-n
</CsOptions>
<CsInstruments>
sr     = 44100
ksmps  = 32
nchnls = 1
0dbfs  = 1

opcode sumtab(fn:i):i
    s:i = 0
    i:i = 0
    while i < ftlen(fn) do
        s += table:i(i, fn)
        i += 1
    od
    xout s
endop

instr 1
    a:i = ftgen(3, 0, 16, 10, 1)
    b:i = ftgen(3, 0, 16, 10, 1, 0.5)
    if ftlen(3) != 16 then
        prints("[FAIL] reuse: ftlen(3)=%d expected 16\n", ftlen(3))
        exitnow(-1)
    endif
    prints("[reuse] ftlen(3)=%d sum=%f\n", ftlen(3), sumtab(3))
endin

instr 2
    c:i = ftgen(4, 0, 32, 10, 1)
    prints("[free] before: ftlen(4)=%d\n", ftlen(4))
    ftfree(4, 0)
    prints("[free] table 4 released\n")
endin

instr 3
    d:i = ftgen(5, 0, 16, 10, 1)
    e:i = ftgen(5, 0, 64, 10, 1)
    if ftlen(5) != 64 then
        prints("[FAIL] relocate: ftlen(5)=%d expected 64\n", ftlen(5))
        exitnow(-1)
    endif
    prints("[relocate] ftlen(5)=%d sum=%f\n", ftlen(5), sumtab(5))
    prints("[ftlifetime] OK\n")
endin
</CsInstruments>
<CsScore>
i 1 0 0.05
i 2 0.05 0.05
i 3 0.10 0.05
e
</CsScore>
</CsoundSynthesizer>
</details>
<details>
<summary>Test 3: csoundFTAlloc relocation via ftload</summary>

<CsoundSynthesizer>
<CsOptions>
-n
</CsOptions>
<CsInstruments>
sr     = 44100
ksmps  = 32
nchnls = 1
0dbfs  = 1

instr 1
    src:i = ftgen(1, 0, 16, 10, 1)
    ftsave("ftrelo.bin", 0, 1)

    dst:i = ftgen(2, 0, 32, 10, 1)
    prints("[relo] before: ftlen(2)=%d\n", ftlen(2))

    ftload("ftrelo.bin", 0, 2)
    prints("[relo] after : ftlen(2)=%d\n", ftlen(2))

    if ftlen(2) != 16 then
        prints("[FAIL] relocation did not resize table 2\n")
        exitnow(-1)
    endif

    sum:i = 0
    idx:i = 0
    while idx < ftlen(2) do
        sum += table:i(idx, 2)
        idx += 1
    od

    prints("[relo] read back %d points, sum=%f\n", ftlen(2), sum)
    prints("[relo] OK\n")
endin
</CsInstruments>
<CsScore>
i 1 0 0.1
e
</CsScore>
</CsoundSynthesizer>
</details>

I may still be missing something in the FUNC ownership model, so I would really appreciate
a careful review to confirm whether this is indeed a memory bug and whether this is the
right fix.