### PR TITLE
Add a non-blocking readline opcode and host text input API

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -1222,6 +1222,15 @@ jobs:
               done
             '
 
+      - name: Verify readline host API is exported
+        run: |
+          for ARCH in arm arm64 x86 x64; do
+            LIBRARY=$(find "build/$ARCH" -type f -name 'libcsound.so*' -print -quit)
+            test -n "$LIBRARY"
+            readelf --wide --dyn-syms "$LIBRARY" |
+              grep -F 'csoundReadlinePushText' > /dev/null
+          done
+
   wasm_build:
     name: Wasm build (emscripten/vcpkg)
     runs-on: ubuntu-latest
@@ -1293,6 +1302,11 @@ jobs:
           export ANDROID_NDK_ROOT="$PWD/AndroidNDK.app/Contents/NDK"
           cd CsoundAndroid
           sh build.sh
+
+      - name: Verify readline Android binding
+        working-directory: Android
+        run: |
+          grep -R -F 'ReadlinePushText' CsoundAndroid/src/csnd7 > /dev/null
 
       - name: create release package
         working-directory: Android

--- a/Android/CsoundAndroid/jni/Android.mk
+++ b/Android/CsoundAndroid/jni/Android.mk
@@ -87,6 +87,7 @@ $(CSOUND_SRC_ROOT)/OOps/pstream.c \
 $(CSOUND_SRC_ROOT)/OOps/pvfileio.c \
 $(CSOUND_SRC_ROOT)/OOps/pvsanal.c \
 $(CSOUND_SRC_ROOT)/OOps/random.c \
