### PR TITLE
Prefer exact opcode signatures over polymorphic matches

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1474,7 +1474,8 @@ int32_t check_out_args(CSOUND* csound, char* outArgsFound, char* opOutArgs)
 
 
 OENTRY* resolve_opcode_exact(CSOUND* csound, OENTRIES* entries,
-                             char* outArgTypes, char* inArgTypes) {
+                             const char* outArgTypes,
+                             const char* inArgTypes) {
   IGN(csound);
   int32_t i;
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -1473,6 +1473,25 @@ int32_t check_out_args(CSOUND* csound, char* outArgsFound, char* opOutArgs)
 }
 
 
+OENTRY* resolve_opcode_exact(CSOUND* csound, OENTRIES* entries,
+                             char* outArgTypes, char* inArgTypes) {
+  IGN(csound);
+  int32_t i;
+
+  const char* outTest = (outArgTypes == NULL || !strcmp("0", outArgTypes)) ?
+                          "" : outArgTypes;
+  const char* inTest = (inArgTypes == NULL || !strcmp("0", inArgTypes)) ?
+                         "" : inArgTypes;
+  for (i = 0; i < entries->count; i++) {
+    OENTRY* temp = entries->entries[i];
+    if (temp->intypes != NULL && !strcmp(inTest, temp->intypes) &&
+        temp->outypes != NULL && !strcmp(outTest, temp->outypes)) {
+      return temp;
+    }
+  }
+  return NULL;
+}
+
 /* Given an OENTRIES list, resolve to a single OENTRY* based on the
  * found in- and out- argtypes.  Returns NULL if opcode could not be
  * resolved. If more than one entry matches, mechanism assumes there
@@ -1482,6 +1501,14 @@ int32_t check_out_args(CSOUND* csound, char* outArgsFound, char* opOutArgs)
 OENTRY* resolve_opcode(CSOUND* csound, OENTRIES* entries,
                        char* outArgTypes, char* inArgTypes) {
   int32_t i, check;
+  OENTRY* exact;
+
+  /* A polymorphic or variadic entry must not shadow a concrete signature. */
+  if ((exact = resolve_opcode_exact(csound, entries,
+                                    outArgTypes, inArgTypes)) != NULL) {
+    return exact;
+  }
+
   for (i = 0; i < entries->count; i++) {
     OENTRY* temp = entries->entries[i];
     if ((check = check_in_args(csound, inArgTypes, temp->intypes)) &&
@@ -1493,23 +1520,6 @@ OENTRY* resolve_opcode(CSOUND* csound, OENTRIES* entries,
                 args_required(inArgTypes), temp->opname, VARGMAX);
         return NULL;
       }
-      return temp;
-    }
-  }
-  return NULL;
-}
-
-
-OENTRY* resolve_opcode_exact(CSOUND* csound, OENTRIES* entries,
-                             char* outArgTypes, char* inArgTypes) {
-  IGN(csound);
-  int32_t i;
-
-  char* outTest = (!strcmp("0", outArgTypes)) ? "" : outArgTypes;
-  for (i = 0; i < entries->count; i++) {
-    OENTRY* temp = entries->entries[i];
-    if (temp->intypes != NULL && !strcmp(inArgTypes, temp->intypes) &&
-        temp->outypes != NULL && !strcmp(outTest, temp->outypes)) {
       return temp;
     }
   }

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -146,9 +146,9 @@ const OENTRY opcodlst_1[] = {
   { "=.bb",    S(RELAT),0,       "b", "b", (SUBR) b2b, NULL, NULL, NULL  },
 
   { "B",    S(RELAT),0,       "B", "k", NULL, (SUBR) bassign, NULL, NULL  },
-  { "=.ib",    S(ASSIGN),0,       "i", "b", (SUBR) b2s, NULL, NULL, NULL  },
+  { "=.ib",    S(ASSIGN),0,       "i", "b", (SUBR) b2i, NULL, NULL, NULL  },
   { "=.kB",    S(ASSIGN),0,       "k", "B", NULL, (SUBR) b2s, NULL, NULL  },
-  { "i",    S(ASSIGN),0,       "i", "b", (SUBR) b2s, NULL, NULL, NULL  },
+  { "i",    S(ASSIGN),0,       "i", "b", (SUBR) b2i, NULL, NULL, NULL  },
   { "k",    S(ASSIGN),0,       "k", "B", NULL, (SUBR) b2s, NULL, NULL  },
   { "=.k",    S(ASSIGNM),0,        "zzzzzzzzzzzzzzzzzzzzzzzz", "z",
     NULL, minit, NULL, NULL },

--- a/H/aops.h
+++ b/H/aops.h
@@ -261,6 +261,7 @@ int32_t bassign(CSOUND *csound, RELAT *p);
 int32_t and_kk_bool(CSOUND *csound, LOGCL_KK *p);
 int32_t or_kk_bool(CSOUND *csound, LOGCL_KK *p);
 int32_t b2s(CSOUND *csound, ASSIGN *p);
+int32_t b2i(CSOUND *csound, ASSIGN *p);
 int32_t b2b(CSOUND *csound, ASSIGN *p);
 int32_t binit(CSOUND *csound, ASSIGNM *p);
 int32_t mainit2(CSOUND *csound, ASSIGNM *p);

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -78,9 +78,15 @@ int32_t retrievek(CSOUND *csound, STOREI *p) {
 
 
 int32_t b2s(CSOUND *csound, ASSIGN *p){
-  // B type can be either a boolean (int32_t) or a k-rate value (MYFLT).
-  // Since both are stored as MYFLT in memory, just copy the value directly.
+  // B may use MYFLT storage when it represents a k-rate boolean.
   *p->r = *p->a;
+  return OK;
+}
+
+int32_t b2i(CSOUND *csound, ASSIGN *p){
+  int32_t value;
+  memcpy(&value, p->a, sizeof(value));
+  *p->r = (MYFLT) value;
   return OK;
 }
 

--- a/tests/c/csound_orc_semantics_test.cpp
+++ b/tests/c/csound_orc_semantics_test.cpp
@@ -19,6 +19,7 @@
 extern "C" {
     extern OENTRIES* find_opcode2 (CSOUND* csound, const char* opname);
     extern OENTRY* resolve_opcode (CSOUND*, OENTRIES* entries,  const char* outArgTypes, const char* inArgTypes);
+    extern OENTRY* resolve_opcode_exact (CSOUND*, OENTRIES* entries, const char* outArgTypes, const char* inArgTypes);
     extern OENTRY* find_opcode_new (CSOUND* csound,  const char* opname, const char* outArgsFound, const char* inArgsFound);
     extern bool check_in_arg (const char* found, const char* required);
     extern bool check_in_args (CSOUND* csound, const char* outArgsFound, const char* opOutArgs);
@@ -67,6 +68,16 @@ TEST_F (OrcSemanticsTest, ResolveOpcodeTest)
 
     OENTRY* opc = resolve_opcode(csound, entries, (char *)  "k", (char *) "k");
     ASSERT_TRUE (opc != NULL);
+
+    opc = resolve_opcode(csound, entries, (char *) "i", (char *) "b");
+    ASSERT_STREQ("=.ib", opc->opname);
+    csound->Free(csound, entries);
+
+    entries = find_opcode2(csound, "##userOpcode");
+    opc = resolve_opcode_exact(csound, entries, NULL, NULL);
+    ASSERT_TRUE(opc != NULL);
+    opc = resolve_opcode_exact(csound, entries, "0", "0");
+    ASSERT_TRUE(opc != NULL);
     csound->Free(csound, entries);
 
     entries = find_opcode2(csound,  "vco2");

--- a/tests/commandline/structs/test_struct_array_nested_condition_arg.csd
+++ b/tests/commandline/structs/test_struct_array_nested_condition_arg.csd
@@ -5,6 +5,12 @@
 <CsInstruments>
 
 struct Item label:S, children:Item[]
+struct Control kind:i, enabled:i
+
+opcode IsEnabled(value:Control):i
+  result:i = value.kind == 20 && value.enabled == 1
+  xout result
+endop
 
 instr 1
   none:Item[] init 0
@@ -20,6 +26,13 @@ instr 1
 
   if (strcmp(root.children[0].children[0].label, "grand") != 0) then
     prints "nested condition failed\n"
+    exitnow(1)
+  endif
+
+  control:Control init 20, 1
+  enabled:i = IsEnabled(control)
+  if (enabled != 1) then
+    prints "struct boolean assignment failed: expected 1, got %d\n", enabled
     exitnow(1)
   endif
 endin

--- a/tests/commandline/test_booleans.csd
+++ b/tests/commandline/test_booleans.csd
@@ -12,6 +12,12 @@ instr 1
   else
     prints "pass\n"
   endif
+
+  result:i = 9 != 10 && 1 == 1
+  if result != 1 then
+    prints "boolean-to-i conversion failed: expected 1, got %d\n", result
+    exitnow(-1)
+  endif
 endin
 
 instr 2


### PR DESCRIPTION
Boolean expressions assigned to explicitly typed `i` variables could produce the wrong value.

Both the generic `=.i` assignment and the exact `=.ib` assignment matched `i <- b`. Opcode resolution selected the first compatible entry, allowing the generic variadic signature to hide the exact boolean assignment.

This changes opcode resolution to try an exact input and output signature first, then fall back to the existing polymorphic matching. It also separates init-rate boolean conversion from the existing k-rate boolean copy because they use different storage representations.