### PR TITLE
Fix input and output order in declared UDO signatures

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -3656,7 +3656,7 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
                                                      current->left->right,
                                                      typeTable);
       add_udo_definition(csound, false, current->value->lexeme,
-             inArgStringDecl, outArgStringDecl, UNDEFINED);
+                         outArgStringDecl, inArgStringDecl, UNDEFINED);
       csound->inZero = 0;
       if (UNLIKELY(csoundGetDebug(csound) & DEBUG_SEMANTICS))
 	csound->Message(csound, "UDO declared\n");

--- a/tests/commandline/test_declare.csd
+++ b/tests/commandline/test_declare.csd
@@ -7,17 +7,24 @@ nchnls = 2
 0dbfs = 1
 
 struct TypeX val1:i
+struct TypeY val1:i
 
-declare myFun(arg1:TypeX):(TypeX)
+declare myFun(arg1:TypeX, amount:i):(TypeY)
 
 instr 1
   varX:TypeX init 1
-  varY:TypeX = myFun(varX)
-  print(varY.val1)
+  varY:TypeY = myFun(varX, 2)
+
+  if (varY.val1 != 3) then
+    prints "declare signature test failed: expected 3, got %d\n", varY.val1
+    exitnow(1)
+  else
+    prints "declare signature test passed\n"
+  endif
 endin
 
-opcode myFun(arg1:TypeX):TypeX
-  retVal:TypeX init arg1.val1 + 1
+opcode myFun(arg1:TypeX, amount:i):TypeY
+  retVal:TypeY init arg1.val1 + amount
   xout(retVal)
 endop
 


### PR DESCRIPTION
Forward-declared UDO signatures stored their input and output types in the opposite order.

This caused calls to a declared UDO to resolve against the wrong signature, particularly when the input and output types differed.

This change keeps the declared signature in the same input/output order as the UDO definition. Regression coverage verifies that forward declarations resolve and compile with distinct argument and return types.