+$(CSOUND_SRC_ROOT)/OOps/readline.c \
 $(CSOUND_SRC_ROOT)/OOps/remote.c \
 $(CSOUND_SRC_ROOT)/OOps/schedule.c \
 $(CSOUND_SRC_ROOT)/OOps/sndinfUG.c \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -954,6 +954,7 @@ set(libcsound_SRCS
     OOps/pvfileio.c
     OOps/pvsanal.c
     OOps/random.c
+    OOps/readline.c
     OOps/remote.c
     OOps/schedule.c
     OOps/sndinfUG.c

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -2076,6 +2076,8 @@ const OENTRY opcodlst_1[] = {
     NULL, (SUBR) sensekey_perf, NULL                      },
   { "sensekey",    S(KSENSE),0,                  "kz",           "",
     NULL, (SUBR) sensekey_perf, NULL                      },
+  { "readline",    S(READLINE_OPCODE),0,         "Sk",           "S",
+    (SUBR) readline_init, (SUBR) readline_perf, (SUBR) readline_deinit },
   { "remove",      S(DELETEIN),0,               "",             "T",
     (SUBR) delete_instr, NULL, NULL                       },
   //  { "##globallock",   S(GLOBAL_LOCK_UNLOCK),0,  "", "i",

--- a/H/entry.h
+++ b/H/entry.h
@@ -63,6 +63,7 @@
 #include "ugtabs.h"
 #include "compile_ops.h"
 #include "lpred.h"
+#include "readline.h"
 #include "midiops3.h"
 #include "midiops2.h"
 #include "pitch.h"

--- a/H/readline.h
+++ b/H/readline.h
@@ -1,0 +1,38 @@
+/*
+  readline.h:
+
+  Copyright (C) 2026 The Csound Developers
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+#pragma once
+
+#include "csoundCore.h"
+
+/* status is 1 for a completed line, 0 while waiting, and -1 at EOF. */
+typedef struct {
+  OPDS h;
+  STRINGDAT *line;
+  MYFLT *status;
+  STRINGDAT *prompt;
+  void *state;
+} READLINE_OPCODE;
+
+int32_t readline_init(CSOUND *, READLINE_OPCODE *);
+int32_t readline_perf(CSOUND *, READLINE_OPCODE *);
+int32_t readline_deinit(CSOUND *, READLINE_OPCODE *);

--- a/OOps/readline.c
+++ b/OOps/readline.c
@@ -30,6 +30,7 @@
 #if defined(WIN32)
 #include <conio.h>
 #include <io.h>
+#include <windows.h>
 #elif defined(HAVE_TERMIOS_H) && defined(HAVE_UNISTD_H) && \
       !defined(__EMSCRIPTEN__) && !defined(__wasi__)
 #define CSOUND_READLINE_POSIX 1
@@ -40,6 +41,12 @@
 
 #define READLINE_GLOBALS_NAME "::readline_globals::"
 #define READLINE_INITIAL_CAPACITY 128
+#define READLINE_OUTPUT_CAPACITY 65536
+#define READLINE_OUTPUT_CHUNK 1024
+
+#if defined(WIN32) && !defined(ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
 
 enum {
   READLINE_POLL_ERROR = -2,
@@ -60,17 +67,37 @@ enum {
   READLINE_KEY_RIGHT
 };
 
+enum {
+  READLINE_PENDING_NONE = 0,
+  READLINE_PENDING_LINE = 1,
+  READLINE_PENDING_EOF = -1
+};
+
+typedef struct {
+  const char *data;
+  size_t length;
+} READLINE_OUTPUT_PART;
+
 typedef struct {
   READLINE_OPCODE *active;
   int32_t resetRegistered;
 } READLINE_GLOBALS;
 
 typedef struct {
+  CSOUND *csound;
   READLINE_GLOBALS *globals;
   char *buffer;
+  void *outputBuffer;
+  void *writerThread;
   size_t length;
   size_t cursor;
   size_t capacity;
+  int32_t writerStop;
+  int32_t outputError;
+  int32_t outputQueued;
+  int32_t outputCompleted;
+  int32_t pendingStatus;
+  int32_t pendingTarget;
   int32_t promptPending;
   int32_t lineOpen;
   int32_t eof;
@@ -78,6 +105,11 @@ typedef struct {
   int32_t interactive;
   int32_t terminalModeSet;
   int32_t ownsProcessInput;
+#if defined(WIN32)
+  HANDLE outputHandle;
+  DWORD savedOutputMode;
+  int32_t outputModeSet;
+#endif
 #if defined(CSOUND_READLINE_POSIX)
   struct termios savedTerminalMode;
 #endif
@@ -187,17 +219,134 @@ static int32_t copy_line_to_output(CSOUND *csound, READLINE_OPCODE *p)
   return OK;
 }
 
-static void write_prompt(READLINE_OPCODE *p)
+static uintptr_t terminal_writer(void *userData)
+{
+  READLINE_STATE *state = (READLINE_STATE *) userData;
+  char output[READLINE_OUTPUT_CHUNK];
+
+  for (;;) {
+    int32_t count = state->csound->ReadCircularBuffer(
+      state->csound, state->outputBuffer, output, READLINE_OUTPUT_CHUNK);
+
+    if (count == 0) {
+      if (ATOMIC_GET(state->writerStop))
+        break;
+      state->csound->Sleep(1);
+      continue;
+    }
+
+    size_t offset = 0;
+    while (offset < (size_t) count) {
+      size_t written = fwrite(output + offset, 1,
+                              (size_t) count - offset, stdout);
+
+      if (written > 0) {
+        offset += written;
+      }
+      else if (ferror(stdout) && errno == EINTR) {
+        clearerr(stdout);
+      }
+      else {
+        ATOMIC_SET(state->outputError, 1);
+        return 0;
+      }
+    }
+
+    if (fflush(stdout) != 0) {
+      ATOMIC_SET(state->outputError, 1);
+      return 0;
+    }
+    ATOMIC_ADD(state->outputCompleted, count);
+  }
+
+  return 0;
+}
+
+static int32_t start_terminal_writer(CSOUND *csound, READLINE_STATE *state)
+{
+  if (!state->interactive)
+    return OK;
+
+  state->outputBuffer = csound->CreateCircularBuffer(
+    csound, READLINE_OUTPUT_CAPACITY, sizeof(char));
+  if (UNLIKELY(state->outputBuffer == NULL))
+    return NOTOK;
+
+  state->writerThread = csound->CreateThread(terminal_writer, state);
+  if (UNLIKELY(state->writerThread == NULL)) {
+    csound->DestroyCircularBuffer(csound, state->outputBuffer);
+    state->outputBuffer = NULL;
+    return NOTOK;
+  }
+  return OK;
+}
+
+static void stop_terminal_writer(READLINE_STATE *state)
+{
+  if (state->writerThread != NULL) {
+    ATOMIC_SET(state->writerStop, 1);
+    state->csound->JoinThread(state->writerThread);
+    state->writerThread = NULL;
+  }
+
+  if (state->outputBuffer != NULL) {
+    state->csound->DestroyCircularBuffer(state->csound, state->outputBuffer);
+    state->outputBuffer = NULL;
+  }
+}
+
+static int32_t queue_terminal_output(READLINE_STATE *state,
+                                     const READLINE_OUTPUT_PART *parts,
+                                     size_t partCount)
+{
+  size_t total = 0;
+
+  if (!state->interactive)
+    return OK;
+
+  for (size_t index = 0; index < partCount; index++) {
+    if (parts[index].length > (size_t) INT32_MAX - total)
+      return NOTOK;
+    total += parts[index].length;
+  }
+
+  if (total == 0)
+    return OK;
+  if (state->outputBuffer == NULL ||
+      state->csound->CheckCircularBuffer(
+        state->csound, state->outputBuffer, 1) < (int32_t) total)
+    return NOTOK;
+
+  for (size_t index = 0; index < partCount; index++) {
+    int32_t length = (int32_t) parts[index].length;
+
+    if (length == 0)
+      continue;
+    if (state->csound->WriteCircularBuffer(
+          state->csound, state->outputBuffer,
+          parts[index].data, length) != length)
+      return NOTOK;
+    ATOMIC_ADD(state->outputQueued, length);
+  }
+  return OK;
+}
+
+static int32_t write_prompt(READLINE_OPCODE *p)
 {
   READLINE_STATE *state = (READLINE_STATE *) p->state;
 
   if (state->interactive && p->prompt->data != NULL &&
       p->prompt->data[0] != '\0') {
-    fputs(p->prompt->data, stdout);
-    fflush(stdout);
+    READLINE_OUTPUT_PART part = {
+      p->prompt->data, strlen(p->prompt->data)
+    };
+
+    if (UNLIKELY(queue_terminal_output(state, &part, 1) != OK))
+      return NOTOK;
     state->lineOpen = 1;
   }
   state->promptPending = 0;
+  return OK;
 }
 
 static int32_t is_utf8_continuation(char value)
@@ -239,75 +388,136 @@ static size_t count_characters(const READLINE_STATE *state, size_t start)
   return count;
 }
 
-static void move_terminal_cursor(READLINE_STATE *state, size_t count,
-                                 char direction)
+static int32_t format_cursor_sequence(char *buffer, size_t capacity,
+                                      size_t count, char direction,
+                                      size_t *length)
 {
-  if (state->interactive && count > 0) {
-    fprintf(stdout, "\033[%zu%c", count, direction);
-    fflush(stdout);
-  }
+  int32_t result = snprintf(buffer, capacity, "\033[%zu%c",
+                            count, direction);
+
+  if (UNLIKELY(result < 0 || (size_t) result >= capacity))
+    return NOTOK;
+  *length = (size_t) result;
+  return OK;
 }
 
-static void redraw_after_insert(READLINE_STATE *state, size_t insertPosition,
-                                int32_t fromTerminal)
+static int32_t move_terminal_cursor(READLINE_STATE *state, size_t count,
+                                    char direction)
 {
-  if (!state->interactive || !fromTerminal)
-    return;
+  char sequence[64];
+  size_t length;
+  READLINE_OUTPUT_PART part;
 
-  fwrite(state->buffer + insertPosition, 1,
-         state->length - insertPosition, stdout);
-  move_terminal_cursor(state, count_characters(state, state->cursor), 'D');
-  fflush(stdout);
-  state->lineOpen = 1;
+  if (!state->interactive || count == 0)
+    return OK;
+  if (UNLIKELY(format_cursor_sequence(sequence, sizeof(sequence),
+                                      count, direction, &length) != OK))
+    return NOTOK;
+
+  part.data = sequence;
+  part.length = length;
+  return queue_terminal_output(state, &part, 1);
 }
 
-static void redraw_after_backspace(READLINE_STATE *state,
+static int32_t redraw_after_insert(READLINE_STATE *state,
+                                   size_t insertPosition,
                                    int32_t fromTerminal)
 {
-  size_t tailLength;
+  char cursorSequence[64];
+  size_t cursorLength = 0;
+  size_t cursorCount;
+  READLINE_OUTPUT_PART parts[2];
 
   if (!state->interactive || !fromTerminal)
-    return;
+    return OK;
 
-  move_terminal_cursor(state, 1, 'D');
-  tailLength = state->length - state->cursor;
-  if (tailLength > 0)
-    fwrite(state->buffer + state->cursor, 1, tailLength, stdout);
-  fputc(' ', stdout);
-  move_terminal_cursor(state,
-                       count_characters(state, state->cursor) + 1, 'D');
-  fflush(stdout);
+  cursorCount = count_characters(state, state->cursor);
+  if (cursorCount > 0 &&
+      UNLIKELY(format_cursor_sequence(
+                 cursorSequence, sizeof(cursorSequence), cursorCount,
+                 'D', &cursorLength) != OK))
+    return NOTOK;
+
+  parts[0].data = state->buffer + insertPosition;
+  parts[0].length = state->length - insertPosition;
+  parts[1].data = cursorSequence;
+  parts[1].length = cursorLength;
+  if (UNLIKELY(queue_terminal_output(state, parts, 2) != OK))
+    return NOTOK;
+  state->lineOpen = 1;
+  return OK;
 }
 
-static void move_cursor_left(READLINE_STATE *state, int32_t fromTerminal)
+static int32_t redraw_after_backspace(READLINE_STATE *state,
+                                      int32_t fromTerminal)
+{
+  char leftSequence[64];
+  char rightSequence[64];
+  size_t leftLength;
+  size_t rightLength;
+  size_t tailLength;
+  READLINE_OUTPUT_PART parts[4];
+
+  if (!state->interactive || !fromTerminal)
+    return OK;
+
+  if (UNLIKELY(format_cursor_sequence(
+                 leftSequence, sizeof(leftSequence), 1,
+                 'D', &leftLength) != OK))
+    return NOTOK;
+
+  tailLength = state->length - state->cursor;
+  if (UNLIKELY(format_cursor_sequence(
+                 rightSequence, sizeof(rightSequence),
+                 count_characters(state, state->cursor) + 1,
+                 'D', &rightLength) != OK))
+    return NOTOK;
+
+  parts[0].data = leftSequence;
+  parts[0].length = leftLength;
+  parts[1].data = state->buffer + state->cursor;
+  parts[1].length = tailLength;
+  parts[2].data = " ";
+  parts[2].length = 1;
+  parts[3].data = rightSequence;
+  parts[3].length = rightLength;
+  return queue_terminal_output(state, parts, 4);
+}
+
+static int32_t move_cursor_left(READLINE_STATE *state, int32_t fromTerminal)
 {
   size_t position = previous_character(state, state->cursor);
 
   if (position != state->cursor) {
     state->cursor = position;
     if (fromTerminal)
-      move_terminal_cursor(state, 1, 'D');
+      return move_terminal_cursor(state, 1, 'D');
   }
+  return OK;
 }
 
-static void move_cursor_right(READLINE_STATE *state, int32_t fromTerminal)
+static int32_t move_cursor_right(READLINE_STATE *state, int32_t fromTerminal)
 {
   size_t position = next_character(state, state->cursor);
 
   if (position != state->cursor) {
     state->cursor = position;
     if (fromTerminal)
-      move_terminal_cursor(state, 1, 'C');
+      return move_terminal_cursor(state, 1, 'C');
   }
+  return OK;
 }
 
-static void finish_terminal_line(READLINE_STATE *state)
+static int32_t finish_terminal_line(READLINE_STATE *state)
 {
   if (state->interactive) {
-    fputs("\r\n", stdout);
-    fflush(stdout);
+    READLINE_OUTPUT_PART part = { "\r\n", 2 };
+
+    if (UNLIKELY(queue_terminal_output(state, &part, 1) != OK))
+      return NOTOK;
   }
   state->lineOpen = 0;
+  return OK;
 }
 
 static int32_t configure_terminal(CSOUND *csound, READLINE_STATE *state)
@@ -315,7 +525,28 @@ static int32_t configure_terminal(CSOUND *csound, READLINE_STATE *state)
 #if defined(WIN32)
   state->interactive = _isatty(_fileno(stdin)) &&
                        _isatty(_fileno(stdout));
-  IGN(csound);
+
+  if (state->interactive) {
+    DWORD mode;
+
+    state->outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (UNLIKELY(state->outputHandle == NULL ||
+                 state->outputHandle == INVALID_HANDLE_VALUE ||
+                 !GetConsoleMode(state->outputHandle, &mode)))
+      return csound->InitError(
+        csound, "%s", Str("readline: failed to read console mode"));
+
+    state->savedOutputMode = mode;
+    if (!(mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+      if (UNLIKELY(!SetConsoleMode(
+                     state->outputHandle,
+                     mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)))
+        return csound->InitError(
+          csound, "%s",
+          Str("readline: failed to enable virtual terminal mode"));
+      state->outputModeSet = 1;
+    }
+  }
 #elif defined(CSOUND_READLINE_POSIX)
   state->interactive = isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
 
@@ -342,15 +573,17 @@ static int32_t configure_terminal(CSOUND *csound, READLINE_STATE *state)
   return OK;
 }
 
-static void restore_terminal(READLINE_STATE *state)
+static void restore_terminal_modes(READLINE_STATE *state)
 {
   if (state == NULL)
     return;
 
-  if (state->lineOpen)
-    finish_terminal_line(state);
-
-#if defined(CSOUND_READLINE_POSIX)
+#if defined(WIN32)
+  if (state->outputModeSet) {
+    SetConsoleMode(state->outputHandle, state->savedOutputMode);
+    state->outputModeSet = 0;
+  }
+#elif defined(CSOUND_READLINE_POSIX)
   if (state->terminalModeSet) {
     tcsetattr(STDIN_FILENO, TCSANOW, &state->savedTerminalMode);
     state->terminalModeSet = 0;
@@ -368,7 +601,8 @@ static void release_readline(CSOUND *csound, READLINE_OPCODE *p)
     return;
 
   state = (READLINE_STATE *) p->state;
-  restore_terminal(state);
+  state->lineOpen = 0;
+  restore_terminal_modes(state);
 
   if (state->globals != NULL && state->globals->active == p)
     state->globals->active = NULL;
@@ -382,6 +616,10 @@ static void release_readline(CSOUND *csound, READLINE_OPCODE *p)
 static int32_t readline_perf_error(CSOUND *csound, READLINE_OPCODE *p,
                                    const char *message)
 {
+  if (p != NULL && p->state != NULL) {
+    READLINE_STATE *state = (READLINE_STATE *) p->state;
+    ATOMIC_SET(state->writerStop, 1);
+  }
   release_readline(csound, p);
   return csound->PerfError(csound, &p->h, "%s", message);
 }
@@ -391,7 +629,7 @@ static int32_t readline_reset(CSOUND *csound, void *userData)
   READLINE_GLOBALS *globals = (READLINE_GLOBALS *) userData;
 
   if (globals != NULL && globals->active != NULL)
-    release_readline(csound, globals->active);
+    readline_deinit(csound, globals->active);
   return OK;
 }
 
@@ -576,6 +814,7 @@ int32_t readline_init(CSOUND *csound, READLINE_OPCODE *p)
   }
 
   state->globals = globals;
+  state->csound = csound;
   state->capacity = READLINE_INITIAL_CAPACITY;
   state->promptPending = 1;
   state->ownsProcessInput = 1;
@@ -585,6 +824,11 @@ int32_t readline_init(CSOUND *csound, READLINE_OPCODE *p)
   if (UNLIKELY(configure_terminal(csound, state) != OK)) {
     readline_deinit(csound, p);
     return NOTOK;
+  }
+  if (UNLIKELY(start_terminal_writer(csound, state) != OK)) {
+    readline_deinit(csound, p);
+    return csound->InitError(
+      csound, "%s", Str("readline: failed to start terminal writer"));
   }
   return OK;
 }
@@ -602,13 +846,38 @@ int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
                                Str("readline: not initialized"));
 
   *p->status = FL(0.0);
+  if (UNLIKELY(ATOMIC_GET(state->outputError)))
+    return readline_perf_error(csound, p,
+                               Str("readline: terminal output error"));
+
+  if (state->pendingStatus != READLINE_PENDING_NONE) {
+    int32_t pendingStatus;
+
+    if (ATOMIC_GET(state->outputCompleted) != state->pendingTarget)
+      return OK;
+
+    pendingStatus = state->pendingStatus;
+    state->pendingStatus = READLINE_PENDING_NONE;
+    if (pendingStatus == READLINE_PENDING_EOF) {
+      state->eof = 1;
+      *p->status = FL(-1.0);
+      release_readline(csound, p);
+    }
+    else {
+      *p->status = FL(1.0);
+    }
+    return OK;
+  }
+
   if (state->eof) {
     *p->status = FL(-1.0);
     return OK;
   }
 
-  if (state->promptPending)
-    write_prompt(p);
+  if (state->promptPending &&
+      UNLIKELY(write_prompt(p) != OK))
+    return readline_perf_error(
+      csound, p, Str("readline: terminal output queue full"));
 
   pollResult = poll_terminal(csound, &key, &fromTerminal);
   if (pollResult == READLINE_POLL_NONE)
@@ -617,19 +886,33 @@ int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
     return readline_perf_error(csound, p, Str("readline: input error"));
   if (pollResult == READLINE_POLL_EOF ||
       ((key == 4 || key == 26) && state->length == 0)) {
-    state->eof = 1;
-    *p->status = FL(-1.0);
-    release_readline(csound, p);
+    if (UNLIKELY(finish_terminal_line(state) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
+    state->pendingStatus = READLINE_PENDING_EOF;
+    state->pendingTarget = ATOMIC_GET(state->outputQueued);
+    ATOMIC_SET(state->writerStop, 1);
+
+    if (ATOMIC_GET(state->outputCompleted) == state->pendingTarget) {
+      state->pendingStatus = READLINE_PENDING_NONE;
+      state->eof = 1;
+      *p->status = FL(-1.0);
+      release_readline(csound, p);
+    }
     return OK;
   }
 
   escapeAction = consume_escape(state, key);
   if (escapeAction == READLINE_ESCAPE_LEFT) {
-    move_cursor_left(state, fromTerminal);
+    if (UNLIKELY(move_cursor_left(state, fromTerminal) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
     return OK;
   }
   if (escapeAction == READLINE_ESCAPE_RIGHT) {
-    move_cursor_right(state, fromTerminal);
+    if (UNLIKELY(move_cursor_right(state, fromTerminal) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
     return OK;
   }
   if (escapeAction == READLINE_ESCAPE_CONSUMED)
@@ -639,18 +922,28 @@ int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
     if (UNLIKELY(copy_line_to_output(csound, p) != OK))
       return readline_perf_error(
         csound, p, Str("readline: memory allocation failure"));
-    finish_terminal_line(state);
+    if (UNLIKELY(finish_terminal_line(state) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
     state->length = 0;
     state->cursor = 0;
     state->buffer[0] = '\0';
     state->promptPending = 1;
-    *p->status = FL(1.0);
+    state->pendingStatus = READLINE_PENDING_LINE;
+    state->pendingTarget = ATOMIC_GET(state->outputQueued);
+
+    if (ATOMIC_GET(state->outputCompleted) == state->pendingTarget) {
+      state->pendingStatus = READLINE_PENDING_NONE;
+      *p->status = FL(1.0);
+    }
     return OK;
   }
 
   if (key == 8 || key == 127) {
-    if (remove_character(state))
-      redraw_after_backspace(state, fromTerminal);
+    if (remove_character(state) &&
+        UNLIKELY(redraw_after_backspace(state, fromTerminal) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
     return OK;
   }
 
@@ -660,7 +953,10 @@ int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
     if (UNLIKELY(insert_character(csound, state, key) != OK))
       return readline_perf_error(
         csound, p, Str("readline: memory allocation failure"));
-    redraw_after_insert(state, insertPosition, fromTerminal);
+    if (UNLIKELY(redraw_after_insert(
+                   state, insertPosition, fromTerminal) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: terminal output queue full"));
   }
   return OK;
 }
@@ -673,6 +969,9 @@ int32_t readline_deinit(CSOUND *csound, READLINE_OPCODE *p)
     return OK;
 
   state = (READLINE_STATE *) p->state;
+  if (state->lineOpen && !ATOMIC_GET(state->outputError))
+    (void) finish_terminal_line(state);
+  stop_terminal_writer(state);
   release_readline(csound, p);
   csound->Free(csound, state->buffer);
   csound->Free(csound, state);

--- a/OOps/readline.c
+++ b/OOps/readline.c
@@ -1,0 +1,681 @@
+/*
+  readline.c:
+
+  Copyright (C) 2026 The Csound Developers
+
+  This file is part of Csound.
+
+  The Csound Library is free software; you can redistribute it
+  and/or modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  Csound is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with Csound; if not, write to the Free Software
+  Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+#include "readline.h"
+#include "csound_threads.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#if defined(WIN32)
+#include <conio.h>
+#include <io.h>
+#elif defined(HAVE_TERMIOS_H) && defined(HAVE_UNISTD_H) && \
+      !defined(__EMSCRIPTEN__) && !defined(__wasi__)
+#define CSOUND_READLINE_POSIX 1
+#include <sys/select.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+#define READLINE_GLOBALS_NAME "::readline_globals::"
+#define READLINE_INITIAL_CAPACITY 128
+
+enum {
+  READLINE_POLL_ERROR = -2,
+  READLINE_POLL_EOF = -1,
+  READLINE_POLL_NONE = 0,
+  READLINE_POLL_CHARACTER = 1
+};
+
+enum {
+  READLINE_ESCAPE_NONE = 0,
+  READLINE_ESCAPE_CONSUMED,
+  READLINE_ESCAPE_LEFT,
+  READLINE_ESCAPE_RIGHT
+};
+
+enum {
+  READLINE_KEY_LEFT = 0x100,
+  READLINE_KEY_RIGHT
+};
+
+typedef struct {
+  READLINE_OPCODE *active;
+  int32_t resetRegistered;
+} READLINE_GLOBALS;
+
+typedef struct {
+  READLINE_GLOBALS *globals;
+  char *buffer;
+  size_t length;
+  size_t cursor;
+  size_t capacity;
+  int32_t promptPending;
+  int32_t lineOpen;
+  int32_t eof;
+  int32_t escapeState;
+  int32_t interactive;
+  int32_t terminalModeSet;
+  int32_t ownsProcessInput;
+#if defined(CSOUND_READLINE_POSIX)
+  struct termios savedTerminalMode;
+#endif
+} READLINE_STATE;
+
+#if defined(HAVE_PTHREAD_SPIN_LOCK)
+static spin_lock_t processOwnerLock;
+static pthread_once_t processOwnerLockOnce = PTHREAD_ONCE_INIT;
+
+static void init_process_owner_lock(void)
+{
+  (void) csoundSpinLockInit(&processOwnerLock);
+}
+#else
+static spin_lock_t processOwnerLock = SPINLOCK_INIT;
+#endif
+static CSOUND *processOwner = NULL;
+
+static int32_t readline_reset(CSOUND *, void *);
+
+static int32_t claim_process_input(CSOUND *csound)
+{
+  int32_t claimed;
+
+#if defined(HAVE_PTHREAD_SPIN_LOCK)
+  (void) pthread_once(&processOwnerLockOnce, init_process_owner_lock);
+#endif
+  csoundSpinLock(&processOwnerLock);
+  claimed = processOwner == NULL || processOwner == csound;
+  if (claimed)
+    processOwner = csound;
+  csoundSpinUnLock(&processOwnerLock);
+
+  return claimed;
+}
+
+static void release_process_input(CSOUND *csound)
+{
+  csoundSpinLock(&processOwnerLock);
+  if (processOwner == csound)
+    processOwner = NULL;
+  csoundSpinUnLock(&processOwnerLock);
+}
+
+static READLINE_GLOBALS *get_readline_globals(CSOUND *csound)
+{
+  READLINE_GLOBALS *globals =
+    (READLINE_GLOBALS *) csound->QueryGlobalVariable(
+      csound, READLINE_GLOBALS_NAME);
+
+  if (globals == NULL) {
+    if (UNLIKELY(csound->CreateGlobalVariable(
+                   csound, READLINE_GLOBALS_NAME,
+                   sizeof(READLINE_GLOBALS)) != OK))
+      return NULL;
+
+    globals = (READLINE_GLOBALS *) csound->QueryGlobalVariable(
+      csound, READLINE_GLOBALS_NAME);
+  }
+
+  if (globals != NULL && !globals->resetRegistered) {
+    if (UNLIKELY(csound->RegisterResetCallback(
+                   csound, globals, readline_reset) != OK))
+      return NULL;
+    globals->resetRegistered = 1;
+  }
+
+  return globals;
+}
+
+static int32_t grow_buffer(CSOUND *csound, READLINE_STATE *state,
+                           size_t required)
+{
+  size_t capacity = state->capacity;
+  char *buffer;
+
+  if (required <= capacity)
+    return OK;
+
+  while (capacity < required)
+    capacity *= 2;
+
+  buffer = (char *) csound->ReAlloc(csound, state->buffer, capacity);
+  if (UNLIKELY(buffer == NULL))
+    return NOTOK;
+
+  state->buffer = buffer;
+  state->capacity = capacity;
+  return OK;
+}
+
+static int32_t copy_line_to_output(CSOUND *csound, READLINE_OPCODE *p)
+{
+  READLINE_STATE *state = (READLINE_STATE *) p->state;
+  size_t required = state->length + 1;
+
+  if (required > p->line->size) {
+    char *data = (char *) csound->ReAlloc(csound, p->line->data,
+                                          required);
+    if (UNLIKELY(data == NULL))
+      return NOTOK;
+    p->line->data = data;
+    p->line->size = required;
+  }
+
+  memcpy(p->line->data, state->buffer, required);
+  return OK;
+}
+
+static void write_prompt(READLINE_OPCODE *p)
+{
+  READLINE_STATE *state = (READLINE_STATE *) p->state;
+
+  if (state->interactive && p->prompt->data != NULL &&
+      p->prompt->data[0] != '\0') {
+    fputs(p->prompt->data, stdout);
+    fflush(stdout);
+    state->lineOpen = 1;
+  }
+  state->promptPending = 0;
+}
+
+static int32_t is_utf8_continuation(char value)
+{
+  return ((unsigned char) value & 0xc0U) == 0x80U;
+}
+
+static size_t previous_character(const READLINE_STATE *state, size_t position)
+{
+  if (position == 0)
+    return 0;
+
+  position--;
+  while (position > 0 && is_utf8_continuation(state->buffer[position]))
+    position--;
+  return position;
+}
+
+static size_t next_character(const READLINE_STATE *state, size_t position)
+{
+  if (position >= state->length)
+    return state->length;
+
+  position++;
+  while (position < state->length &&
+         is_utf8_continuation(state->buffer[position]))
+    position++;
+  return position;
+}
+
+static size_t count_characters(const READLINE_STATE *state, size_t start)
+{
+  size_t count = 0;
+
+  for (size_t index = start; index < state->length; index++) {
+    if (!is_utf8_continuation(state->buffer[index]))
+      count++;
+  }
+  return count;
+}
+
+static void move_terminal_cursor(READLINE_STATE *state, size_t count,
+                                 char direction)
+{
+  if (state->interactive && count > 0) {
+    fprintf(stdout, "\033[%zu%c", count, direction);
+    fflush(stdout);
+  }
+}
+
+static void redraw_after_insert(READLINE_STATE *state, size_t insertPosition,
+                                int32_t fromTerminal)
+{
+  if (!state->interactive || !fromTerminal)
+    return;
+
+  fwrite(state->buffer + insertPosition, 1,
+         state->length - insertPosition, stdout);
+  move_terminal_cursor(state, count_characters(state, state->cursor), 'D');
+  fflush(stdout);
+  state->lineOpen = 1;
+}
+
+static void redraw_after_backspace(READLINE_STATE *state,
+                                   int32_t fromTerminal)
+{
+  size_t tailLength;
+
+  if (!state->interactive || !fromTerminal)
+    return;
+
+  move_terminal_cursor(state, 1, 'D');
+  tailLength = state->length - state->cursor;
+  if (tailLength > 0)
+    fwrite(state->buffer + state->cursor, 1, tailLength, stdout);
+  fputc(' ', stdout);
+  move_terminal_cursor(state,
+                       count_characters(state, state->cursor) + 1, 'D');
+  fflush(stdout);
+}
+
+static void move_cursor_left(READLINE_STATE *state, int32_t fromTerminal)
+{
+  size_t position = previous_character(state, state->cursor);
+
+  if (position != state->cursor) {
+    state->cursor = position;
+    if (fromTerminal)
+      move_terminal_cursor(state, 1, 'D');
+  }
+}
+
+static void move_cursor_right(READLINE_STATE *state, int32_t fromTerminal)
+{
+  size_t position = next_character(state, state->cursor);
+
+  if (position != state->cursor) {
+    state->cursor = position;
+    if (fromTerminal)
+      move_terminal_cursor(state, 1, 'C');
+  }
+}
+
+static void finish_terminal_line(READLINE_STATE *state)
+{
+  if (state->interactive) {
+    fputs("\r\n", stdout);
+    fflush(stdout);
+  }
+  state->lineOpen = 0;
+}
+
+static int32_t configure_terminal(CSOUND *csound, READLINE_STATE *state)
+{
+#if defined(WIN32)
+  state->interactive = _isatty(_fileno(stdin)) &&
+                       _isatty(_fileno(stdout));
+  IGN(csound);
+#elif defined(CSOUND_READLINE_POSIX)
+  state->interactive = isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
+
+  if (state->interactive) {
+    struct termios mode;
+
+    if (UNLIKELY(tcgetattr(STDIN_FILENO, &state->savedTerminalMode) != 0))
+      return csound->InitError(csound, "%s",
+                               Str("readline: failed to read terminal mode"));
+
+    mode = state->savedTerminalMode;
+    mode.c_lflag &= (tcflag_t) ~(ICANON | ECHO);
+    mode.c_cc[VMIN] = 0;
+    mode.c_cc[VTIME] = 0;
+    if (UNLIKELY(tcsetattr(STDIN_FILENO, TCSAFLUSH, &mode) != 0))
+      return csound->InitError(csound, "%s",
+                               Str("readline: failed to set terminal mode"));
+    state->terminalModeSet = 1;
+  }
+#else
+  IGN(csound);
+  state->interactive = 0;
+#endif
+  return OK;
+}
+
+static void restore_terminal(READLINE_STATE *state)
+{
+  if (state == NULL)
+    return;
+
+  if (state->lineOpen)
+    finish_terminal_line(state);
+
+#if defined(CSOUND_READLINE_POSIX)
+  if (state->terminalModeSet) {
+    tcsetattr(STDIN_FILENO, TCSANOW, &state->savedTerminalMode);
+    state->terminalModeSet = 0;
+  }
+#else
+  state->terminalModeSet = 0;
+#endif
+}
+
+static void release_readline(CSOUND *csound, READLINE_OPCODE *p)
+{
+  READLINE_STATE *state;
+
+  if (p == NULL || p->state == NULL)
+    return;
+
+  state = (READLINE_STATE *) p->state;
+  restore_terminal(state);
+
+  if (state->globals != NULL && state->globals->active == p)
+    state->globals->active = NULL;
+
+  if (state->ownsProcessInput) {
+    release_process_input(csound);
+    state->ownsProcessInput = 0;
+  }
+}
+
+static int32_t readline_perf_error(CSOUND *csound, READLINE_OPCODE *p,
+                                   const char *message)
+{
+  release_readline(csound, p);
+  return csound->PerfError(csound, &p->h, "%s", message);
+}
+
+static int32_t readline_reset(CSOUND *csound, void *userData)
+{
+  READLINE_GLOBALS *globals = (READLINE_GLOBALS *) userData;
+
+  if (globals != NULL && globals->active != NULL)
+    release_readline(csound, globals->active);
+  return OK;
+}
+
+static int32_t poll_terminal(CSOUND *csound, int32_t *key,
+                             int32_t *fromTerminal)
+{
+  int32_t callbackKey = 0;
+  int32_t callbackResult = csound->doCsoundCallback(
+    csound, &callbackKey, CSOUND_CALLBACK_KBD_TEXT);
+
+  if (UNLIKELY(callbackResult < 0))
+    return READLINE_POLL_ERROR;
+  if (callbackKey > 0) {
+    *key = callbackKey;
+    *fromTerminal = 0;
+    return READLINE_POLL_CHARACTER;
+  }
+
+  if (csound->inChar_ > 0) {
+    *key = csound->inChar_;
+    csound->inChar_ = 0;
+    *fromTerminal = 0;
+    return READLINE_POLL_CHARACTER;
+  }
+
+#if defined(WIN32)
+  if (_kbhit()) {
+    int32_t input = _getch();
+
+    if (input == 0 || input == 0xe0) {
+      switch (_getch()) {
+      case 75:
+        input = READLINE_KEY_LEFT;
+        break;
+      case 77:
+        input = READLINE_KEY_RIGHT;
+        break;
+      default:
+        return READLINE_POLL_NONE;
+      }
+    }
+    *key = input;
+    *fromTerminal = 1;
+    return READLINE_POLL_CHARACTER;
+  }
+#elif defined(CSOUND_READLINE_POSIX)
+  {
+    fd_set readfds;
+    struct timeval timeout = { 0, 0 };
+    unsigned char input;
+    int32_t selected;
+    ssize_t count;
+
+    FD_ZERO(&readfds);
+    FD_SET(STDIN_FILENO, &readfds);
+    selected = select(STDIN_FILENO + 1, &readfds, NULL, NULL, &timeout);
+    if (selected == 0)
+      return READLINE_POLL_NONE;
+    if (selected < 0)
+      return errno == EINTR ? READLINE_POLL_NONE : READLINE_POLL_ERROR;
+
+    count = read(STDIN_FILENO, &input, 1);
+    if (count == 0)
+      return READLINE_POLL_EOF;
+    if (count < 0)
+      return errno == EAGAIN || errno == EINTR ?
+        READLINE_POLL_NONE : READLINE_POLL_ERROR;
+
+    *key = (int32_t) input;
+    *fromTerminal = 1;
+    return READLINE_POLL_CHARACTER;
+  }
+#endif
+
+  return READLINE_POLL_NONE;
+}
+
+static int32_t insert_character(CSOUND *csound, READLINE_STATE *state,
+                                int32_t key)
+{
+  if (UNLIKELY(grow_buffer(csound, state, state->length + 2) != OK))
+    return NOTOK;
+
+  memmove(state->buffer + state->cursor + 1,
+          state->buffer + state->cursor,
+          state->length - state->cursor + 1);
+  state->buffer[state->cursor++] = (char) key;
+  state->length++;
+  return OK;
+}
+
+static int32_t remove_character(READLINE_STATE *state)
+{
+  size_t position;
+  size_t removed;
+
+  if (state->cursor == 0)
+    return 0;
+
+  position = previous_character(state, state->cursor);
+  removed = state->cursor - position;
+  memmove(state->buffer + position, state->buffer + state->cursor,
+          state->length - state->cursor + 1);
+  state->cursor = position;
+  state->length -= removed;
+  return 1;
+}
+
+static int32_t consume_escape(READLINE_STATE *state, int32_t key)
+{
+  if (key == READLINE_KEY_LEFT || key == READLINE_KEY_RIGHT) {
+    state->escapeState = 0;
+    return key == READLINE_KEY_LEFT ?
+      READLINE_ESCAPE_LEFT : READLINE_ESCAPE_RIGHT;
+  }
+
+  if (state->escapeState == 0) {
+    if (key == 27) {
+      state->escapeState = 1;
+      return READLINE_ESCAPE_CONSUMED;
+    }
+    return READLINE_ESCAPE_NONE;
+  }
+
+  if (state->escapeState == 1 && (key == '[' || key == 'O')) {
+    state->escapeState = 2;
+    return READLINE_ESCAPE_CONSUMED;
+  }
+
+  if (state->escapeState == 2 && key >= 0x40 && key <= 0x7e) {
+    state->escapeState = 0;
+    if (key == 'D')
+      return READLINE_ESCAPE_LEFT;
+    if (key == 'C')
+      return READLINE_ESCAPE_RIGHT;
+  }
+  else if (state->escapeState == 1) {
+    state->escapeState = 0;
+  }
+  return READLINE_ESCAPE_CONSUMED;
+}
+
+int32_t readline_init(CSOUND *csound, READLINE_OPCODE *p)
+{
+  READLINE_GLOBALS *globals;
+  READLINE_STATE *state;
+
+  p->state = NULL;
+  *p->status = FL(0.0);
+  if (p->line->data != NULL)
+    p->line->data[0] = '\0';
+
+  globals = get_readline_globals(csound);
+  if (UNLIKELY(globals == NULL))
+    return csound->InitError(csound, "%s",
+                             Str("readline: failed to allocate global state"));
+  if (UNLIKELY(globals->active != NULL))
+    return csound->InitError(csound, "%s",
+                             Str("readline: another prompt is already active"));
+  if (UNLIKELY(csound->stdin_assign_flg != 0))
+    return csound->InitError(csound, "%s",
+                             Str("readline: stdin is already in use"));
+  if (UNLIKELY(!claim_process_input(csound)))
+    return csound->InitError(csound, "%s",
+                             Str("readline: stdin is owned by another Csound instance"));
+
+  state = (READLINE_STATE *) csound->Calloc(csound,
+                                             sizeof(READLINE_STATE));
+  if (UNLIKELY(state == NULL)) {
+    release_process_input(csound);
+    return csound->InitError(csound, "%s",
+                             Str("readline: memory allocation failure"));
+  }
+
+  state->buffer = (char *) csound->Calloc(csound,
+                                           READLINE_INITIAL_CAPACITY);
+  if (UNLIKELY(state->buffer == NULL)) {
+    csound->Free(csound, state);
+    release_process_input(csound);
+    return csound->InitError(csound, "%s",
+                             Str("readline: memory allocation failure"));
+  }
+
+  state->globals = globals;
+  state->capacity = READLINE_INITIAL_CAPACITY;
+  state->promptPending = 1;
+  state->ownsProcessInput = 1;
+  p->state = state;
+  globals->active = p;
+
+  if (UNLIKELY(configure_terminal(csound, state) != OK)) {
+    readline_deinit(csound, p);
+    return NOTOK;
+  }
+  return OK;
+}
+
+int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
+{
+  READLINE_STATE *state = (READLINE_STATE *) p->state;
+  int32_t key = 0;
+  int32_t fromTerminal = 0;
+  int32_t pollResult;
+  int32_t escapeAction;
+
+  if (UNLIKELY(state == NULL))
+    return readline_perf_error(csound, p,
+                               Str("readline: not initialized"));
+
+  *p->status = FL(0.0);
+  if (state->eof) {
+    *p->status = FL(-1.0);
+    return OK;
+  }
+
+  if (state->promptPending)
+    write_prompt(p);
+
+  pollResult = poll_terminal(csound, &key, &fromTerminal);
+  if (pollResult == READLINE_POLL_NONE)
+    return OK;
+  if (pollResult == READLINE_POLL_ERROR)
+    return readline_perf_error(csound, p, Str("readline: input error"));
+  if (pollResult == READLINE_POLL_EOF ||
+      ((key == 4 || key == 26) && state->length == 0)) {
+    state->eof = 1;
+    *p->status = FL(-1.0);
+    release_readline(csound, p);
+    return OK;
+  }
+
+  escapeAction = consume_escape(state, key);
+  if (escapeAction == READLINE_ESCAPE_LEFT) {
+    move_cursor_left(state, fromTerminal);
+    return OK;
+  }
+  if (escapeAction == READLINE_ESCAPE_RIGHT) {
+    move_cursor_right(state, fromTerminal);
+    return OK;
+  }
+  if (escapeAction == READLINE_ESCAPE_CONSUMED)
+    return OK;
+
+  if (key == '\n' || key == '\r') {
+    if (UNLIKELY(copy_line_to_output(csound, p) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: memory allocation failure"));
+    finish_terminal_line(state);
+    state->length = 0;
+    state->cursor = 0;
+    state->buffer[0] = '\0';
+    state->promptPending = 1;
+    *p->status = FL(1.0);
+    return OK;
+  }
+
+  if (key == 8 || key == 127) {
+    if (remove_character(state))
+      redraw_after_backspace(state, fromTerminal);
+    return OK;
+  }
+
+  if (key == '\t' || key >= 32) {
+    size_t insertPosition = state->cursor;
+
+    if (UNLIKELY(insert_character(csound, state, key) != OK))
+      return readline_perf_error(
+        csound, p, Str("readline: memory allocation failure"));
+    redraw_after_insert(state, insertPosition, fromTerminal);
+  }
+  return OK;
+}
+
+int32_t readline_deinit(CSOUND *csound, READLINE_OPCODE *p)
+{
+  READLINE_STATE *state;
+
+  if (p == NULL || p->state == NULL)
+    return OK;
+
+  state = (READLINE_STATE *) p->state;
+  release_readline(csound, p);
+  csound->Free(csound, state->buffer);
+  csound->Free(csound, state);
+  p->state = NULL;
+  return OK;
+}

--- a/OOps/readline.c
+++ b/OOps/readline.c
@@ -41,6 +41,7 @@
 
 #define READLINE_GLOBALS_NAME "::readline_globals::"
 #define READLINE_INITIAL_CAPACITY 128
+#define READLINE_INPUT_CAPACITY 65536
 #define READLINE_OUTPUT_CAPACITY 65536
 #define READLINE_OUTPUT_CHUNK 1024
 
@@ -80,6 +81,7 @@ typedef struct {
 
 typedef struct {
   READLINE_OPCODE *active;
+  void *inputBuffer;
   int32_t resetRegistered;
 } READLINE_GLOBALS;
 
@@ -177,7 +179,39 @@ static READLINE_GLOBALS *get_readline_globals(CSOUND *csound)
     globals->resetRegistered = 1;
   }
 
+  if (globals != NULL && globals->inputBuffer == NULL) {
+    globals->inputBuffer = csound->CreateCircularBuffer(
+      csound, READLINE_INPUT_CAPACITY, sizeof(char));
+    if (UNLIKELY(globals->inputBuffer == NULL))
+      return NULL;
+  }
+
   return globals;
+}
+
+int32_t csoundReadlinePushText(CSOUND *csound, const char *text)
+{
+  READLINE_GLOBALS *globals;
+  size_t length;
+
+  if (UNLIKELY(csound == NULL || text == NULL))
+    return CSOUND_ERROR;
+
+  length = strlen(text);
+  if (length == 0)
+    return CSOUND_SUCCESS;
+  if (UNLIKELY(length > (size_t) INT32_MAX))
+    return CSOUND_ERROR;
+
+  globals = get_readline_globals(csound);
+  if (UNLIKELY(globals == NULL ||
+               csound->CheckCircularBuffer(
+                 csound, globals->inputBuffer, 1) < (int32_t) length))
+    return CSOUND_ERROR;
+
+  return csound->WriteCircularBuffer(
+           csound, globals->inputBuffer, text, (int32_t) length) ==
+         (int32_t) length ? CSOUND_SUCCESS : CSOUND_ERROR;
 }
 
 static int32_t grow_buffer(CSOUND *csound, READLINE_STATE *state,
@@ -628,12 +662,19 @@ static int32_t readline_reset(CSOUND *csound, void *userData)
 {
   READLINE_GLOBALS *globals = (READLINE_GLOBALS *) userData;
 
-  if (globals != NULL && globals->active != NULL)
-    readline_deinit(csound, globals->active);
+  if (globals != NULL) {
+    if (globals->active != NULL)
+      readline_deinit(csound, globals->active);
+    if (globals->inputBuffer != NULL) {
+      csound->DestroyCircularBuffer(csound, globals->inputBuffer);
+      globals->inputBuffer = NULL;
+    }
+  }
   return OK;
 }
 
-static int32_t poll_terminal(CSOUND *csound, int32_t *key,
+static int32_t poll_terminal(CSOUND *csound, READLINE_STATE *state,
+                             int32_t *key,
                              int32_t *fromTerminal)
 {
   int32_t callbackKey = 0;
@@ -653,6 +694,17 @@ static int32_t poll_terminal(CSOUND *csound, int32_t *key,
     csound->inChar_ = 0;
     *fromTerminal = 0;
     return READLINE_POLL_CHARACTER;
+  }
+
+  if (state->globals != NULL && state->globals->inputBuffer != NULL) {
+    unsigned char input;
+
+    if (csound->ReadCircularBuffer(
+          csound, state->globals->inputBuffer, &input, 1) == 1) {
+      *key = (int32_t) input;
+      *fromTerminal = 0;
+      return READLINE_POLL_CHARACTER;
+    }
   }
 
 #if defined(WIN32)
@@ -879,7 +931,7 @@ int32_t readline_perf(CSOUND *csound, READLINE_OPCODE *p)
     return readline_perf_error(
       csound, p, Str("readline: terminal output queue full"));
 
-  pollResult = poll_terminal(csound, &key, &fromTerminal);
+  pollResult = poll_terminal(csound, state, &key, &fromTerminal);
   if (pollResult == READLINE_POLL_NONE)
     return OK;
   if (pollResult == READLINE_POLL_ERROR)

--- a/include/csound.h
+++ b/include/csound.h
@@ -1196,16 +1196,27 @@ extern "C" {
 
   /**
    * Set the ASCII code of the most recent key pressed.
-   * This value is used by the 'sensekey' opcode if a callback
-   * for returning keyboard events is not set (see
+   * This value is used by keyboard input opcodes such as 'sensekey' and
+   * 'readline' if a callback for returning keyboard events is not set (see
    * csoundRegisterKeyboardCallback()).
    */
   PUBLIC void csoundKeyPress(CSOUND *, char c);
 
   /**
+   * Queue UTF-8 text for consumption by the readline opcode. A newline
+   * character completes the current line. Text may be queued before or
+   * during performance, allowing hosts without terminal input, such as
+   * Android and WebAssembly applications, to connect their own text input.
+   *
+   * Returns CSOUND_SUCCESS on success or CSOUND_ERROR if the arguments are
+   * invalid or the input queue does not have enough space for the full text.
+   */
+  PUBLIC int32_t csoundReadlinePushText(CSOUND *, const char *text);
+
+  /**
    * Registers general purpose callback functions that will be called to query
    * keyboard events. These callbacks are called on every control period by
-   * the sensekey opcode.
+   * opcodes that consume keyboard input.
    * The callback is preserved on csoundReset(), and multiple
    * callbacks may be set and will be called in reverse order of
    * registration. If the same function is set again, it is only moved

--- a/include/csound.hpp
+++ b/include/csound.hpp
@@ -318,6 +318,10 @@ class PUBLIC Csound
   {
     csoundKeyPress(csound, c);
   }
+  virtual int32_t ReadlinePushText(const char *text)
+  {
+    return csoundReadlinePushText(csound, text);
+  }
   virtual void Event(int32_t type, MYFLT *pFields, int32_t numFields, int32_t async = 0)
   {
     csoundEvent(csound, type, pFields, numFields, async);

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -207,6 +207,42 @@ TEST_F (IOTests, testReadline)
     ASSERT_STREQ(line, "abcd");
 }
 
+TEST_F (IOTests, testReadlineHostInput)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+
+    const char *instrument =
+        "ksmps = 1\n"
+        "chnk \"readline_status\", 2\n"
+        "chnS \"readline_line\", 2\n"
+        "instr 1\n"
+        "  Sline, kstatus readline \"\"\n"
+        "  if (kstatus == 1) then\n"
+        "    chnset Sline, \"readline_line\"\n"
+        "    chnset kstatus, \"readline_status\"\n"
+        "  endif\n"
+        "endin\n";
+
+    ASSERT_EQ(csoundCompileOrc(csound, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundReadlinePushText(csound, "from host\n"),
+              CSOUND_SUCCESS);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    MYFLT status = 0;
+    int32_t error = 0;
+    for (int32_t cycle = 0; cycle < 32 && status == 0; cycle++) {
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        status = csoundGetControlChannel(csound, "readline_status", &error);
+        ASSERT_EQ(error, CSOUND_SUCCESS);
+    }
+
+    char line[32];
+    ASSERT_EQ(status, FL(1.0));
+    csoundGetStringChannel(csound, "readline_line", line);
+    ASSERT_STREQ(line, "from host");
+}
+
 TEST_F (IOTests, testReadlineRejectsSecondPrompt)
 {
     ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -106,6 +106,27 @@ int32_t key_callback_txt(void *userData, void *p, uint32_t type)
     return CSOUND_SUCCESS;
 }
 
+struct ReadlineInput {
+    const char *text;
+    size_t position;
+};
+
+int32_t readline_callback(void *userData, void *p, uint32_t type)
+{
+    ReadlineInput *input = (ReadlineInput *) userData;
+    unsigned char character = (unsigned char) input->text[input->position];
+
+    *((int32_t *) p) = (int32_t) character;
+    if (character != '\0')
+        input->position++;
+    return CSOUND_SUCCESS;
+}
+
+int32_t readline_error_callback(void *, void *, uint32_t)
+{
+    return CSOUND_ERROR;
+}
+
 TEST_F (IOTests, testKeyboardIO)
 {
     int32_t ret, prev = 100;
@@ -144,6 +165,141 @@ TEST_F (IOTests, testKeyboardIO)
 
     // val = csoundGetControlChannel(csound, "down2", &err);
     // ASSERT_DOUBLE_EQ (val, 1.0);
+}
+
+TEST_F (IOTests, testReadline)
+{
+    ReadlineInput input = {
+        "acd\033[D\033[Db\033[CX\177\033[C\n", 0
+    };
+    int32_t ret = csoundRegisterKeyboardCallback(
+        csound, readline_callback, &input, CSOUND_CALLBACK_KBD_TEXT);
+    ASSERT_EQ(ret, CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+
+    const char *instrument =
+        "ksmps = 1\n"
+        "chnk \"readline_status\", 2\n"
+        "chnS \"readline_line\", 2\n"
+        "instr 1\n"
+        "  Sline, kstatus readline \"\"\n"
+        "  if (kstatus == 1) then\n"
+        "    chnset Sline, \"readline_line\"\n"
+        "    chnset kstatus, \"readline_status\"\n"
+        "  endif\n"
+        "endin\n";
+
+    ASSERT_EQ(csoundCompileOrc(csound, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    MYFLT status = 0;
+    int32_t error = 0;
+    for (int32_t cycle = 0; cycle < 32 && status == 0; cycle++) {
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        status = csoundGetControlChannel(csound, "readline_status", &error);
+        ASSERT_EQ(error, CSOUND_SUCCESS);
+    }
+
+    char line[32];
+    ASSERT_EQ(status, FL(1.0));
+    csoundGetStringChannel(csound, "readline_line", line);
+    ASSERT_STREQ(line, "abcd");
+}
+
+TEST_F (IOTests, testReadlineRejectsSecondPrompt)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+
+    const char *instrument =
+        "ksmps = 1\n"
+        "instr 1\n"
+        "  Sfirst, kfirst readline \"first> \"\n"
+        "  Ssecond, ksecond readline \"second> \"\n"
+        "endin\n";
+
+    ASSERT_EQ(csoundCompileOrc(csound, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    ASSERT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+}
+
+TEST_F (IOTests, testReadlineReportsEof)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+
+    const char *instrument =
+        "ksmps = 1\n"
+        "chnk \"readline_status\", 2\n"
+        "chnk \"second_readline_status\", 2\n"
+        "chnS \"second_readline_line\", 2\n"
+        "instr 1\n"
+        "  Sline, kstatus readline \"\"\n"
+        "  chnset kstatus, \"readline_status\"\n"
+        "endin\n"
+        "instr 2\n"
+        "  Sline, kstatus readline \"\"\n"
+        "  if (kstatus == 1) then\n"
+        "    chnset Sline, \"second_readline_line\"\n"
+        "    chnset kstatus, \"second_readline_status\"\n"
+        "  endif\n"
+        "endin\n";
+
+    ASSERT_EQ(csoundCompileOrc(csound, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    csoundKeyPress(csound, '\004');
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    int32_t error = 0;
+    MYFLT status = csoundGetControlChannel(
+        csound, "readline_status", &error);
+    ASSERT_EQ(error, CSOUND_SUCCESS);
+    ASSERT_EQ(status, FL(-1.0));
+
+    csoundEventString(csound, "i 2 0 1", 0);
+    csoundKeyPress(csound, 'x');
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+    csoundKeyPress(csound, '\n');
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    status = csoundGetControlChannel(
+        csound, "second_readline_status", &error);
+    ASSERT_EQ(error, CSOUND_SUCCESS);
+    ASSERT_EQ(status, FL(1.0));
+
+    char line[8];
+    csoundGetStringChannel(csound, "second_readline_line", line);
+    ASSERT_STREQ(line, "x");
+}
+
+TEST_F (IOTests, testReadlineReleasesInputAfterError)
+{
+    const char *instrument =
+        "ksmps = 1\n"
+        "instr 1\n"
+        "  Sline, kstatus readline \"\"\n"
+        "endin\n";
+    ASSERT_EQ(csoundRegisterKeyboardCallback(
+        csound, readline_error_callback, nullptr,
+        CSOUND_CALLBACK_KBD_TEXT), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompileOrc(csound, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    // A performance error need not change this control period's return value.
+    (void) csoundPerformKsmps(csound);
+
+    CSOUND *other = csoundCreate(NULL, NULL);
+    ASSERT_NE(other, nullptr);
+    csoundCreateMessageBuffer(other, 0);
+    ASSERT_EQ(csoundSetOption(other, "--logfile=NULL"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(other, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompileOrc(other, instrument, 0), CSOUND_SUCCESS);
+    csoundEventString(other, "i 1 0 1", 0);
+    ASSERT_EQ(csoundStart(other), CSOUND_SUCCESS);
+    EXPECT_EQ(csoundPerformKsmps(other), CSOUND_SUCCESS);
+    csoundDestroy(other);
 }
 
 

--- a/wasm/browser/externs.js
+++ b/wasm/browser/externs.js
@@ -138,6 +138,7 @@ var WasiFS;
  * csoundPushMidiMessage: function(CsoundInst, number, number, number): number,
  * csoundInputMessage: function(CsoundInst, string): number,
  * csoundInputMessageAsync: function(CsoundInst, string): number,
+ * csoundReadlinePushText: function(CsoundInst, string): number,
  * csoundGetControlChannel: function(CsoundInst, string): number,
  * csoundSetControlChannel: function(CsoundInst, string, number): undefined,
  * csoundGetStringChannel: function(CsoundInst, string): string,

--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -258,6 +258,10 @@ declare interface CsoundObj {
    */
   inputMessageAsync: (scoreEvent: string) => Promise<number>;
   /**
+   * Queues text for the readline opcode. Include a newline to submit the line.
+   */
+  readlinePushText: (text: string) => Promise<number>;
+  /**
    * Retrieves the value of control channel identified by channelName.
    * If the err argument is not NULL, the error (or success) code finding
    * or accessing the channel is stored in it.
@@ -648,6 +652,7 @@ declare interface LibCsoundObj {
   _isRequestingRtMidiInput: (csound: number) => number;
   csoundInputMessage: (csound: number, scoreEvent: string) => number;
   csoundInputMessageAsync: (csound: number, scoreEvent: string) => number;
+  csoundReadlinePushText: (csound: number, text: string) => number;
   csoundGetControlChannel: (csound: number, channelName: string) => number;
   csoundSetControlChannel: (csound: number, channelName: string, value: number) => void;
   csoundGetStringChannel: (csound: number, channelName: string) => string;

--- a/wasm/browser/src/libcsound.js
+++ b/wasm/browser/src/libcsound.js
@@ -68,6 +68,7 @@ import {
 import {
   csoundInputMessage,
   csoundInputMessageAsync,
+  csoundReadlinePushText,
   csoundGetControlChannel,
   csoundSetControlChannel,
   csoundGetStringChannel,
@@ -197,6 +198,7 @@ export const api = {
   // @module/control_events
   csoundInputMessage,
   csoundInputMessageAsync,
+  csoundReadlinePushText,
   csoundGetControlChannel,
   csoundSetControlChannel,
   csoundGetStringChannel,

--- a/wasm/browser/src/modules/control-events.js
+++ b/wasm/browser/src/modules/control-events.js
@@ -49,6 +49,20 @@ export const csoundInputMessageAsync = (wasm) => (csound, scoEvent) => {
 csoundInputMessageAsync["toString"] = () => "inputMessageAsync = async (scoreEvent) => Number;";
 
 /**
+ * Queues text for the readline opcode. Include a newline to submit the line.
+ * @function
+ */
+export const csoundReadlinePushText = (wasm) => (csound, text) => {
+  const stringPtr = string2ptr(wasm, text);
+  const result = wasm.exports["csoundReadlinePushText"](csound, stringPtr);
+  freeStringPtr(wasm, stringPtr);
+  return result;
+};
+
+csoundReadlinePushText["toString"] = () =>
+  "readlinePushText = async (text) => Number;";
+
+/**
  * Retrieves the value of control channel identified by channelName.
  * If the err argument is not NULL, the error (or success) code finding
  * or accessing the channel is stored in it.

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -1185,6 +1185,50 @@ e
       cs.csoundDestroy(csound);
     });
 
+    it("can feed readline from host text", function () {
+      const csound = cs.csoundCreate();
+      assert.notEqual(csound, 0, "csoundCreate returns non-zero pointer");
+
+      try {
+        assert.equal(0, cs.csoundSetOption(csound, "-d"));
+        assert.equal(0, cs.csoundSetOption(csound, "-n"));
+        assert.equal(
+          0,
+          cs.csoundCompileOrc(
+            csound,
+            `ksmps = 1
+chnk "readline_status", 2
+chnS "readline_line", 2
+instr 1
+  Sline, kstatus readline ""
+  if (kstatus == 1) then
+    chnset Sline, "readline_line"
+    chnset kstatus, "readline_status"
+  endif
+endin
+schedule(1, 0, 1)`,
+          ),
+        );
+        assert.equal(0, cs.csoundReadlinePushText(csound, "from wasi\n"));
+        assert.equal(0, cs.csoundStart(csound));
+
+        let status = 0;
+        for (let cycle = 0; cycle < 32 && status === 0; cycle++) {
+          assert.equal(0, cs.csoundPerformKsmps(csound));
+          status = cs.csoundGetControlChannel(csound, "readline_status");
+        }
+
+        assert.equal(1, status, "readline reports a completed line");
+        assert.equal(
+          "from wasi",
+          cs.csoundGetStringChannel(csound, "readline_line"),
+        );
+      } finally {
+        cs.csoundStop(csound);
+        cs.csoundDestroy(csound);
+      }
+    });
+
     it("exposes UGEN_ARG_TYPE enum", function () {
       assert.isObject(cs.UGEN_ARG_TYPE, "UGEN_ARG_TYPE is an object");
       assert.equal(cs.UGEN_ARG_TYPE.I, 0);

--- a/wasm/src/exports.json
+++ b/wasm/src/exports.json
@@ -122,6 +122,7 @@
   "csoundRandMT",
   "csoundReadCircularBuffer",
   "csoundReadScore",
+  "csoundReadlinePushText",
   "csoundRegisterKeyboardCallback",
   "csoundRemoveKeyboardCallback",
   "csoundReset",


### PR DESCRIPTION
Adds a core `readline` opcode for building interactive terminal programs in Csound.

```csound
  Sline, kstatus readline Sprompt
```

The opcode polls input at k-rate, so it does not block audio or scheduling. It supports ANSI and multi-line prompts, left and right cursor movement, insertion, backspace, EOF, and keyboard callbacks.

Only one prompt can own stdin at a time. The original terminal settings are restored when the opcode ends, Csound resets, or EOF is reached.

This PR also adds a host-fed input API for non-terminal targets:

- New C API: `csoundReadlinePushText(CSOUND *, const char *text)` (also exposed in `csound.hpp`)
- Allows hosts to queue UTF-8 text for `readline` (newline submits a line)
- Intended for environments like Android and WebAssembly where terminal stdin is not typical

Platform integration included:

- Android build includes `OOps/readline.c` and exports the new host API
- WASM exports `csoundReadlinePushText` and adds browser bindings/types (`readlinePushText`)

Tests included:

- C test: host-fed readline input (`tests/c/io_test.cpp`)
- WASM browser test: feed readline from host text (`wasm/browser/tests/tests.js`)

Example:

```csound
<CsoundSynthesizer>
<CsOptions>
-odac -d -m128
</CsOptions>
<CsInstruments>
sr = 44100
ksmps = 32
nchnls = 2
0dbfs = 1

instr 1
  Sescape sprintf "%c", 27
  Sclear sprintf "%s[2J%s[H", Sescape, Sescape
  Sprompt sprintf "%s[2m‚ï≠‚îÄ Csound note console\n‚ï∞‚îÄ c d e g chord q %s[22;36m‚Ä∫%s[0m ", \
    Sescape, Sescape, Sescape

  prints "%s", Sclear
  Sline, kstatus readline Sprompt

  kC strcmpk Sline, "c"
  kD strcmpk Sline, "d"
  kE strcmpk Sline, "e"
  kG strcmpk Sline, "g"
  kChord strcmpk Sline, "chord"
  kQuit strcmpk Sline, "q"

  if (kstatus == 1) then
    if (kC == 0) then
      event "i", 2, 0, 0.9, 60, 0.25
      printf "  ‚ô™ C4\n", kstatus
    elseif (kD == 0) then
      event "i", 2, 0, 0.9, 62, 0.38
      printf "  ‚ô™ D4\n", kstatus
    elseif (kE == 0) then
      event "i", 2, 0, 0.9, 64, 0.50
      printf "  ‚ô™ E4\n", kstatus
    elseif (kG == 0) then
      event "i", 2, 0, 1.1, 67, 0.68
      printf "  ‚ô™ G4\n", kstatus
    elseif (kChord == 0) then
      event "i", 2, 0, 1.5, 60, 0.25
      event "i", 2, 0.06, 1.5, 64, 0.50
      event "i", 2, 0.12, 1.5, 67, 0.72
      printf "  ‚ô™ C major\n", kstatus
    elseif (kQuit == 0) then
      printf "  done\n", kstatus
      event "i", 99, 0, 0
    else
      printf "  unknown note: %s\n", kstatus, Sline
    endif
  elseif (kstatus < 0) then
    event "i", 99, 0, 0
  endif
endin

instr 2
  iFrequency = cpsmidinn(p4)
  aEnvelope linseg 0, 0.02, 1, p3 - 0.02, 0
  aFundamental poscil 0.13, iFrequency
  aOvertone poscil 0.035, iFrequency * 2.01
  aSignal = (aFundamental + aOvertone) * aEnvelope
  aLeft, aRight pan2 aSignal, p5
  outs aLeft, aRight
endin

instr 99
  exitnow(0)
endin
</CsInstruments>
<CsScore>
i 1 0 12
</CsScore>
</CsoundSynthesizer>
```

Gif recording of that example

<img src="https://github.com/user-attachments/assets/11a9cf22-bcea-4877-b63f-9f5fc8c6c194">