### PR TITLE
Preserve UDO inputs that alias output variables

### DIFF
--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -745,6 +745,7 @@ static void pbr_apply_entries(CSOUND *csound,
                               UOPCODE *p,
                               OPDS *chain,
                               char *op_mem_start,
+                              XIN *xin,
                               const PBR_REWIRE_ENTRY *entries,
                               int32_t entry_count) {
   int32_t max_ar_index;
@@ -761,15 +762,32 @@ static void pbr_apply_entries(CSOUND *csound,
 
   for (i = 0; i < entry_count; i++) {
     const PBR_REWIRE_ENTRY *entry = &entries[i];
+    MYFLT *target;
 
     if (entry->ar_index < 0 || entry->ar_index >= max_ar_index) {
       continue;
     }
 
+    target = p->ar[entry->ar_index];
+    if (xin != NULL &&
+        entry->ar_index >= p->buf->opcode_info->outchns) {
+      int32_t input_index = entry->ar_index - p->buf->opcode_info->outchns;
+      int32_t output_index;
+
+      for (output_index = 0;
+           output_index < p->buf->opcode_info->outchns;
+           output_index++) {
+        if (p->ar[output_index] == target) {
+          target = xin->args[input_index];
+          break;
+        }
+      }
+    }
+
     rewire_argpp(csound,
                  (OPDS *)(op_mem_start + entry->opcode_mem_offset),
                  entry->arg_index,
-                 p->ar[entry->ar_index],
+                 target,
                  entry->structPath);
   }
 }
@@ -791,6 +809,57 @@ static void pbr_copy_value(CSOUND *csound, MYFLT *dst, MYFLT *src, INSDS *ctx) {
   } else {
     *dst = *src;
   }
+}
+
+static XIN *pbr_find_xin(INSDS *lcurip) {
+  OPDS *op;
+
+  if (lcurip == NULL) {
+    return NULL;
+  }
+
+  for (op = (OPDS *)lcurip->nxti; op != NULL; op = op->nxti) {
+    const char *opname = op->optext != NULL && op->optext->t.oentry != NULL ?
+      op->optext->t.oentry->opname : NULL;
+    if (opname != NULL && strcmp(opname, "xin") == 0) {
+      return (XIN *)op;
+    }
+  }
+
+  return NULL;
+}
+
+static XIN *pbr_snapshot_colliding_inputs(CSOUND *csound,
+                                          UOPCODE *p,
+                                          INSDS *lcurip) {
+  OPCODINFO *udoinfo;
+  XIN *xin;
+  int32_t i;
+
+  if (p == NULL || p->buf == NULL || p->buf->opcode_info == NULL ||
+      lcurip == NULL) {
+    return NULL;
+  }
+
+  udoinfo = p->buf->opcode_info;
+  xin = pbr_find_xin(lcurip);
+  if (xin == NULL) {
+    return NULL;
+  }
+
+  for (i = 0; i < udoinfo->inchns; i++) {
+    MYFLT *input = p->ar[udoinfo->outchns + i];
+    int32_t j;
+
+    for (j = 0; j < udoinfo->outchns; j++) {
+      if (p->ar[j] == input) {
+        pbr_copy_value(csound, xin->args[i], input, lcurip);
+        break;
+      }
+    }
+  }
+
+  return xin;
 }
 
 static int32_t pbr_is_readonly_source(MYFLT *src) {
@@ -1130,17 +1199,20 @@ static void handle_pass_by_ref(CSOUND* csound, UOPCODE* p, INSDS* lcurip) {
   OPCODINFO *udoinfo = (OPCODINFO*) p->h.optext->t.oentry->useropinfo;
   PBR_REWIRE_PLAN *plan = udoinfo != NULL ? udoinfo->pbr_plan : NULL;
   char *op_mem_start = pbr_get_opcode_mem_start(lcurip);
+  XIN *xin;
 
   if (plan == NULL || op_mem_start == NULL) {
     return;
   }
 
+  xin = pbr_snapshot_colliding_inputs(csound, p, lcurip);
+
   /* Rewire internal opcodes to point at caller storage.  For pass-through
      variables (xin->xout same name), the alias now points at the output slot
      so internal writes go to the caller's output variable. */
-  pbr_apply_entries(csound, p, lcurip->nxti, op_mem_start,
+  pbr_apply_entries(csound, p, lcurip->nxti, op_mem_start, xin,
                     plan->init_entries, plan->init_count);
-  pbr_apply_entries(csound, p, lcurip->nxtp, op_mem_start,
+  pbr_apply_entries(csound, p, lcurip->nxtp, op_mem_start, xin,
                     plan->perf_entries, plan->perf_count);
 
   /* Seed pass-through outputs before the internal chain runs.  Constants and
@@ -2049,6 +2121,7 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
     return OK;
   p->ip->spin = p->parent_ip->spin;
   p->ip->spout = p->parent_ip->spout;
+  pbr_snapshot_colliding_inputs(csound, p, p->ip);
   pbr_seed_pass_through_outputs(csound, p, p->ip);
   p->ip->kcounter++;  /* kcount should be incremented BEFORE perf */
   if (UNLIKELY(!(CS_PDS = (OPDS*) (p->ip->nxtp))))

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -842,10 +842,7 @@ static XIN *pbr_snapshot_colliding_inputs(CSOUND *csound,
   }
 
   udoinfo = p->buf->opcode_info;
-  xin = pbr_find_xin(lcurip);
-  if (xin == NULL) {
-    return NULL;
-  }
+  xin = NULL;
 
   for (i = 0; i < udoinfo->inchns; i++) {
     MYFLT *input = p->ar[udoinfo->outchns + i];
@@ -853,6 +850,12 @@ static XIN *pbr_snapshot_colliding_inputs(CSOUND *csound,
 
     for (j = 0; j < udoinfo->outchns; j++) {
       if (p->ar[j] == input) {
+        if (xin == NULL) {
+          xin = pbr_find_xin(lcurip);
+          if (xin == NULL) {
+            return NULL;
+          }
+        }
         pbr_copy_value(csound, xin->args[i], input, lcurip);
         break;
       }

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -156,6 +156,52 @@ opcode scaleAudio(aSig):a
 endop
 
 
+// Recursive series filter from the opcode manual, in classic pass-by-copy
+// and modern pass-by-reference forms.
+opcode LowpassByCopy, a, akk
+    setksmps 1
+    aIn, kCoefficient1, kCoefficient2 xin
+    aOut init 0
+    aOut = aIn * kCoefficient1 + aOut * kCoefficient2
+    xout aOut
+endop
+
+
+opcode RecursiveLowpassByCopy, a, akkpp
+    aIn, kCoefficient1, kCoefficient2, iDepth, iCount xin
+    if (iCount >= iDepth) goto done
+    aIn RecursiveLowpassByCopy aIn, kCoefficient1, kCoefficient2, \
+        iDepth, iCount + 1
+done:
+    aOut LowpassByCopy aIn, kCoefficient1, kCoefficient2
+    xout aOut
+endop
+
+
+opcode LowpassByReference(input:a, coefficient1:k, coefficient2:k):a
+    sampleIndex:k = 0
+    output:a init 0
+    previous:k init 0
+    while sampleIndex < ksmps do
+        output[sampleIndex] = input[sampleIndex] * coefficient1 + \
+            previous * coefficient2
+        previous = output[sampleIndex]
+        sampleIndex += 1
+    od
+    xout output
+endop
+
+
+opcode RecursiveLowpassByReference(signal:a, coefficient1:k, coefficient2:k, \
+                                   depth:p, count:p):a
+    if (count < depth) then
+        signal = RecursiveLowpassByReference(signal, coefficient1, \
+                                             coefficient2, depth, count + 1)
+    endif
+    xout LowpassByReference(signal, coefficient1, coefficient2)
+endop
+
+
 instr 1
     iv = 33
     iv2 = 77
@@ -539,6 +585,29 @@ instr 36
 endin
 
 
+instr 37
+    // Recursive pass-by-reference filtering must match the classic copy path.
+    input:a = oscili(0.5, 220)
+    coefficient:k = linseg(0.2, p3, 0.8)
+    byCopy:a RecursiveLowpassByCopy input, coefficient, 1 - coefficient, 10
+    byReference:a = RecursiveLowpassByReference(input, coefficient, \
+                                                 1 - coefficient, 10)
+    difference:a = byCopy - byReference
+    peakError:k peak difference
+    outputPeak:k peak byCopy
+
+    if (peakError > 0.000001) then
+        printks "ERROR: recursive pass-by-reference filter differs by %g\n", \
+            0, peakError
+        exitnowk(-1)
+    endif
+    if (timeinstk() == 2 && outputPeak == 0) then
+        printks "ERROR: recursive filter produced no signal\n", 0
+        exitnowk(-1)
+    endif
+endin
+
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -563,6 +632,7 @@ i33 0 1
 i34 0 1
 i35 0 1
 i36 0 0.01
+i37 0 0.05
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -72,6 +72,14 @@ opcode incrAndReturnK(kval):k
 endop
 
 
+// Writes the output before reading the input, exposing caller-side aliasing.
+opcode incrementAliasedK(source:k):k
+    result:k = 0
+    result = source + 1
+    xout result
+endop
+
+
 opcode incrExpr(ival):(i,i)
     xout ival + 1, ival + 2
 endop
@@ -517,6 +525,20 @@ instr 35
 endin
 
 
+// The output and input share caller storage at performance time. The input
+// must retain its value until incrementAliasedK reads it.
+instr 36
+    value:k init 5
+    value = incrementAliasedK(value)
+
+    if (timeinstk() == 1 && value != 6) then
+        printks "ERROR: aliased k input was overwritten: expected 6, got %g\n", \
+            0, value
+        exitnowk(-1)
+    endif
+endin
+
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -540,6 +562,7 @@ i32 0 0.01
 i33 0 1
 i34 0 1
 i35 0 1
+i36 0 0.01
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -13,6 +13,14 @@ nchnls	= 2
 
 struct TestStruct member1:i
 struct TestStruct2515 var1:i, var2:i
+struct AccumulatorNode value:i, previous:AccumulatorNode[], length:i
+
+opcode prependNode(value:i, previous:AccumulatorNode):AccumulatorNode
+    previousItems:AccumulatorNode[] init 1
+    node:AccumulatorNode init value, previousItems, 1
+    node.previous[0] = previous
+    xout node
+endop
 
 // increments the value in the passed-in pointer
 opcode incr(ival):void
@@ -497,6 +505,18 @@ instr 34
 endin
 
 
+// The output and final input share caller storage. Constructing the output
+// must not overwrite the input before the UDO embeds its previous value.
+instr 35
+    noPrevious:AccumulatorNode[] init 0
+    accumulator:AccumulatorNode init 1, noPrevious, 0
+    accumulator = prependNode(2, accumulator)
+
+    assertEquals(accumulator.value, 2)
+    assertEquals(accumulator.previous[0].value, 1)
+endin
+
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -519,6 +539,7 @@ i31 0 0.01
 i32 0 0.01
 i33 0 1
 i34 0 1
+i35 0 1
 ; i"SoundTest" 0 4 220 0.25
 ; i"SoundTest" 1 3 330 0.25
 ; i"SoundTest" 2 3 440 0.25


### PR DESCRIPTION
A new-style UDO could overwrite an input too early when the same caller variable was used for both the input and output.

For example:

```csound
accumulator = append(2, accumulator)
```

The output was constructed directly in accumulator, so the UDO lost the previous input value before it could embed or read it.

This change snapshots inputs whose storage aliases an output and wires input reads to that preserved value. Inputs and outputs that do not alias keep their existing pass-by-reference behavior.