### PR TITLE
Expose application command-line arguments through argv

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -1781,6 +1781,8 @@ const OENTRY opcodlst_1[] = {
     (SUBR) strset_init, NULL, NULL                        },
   { "strget",   S(STRGET_OP),0,     "S",    "i",
     (SUBR) strget_init, NULL, NULL                        },
+  { "argv",     S(ARGV_OP),0,       "S[]",  "",
+    (SUBR) commandline_args_init, NULL, NULL               },
   {  "S",   S(STRGET_OP),0,     "S",    "i",
      (SUBR) s_opcode, NULL, NULL                           },
   {  "S",   S(STRGET_OP),0,     "S",    "k",

--- a/Frontends/csound/csound_main.c
+++ b/Frontends/csound/csound_main.c
@@ -182,6 +182,8 @@ int main(int argc, char **argv)
 
     /* open log file if specified */
     for (i = 1; i < argc; i++) {
+      if (strcmp(argv[i], "--") == 0)
+        break;
       if (strncmp(argv[i], "-O", 2) == 0 && (int) strlen(argv[i]) > 2)
         fname = argv[i] + 2;
       else if (strncmp(argv[i], "--logfile=", 10) == 0 &&

--- a/Frontends/csound/sched.c
+++ b/Frontends/csound/sched.c
@@ -94,6 +94,7 @@ static int parse_sched_opt(const char *s, int *priority, int *cpuMax, int *secs)
     return 0;
 }
 
+
 static void *wd_thread_routine(void *dummy)
 {
     uint32_t t0, t1;
@@ -129,6 +130,12 @@ int set_rt_priority(int argc, const char **argv)
     memset(&p, 0, sizeof(struct sched_param));
     priority = sched_get_priority_max(SCHED_RR);
     rtmode = 0;
+    for (i = 1; i < argc; i++) {
+      if (strcmp(argv[i], "--") == 0) {
+        argc = i;
+        break;
+      }
+    }
     if (argc > 2) {
       for (i = 1; i <= (argc - 2); i++) {
         if (!(strcmp(argv[i], "-o")) &&                 /* check if input   */
@@ -235,4 +242,3 @@ int set_rt_priority(int argc, const char **argv)
     }
     return 0;
 }
-

--- a/H/str_ops.h
+++ b/H/str_ops.h
@@ -158,7 +158,7 @@ typedef struct {
 int32_t     eqs(CSOUND *, void *);
 int32_t     strset_init(CSOUND *, void *);
 int32_t     strget_init(CSOUND *, void *);
-int32_t     commandline_args_init(CSOUND *, void *);
+int32_t     commandline_args_init(CSOUND *, ARGV_OP *);
 int32_t     strcpy_opcode_p(CSOUND *, void *);
 int32_t     strcpy_opcode_S(CSOUND *, void *);
 int32_t     strassign_k(CSOUND *, void *);

--- a/H/str_ops.h
+++ b/H/str_ops.h
@@ -35,6 +35,11 @@ typedef struct {
 } STRSET_OP;
 
 typedef struct {
+    OPDS      h;
+    ARRAYDAT  *args;
+} ARGV_OP;
+
+typedef struct {
     OPDS    h;
     MYFLT   *r;
     STRINGDAT  *str;
@@ -153,6 +158,7 @@ typedef struct {
 int32_t     eqs(CSOUND *, void *);
 int32_t     strset_init(CSOUND *, void *);
 int32_t     strget_init(CSOUND *, void *);
+int32_t     commandline_args_init(CSOUND *, void *);
 int32_t     strcpy_opcode_p(CSOUND *, void *);
 int32_t     strcpy_opcode_S(CSOUND *, void *);
 int32_t     strassign_k(CSOUND *, void *);

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -25,6 +25,7 @@
 #include "csoundCore.h"
 #define CSOUND_STR_OPS_C    1
 #include "str_ops.h"
+#include "arrays.h"
 #include <ctype.h>
 #ifdef HAVE_CURL
 #include <curl/curl.h>
@@ -166,6 +167,27 @@ int32_t strget_init(CSOUND *csound, STRGET_OP *p)
     p->r->size = size + 1;
   }
   strcpy((char*) p->r->data, csound->strsets[indx]);
+  return OK;
+}
+
+int32_t commandline_args_init(CSOUND *csound, ARGV_OP *p)
+{
+  int32_t count = csoundGetCommandLineArgCount(csound);
+  const CS_TYPE *stringType = csound->GetType(csound, "S");
+
+  tabinit(csound, p->args, count, p->h.insdshead);
+  for (int32_t index = 0; index < count; index++) {
+    const char *argument = csoundGetCommandLineArg(csound, index);
+    STRINGDAT source = {
+      (char *) argument,
+      strlen(argument) + 1,
+      0,
+      -1
+    };
+    STRINGDAT *destination = &((STRINGDAT *) p->args->data)[index];
+    stringType->copyValue(csound, stringType, destination, &source,
+                          p->h.insdshead);
+  }
   return OK;
 }
 

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -173,7 +173,6 @@ int32_t strget_init(CSOUND *csound, STRGET_OP *p)
 int32_t commandline_args_init(CSOUND *csound, ARGV_OP *p)
 {
   int32_t count = csoundGetCommandLineArgCount(csound);
-  const CS_TYPE *stringType = csound->GetType(csound, "S");
 
   tabinit(csound, p->args, count, p->h.insdshead);
   for (int32_t index = 0; index < count; index++) {
@@ -184,9 +183,10 @@ int32_t commandline_args_init(CSOUND *csound, ARGV_OP *p)
       0,
       -1
     };
-    STRINGDAT *destination = &((STRINGDAT *) p->args->data)[index];
-    stringType->copyValue(csound, stringType, destination, &source,
-                          p->h.insdshead);
+    char *destination = (char *) p->args->data +
+      ((size_t) index * p->args->arrayMemberSize);
+    p->args->arrayType->copyValue(csound, p->args->arrayType,
+                                  destination, &source, p->h.insdshead);
   }
   return OK;
 }

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -182,6 +182,7 @@ static const char *shortUsageList[] = {
     Str_noop("-Q dnam     select MIDI output device"),
     Str_noop("-z          list opcodes in this version"),
     Str_noop("-Z          dither output"),
+    Str_noop("-- args...  expose following arguments through the argv opcode"),
 #if defined(LINUX)
     Str_noop("--sched     set real-time priority and lock memory"),
     Str_noop("              (requires -d and real time audio (-iadc/-odac))"),
@@ -191,6 +192,7 @@ static const char *shortUsageList[] = {
     NULL};
 
 static const char *longUsageList[] = {
+    Str_noop("-- args...              application arguments for the argv opcode"),
     Str_noop("--code=string           compile code string"),
     Str_noop("--events=string         perform events in string"), 
     "--format={wav,aiff,au,raw,paf,svx,nist,voc,ircam,w64,mat4,mat5",

--- a/Top/argdecode.c
+++ b/Top/argdecode.c
@@ -1295,6 +1295,22 @@ static int32_t decode_long(CSOUND *csound, char *s, int32_t argc, char **argv) {
   return 1;
 }
 
+static int32_t capture_application_arguments(CSOUND *csound, int32_t *argc,
+                                             const char **argv)
+{
+  for (int32_t index = 1; index <= *argc; index++) {
+    if (argv[index] != NULL && strcmp(argv[index], "--") == 0) {
+      /* Option sources are decoded in precedence order. A later separator
+         replaces application arguments captured from an earlier source. */
+      int32_t result = csoundSetCommandLineArgs(
+        csound, *argc - index, &argv[index + 1]);
+      *argc = index - 1;
+      return result;
+    }
+  }
+  return CSOUND_SUCCESS;
+}
+
 int32_t argdecode(CSOUND *csound, int32_t argc, const char **argv_) {
   OPARMS *O = csound->oparms;
   char *s, **argv;
@@ -1304,6 +1320,13 @@ int32_t argdecode(CSOUND *csound, int32_t argc, const char **argv_) {
   /* make a copy of the option list */
   char *p1, *p2;
   int32_t nbytes, i;
+  if (UNLIKELY(capture_application_arguments(csound, &argc, argv_) !=
+               CSOUND_SUCCESS)) {
+    return 0;
+  }
+  if (argc == 0) {
+    return 1;
+  }
   /* calculate the number of bytes to allocate */
   /* N.B. the argc value passed to argdecode is decremented by one */
   nbytes = (argc + 1) * (int32_t)sizeof(char *);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -643,6 +643,7 @@ static const CSOUND cenviron_ = {
   (void (*)(CSOUND *, const MYFLT *, int32_t)) NULL,  /*  audtran     */
   NULL,           /*  hostdata            */
   NULL, NULL,     /*  orchname, scorename */
+  0, NULL,        /*  command line args   */
   NULL, NULL,     /*  orchstr, *scorestr  */
   (OPDS*) NULL,   /*  ids                 */
   { (CS_VAR_POOL*)NULL,

--- a/Top/main.c
+++ b/Top/main.c
@@ -153,6 +153,76 @@ static void put_sorted_score(CSOUND *csound, char *ss, FILE *ff) {
   }
 }
 
+int32_t csoundSetCommandLineArgs(CSOUND *csound, int32_t argc,
+                                 const char **argv)
+{
+  char **copy = NULL;
+  size_t pointerBytes;
+  size_t totalBytes;
+
+  if (UNLIKELY(csound == NULL || argc < 0 || (argc > 0 && argv == NULL)))
+    return CSOUND_ERROR;
+
+  if (UNLIKELY((size_t) argc > SIZE_MAX / sizeof(char *)))
+    return CSOUND_MEMORY;
+
+  pointerBytes = (size_t) argc * sizeof(char *);
+  totalBytes = pointerBytes;
+  for (int32_t index = 0; index < argc; index++) {
+    size_t length;
+
+    if (UNLIKELY(argv[index] == NULL))
+      return CSOUND_ERROR;
+    length = strlen(argv[index]) + 1;
+    if (UNLIKELY(length > SIZE_MAX - totalBytes))
+      return CSOUND_MEMORY;
+    totalBytes += length;
+  }
+
+  if (argc > 0) {
+    char *destination;
+
+    copy = (char **) csound->Malloc(csound, totalBytes);
+    if (UNLIKELY(copy == NULL))
+      return CSOUND_MEMORY;
+
+    destination = (char *) copy + pointerBytes;
+    for (int32_t index = 0; index < argc; index++) {
+      size_t length = strlen(argv[index]) + 1;
+      copy[index] = destination;
+      memcpy(destination, argv[index], length);
+      destination += length;
+    }
+  }
+
+  if (csound->commandLineArgs != NULL)
+    csound->Free(csound, csound->commandLineArgs);
+  csound->commandLineArgs = copy;
+  csound->commandLineArgCount = argc;
+  return CSOUND_SUCCESS;
+}
+
+int32_t csoundGetCommandLineArgCount(CSOUND *csound)
+{
+  return csound != NULL ? csound->commandLineArgCount : 0;
+}
+
+const char *csoundGetCommandLineArg(CSOUND *csound, int32_t index)
+{
+  if (csound == NULL || index < 0 || index >= csound->commandLineArgCount)
+    return NULL;
+  return csound->commandLineArgs[index];
+}
+
+static int32_t command_line_separator(int32_t argc, const char **argv)
+{
+  for (int32_t index = 1; index < argc; index++) {
+    if (argv[index] != NULL && strcmp(argv[index], "--") == 0)
+      return index;
+  }
+  return argc;
+}
+
  int32_t csoundCompile(CSOUND *csound, int32_t argc, const char **argv) {
   OPARMS *O = csound->oparms;
   char *s;
@@ -173,6 +243,18 @@ static void put_sorted_score(CSOUND *csound, char *ss, FILE *ff) {
                     Str("Csound is already started, call csoundReset()\n"
                         "before starting again.\n"));
     return CSOUND_ERROR;
+  }
+
+  {
+    int32_t separator = command_line_separator(argc, argv);
+    if (separator < argc) {
+      int32_t result = csoundSetCommandLineArgs(
+        csound, argc - separator - 1, &argv[separator + 1]);
+      if (UNLIKELY(result != CSOUND_SUCCESS))
+        return result;
+      ac = separator;
+      argc = separator;
+    }
   }
 
   if (UNLIKELY(--argc <= 0)) {
@@ -647,4 +729,3 @@ extern int32_t DummyMidiWrite(CSOUND *csound, void *userData,
 
   return start_engine(csound);
 }
-

--- a/Top/main.c
+++ b/Top/main.c
@@ -214,15 +214,6 @@ const char *csoundGetCommandLineArg(CSOUND *csound, int32_t index)
   return csound->commandLineArgs[index];
 }
 
-static int32_t command_line_separator(int32_t argc, const char **argv)
-{
-  for (int32_t index = 1; index < argc; index++) {
-    if (argv[index] != NULL && strcmp(argv[index], "--") == 0)
-      return index;
-  }
-  return argc;
-}
-
  int32_t csoundCompile(CSOUND *csound, int32_t argc, const char **argv) {
   OPARMS *O = csound->oparms;
   char *s;
@@ -243,18 +234,6 @@ static int32_t command_line_separator(int32_t argc, const char **argv)
                     Str("Csound is already started, call csoundReset()\n"
                         "before starting again.\n"));
     return CSOUND_ERROR;
-  }
-
-  {
-    int32_t separator = command_line_separator(argc, argv);
-    if (separator < argc) {
-      int32_t result = csoundSetCommandLineArgs(
-        csound, argc - separator - 1, &argv[separator + 1]);
-      if (UNLIKELY(result != CSOUND_SUCCESS))
-        return result;
-      ac = separator;
-      argc = separator;
-    }
   }
 
   if (UNLIKELY(--argc <= 0)) {

--- a/Top/one_file.c
+++ b/Top/one_file.c
@@ -334,10 +334,14 @@ int32_t read_options(CSOUND *csound, CORFIL *cf, int32_t readingCsOptions)
               p++;
             }
             if (*p == '"') {
+              if (isspace(*(p+1))) {
+                *p++ = '\0';
+                /* The quoted argument was already added above. */
+                continue;
+              }
               /* ETX char used to mark the limits of a string */
-              *p = (isspace(*(p+1)) ? '\0' : 3);
+              *p = 3;
             }
-            //            break;
           }
 
           if (*p==';' ||

--- a/include/csound.h
+++ b/include/csound.h
@@ -628,6 +628,8 @@ extern "C" {
    * Compiles Csound input files (such as an orchestra and score, or CSD)
    * as directed by the supplied command-line arguments,
    * but does not perform them. Returns a non-zero error code on failure.
+   * An exact "--" ends Csound option parsing; following arguments are copied
+   * into the application argument list exposed by the argv opcode and API.
    * In this mode, the sequence of calls should be as follows:
    * /code
    *       csoundCompile(csound, argc, argv);
@@ -637,6 +639,24 @@ extern "C" {
    * /endcode
    */
   PUBLIC int32_t csoundCompile(CSOUND *, int32_t argc, const char **argv);
+
+  /**
+   * Replace the application arguments exposed to the orchestra. Arguments
+   * passed after "--" to csoundCompile() are stored through this API.
+   * The strings are copied and remain valid until they are replaced or the
+   * Csound instance is reset. Pass zero arguments to clear the list.
+   */
+  PUBLIC int32_t csoundSetCommandLineArgs(CSOUND *csound, int32_t argc,
+                                          const char **argv);
+
+  /** Return the number of application arguments exposed to the orchestra. */
+  PUBLIC int32_t csoundGetCommandLineArgCount(CSOUND *csound);
+
+  /**
+   * Return an application argument by zero-based index, or NULL when the
+   * index is outside the current argument list.
+   */
+  PUBLIC const char *csoundGetCommandLineArg(CSOUND *csound, int32_t index);
 
   /**
    * Parse, and compile the given orchestra from an ASCII string,

--- a/include/csound.hpp
+++ b/include/csound.hpp
@@ -153,6 +153,21 @@ class PUBLIC Csound
     return csoundCompile(csound, argc, argv);
   }
 
+  virtual int32_t SetCommandLineArgs(int32_t argc, const char **argv)
+  {
+    return csoundSetCommandLineArgs(csound, argc, argv);
+  }
+
+  virtual int32_t GetCommandLineArgCount()
+  {
+    return csoundGetCommandLineArgCount(csound);
+  }
+
+  virtual const char *GetCommandLineArg(int32_t index)
+  {
+    return csoundGetCommandLineArg(csound, index);
+  }
+
   virtual int32_t Compile(const char *csdName)
   {
     const char  *argv[3];

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -1536,6 +1536,8 @@ struct CSOUND_ {
   void (*audtran)(CSOUND *, const MYFLT *, int32_t);
   void *hostdata;
   char *orchname, *scorename;
+  int32_t commandLineArgCount;
+  char **commandLineArgs;
   CORFIL *orchstr, *scorestr;
   OPDS *ids;                /* used by init loops */
   ENGINE_STATE engineState; /* current Engine State merged after

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -72,3 +72,105 @@ TEST_F (EngineTests, testScoreRewind)
     csoundRewindScore(csound);
     ASSERT_TRUE(csoundPerformKsmps(csound) == 0); 
 }
+
+TEST_F (EngineTests, testCommandLineArgumentsApi)
+{
+    char firstArgument[] = "concert.orc";
+    const char *arguments[] = {
+      firstArgument,
+      "first violin",
+      "--quiet",
+      ""
+    };
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 4, arguments), CSOUND_SUCCESS);
+    firstArgument[0] = 'X';
+
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 4);
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 0), "concert.orc");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 1), "first violin");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 2), "--quiet");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 3), "");
+    ASSERT_EQ(csoundGetCommandLineArg(csound, -1), nullptr);
+    ASSERT_EQ(csoundGetCommandLineArg(csound, 4), nullptr);
+    ASSERT_EQ(csoundEvalCode(csound, R"(
+      Sarguments:S[] argv
+      return lenarray(Sarguments)
+    )"), 4);
+
+    const char *invalidArguments[] = {nullptr};
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 1, invalidArguments),
+              CSOUND_ERROR);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 4);
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 0, nullptr), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 0);
+    ASSERT_EQ(csoundEvalCode(csound, R"(
+      Sarguments:S[] argv
+      return lenarray(Sarguments)
+    )"), 0);
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 4, arguments), CSOUND_SUCCESS);
+    csoundReset(csound);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 0);
+}
+
+TEST_F (EngineTests, testCommandLineArgumentSeparator)
+{
+    const char *staleArguments[] = {"stale"};
+    const char *arguments[] = {
+      "csound",
+      "-n",
+      "--suppress-version",
+      "--code=instr 1\nendin",
+      "--",
+      "concert.orc",
+      "first violin",
+      "--logfile=ignored",
+      ""
+    };
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 1, staleArguments),
+              CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompile(csound, 9, arguments), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 4);
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 0), "concert.orc");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 1), "first violin");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 2), "--logfile=ignored");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 3), "");
+}
+
+TEST_F (EngineTests, testExplicitCommandLineArgumentsSurviveCompile)
+{
+    const char *applicationArguments[] = {"concert.orc", "first violin"};
+    const char *compileArguments[] = {
+      "csound",
+      "-n",
+      "--suppress-version",
+      "--code=instr 1\nendin"
+    };
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 2, applicationArguments),
+              CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompile(csound, 4, compileArguments), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 2);
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 0), "concert.orc");
+    ASSERT_STREQ(csoundGetCommandLineArg(csound, 1), "first violin");
+}
+
+TEST_F (EngineTests, testEmptyCommandLineArgumentSeparator)
+{
+    const char *staleArguments[] = {"stale"};
+    const char *compileArguments[] = {
+      "csound",
+      "-n",
+      "--suppress-version",
+      "--code=instr 1\nendin",
+      "--"
+    };
+
+    ASSERT_EQ(csoundSetCommandLineArgs(csound, 1, staleArguments),
+              CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompile(csound, 5, compileArguments), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundGetCommandLineArgCount(csound), 0);
+}

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -104,6 +104,8 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
     """
     filename = test_data[0]
     desc = test_data[1]
+    test_run_args = test_data[3] if len(test_data) >= 4 else run_args
+    application_args = test_data[4] if len(test_data) >= 5 else ""
 
     logger.debug(f"Starting test {test_index + 1}: {filename} - {desc}")
     start_time = time.time()
@@ -123,7 +125,10 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
             executable = f"{runtimeEnvironment} {executable}"
 
         # Use temp file for stderr capture (like the original implementation)
-        command = f"{executable} {run_args} {sourceDirectory}/{filename} 2> {temp_file}"
+        command = (
+            f"{executable} {test_run_args} {sourceDirectory}/{filename} "
+            f"{application_args} 2> {temp_file}"
+        )
 
         logger.debug(f"Executing command: {command}")
 
@@ -695,6 +700,13 @@ def runTest():
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],
+        [
+            "test_commandline_args.csd",
+            "application arguments after -- are available through argv",
+            0,
+            "-nd",
+            '-- concert.orc "first violin" --logfile=ignored ""',
+        ],
     ]
 
     arrayTests = [

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -704,7 +704,20 @@ def runTest():
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],
         [
             "test_commandline_args.csd",
-            "application arguments after -- are available through argv",
+            "command line application arguments after -- are available through argv",
+            0,
+            "-nd",
+            '-- concert.orc "first violin" --logfile=ignored ""',
+        ],
+        [
+            "test_csoptions_args.csd",
+            "CsOptions application arguments after -- are available through argv",
+            0,
+            "-nd",
+        ],
+        [
+            "test_commandline_overrides_csoptions_args.csd",
+            "command line application arguments override CsOptions arguments",
             0,
             "-nd",
             '-- concert.orc "first violin" --logfile=ignored ""',

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -95,7 +95,9 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
 
     Args:
         test_index: Index of the test in the original test list
-        test_data: Test data tuple [filename, description, optional_expected_result]
+        test_data: Test data tuple [filename, description,
+            optional_expected_result, optional_run_args,
+            optional_application_args]
         run_args: Arguments to pass to csound
         temp_file: Temporary file for csound output
 

--- a/tests/commandline/test_commandline_args.csd
+++ b/tests/commandline/test_commandline_args.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+
+instr 1
+  Sarguments:S[] argv
+
+  if (lenarray(Sarguments) != 4) then
+    prints "argv length failed: expected 4, got %d\n", lenarray(Sarguments)
+    exitnow(1)
+  endif
+
+  if (strcmp(Sarguments[0], "concert.orc") != 0 || \
+      strcmp(Sarguments[1], "first violin") != 0 || \
+      strcmp(Sarguments[2], "--logfile=ignored") != 0 || \
+      strcmp(Sarguments[3], "") != 0) then
+    prints "argv values failed: '%s', '%s', '%s', '%s'\n", \
+      Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_commandline_overrides_csoptions_args.csd
+++ b/tests/commandline/test_commandline_overrides_csoptions_args.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -- options.orc "viola section" --from=csoptions ""
+</CsOptions>
+<CsInstruments>
+
+instr 1
+  Sarguments:S[] argv
+
+  if (lenarray(Sarguments) != 4) then
+    prints "argv length failed: expected 4, got %d\n", lenarray(Sarguments)
+    exitnow(1)
+  endif
+
+  if (strcmp(Sarguments[0], "concert.orc") != 0 || \
+      strcmp(Sarguments[1], "first violin") != 0 || \
+      strcmp(Sarguments[2], "--logfile=ignored") != 0 || \
+      strcmp(Sarguments[3], "") != 0) then
+    prints "command line did not override CsOptions: '%s', '%s', '%s', '%s'\n", \
+      Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_csoptions_args.csd
+++ b/tests/commandline/test_csoptions_args.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -- options.orc "viola section" --from=csoptions ""
+</CsOptions>
+<CsInstruments>
+
+instr 1
+  Sarguments:S[] argv
+
+  if (lenarray(Sarguments) != 4) then
+    prints "argv length failed: expected 4, got %d\n", lenarray(Sarguments)
+    exitnow(1)
+  endif
+
+  if (strcmp(Sarguments[0], "options.orc") != 0 || \
+      strcmp(Sarguments[1], "viola section") != 0 || \
+      strcmp(Sarguments[2], "--from=csoptions") != 0 || \
+      strcmp(Sarguments[3], "") != 0) then
+    prints "argv values failed: '%s', '%s', '%s', '%s'\n", \
+      Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Csound currently treats every command-line argument as an engine option or input file. This makes it difficult to build orchestra programs that accept their own arguments.

This adds `--` as a separator:

  ```sh
csound program.csd -- lyrics_1.txt first second
```

Arguments after -- are copied into the Csound instance and exposed through the new init-time argv opcode:

```csound
Sargs:S[] argv
```

The change also adds C and C++ APIs for setting and reading application arguments. Existing command-line behavior before `--` remains unchanged, and arguments after it are never interpreted as Csound options.

This also allows an orchestra to act as a script host. For example, an executable musical cue file could select its Csound runner with a shebang:

  ```bash
#!/usr/bin/env -S csound --orc /usr/local/share/csound/cue-runner.orc --
tempo 96
instrument glass
play C4 0.5
play G4 1.0
```

It could then be launched directly:

```bash
./morning.cue concert-hall
```

The runner receives the cue filename and preset through argv.