### PR TITLE
Fix recursive struct-array ownership and reclaim init-only UDO frames

### DIFF
--- a/Engine/csound_standard_types.c
+++ b/Engine/csound_standard_types.c
@@ -22,6 +22,7 @@
 
 #include "csoundCore.h"
 #include "csound_standard_types.h"
+#include "arrays.h"
 #include "pstream.h"
 #include "find_opcode.h"
 #include <stdlib.h>
@@ -137,149 +138,122 @@ static void string_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
     sDest->timestamp = kcnt;
 }
 
-static size_t array_get_num_members(ARRAYDAT* aSrc) {
-    int32_t i, retVal = 0;
-
-    if (aSrc->dimensions <= 0) {
-      return retVal;
-    }
-
-    retVal = aSrc->sizes[0];
-
-    for (i = 1; i < aSrc->dimensions; i++) {
-      retVal *= aSrc->sizes[i];
-    }
-    return (size_t)retVal;
-}
-
-/*
- * array_copy_value - Copy array data with optimized handling for user-defined types
- *
- * Memory Ownership Semantics:
- * - For UDT arrays (user-defined structs): Creates non-owning aliases (allocated=0)
- *   where aDest->sizes and aDest->data point to aSrc's buffers
- * - For regular arrays: Performs deep copy with owned memory allocation
- * - Pre-existing destination memory is always freed before reallocation
- * - Early alias check prevents unnecessary allocations and potential leaks
- *
- * Parameters:
- *   csound - Csound instance
- *   cstype - Type information for validation
- *   dest - Destination ARRAYDAT (may be uninitialized)
- *   src - Source ARRAYDAT (must be valid)
- *   ctx - Instrument context for variable creation
- */
+/* Structured arrays share backing storage and detach on write. Other arrays
+   retain their established deep-copy semantics; they do not retain recursive
+   struct graphs and do not need ownership sharing for this lifetime fix. */
 static void array_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
                       const void* src, INSDS *ctx) {
     ARRAYDAT* aDest = (ARRAYDAT*)dest;
+    /* The type callback declares src const. Structured copies may attach an
+       ownership sidecar, which changes bookkeeping but not the source value. */
     ARRAYDAT* aSrc = (ARRAYDAT*)src;
-    CSOUND* cs = (CSOUND*)csound;
-    CS_VARIABLE* var;
-    size_t j;
-    int32_t memMyfltSize;
-    size_t arrayNumMembers;
+    CS_VARIABLE* var = NULL;
+    size_t arrayNumMembers, capacity, requiredBytes = 0;
+    int32_t needsAllocation;
 
-    /* If destination is NULL, nothing to do. */
-    if (UNLIKELY(aDest == NULL)) {
+    IGN(cstype);
+
+    if (UNLIKELY(aDest == NULL || aSrc == NULL) || aDest == aSrc) {
+        return;
+    }
+    if (UNLIKELY(!csound_array_element_types_compatible(
+                   aDest->arrayType, aSrc->arrayType))) {
+        csound->Die(csound, "array element types do not match during copy");
+        return;
+    }
+    if (aDest->arrayType == NULL) {
+        aDest->arrayType = aSrc->arrayType;
+    }
+    /* Structured arrays share backing storage until a writer detaches. */
+    if (aSrc->arrayType != NULL && aSrc->arrayType->userDefinedType) {
+        csound_array_share(csound, aDest, aSrc);
+        return;
+    }
+    if (aDest->data != NULL && aDest->data == aSrc->data) {
+        /* A legacy view can reach this callback with a different ARRAYDAT but
+           the same allocation. Reallocating the destination would invalidate
+           the source, while the value is already identical. */
         return;
     }
 
-    /* Optimization and safety: for arrays of user-defined structs, perform a
-       shallow alias instead of deep-copying elements. This avoids heavy copy
-       and shared-ownership bugs; alias is non-owning (allocated=0).
-       This check is done BEFORE any allocations to prevent memory leaks. */
-    if (aSrc && aSrc->arrayType && aSrc->arrayType->userDefinedType) {
-        if (aDest->sizes == aSrc->sizes && aDest->data == aSrc->data) {
-            aDest->arrayMemberSize = aSrc->arrayMemberSize;
-            aDest->dimensions      = aSrc->dimensions;
-            aDest->arrayType       = aSrc->arrayType;
-            aDest->allocated       = 0;
+    if (UNLIKELY(csound_array_member_count(aSrc, &arrayNumMembers) != OK)) {
+        csound->Die(csound, "invalid array dimensions during copy");
+        return;
+    }
+    if (UNLIKELY(arrayNumMembers > 0 && aSrc->data == NULL)) {
+        csound->Die(csound, "array data is missing during copy");
+        return;
+    }
+    capacity = arrayNumMembers > 0 ? arrayNumMembers : 1;
+    if (aSrc->data != NULL) {
+        if (UNLIKELY(csound_array_allocation_size(
+                       aSrc->arrayMemberSize, capacity,
+                       &requiredBytes) != OK)) {
+            csound->Die(csound, "array allocation size overflow during copy");
             return;
         }
-
-        /* Free only owned destination storage before creating an alias. */
-        if (aDest->allocated > 0) {
-            if (aDest->sizes != NULL) {
-                cs->Free(cs, aDest->sizes);
-                aDest->sizes = NULL;
-            }
-            if (aDest->data != NULL) {
-                cs->Free(cs, aDest->data);
-                aDest->data = NULL;
-            }
-        } else if (aDest->data == NULL && aDest->sizes != NULL) {
-            cs->Free(cs, aDest->sizes);
-            aDest->sizes = NULL;
+        /* allocated == 0 is the legacy non-owning-view marker. Owners must
+           report enough capacity for every logical element copied below. */
+        if (UNLIKELY(aSrc->allocated > 0 &&
+                     aSrc->allocated < requiredBytes)) {
+            csound->Die(csound, "array source capacity is too small");
+            return;
         }
-
-        /* Shallow alias for arrays of structs - non-owning reference */
-        aDest->arrayMemberSize = aSrc->arrayMemberSize;
-        aDest->dimensions      = aSrc->dimensions;
-        aDest->sizes           = aSrc->sizes;
-        aDest->arrayType       = aSrc->arrayType;
-        aDest->data            = aSrc->data;
-        aDest->allocated       = 0; /* Non-owning alias */
-        return;
     }
 
-    /* If destination is an uninitialised array shell (arrayType == NULL),
-       initialise it from the source so we can perform a copy. */
-    if (UNLIKELY(aDest->arrayType == NULL) && aSrc && aSrc->arrayType != NULL) {
-        /* Bootstrap destination metadata and storage from source */
-        aDest->arrayType = aSrc->arrayType;
-        aDest->dimensions = aSrc->dimensions;
-        if (aDest->sizes != NULL) { cs->Free(cs, aDest->sizes); }
-        aDest->sizes = cs->Malloc(cs, sizeof(int32_t) * aSrc->dimensions);
-        memcpy(aDest->sizes, aSrc->sizes, sizeof(int32_t) * aSrc->dimensions);
-        aDest->arrayMemberSize = aSrc->arrayMemberSize;
-        size_t nm = array_get_num_members(aSrc);
-        if (aDest->data != NULL) { cs->Free(cs, aDest->data); }
-        aDest->data = cs->Calloc(cs, aSrc->arrayMemberSize * nm);
-        aDest->allocated = aSrc->arrayMemberSize * nm;
-    }
+    /* Use exact capacity so shrinking a managed array releases trailing
+       element storage instead of retaining it until instrument teardown. */
+    needsAllocation = aDest->storage != NULL || aDest->data == NULL ||
+      aSrc->arrayMemberSize != aDest->arrayMemberSize ||
+      aSrc->dimensions != aDest->dimensions ||
+      (aSrc->dimensions > 0 && aDest->sizes == NULL) ||
+      requiredBytes != aDest->allocated;
 
-    arrayNumMembers = array_get_num_members(aSrc);
-    memMyfltSize = aSrc->arrayMemberSize / sizeof(MYFLT);
-
-    /* If source and destination are the same array object, skip copy */
-    if (aDest == aSrc) {
-        return;
-    }
-
-    if(aDest->data == NULL ||
-       aSrc->arrayMemberSize != aDest->arrayMemberSize ||
-       aSrc->dimensions != aDest->dimensions ||
-       aSrc->arrayType != aDest->arrayType ||
-       arrayNumMembers > array_get_num_members(aDest)) {
-
+    if (needsAllocation) {
+        csound_free_array_storage(csound, aDest);
         aDest->arrayMemberSize = aSrc->arrayMemberSize;
         aDest->dimensions = aSrc->dimensions;
-        if(aDest->sizes != NULL) {
-            cs->Free(cs, aDest->sizes);
+        if (aSrc->dimensions > 0 && aSrc->sizes != NULL) {
+            aDest->sizes = csound->Malloc(
+              csound, sizeof(int32_t) * (size_t)aSrc->dimensions);
+            memcpy(aDest->sizes, aSrc->sizes,
+                   sizeof(int32_t) * (size_t)aSrc->dimensions);
         }
-        aDest->sizes = cs->Malloc(cs, sizeof(int32_t) * aSrc->dimensions);
-        memcpy(aDest->sizes, aSrc->sizes, sizeof(int32_t) * aSrc->dimensions);
-        aDest->arrayType = aSrc->arrayType;
-        if(aDest->data != NULL) {
-            cs->Free(cs, aDest->data);
-        }
-        aDest->data = cs->Calloc(cs, aSrc->arrayMemberSize * arrayNumMembers);
-        aDest->allocated = aSrc->arrayMemberSize * arrayNumMembers;
-    } else if(arrayNumMembers <= array_get_num_members(aDest)) // set sizes, don't reallocate
-      for(j = 0; j < aDest->dimensions; j++) aDest->sizes[j] = aSrc->sizes[j];
-    
 
-    var = aDest->arrayType->createVariable(cs, (void *)aDest->arrayType, ctx);
-    for (j = 0; j < arrayNumMembers; j++) {
-        size_t index = j * memMyfltSize;
-        if(var->initializeVariableMemory != NULL) {
-          var->initializeVariableMemory(csound, var, aDest->data + index);
+        if (aSrc->data == NULL || aSrc->arrayMemberSize <= 0) {
+            return;
         }
-        aDest->arrayType->copyValue(csound, aDest->arrayType,
-                                    aDest->data + index,
-                                    aSrc->data + index, ctx);
+        aDest->allocated = requiredBytes;
+        aDest->data = csound->Calloc(csound, aDest->allocated);
+
+        var = array_element_create_variable(csound, aDest->arrayType, ctx);
+        if (var != NULL && var->initializeVariableMemory != NULL) {
+            for (size_t i = 0; i < capacity; i++) {
+                var->initializeVariableMemory(csound, var,
+                  (MYFLT*)((char*)aDest->data +
+                           i * (size_t)aDest->arrayMemberSize));
+            }
+        }
+    } else if (aDest->dimensions > 0) {
+        memcpy(aDest->sizes, aSrc->sizes,
+               sizeof(int32_t) * (size_t)aDest->dimensions);
     }
 
+    for (size_t i = 0; i < arrayNumMembers; i++) {
+        size_t offset = i * (size_t)aSrc->arrayMemberSize;
+        void* destElement = (char*)aDest->data + offset;
+        const void* srcElement = (const char*)aSrc->data + offset;
+        if (aDest->arrayType != NULL &&
+            aDest->arrayType->copyValue != NULL) {
+            aDest->arrayType->copyValue(csound, aDest->arrayType,
+                                        destElement, srcElement, ctx);
+        } else {
+            memcpy(destElement, srcElement, (size_t)aSrc->arrayMemberSize);
+        }
+    }
+    if (var != NULL) {
+        csound->Free(csound, var);
+    }
 }
 
 static void opcodedef_copy_value(CSOUND* csound, const CS_TYPE* cstype, void* dest,
@@ -358,6 +332,7 @@ static void array_init_memory(CSOUND *csound, CS_VARIABLE* var, MYFLT* memblock)
     dat->arrayMemberSize = 0;
     dat->dimensions = 0;
     dat->sizes = NULL;
+    dat->storage = NULL;
 
     // Initialize array dimensions if they were set during variable creation
     if (var->dimensions > 0) {
@@ -530,54 +505,178 @@ static void string_free_var_mem(void* csnd, void* p) {
     string_free_internal(csound, dat);
 }
 
-static void array_free_var_mem(void* csnd, void* p) {
-    CSOUND* csound = (CSOUND*)csnd;
-    ARRAYDAT* dat = (ARRAYDAT*)p;
+static void array_clear_view(ARRAYDAT* dat) {
+    /* Keep arrayType: it is the variable's declared element type and is needed
+       if the same ARRAYDAT is initialized again. */
+    dat->dimensions = 0;
+    dat->sizes = NULL;
+    dat->arrayMemberSize = 0;
+    dat->data = NULL;
+    dat->allocated = 0;
+    dat->storage = NULL;
+}
 
-    /* Only free backing storage if this ARRAYDAT owns it. Aliases set allocated=0. */
-    if (dat->allocated > 0 && dat->data != NULL) {
-        const CS_TYPE* arrayType = dat->arrayType;
+void csound_free_array_storage(CSOUND* csound, ARRAYDAT* dat) {
+    int32_t ownsData;
 
-        if (arrayType->freeVariableMemory != NULL) {
-            MYFLT* mem = dat->data;
-            size_t memMyfltSize = 0;
-            // Compute element count without trusting dat->sizes pointer, which may be shared/aliased
-            size_t i;
-            size_t elemCount = 0;
+    if (dat == NULL) {
+        return;
+    }
 
-            // Safe division with checks for arrayMemberSize and sizeof(MYFLT)
-            if (dat->arrayMemberSize > 0 && sizeof(MYFLT) > 0) {
-                memMyfltSize = (size_t)dat->arrayMemberSize / sizeof(MYFLT);
-
-                if (dat->allocated > 0) {
-                    elemCount = (size_t)dat->allocated / (size_t)dat->arrayMemberSize;
-                }
-            } else if (dat->sizes) {
-                // Fallback to sizes if available
-                elemCount = (dat->dimensions > 0) ? (size_t)dat->sizes[0] : 0;
-                for (i = 1; i < (size_t)dat->dimensions; i++) {
-                    // Check for multiplication overflow
-                    if (elemCount > 0 && (size_t)dat->sizes[i] > SIZE_MAX / elemCount) {
-                        // Overflow would occur, cap at SIZE_MAX
-                        elemCount = SIZE_MAX;
-                        break;
-                    }
-                    elemCount *= (size_t)dat->sizes[i];
-                }
-            }
-
-            for (i = 0; i < elemCount; i++) {
-                arrayType->freeVariableMemory(csound,
-                                              mem + (i * memMyfltSize));
-            }
+    if (dat->storage != NULL) {
+        CS_ARRAY_STORAGE* storage = dat->storage;
+        int32_t refs = cs_array_storage_release_ref(csound, storage);
+        if (UNLIKELY(refs < 0)) {
+            csound->Die(csound, "negative shared array reference count");
+            return;
         }
+        if (refs == 0) {
+            cs_array_storage_destroy_inline(csound, storage);
+        }
+        array_clear_view(dat);
+        return;
+    }
 
+    /* Aliases have data but allocated == 0. An empty array still owns its
+       one-element placeholder, so allocated remains greater than zero. */
+    ownsData = dat->allocated > 0 && dat->data != NULL;
+    if (ownsData) {
+        csound_array_free_elements_inline(csound, dat->arrayType, dat->data,
+                                          dat->allocated,
+                                          dat->arrayMemberSize);
         csound->Free(csound, dat->data);
     }
 
-    if (dat->allocated > 0 && dat->sizes != NULL) {
+    /* An uninitialised array shell owns its sizes metadata. Aliases own
+       neither sizes nor data, and must only be detached. */
+    if (dat->sizes != NULL && (ownsData || dat->data == NULL)) {
         csound->Free(csound, dat->sizes);
     }
+
+    array_clear_view(dat);
+}
+
+void csound_array_share(CSOUND* csound, ARRAYDAT* dest, ARRAYDAT* src) {
+    CS_ARRAY_STORAGE* storage;
+    size_t logicalCount, capacity, strideBytes;
+
+    if (dest == NULL || src == NULL || dest == src) {
+        return;
+    }
+    if (UNLIKELY(src->arrayType == NULL ||
+                 !src->arrayType->userDefinedType ||
+                 csound_array_member_count(src, &logicalCount) != OK)) {
+        csound->Die(csound, "invalid structured array during copy");
+        return;
+    }
+    if (dest->data != NULL && dest->data == src->data &&
+        dest->storage != NULL && dest->storage == src->storage) {
+        return;
+    }
+    if (src->data == NULL) {
+        if (UNLIKELY(src->storage != NULL)) {
+            csound->Die(csound,
+                        "structured array has storage without array data");
+            return;
+        }
+        csound_free_array_storage(csound, dest);
+        dest->dimensions = src->dimensions;
+        dest->arrayMemberSize = src->arrayMemberSize;
+        dest->arrayType = src->arrayType;
+        if (src->dimensions > 0 && src->sizes != NULL) {
+            dest->sizes = csound->Malloc(
+              csound, sizeof(int32_t) * (size_t)src->dimensions);
+            memcpy(dest->sizes, src->sizes,
+                   sizeof(int32_t) * (size_t)src->dimensions);
+        }
+        return;
+    }
+
+    storage = src->storage;
+    if (storage == NULL) {
+        CS_ARRAY_STORAGE candidate = {0};
+
+        /* A raw alias (allocated == 0) has no owner that can participate in
+           reference counting. Internal structured-array copies now always
+           carry a sidecar, so accepting such a source would risk freeing
+           memory owned elsewhere. */
+        if (UNLIKELY(src->allocated == 0 || src->arrayMemberSize <= 0 ||
+                     src->allocated % (size_t)src->arrayMemberSize != 0)) {
+            csound->Die(csound,
+                        "cannot share non-owning structured-array storage");
+            return;
+        }
+
+        candidate.refs = 1;
+        candidate.dimensions = src->dimensions;
+        candidate.arrayMemberSize = src->arrayMemberSize;
+        candidate.arrayType = src->arrayType;
+        candidate.sizes = src->sizes;
+        candidate.data = src->data;
+        candidate.allocated = src->allocated;
+        if (UNLIKELY(cs_array_storage_layout(
+                       src, &candidate, &logicalCount,
+                       &capacity, &strideBytes) != OK)) {
+            csound->Die(csound,
+                        "invalid structured-array storage during copy");
+            return;
+        }
+
+        /* Install the sidecar lazily. This is the bookkeeping-only source
+           mutation mentioned in array_copy_value; normal array access remains
+           unchanged, and additional views report allocated == 0. */
+        storage = csound->Calloc(csound, sizeof(CS_ARRAY_STORAGE));
+        *storage = candidate;
+#if !defined(MSVC) && !defined(HAVE_ATOMIC_BUILTIN)
+        /* Csound's generic atomic fallback is intentionally non-atomic. A
+           sidecar can outlive the lock protecting its original ARRAYDAT, so
+           non-atomic targets serialize reference changes with a mutex. */
+        storage->refLock = csound->Create_Mutex(0);
+        if (UNLIKELY(storage->refLock == NULL)) {
+            csound->Free(csound, storage);
+            csound->Die(csound,
+                        "could not create shared-array reference lock");
+            return;
+        }
+#endif
+        src->storage = storage;
+    }
+    else if (UNLIKELY(cs_array_storage_layout(
+                        src, storage, &logicalCount,
+                        &capacity, &strideBytes) != OK)) {
+        csound->Die(csound, "invalid structured-array storage during copy");
+        return;
+    }
+
+    /* Validate and retain the source before releasing the destination. This
+       matters for legacy aliases that may point at destination-owned data. */
+    if (UNLIKELY(dest->data == src->data && dest->storage != storage &&
+                 (dest->storage != NULL || dest->allocated > 0))) {
+        csound->Die(csound, "conflicting structured-array ownership");
+        return;
+    }
+    if (UNLIKELY(cs_array_storage_try_add_ref(csound, storage) == NOTOK)) {
+        csound->Die(csound, "invalid shared array reference count");
+        return;
+    }
+    csound_free_array_storage(csound, dest);
+
+    dest->dimensions = src->dimensions;
+    dest->sizes = src->sizes;
+    dest->arrayMemberSize = src->arrayMemberSize;
+    dest->arrayType = src->arrayType;
+    dest->data = src->data;
+    dest->allocated = 0;
+    dest->storage = storage;
+}
+
+void csound_array_prepare_write(CSOUND* csound, ARRAYDAT* array,
+                                INSDS* ctx) {
+    csound_array_prepare_write_inline(csound, array, ctx);
+}
+
+static void array_free_var_mem(void* csnd, void* p) {
+    csound_free_array_storage((CSOUND*)csnd, (ARRAYDAT*)p);
 }
 
 /* STANDARD TYPE DEFINITIONS */

--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1715,6 +1715,17 @@ void csoundReinitInstrumentArgpp(CSOUND *csound, INSDS *ip)
     }
 }
 
+void recycle_udo_instance(CSOUND *csound, INSDS *ip)
+{
+  /* Reset local values and their cached argument pointers before deact()
+     publishes the frame on the reusable-instance list. Callers must first
+     exclude deinit callbacks and resources that still depend on local data. */
+  free_instr_var_memory(csound, ip);
+  csoundInitializeVarPool(csound, ip->lclbas, ip->instr->varPool);
+  csoundReinitInstrumentArgpp(csound, ip);
+  deact(csound, ip);
+}
+
 static INSDS *instantiate(CSOUND *csound, int32_t insno, int32_t link)
 {
   INSTRTXT  *tp;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -53,6 +53,41 @@ static int32_t count_args(const char *args) {
   return count;
 }
 
+static int32_t useropcd_init_only(CSOUND *csound, UOPCODE *p)
+{
+  IGN(csound);
+  IGN(p);
+  return OK;
+}
+
+static int32_t udo_has_rate_converter(const UOPCODE *opcode)
+{
+  int32_t index;
+
+  for (index = 0; index < OPCODENUMOUTS_MAX; index++) {
+    if (opcode->cvt_in[index] != NULL || opcode->cvt_out[index] != NULL) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int32_t udo_frame_can_be_recycled(const UOPCODE *opcode,
+                                         const INSDS *parent,
+                                         const INSDS *child)
+{
+  /* Exactly zero is intentional: negative p3 is indefinite, while a positive
+     p3 may still execute. Rate converters are normally released when the
+     parent follows its UDO deactivation chain, so keep that path when present.
+     Opcode AUXCH allocations remain attached to the inactive INSDS for reuse;
+     unlike deinit callbacks, files, or nested instances, they do not depend on
+     local variable ownership and therefore do not block recycling. */
+  return parent != NULL && parent->p3.value == FL(0.0) &&
+         parent->xtratim == 0 && child != NULL && child->xtratim == 0 &&
+         child->nxtd == NULL && child->fdchp == NULL &&
+         child->subins_deact == NULL && !udo_has_rate_converter(opcode);
+}
+
 static inline void rewire_argpp(CSOUND *csound, OPDS *chain, int32_t index,
                                 MYFLT *argPtr, const char *structPath);
 static MYFLT *pbr_resolve_struct_target(CSOUND *csound, MYFLT *argPtr,
@@ -1277,6 +1312,8 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   uint32_t i;
   OPCODINFO    *inm;
   OPCOD_IOBUFS *buf = p->buf;
+  void         *previous_deact = NULL;
+  int32_t       attached_instance = 0;
   /* look up the 'fake' instr number, and opcode name */
   inm = (OPCODINFO*) p->h.optext->t.oentry->useropinfo;
   if (inm != NULL) {
@@ -1332,7 +1369,9 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
     tp->active++;
     tp->instcnt++;
     /* link into deact chain */
-    lcurip->opcod_deact = parent_ip->opcod_deact;
+    previous_deact = parent_ip->opcod_deact;
+    attached_instance = 1;
+    lcurip->opcod_deact = previous_deact;
     lcurip->subins_deact = NULL;
     parent_ip->opcod_deact = (void*) p;
     p->ip = lcurip;
@@ -1507,7 +1546,10 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
           if (v->varType == &CS_VAR_TYPE_ARRAY && (wantedSubType == NULL
                                                    || v->subType == wantedSubType)) {
             ARRAYDAT* cand = (ARRAYDAT*)(lcurip->lclbas + v->memBlockIndex);
-            if (cand && cand->data && cand->allocated > 0
+            /* A structured-array view can carry capacity in its sidecar while
+               ARRAYDAT.allocated remains zero for legacy ownership checks. */
+            if (cand && cand->data &&
+                (cand->allocated > 0 || cand->storage != NULL)
                 && cand->dimensions >= 0 && cand->arrayType) {
               if ((void*)cand != dst) {
                 src = (void*)cand;
@@ -1544,6 +1586,23 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   /* restore globals */
   csound->ids = saved_ids;
   csound->curip = parent_ip;
+
+  /* A zero-duration parent cannot run this frame at performance time. Type
+     copy callbacks above have already retained any structured output storage,
+     so a frame with no deferred lifetime can now be recycled. */
+  if (attached_instance &&
+      udo_frame_can_be_recycled(p, p->parent_ip, lcurip) &&
+      p->parent_ip->opcod_deact == (void *)p &&
+      lcurip->opcod_deact == previous_deact) {
+    p->parent_ip->opcod_deact = previous_deact;
+    lcurip->opcod_deact = NULL;
+    recycle_udo_instance(csound, lcurip);
+    p->ip = NULL;
+    p->buf = NULL;
+    p->parent_ip = NULL;
+    p->h.perf = (SUBR)useropcd_init_only;
+    return OK;
+  }
 
   /* ksmps and esr may have changed, check against insdshead
      select perf routine and scale xtratim accordingly.

--- a/H/prototyp.h
+++ b/H/prototyp.h
@@ -82,6 +82,7 @@ extern "C" {
   void free_instance(CSOUND *csound, INSDS *ip);
   int32_t instr_num(CSOUND *csound, INSTRTXT *instr);
   void free_instr_var_memory(CSOUND* csound, INSDS* ip);
+  void recycle_udo_instance(CSOUND* csound, INSDS* ip);
   int32_t init_instance(CSOUND *csound, INSDS *ip, EVTBLK *newevtp);
   int32_t instr_context_check(CSOUND *csound, INSDS *ip, INSDS *insdshead);
   int32_t insert_midi_event(CSOUND *, int32_t,  MCHNBLK*, MEVENT*);

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -28,19 +28,27 @@
 
 static int32_t is_intentionally_empty_array(const ARRAYDAT *dat)
 {
+  size_t allocated = dat != NULL && dat->storage != NULL
+                       ? dat->storage->allocated
+                       : (dat != NULL ? dat->allocated : 0);
+
   return dat != NULL && dat->data != NULL && dat->dimensions == 1 &&
          dat->sizes != NULL && dat->sizes[0] == 0 &&
          dat->arrayMemberSize > 0 &&
-         dat->allocated == (size_t) dat->arrayMemberSize;
+         allocated == (size_t)dat->arrayMemberSize;
 }
 
 int32_t array_init(CSOUND *csound, ARRAYINIT *p)
 {
   ARRAYDAT* arrayDat = p->arrayDat;
-  int32_t i, size;
+  int32_t i;
+  size_t elementCount, capacity, bytes;
 
   int32_t inArgCount = p->INOCOUNT;
 
+  if (UNLIKELY(arrayDat == NULL))
+    return csound->InitError(csound, "%s",
+                             Str("array_init: NULL output array"));
   if (UNLIKELY(inArgCount == 0))
     return
       csound->InitError(csound, "%s",
@@ -73,6 +81,7 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
     }
   }
 
+  csound_free_array_storage(csound, arrayDat);
   arrayDat->dimensions = inArgCount;
   arrayDat->sizes = csound->Calloc(csound, sizeof(int32_t) * inArgCount);
   for (i = 0; i < inArgCount; i++) {
@@ -82,12 +91,9 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
     arrayDat->sizes[i] = v;
   }
 
-  size = arrayDat->sizes[0];
-  if (inArgCount > 1) {
-    for (i = 1; i < inArgCount; i++) {
-      size *= arrayDat->sizes[i];
-    }
-  }
+  if (UNLIKELY(csound_array_member_count(arrayDat, &elementCount) != OK))
+    return csound->InitError(csound, "%s",
+                             Str("array_init: array dimensions overflow"));
 
   {
     // Safety: check for NULL arrayType
@@ -107,18 +113,30 @@ int32_t array_init(CSOUND *csound, ARRAYINIT *p)
       }
     }
 
-    CS_VARIABLE* var = arrayDat->arrayType->createVariable(csound, (void *)
-                                                           arrayDat->arrayType,
-                                                           p->h.insdshead);
+    CS_VARIABLE* var = array_element_create_variable(
+      csound, arrayDat->arrayType, p->h.insdshead);
     char *mem;
+    if (UNLIKELY(var == NULL || var->memBlockSize <= 0 ||
+                 var->initializeVariableMemory == NULL)) {
+      if (var != NULL)
+        csound->Free(csound, var);
+      return csound->InitError(csound, "%s",
+                               Str("array_init: invalid element type"));
+    }
     arrayDat->arrayMemberSize = var->memBlockSize;
-    int32_t allocCount = size > 0 ? size : 1;
-    arrayDat->data = csound->Calloc(csound,
-                                    arrayDat->allocated=var->memBlockSize*allocCount);
+    capacity = elementCount > 0 ? elementCount : 1;
+    if (UNLIKELY(csound_array_allocation_size(
+                   arrayDat->arrayMemberSize, capacity, &bytes) != OK)) {
+      csound->Free(csound, var);
+      return csound->InitError(csound, "%s",
+                               Str("array_init: allocation size overflow"));
+    }
+    arrayDat->allocated = bytes;
+    arrayDat->data = csound->Calloc(csound, bytes);
     mem = (char *) arrayDat->data;
-    for (i=0; i < allocCount; i++) {
+    for (size_t index = 0; index < capacity; index++) {
       var->initializeVariableMemory(csound, var,
-                                    (MYFLT*)(mem+i*var->memBlockSize));
+        (MYFLT*)(mem + index * (size_t)var->memBlockSize));
     }
     csound->Free(csound, var);
 
@@ -300,6 +318,7 @@ int32_t array_set(CSOUND* csound, ARRAY_SET *p)
   if (UNLIKELY(dat == NULL)) {
     return csound->PerfError(csound, &(p->h), Str("array_set: NULL array"));
   }
+  csound_array_prepare_write(csound, dat, p->h.insdshead);
   MYFLT* mem = (MYFLT*)dat->data;
   int32_t i;
   int32_t end, index = 0, incr;
@@ -470,7 +489,6 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
 
   MYFLT* mem = dat->data;
   int32_t i;
-  int32_t incr;
   int32_t end;
   int32_t index;
   int32_t indefArgCount = p->INOCOUNT - 1;
@@ -531,6 +549,10 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     }
 
     if (needsAutoSizing) {
+      /* Size recovery changes array metadata. Detach a structured view first
+         so a read from malformed legacy metadata cannot resize its siblings. */
+      csound_array_prepare_write(csound, dat, p->h.insdshead);
+      mem = dat->data;
       // Set a default size for struct arrays that were declared but not properly initialized
       for (int32_t j = 0; j < dat->dimensions; j++) {
         dat->sizes[j] = 2; // Default size
@@ -581,7 +603,7 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
   }
 
 
-  /* Special case: signal-as-array view (a[k]) — dimensions==0 and element type is 'a'.
+  /* Special case: signal-as-array view (a[k]): dimensions==0 and element type is 'a'.
      Here, dat->data points to the a-signal vector (MYFLT[ksmps]). The index is a k-rate
      sample index, so we simply pick that element. */
   if (dat->dimensions == 0 && dat->arrayType == &CS_VAR_TYPE_A) {
@@ -598,81 +620,38 @@ int32_t array_get(CSOUND* csound, ARRAY_GET *p)
     return OK;
   }
 
-  incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
-  mem += incr;
+  if (UNLIKELY(index < 0 || dat->arrayMemberSize <= 0 ||
+               (size_t)index >
+                 (SIZE_MAX - (size_t)dat->arrayMemberSize) /
+                   (size_t)dat->arrayMemberSize)) {
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("Invalid array element offset"));
+  }
+  size_t offset = (size_t)index * (size_t)dat->arrayMemberSize;
+  size_t allocatedBytes = dat->storage != NULL
+                            ? dat->storage->allocated
+                            : dat->allocated;
+  if (UNLIKELY(allocatedBytes > 0 &&
+               offset + (size_t)dat->arrayMemberSize > allocatedBytes)) {
+    return csound->PerfError(
+      csound, &(p->h),
+      Str("Array element %d exceeds allocated storage (%zu + %d > %zu)"),
+      index, offset, dat->arrayMemberSize, allocatedBytes);
+  }
+  mem = (MYFLT*)((char*)dat->data + offset);
 
 
 
-  /* Proper handling for arrays of user-defined structs: alias element instead of deep copy */
+  /* User-defined struct elements are copied into the output. Their nested
+     arrays retain shared backing storage through the normal type copy path. */
   if (dat->arrayType && dat->arrayType->userDefinedType) {
-    if (UNLIKELY(dat->data == NULL)) {
-      // Try to initialize the array if it's not initialized yet
-      if (dat->dimensions > 0 && dat->sizes != NULL) {
-
-
-        // Check if sizes are set (non-zero) or if we need to use a default
-        int32_t totalSize = 1;
-        int needsDefaultSizing = 0;
-
-        for (int32_t i = 0; i < dat->dimensions; i++) {
-          if (dat->sizes[i] <= 0) {
-            needsDefaultSizing = 1;
-            break;
-          }
-          totalSize *= dat->sizes[i];
-        }
-
-        // If sizes aren't set, this array was declared but not initialized with explicit sizes
-        // This happens with declarations like "relatives:Person[] init 2" where the init
-        // opcode should have set the sizes, but it didn't get called properly
-        if (needsDefaultSizing) {
-          // For struct arrays, we can try to infer the size from the access pattern
-          // or use a reasonable default. Since this is likely from a declaration like
-          // "relatives:Person[] init 2", we'll try to use a default size.
-
-
-          // Set a default size for 1D arrays - this is a fallback for when
-          // the init opcode wasn't called properly
-          for (int32_t i = 0; i < dat->dimensions; i++) {
-            dat->sizes[i] = 2; // Default size, could be made configurable
-          }
-          totalSize = 1;
-          for (int32_t i = 0; i < dat->dimensions; i++) {
-            totalSize *= dat->sizes[i];
-          }
-        }
-
-        CS_VARIABLE* var = dat->arrayType->createVariable(csound, (void*)dat->arrayType, p->h.insdshead);
-        dat->arrayMemberSize = var->memBlockSize;
-        dat->data = csound->Calloc(csound, dat->arrayMemberSize * totalSize);
-        dat->allocated = dat->arrayMemberSize * totalSize;
-
-        // Initialize each struct element
-        char *arrayMem = (char *) dat->data;
-        for (int32_t i = 0; i < totalSize; i++) {
-          if (var->initializeVariableMemory != NULL) {
-            var->initializeVariableMemory(csound, var, (MYFLT*)(arrayMem + i * var->memBlockSize));
-          }
-        }
-        csound->Free(csound, var);
-
-        // Recalculate mem pointer after initialization
-        mem = dat->data;
-        incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
-        mem += incr;
-      } else {
-        return OK; /* Gracefully skip rather than aborting init/perf */
-      }
+    if (UNLIKELY(p->out == NULL)) {
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("Invalid struct output"));
     }
-    CS_STRUCT_VAR* srcVar = (CS_STRUCT_VAR*) (mem);
-    CS_STRUCT_VAR* dstVar = (CS_STRUCT_VAR*) (p->out);
-    if (UNLIKELY(srcVar == NULL)) {
-      return csound->PerfError(csound, &(p->h), "%s", Str("Invalid struct element"));
-    }
-    /* Alias the underlying members; this is a read/view of the array element */
-    dstVar->members     = srcVar->members;
-    dstVar->memberCount = srcVar->memberCount;
-    dstVar->ownsMembers = 0;
+    dat->arrayType->copyValue(csound, dat->arrayType,
+                              (void*)p->out, (void*)mem,
+                              p->h.insdshead);
   } else {
     if (UNLIKELY(mem == NULL)) {
       /* Report error in the correct phase */
@@ -3446,8 +3425,6 @@ static int32_t get_array_total_size(ARRAYDAT* dat)
 
 int32_t tabcopy(CSOUND *csound, TABCPY *p)
 {
-  int32_t i, arrayTotalSize, memMyfltSize;
-
   if (UNLIKELY(p->src->data==NULL) || p->src->dimensions <= 0 )
     return csound->InitError(csound, "%s", Str("array-variable not initialised"));
   if (UNLIKELY(p->dst->dimensions > 0 &&
@@ -3462,44 +3439,11 @@ int32_t tabcopy(CSOUND *csound, TABCPY *p)
 
   if (p->src == p->dst) return OK;
 
-  if (p->src->arrayType && p->src->arrayType->userDefinedType) {
-    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
-                                p->dst, p->src, p->h.insdshead);
-    return OK;
-  }
-
-  arrayTotalSize = get_array_total_size(p->src);
-  memMyfltSize = p->src->arrayMemberSize / sizeof(MYFLT);
-  p->dst->arrayMemberSize = p->src->arrayMemberSize;
-
-
-
-  if (arrayTotalSize != get_array_total_size(p->dst)) {
-    p->dst->dimensions = p->src->dimensions;
-
-    p->dst->sizes = csound->Malloc(csound, sizeof(int32_t) * p->src->dimensions);
-    memcpy(p->dst->sizes, p->src->sizes, sizeof(int32_t) * p->src->dimensions);
-
-    if (p->dst->data == NULL) {
-      p->dst->data = csound->Calloc(csound,
-                                    p->src->arrayMemberSize * arrayTotalSize);
-      p->dst->allocated = p->src->arrayMemberSize * arrayTotalSize;
-    } else {
-      p->dst->data = csound->ReAlloc(csound, p->dst->data,
-                                     p->src->arrayMemberSize * arrayTotalSize);
-      memset(p->dst->data, 0, p->src->arrayMemberSize * arrayTotalSize);
-    }
-  }
-
-  for (i = 0; i < arrayTotalSize; i++) {
-    int32_t index = (i * memMyfltSize);
-    p->dst->arrayType->copyValue(csound, p->dst->arrayType,
-                                 (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index), p->h.insdshead);
-  }
-
-
-
+  /* The registered copy routine owns element lifetime and keeps dimensions,
+     capacity, and backing-storage metadata in sync. Reimplementing resize here
+     used to leave ARRAYDAT.allocated stale after a string-array assignment. */
+  CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                              p->dst, p->src, p->h.insdshead);
   return OK;
 }
 
@@ -3539,8 +3483,6 @@ int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
 
 int32_t tabcopyk(CSOUND *csound, TABCPY *p)
 {
-  int32_t i, arrayTotalSize, memMyfltSize;
-
   if (UNLIKELY(p->src->data==NULL) || p->src->dimensions <= 0 )
     return csound->PerfError(csound, &(p->h), "%s", Str("array-variable not initialised"));
   if (UNLIKELY(p->dst->dimensions > 0 &&
@@ -3555,48 +3497,14 @@ int32_t tabcopyk(CSOUND *csound, TABCPY *p)
 
   if (p->src == p->dst) return OK;
 
-  if (p->src->arrayType && p->src->arrayType->userDefinedType) {
-    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
-                                p->dst, p->src, p->h.insdshead);
-    return OK;
-  }
-
-  arrayTotalSize = get_array_total_size(p->src);
-  memMyfltSize = p->src->arrayMemberSize / sizeof(MYFLT);
-  p->dst->arrayMemberSize = p->src->arrayMemberSize;
-
-  if (arrayTotalSize != get_array_total_size(p->dst)) {
-    p->dst->dimensions = p->src->dimensions;
-
-    p->dst->sizes = csound->Malloc(csound, sizeof(int32_t) * p->src->dimensions);
-    memcpy(p->dst->sizes, p->src->sizes, sizeof(int32_t) * p->src->dimensions);
-
-    if (p->dst->data == NULL) {
-      p->dst->data = csound->Calloc(csound,
-                                    p->src->arrayMemberSize * arrayTotalSize);
-      p->dst->allocated = p->src->arrayMemberSize * arrayTotalSize;
-    } else {
-      p->dst->data = csound->ReAlloc(csound, p->dst->data,
-                                     p->src->arrayMemberSize * arrayTotalSize);
-      memset(p->dst->data, 0, p->src->arrayMemberSize * arrayTotalSize);
-    }
-  }
-
-  for (i = 0; i < arrayTotalSize; i++) {
-    int32_t index = (i * memMyfltSize);
-    p->dst->arrayType->copyValue(csound, p->dst->arrayType,
-                                 (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index), p->h.insdshead);
-  }
-
+  CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                              p->dst, p->src, p->h.insdshead);
   return OK;
 }
 
 
 int32_t tabcopy1(CSOUND *csound, TABCPY *p)
 {
-  int32_t i, arrayTotalSize, memMyfltSize;
-
   if (UNLIKELY(p->src->data==NULL) || p->src->dimensions <= 0 )
     return csound->InitError(csound, "%s", Str("array-variable not initialised"));
   if (p->dst->dimensions > 0 && p->src->dimensions != p->dst->dimensions)
@@ -3605,42 +3513,16 @@ int32_t tabcopy1(CSOUND *csound, TABCPY *p)
 
   if (p->src == p->dst) return OK;
 
-  arrayTotalSize = get_array_total_size(p->src);
-  memMyfltSize = p->src->arrayMemberSize / sizeof(MYFLT);
-  p->dst->arrayMemberSize = p->src->arrayMemberSize;
-
-  if (arrayTotalSize != get_array_total_size(p->dst)) {
-    p->dst->dimensions = p->src->dimensions;
-
-    p->dst->sizes = csound->Malloc(csound, sizeof(int32_t) * p->src->dimensions);
-    memcpy(p->dst->sizes, p->src->sizes, sizeof(int32_t) * p->src->dimensions);
-
-    if (p->dst->data == NULL) {
-      p->dst->data = csound->Calloc(csound,
-                                    p->src->arrayMemberSize * arrayTotalSize);
-      p->dst->allocated = p->src->arrayMemberSize * arrayTotalSize;
-    } else {
-      p->dst->data = csound->ReAlloc(csound, p->dst->data,
-                                     p->src->arrayMemberSize * arrayTotalSize);
-      memset(p->dst->data, 0, p->src->arrayMemberSize * arrayTotalSize);
-    }
-  }
-
-
-  for (i = 0; i < arrayTotalSize; i++) {
-    int32_t index = (i * memMyfltSize);
-    p->dst->arrayType->copyValue(csound,
-                                 p->dst->arrayType,
-                                 (void*)(p->dst->data + index),
-                                 (void*)(p->src->data + index),  p->h.insdshead);
-  }
-
+  CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                              p->dst, p->src, p->h.insdshead);
   return OK;
 }
 
 int32_t tabcopy2(CSOUND *csound, TABCPY *p)
 {                               /* Like tabcopy but sample-accurate */
-  int32_t i, j, arrayTotalSize;
+  int32_t i, j;
+  int32_t layoutDiff;
+  size_t elementCount, capacity, bytes;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   int32_t nsmps = CS_KSMPS;
@@ -3659,24 +3541,34 @@ int32_t tabcopy2(CSOUND *csound, TABCPY *p)
 
   if (p->src == p->dst) return OK;
 
-  arrayTotalSize = get_array_total_size(p->src);
+  if (UNLIKELY(csound_array_member_count(p->src, &elementCount) != OK))
+    return csound->InitError(csound, "%s",
+                             Str("array-variable dimensions overflow"));
   p->dst->arrayMemberSize = p->src->arrayMemberSize;
+  capacity = elementCount > 0 ? elementCount : 1;
+  if (UNLIKELY(csound_array_allocation_size(
+                 p->src->arrayMemberSize, capacity, &bytes) != OK))
+    return csound->InitError(csound, "%s",
+                             Str("array-variable allocation size overflow"));
 
-  if (arrayTotalSize != get_array_total_size(p->dst)) {
+  layoutDiff = p->dst->dimensions != p->src->dimensions ||
+               p->dst->sizes == NULL ||
+               memcmp(p->dst->sizes, p->src->sizes,
+                      sizeof(int32_t) * (size_t)p->src->dimensions) != 0;
+  if (layoutDiff || p->dst->allocated != bytes) {
     p->dst->dimensions = p->src->dimensions;
 
-    p->dst->sizes = csound->Malloc(csound, sizeof(int32_t) * p->src->dimensions);
+    p->dst->sizes = csound->ReAlloc(
+      csound, p->dst->sizes, sizeof(int32_t) * p->src->dimensions);
     memcpy(p->dst->sizes, p->src->sizes, sizeof(int32_t) * p->src->dimensions);
 
     if (p->dst->data == NULL) {
-      p->dst->data = csound->Calloc(csound,
-                                    p->src->arrayMemberSize * arrayTotalSize);
-      p->dst->allocated = p->src->arrayMemberSize * arrayTotalSize;
+      p->dst->data = csound->Calloc(csound, bytes);
     } else {
-      p->dst->data = csound->ReAlloc(csound, p->dst->data,
-                                     p->src->arrayMemberSize * arrayTotalSize);
-      memset(p->dst->data, 0, p->src->arrayMemberSize * arrayTotalSize);
+      p->dst->data = csound->ReAlloc(csound, p->dst->data, bytes);
+      memset(p->dst->data, 0, bytes);
     }
+    p->dst->allocated = bytes;
   }
   dest = (MYFLT*)p->dst->data;
   src = (MYFLT*)p->src->data;

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -2358,6 +2358,9 @@ static inline void copy_array(CSOUND *csound,
                               ARRAYDAT *out, const ARRAYDAT *in, spin_lock_t *lock) {
   csoundSpinLock(lock);
   CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY, out, in, NULL);
+  /* csoundSetArrayData() has no CSOUND argument and therefore cannot detach a
+     shared array. Keep channel storage independent at this API boundary. */
+  csound_array_prepare_write(csound, out, NULL);
   csoundSpinUnLock(lock);
 }
 

--- a/OOps/structs.c
+++ b/OOps/structs.c
@@ -29,138 +29,196 @@
 #include "csound_orc_structs.h"
 #include "struct_ops.h"
 
-int32_t array_set_struct(CSOUND* csound, ARRAY_SET *p)
+static int32_t struct_value_matches_type(const CS_TYPE *type,
+                                         const CS_STRUCT_VAR *value)
 {
-  ARRAYDAT* dat = p->arrayDat;
-  if (UNLIKELY(dat == NULL || dat->data == NULL)) {
-    return csound->PerfError(csound, &(p->h), Str("array_set_struct: NULL array"));
+  CONS_CELL *expectedMember;
+
+  if (type == NULL || type->members == NULL || value == NULL ||
+      value->members == NULL ||
+      value->memberCount != cs_cons_length(type->members)) {
+    return 0;
   }
-  int32_t indefArgCount = p->INOCOUNT - 2; // value + at least one index
-  if (UNLIKELY(indefArgCount <= 0))
-    return csound->PerfError(csound, &(p->h), Str("array_set_struct: no indexes"));
-  if (UNLIKELY(dat->dimensions > 0 && indefArgCount != dat->dimensions)) {
-    // Allow flat arrays with no metadata
-    if (!(dat && dat->dimensions == 0)) {
-      return csound->PerfError(csound, &(p->h), Str("array_set_struct: dimension mismatch"));
+  expectedMember = type->members;
+  for (int32_t i = 0; i < value->memberCount; i++) {
+    if (expectedMember == NULL) {
+      return 0;
     }
-  }
-  // Compute flat index
-  size_t index = 0;
-  for (int32_t i = 0; i < indefArgCount; i++) {
-    int32_t end = (int32_t)(*p->indexes[i]);
+    CS_VARIABLE *expected = (CS_VARIABLE *)expectedMember->value;
+    CS_VAR_MEM *actual = value->members[i];
 
-    // Enforce non-negative index check for all cases
-    if (UNLIKELY(end < 0)) {
-      return csound->PerfError(csound, &(p->h), Str("array_set_struct: index %d out of range (negative)"), i+1);
+    if (expected == NULL || expected->varType == NULL || actual == NULL ||
+        actual->varType == NULL ||
+        expected->varType != actual->varType) {
+      return 0;
     }
-
-    if (dat->dimensions > 0 && dat->sizes != NULL) {
-      size_t dim = (size_t)dat->sizes[i];
-      if (UNLIKELY((size_t)end >= dim)) {
-        return csound->PerfError(csound, &(p->h), Str("array_set_struct: index %d out of range"), i+1);
-      }
-      if (UNLIKELY(index > (SIZE_MAX - (size_t)end) / dim)) {
-        return csound->PerfError(csound, &(p->h), Str("array_set_struct: index overflow"));
-      }
-      index = (index * dim) + (size_t)end;
-    } else {
-      // For flat arrays (dat->dimensions == 0), we need to validate bounds differently
-      // We'll check the final computed index against the array size after the loop
-      index = (size_t)end; // flat arrays: last index wins
+    if (expected->varType == &CS_VAR_TYPE_ARRAY &&
+        expected->subType != NULL &&
+        ((ARRAYDAT *)&actual->value)->arrayType != expected->subType) {
+      return 0;
     }
+    expectedMember = expectedMember->next;
   }
+  return expectedMember == NULL;
+}
 
-  // Validate capacity if known
-  if (UNLIKELY(dat->arrayMemberSize <= 0)) {
-    return csound->PerfError(csound, &(p->h), Str("array_set_struct: invalid element size"));
+static int32_t struct_array_flat_index(CSOUND *csound, OPDS *opds,
+                                       const char *opcodeName,
+                                       const ARRAYDAT *array,
+                                       MYFLT *const *indexes,
+                                       int32_t indexCount,
+                                       size_t *result)
+{
+  size_t flatIndex = 0;
+
+  if (UNLIKELY(result == NULL || opcodeName == NULL || array == NULL ||
+               indexes == NULL || array->dimensions <= 0 ||
+               array->sizes == NULL || indexCount != array->dimensions)) {
+    return csound->PerfError(csound, opds,
+                             "%s: array dimensions do not match indexes",
+                             opcodeName);
   }
+  for (int32_t i = 0; i < indexCount; i++) {
+    int32_t coordinate;
+    size_t dimension;
+    MYFLT rawIndex;
 
-  // Address element in bytes (safe for struct payloads)
-  char* base = (char*)dat->data;
-
-  // Validate byte offset is within allocated buffer
-  size_t elemSize = (size_t)dat->arrayMemberSize;
-  if (UNLIKELY(index > (SIZE_MAX - (elemSize - 1)) / elemSize)) {
-    return csound->PerfError(csound, &(p->h), Str("array_set_struct: offset overflow"));
-  }
-  size_t allocatedBytes = (size_t)dat->allocated;
-  if (allocatedBytes == 0 && dat->sizes && dat->dimensions > 0) {
-    allocatedBytes = (size_t)dat->sizes[0] * elemSize;
-  }
-  size_t offset = (size_t)index * elemSize;
-  if (allocatedBytes > 0 && UNLIKELY(offset + elemSize > allocatedBytes)) {
-    return csound->PerfError(csound, &(p->h), Str("array_set_struct: computed offset %zu out of bounds"), offset);
-  }
-
-  char* dstPtr = base + offset;
-
-  // Ensure destination struct is initialized (members allocated)
-  if (dat->arrayType && dat->arrayType->userDefinedType) {
-    CS_STRUCT_VAR* dst = (CS_STRUCT_VAR*)(void*)dstPtr;
-    if (dst && dst->members == NULL) {
-      CS_VARIABLE* var = dat->arrayType->createVariable(csound, (void*)dat->arrayType, p->h.insdshead);
-      if (var && var->initializeVariableMemory) {
-        var->initializeVariableMemory(csound, var, (MYFLT*)dst);
-      }
-      if (var) {
-        csound->Free(csound, var);
-      }
+    if (UNLIKELY(indexes[i] == NULL || array->sizes[i] <= 0)) {
+      return csound->PerfError(csound, opds,
+                               "%s: invalid index or dimension %d",
+                               opcodeName, i + 1);
     }
-  }
-
-  // Copy value into destination using type-aware copier
-  // For struct arrays, we need to copy member by member since the array elements
-  // are raw struct data, not CS_STRUCT_VAR structures with members pointers
-  if (dat->arrayType && dat->arrayType->userDefinedType) {
-    CS_STRUCT_VAR* srcVar = (CS_STRUCT_VAR*)p->value;
-    CS_STRUCT_VAR* dstVar = (CS_STRUCT_VAR*)dstPtr;
-
-    // Validate that dstVar is within bounds before accessing
-    if (UNLIKELY(dstVar == NULL)) {
-      return csound->PerfError(csound, &(p->h), Str("array_set_struct: destination pointer is NULL"));
+    rawIndex = *indexes[i];
+    /* C casts outside the int32_t range are undefined. Fractional indexes
+       retain the established truncation behavior after this range check. */
+    if (UNLIKELY(isnan(rawIndex) || rawIndex < FL(0.0) ||
+                 rawIndex > (MYFLT)INT32_MAX)) {
+      return csound->PerfError(csound, opds,
+                               "%s: invalid index for dimension %d",
+                               opcodeName, i + 1);
     }
-
-    // Ensure both are initialized
-    if (srcVar && srcVar->members && dstVar && dstVar->members && dat->arrayType->members) {
-      // Get member count from the type definition, not the variable
-      int32_t memberCount = cs_cons_length(dat->arrayType->members);
-      for (int32_t i = 0; i < memberCount; i++) {
-        CS_VAR_MEM* srcMember = srcVar->members[i];
-        CS_VAR_MEM* dstMember = dstVar->members[i];
-        if (srcMember && dstMember && srcMember->varType) {
-          // Copy the member value
-          if (srcMember->varType->copyValue) {
-            srcMember->varType->copyValue(csound, srcMember->varType,
-                                         &dstMember->value, &srcMember->value, p->h.insdshead);
-          } else {
-            dstMember->value = srcMember->value;
-          }
-        }
-      }
+    coordinate = (int32_t)rawIndex;
+    dimension = (size_t)array->sizes[i];
+    if (UNLIKELY(coordinate < 0 || (size_t)coordinate >= dimension)) {
+      return csound->PerfError(csound, opds,
+                               "%s: index %d out of range for dimension %d",
+                               opcodeName, coordinate, i + 1);
     }
-  } else if (dat->arrayType && dat->arrayType->copyValue) {
-    dat->arrayType->copyValue(csound, dat->arrayType, (void*)dstPtr, p->value, p->h.insdshead);
-  } else {
-    // Fallback should not happen for struct, but keep parity with array_set
-    if (LIKELY(dstPtr != NULL && p->value != NULL)) *((MYFLT*)dstPtr) = *((MYFLT*)p->value);
+    if (UNLIKELY(flatIndex >
+                 (SIZE_MAX - (size_t)coordinate) / dimension)) {
+      return csound->PerfError(csound, opds, "%s: index overflow",
+                               opcodeName);
+    }
+    flatIndex = flatIndex * dimension + (size_t)coordinate;
   }
+  *result = flatIndex;
   return OK;
 }
 
-void struct_array_member_assign(
-    ARRAYDAT* arraySrc,
-    ARRAYDAT* arrayDst
-) {
-    /* Shallow alias: destination does not own storage */
-    arrayDst->allocated = 0;
-    arrayDst->arrayMemberSize = arraySrc->arrayMemberSize;
-    arrayDst->data = arraySrc->data;
-    arrayDst->dimensions = arraySrc->dimensions;
-    arrayDst->sizes = arraySrc->sizes;
-    arrayDst->arrayType = arraySrc->arrayType;
+static int32_t struct_array_element(CSOUND *csound, OPDS *opds,
+                                    const char *opcodeName,
+                                    const ARRAYDAT *array, size_t index,
+                                    void **result)
+{
+  size_t elementSize;
+  size_t offset;
+  size_t allocated;
+
+  if (UNLIKELY(result == NULL || opcodeName == NULL || array == NULL ||
+               array->data == NULL ||
+               array->arrayMemberSize <= 0)) {
+    return csound->PerfError(csound, opds, "%s: invalid array storage",
+                             opcodeName);
+  }
+  if (UNLIKELY(array->storage != NULL &&
+               (array->storage->data != array->data ||
+                array->storage->arrayType != array->arrayType ||
+                array->storage->arrayMemberSize !=
+                  array->arrayMemberSize))) {
+    return csound->PerfError(csound, opds,
+                             "%s: inconsistent shared array storage",
+                             opcodeName);
+  }
+  elementSize = (size_t)array->arrayMemberSize;
+  if (UNLIKELY(index > (SIZE_MAX - elementSize) / elementSize)) {
+    return csound->PerfError(csound, opds, "%s: offset overflow",
+                             opcodeName);
+  }
+  offset = index * elementSize;
+  allocated = array->storage != NULL
+                ? array->storage->allocated : array->allocated;
+  if (UNLIKELY(allocated < elementSize ||
+               offset > allocated - elementSize)) {
+    return csound->PerfError(csound, opds,
+                             "%s: element exceeds allocated storage",
+                             opcodeName);
+  }
+  *result = (char *)array->data + offset;
+  return OK;
 }
 
-// /* Built-in struct member get/set SUBRs (generic, any struct) */
+int32_t array_set_struct(CSOUND* csound, ARRAY_SET *p)
+{
+  ARRAYDAT* dat = p->arrayDat;
+  CS_STRUCT_VAR *source;
+  CS_STRUCT_VAR *destination;
+  size_t index;
+  void *element;
+  int32_t indexCount = p->INOCOUNT - 2;
+
+  if (UNLIKELY(dat == NULL || p->value == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "array_set_struct: NULL array or value");
+  }
+  if (UNLIKELY(dat->arrayType == NULL ||
+               !dat->arrayType->userDefinedType ||
+               dat->arrayType->copyValue == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "array_set_struct: invalid element type");
+  }
+  csound_array_prepare_write(csound, dat, p->h.insdshead);
+  if (UNLIKELY(struct_array_flat_index(csound, &p->h, "array_set_struct",
+                                       dat, p->indexes, indexCount,
+                                       &index) != OK)) {
+    return NOTOK;
+  }
+  if (UNLIKELY(struct_array_element(csound, &p->h, "array_set_struct",
+                                    dat, index, &element) != OK)) {
+    return NOTOK;
+  }
+
+  source = (CS_STRUCT_VAR *)p->value;
+  destination = (CS_STRUCT_VAR *)element;
+  if (UNLIKELY(!struct_value_matches_type(dat->arrayType, source))) {
+    return csound->PerfError(csound, &p->h,
+                             "array_set_struct: value does not match type");
+  }
+  if (destination->members == NULL) {
+    CS_VARIABLE *var = array_element_create_variable(
+      csound, dat->arrayType, p->h.insdshead);
+    if (UNLIKELY(var == NULL || var->initializeVariableMemory == NULL)) {
+      if (var != NULL) {
+        csound->Free(csound, var);
+      }
+      return csound->PerfError(csound, &p->h,
+                               "array_set_struct: cannot initialize element");
+    }
+    var->initializeVariableMemory(csound, var, element);
+    csound->Free(csound, var);
+  }
+  if (UNLIKELY(!struct_value_matches_type(dat->arrayType, destination))) {
+    return csound->PerfError(csound, &p->h,
+                             "array_set_struct: destination does not match type");
+  }
+
+  /* The registered copier carries nested-array ownership through ordinary
+     struct assignment and through this array-specific lowering path. */
+  dat->arrayType->copyValue(csound, dat->arrayType,
+                            destination, source, p->h.insdshead);
+  return OK;
+}
+
+/* Built-in struct member get/set SUBRs (generic, any struct). */
 int32_t struct_member_get_init(CSOUND *csound, STRUCT_GET *p)
 {
   return OK;
@@ -179,7 +237,12 @@ int32_t struct_member_get_init_and_perf(CSOUND *csound, STRUCT_GET *p)
 int32_t struct_member_get(CSOUND *csound, STRUCT_GET *p)
 {
   if (UNLIKELY(p->nths[0] == NULL)) {
-    return csound->PerfError(csound, &(p->h), "Invalid member index pointer (NULL)");
+    return csound->PerfError(csound, &p->h,
+                             "Invalid member index pointer (NULL)");
+  }
+  if (UNLIKELY(p->out == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "Invalid struct member output (NULL)");
   }
 
   if (UNLIKELY(p->var == NULL)) {
@@ -211,49 +274,16 @@ int32_t struct_member_get(CSOUND *csound, STRUCT_GET *p)
   }
 
   CS_VAR_MEM* member = varIn->members[nthInt];
+  if (UNLIKELY(member == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "Struct member %d is not initialized", nthInt);
+  }
 
   /* Use type-aware copy so array members and non-scalars are handled */
   if (member->varType && member->varType->copyValue) {
-    if (member->varType == &CS_VAR_TYPE_ARRAY) {
-      ARRAYDAT *src = (ARRAYDAT*)&member->value;
-      ARRAYDAT *dst = (ARRAYDAT*)p->out;
-
-      if (src->arrayType && src->arrayType->userDefinedType) {
-        // For arrays of structs: shallow alias
-        dst->arrayType       = src->arrayType;
-        dst->dimensions      = src->dimensions;
-        dst->sizes           = src->sizes;
-        dst->arrayMemberSize = src->arrayMemberSize;
-        dst->data            = src->data;
-        dst->allocated       = 0;
-        /* Ensure dimension metadata exists for destination alias (Option A, UDT arrays) */
-        if ((dst->sizes == NULL || dst->dimensions <= 0) && src && src->arrayMemberSize > 0) {
-          // Copy dimensions from source if they exist
-          // For aliases (allocated=0), only use shallow copy - never allocate new metadata
-          if (src->dimensions > 0 && src->sizes != NULL) {
-            dst->dimensions = src->dimensions;
-            dst->sizes = src->sizes;
-          }
-        }
-
-      } else {
-          /* Ensure dimension metadata exists for destination alias (Option A) */
-          if ((dst->sizes == NULL || dst->dimensions <= 0) && src && src->data && src->arrayMemberSize > 0) {
-            // For aliases (allocated=0), only use shallow copy - never allocate new metadata
-            if (src->dimensions > 0 && src->sizes != NULL) {
-              dst->dimensions = src->dimensions;
-              dst->sizes = src->sizes;
-            }
-          }
-
-        // For arrays of primitives (e.g., S[], k[], i[]): perform deep copy
-        member->varType->copyValue(csound, member->varType, (void*)dst, (void*)src, p->h.insdshead);
-      }
-    } else {
-      member->varType->copyValue(csound, member->varType,
-                                 (void*)p->out, (void*)&member->value,
-                                 p->h.insdshead);
-    }
+    member->varType->copyValue(csound, member->varType,
+                               (void*)p->out, (void*)&member->value,
+                               p->h.insdshead);
   } else {
     *p->out = member->value;
   }
@@ -285,7 +315,12 @@ int32_t struct_member_set(CSOUND *csound, STRUCT_SET *p)
 
   // Check if p->var is NULL before casting
   if (UNLIKELY(p->var == NULL)) {
-    return csound->PerfError(csound, &(p->h), "Invalid struct pointer (NULL)");
+    return csound->PerfError(csound, &p->h,
+                             "Invalid struct pointer (NULL)");
+  }
+  if (UNLIKELY(p->in == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "Invalid struct member input (NULL)");
   }
 
   CS_STRUCT_VAR* var = (CS_STRUCT_VAR*)p->var;
@@ -317,10 +352,10 @@ int32_t struct_member_set(CSOUND *csound, STRUCT_SET *p)
   }
 
   CS_VAR_MEM* member = var->members[nthInt];
-
-
-
-
+  if (UNLIKELY(member == NULL)) {
+    return csound->PerfError(csound, &p->h,
+                             "Struct member %d is not initialized", nthInt);
+  }
 
   /* Type-aware assignment; fall back to scalar write */
   if (member->varType && member->varType->copyValue) {
@@ -345,7 +380,12 @@ int32_t struct_member_array_assign(
 
     // Check if p->var is NULL before casting
     if (UNLIKELY(p->var == NULL)) {
-      return csound->PerfError(csound, &(p->h), "Invalid struct pointer (NULL)");
+      return csound->PerfError(csound, &p->h,
+                               "Invalid struct pointer (NULL)");
+    }
+    if (UNLIKELY(p->in == NULL)) {
+      return csound->PerfError(csound, &p->h,
+                               "Invalid array member input (NULL)");
     }
 
     int nthInt = (int) *p->nths[0];
@@ -366,20 +406,8 @@ int32_t struct_member_array_assign(
     }
 
     ARRAYDAT* dst = (ARRAYDAT*) &member->value;
-    ARRAYDAT* src = p->in;
-
-
-    struct_array_member_assign(src, dst);
-
-    /* Option A: ensure dimension metadata is present for destination view.
-       For aliases, only use shallow copy - never allocate new metadata. */
-    if ((dst->sizes == NULL || dst->dimensions <= 0) && src && src->arrayMemberSize > 0) {
-      // Copy dimensions from source if they exist
-      if (src->dimensions > 0 && src->sizes != NULL) {
-        dst->dimensions = src->dimensions;
-        dst->sizes = src->sizes;
-      }
-    }
+    CS_VAR_TYPE_ARRAY.copyValue(csound, &CS_VAR_TYPE_ARRAY,
+                                dst, p->in, p->h.insdshead);
 
     return OK;
 
@@ -428,147 +456,86 @@ int32_t struct_alias(CSOUND *csound, STRUCT_ALIAS *p)
 int32_t struct_array_get(CSOUND *csound, STRUCT_ARRAY_GET* dat)
 {
   ARRAYDAT* arrayDat = dat->arrayDat;
+  CS_STRUCT_VAR *source;
+  CS_STRUCT_VAR *destination = (CS_STRUCT_VAR *)dat->out;
+  size_t index;
+  size_t totalSize;
+  void *element;
+  int32_t indexCount = dat->INOCOUNT - 1;
 
-  if (UNLIKELY(arrayDat == NULL)) {
-    return csound->PerfError(csound, &(dat->h), "struct_array_get: array is NULL");
+  if (UNLIKELY(arrayDat == NULL || destination == NULL)) {
+    return csound->PerfError(csound, &dat->h,
+                             "struct_array_get: NULL array or output");
+  }
+  if (UNLIKELY(arrayDat->arrayType == NULL ||
+               !arrayDat->arrayType->userDefinedType ||
+               arrayDat->arrayType->copyValue == NULL)) {
+    return csound->PerfError(csound, &dat->h,
+                             "struct_array_get: invalid element type");
   }
 
-  if (arrayDat->dimensions <= 0) {
-    csound->Warning(csound, "struct_array_get: input array has no dimensions\n");
-    return OK;
-  }
-
-  // If array data is NULL, try to initialize it
-  if (arrayDat->data == NULL && arrayDat->arrayType != NULL && arrayDat->arrayType->userDefinedType) {
-    // Calculate total size from dimensions
-    int32_t totalSize = 1;
-    for (int32_t i = 0; i < arrayDat->dimensions; i++) {
-      totalSize *= arrayDat->sizes[i];
+  /* A declared array can have complete dimensions before its backing store is
+     created. Use the same initializer as other array paths before reading. */
+  if (arrayDat->data == NULL) {
+    if (UNLIKELY(csound_array_member_count(arrayDat, &totalSize) != OK ||
+                 totalSize > INT32_MAX)) {
+      return csound->PerfError(csound, &dat->h,
+                               "Invalid struct array dimensions");
     }
+    tabinit(csound, arrayDat, (int32_t)totalSize, dat->h.insdshead);
+  }
+  if (UNLIKELY(struct_array_flat_index(csound, &dat->h,
+                                       "struct_array_get", arrayDat,
+                                       dat->indicies, indexCount,
+                                       &index) != OK)) {
+    return NOTOK;
+  }
+  if (UNLIKELY(struct_array_element(csound, &dat->h, "struct_array_get",
+                                    arrayDat, index, &element) != OK)) {
+    return NOTOK;
+  }
 
-    CS_VARIABLE* var = arrayDat->arrayType->createVariable(csound, (void*)arrayDat->arrayType, dat->h.insdshead);
-    arrayDat->arrayMemberSize = var->memBlockSize;
-    arrayDat->data = csound->Calloc(csound, arrayDat->arrayMemberSize * totalSize);
-    arrayDat->allocated = arrayDat->arrayMemberSize * totalSize;
+  source = (CS_STRUCT_VAR *)element;
+  if (UNLIKELY(!struct_value_matches_type(arrayDat->arrayType, source))) {
+    return csound->PerfError(csound, &dat->h,
+                             "struct_array_get: element does not match type");
+  }
 
-    // Initialize each struct element
-    char *mem = (char *) arrayDat->data;
-    for (int32_t i = 0; i < totalSize; i++) {
-      if (var->initializeVariableMemory != NULL) {
-        var->initializeVariableMemory(csound, var, (MYFLT*)(mem + i * var->memBlockSize));
-      }
+  if (destination->members == NULL || !destination->ownsMembers ||
+      destination->memberCount != source->memberCount) {
+    CS_VARIABLE* helper;
+
+    /* A read result must own its members. Copying into an alias would modify
+       the struct that the previous result referenced. */
+    if (destination->ownsMembers) {
+      csound_free_struct_members(csound, destination);
     }
-    csound->Free(csound, var);
-  }
-
-  if (UNLIKELY(arrayDat->data == NULL)) {
-    csound->Warning(csound, "struct_array_get: array data is still NULL after initialization attempt");
-    return OK;
-  }
-
-  int index = (int)(*dat->indicies[0]);
-
-  /* CRITICAL FIX: Add bounds checking */
-  if (arrayDat->sizes == NULL || arrayDat->dimensions <= 0) {
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array has invalid dimensions or sizes");
-  }
-
-  // Enforce non-negative index check
-  if (index < 0) {
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array index %d is negative", index);
-  }
-
-  if (index >= arrayDat->sizes[0]) {
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array index %d out of bounds (0-%d)", index, arrayDat->sizes[0]-1);
-  }
-
-  char* mem = (char *) arrayDat->data;
-
-  if (UNLIKELY(mem == NULL)) {
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array data is NULL");
-  }
-
-  // CRITICAL: arrayMemberSize is in BYTES for struct arrays, not MYFLT units
-  // Verify the computed address is correct
-  size_t elemSize = (size_t)arrayDat->arrayMemberSize;
-  size_t offset = (size_t)index * elemSize;
-
-  /* Check if offset is within allocated memory
-     Note: alias views set allocated=0; in that case compute effective capacity
-     from sizes[0] * elemSize. */
-  size_t allocatedBytes = (size_t)arrayDat->allocated;
-  if (allocatedBytes == 0 && arrayDat->sizes && arrayDat->dimensions > 0) {
-    allocatedBytes = (size_t)arrayDat->sizes[0] * elemSize;
-  }
-  if (offset + elemSize > allocatedBytes) {
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array access would exceed allocated memory");
-  }
-
-  CS_STRUCT_VAR* srcVar = (CS_STRUCT_VAR*)(mem + offset);
-  CS_STRUCT_VAR* dstVar = (CS_STRUCT_VAR*) dat->out;
-
-  /* Add safety checks before accessing srcVar */
-  if (UNLIKELY(srcVar == NULL)) {
-
-    return csound->PerfError(csound, &(dat->h),
-        "Struct array element at index %d is NULL", index);
-  }
-
-  if (UNLIKELY(dstVar == NULL)) {
-    return csound->PerfError(csound, &(dat->h),
-        "Destination struct variable is NULL");
-  }
-
-  /* Ensure srcVar is initialized */
-  if (srcVar->members == NULL) {
-
-    if (arrayDat->arrayType && arrayDat->arrayType->createVariable) {
-      CS_VARIABLE* helper = arrayDat->arrayType->createVariable(csound, (void*)arrayDat->arrayType, dat->h.insdshead);
-      if (helper && helper->initializeVariableMemory) {
-        helper->initializeVariableMemory(csound, helper, (MYFLT*)srcVar);
-      }
-      if (helper) {
+    else {
+      destination->members = NULL;
+      destination->memberCount = 0;
+      destination->ownsMembers = 0;
+    }
+    helper = array_element_create_variable(csound, arrayDat->arrayType,
+                                           dat->h.insdshead);
+    if (UNLIKELY(helper == NULL ||
+                 helper->initializeVariableMemory == NULL)) {
+      if (helper != NULL) {
         csound->Free(csound, helper);
       }
+      return csound->PerfError(csound, &dat->h,
+                               "Could not initialize struct array output");
     }
-    if (srcVar->members == NULL) {
-      return csound->PerfError(csound, &(dat->h),
-          "Struct array element at index %d is not properly initialized", index);
-    }
+    helper->initializeVariableMemory(csound, helper, (MYFLT *)destination);
+    csound->Free(csound, helper);
+  }
+  if (UNLIKELY(!struct_value_matches_type(arrayDat->arrayType,
+                                          destination))) {
+    return csound->PerfError(csound, &dat->h,
+                             "struct_array_get: output does not match type");
   }
 
-  dstVar = (CS_STRUCT_VAR*)dat->out;
-
-  /* For struct arrays, we copy values also when they are references, because the array
-     element's member storage is separate from the output struct's storage */
-  if (dstVar->members && srcVar->members && dstVar->memberCount == srcVar->memberCount) {
-    for (int i = 0; i < srcVar->memberCount; i++) {
-      CS_VAR_MEM *d = dstVar->members[i], *s = srcVar->members[i];
-      if (!d || !s) continue;
-      if (d->varType && d->varType->copyValue) {
-        d->varType->copyValue(csound, d->varType, &d->value, &s->value, dat->h.insdshead);
-      } else {
-        d->value = s->value;
-      }
-    }
-    /* keep existing ownership as-is after deep copy */
-  } else {
-    /* free previously owned members before aliasing to avoid leaks */
-    if (dstVar->members && dstVar->ownsMembers) {
-      csound_free_struct_members(csound, dstVar);
-      dstVar->members = NULL;
-      dstVar->memberCount = 0;
-      dstVar->ownsMembers = 0;
-    }
-    dstVar->members = srcVar->members;
-    dstVar->memberCount = srcVar->memberCount;
-    dstVar->ownsMembers = 0;
-  }
+  arrayDat->arrayType->copyValue(csound, arrayDat->arrayType,
+                                 destination, source, dat->h.insdshead);
   return OK;
 }
 

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -23,6 +23,156 @@
 #ifndef __ARRAY_H__
 #define __ARRAY_H__
 
+/* Shared backing for arrays of user-defined structs. Recursive struct links
+   are represented by arrays, making this the ownership boundary needed when
+   an instrument frame is recycled. It tracks one allocation, not the complete
+   object graph, and is not a garbage collector; reference cycles are therefore
+   not collected. The count protects storage shared by independently
+   synchronized views. Copying or mutating the same ARRAYDAT still requires
+   Csound's usual lock. */
+typedef struct cs_array_storage {
+    int32_t refs;
+    /* Kept in the layout on every target so separately built plugins agree
+       on the sidecar ABI. It is allocated only when native atomics are absent. */
+    void *refLock;
+    int32_t dimensions;
+    int32_t arrayMemberSize;
+    const CS_TYPE *arrayType;
+    int32_t *sizes;
+    MYFLT *data;
+    size_t allocated;
+} CS_ARRAY_STORAGE;
+
+static inline int32_t cs_array_storage_ref_count(
+    CSOUND *csound, CS_ARRAY_STORAGE *storage)
+{
+#if defined(MSVC)
+    IGN(csound);
+    return (int32_t)InterlockedCompareExchange(
+      (volatile LONG *)&storage->refs, 0, 0);
+#elif defined(HAVE_ATOMIC_BUILTIN)
+    IGN(csound);
+    return __atomic_load_n(&storage->refs, __ATOMIC_ACQUIRE);
+#else
+    int32_t refs;
+    if (UNLIKELY(storage->refLock == NULL)) {
+        return 0;
+    }
+    csound->LockMutex(storage->refLock);
+    refs = storage->refs;
+    csound->UnlockMutex(storage->refLock);
+    return refs;
+#endif
+}
+
+static inline int32_t cs_array_storage_try_add_ref(
+    CSOUND *csound, CS_ARRAY_STORAGE *storage)
+{
+#if defined(MSVC)
+    IGN(csound);
+    LONG refs = InterlockedCompareExchange(
+      (volatile LONG *)&storage->refs, 0, 0);
+    while (refs > 0 && refs < INT32_MAX) {
+        LONG observed = InterlockedCompareExchange(
+          (volatile LONG *)&storage->refs, refs + 1, refs);
+        if (observed == refs) {
+            return (int32_t)(refs + 1);
+        }
+        refs = observed;
+    }
+    return NOTOK;
+#elif defined(HAVE_ATOMIC_BUILTIN)
+    IGN(csound);
+    int32_t refs = __atomic_load_n(&storage->refs, __ATOMIC_RELAXED);
+    while (refs > 0 && refs < INT32_MAX) {
+        if (__atomic_compare_exchange_n(&storage->refs, &refs, refs + 1,
+                                        0, __ATOMIC_ACQ_REL,
+                                        __ATOMIC_ACQUIRE)) {
+            return refs + 1;
+        }
+    }
+    return NOTOK;
+#else
+    int32_t refs;
+    if (UNLIKELY(storage->refLock == NULL)) {
+        return NOTOK;
+    }
+    csound->LockMutex(storage->refLock);
+    if (storage->refs <= 0 || storage->refs == INT32_MAX) {
+        csound->UnlockMutex(storage->refLock);
+        return NOTOK;
+    }
+    refs = ++storage->refs;
+    csound->UnlockMutex(storage->refLock);
+    return refs;
+#endif
+}
+
+static inline int32_t cs_array_storage_try_claim(
+    CSOUND *csound, CS_ARRAY_STORAGE *storage)
+{
+#if defined(MSVC)
+    IGN(csound);
+    return InterlockedCompareExchange((volatile LONG *)&storage->refs,
+                                      0, 1) == 1 ? OK : NOTOK;
+#elif defined(HAVE_ATOMIC_BUILTIN)
+    IGN(csound);
+    int32_t expected = 1;
+    return __atomic_compare_exchange_n(&storage->refs, &expected, 0, 0,
+                                       __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE) ? OK : NOTOK;
+#else
+    int32_t result = NOTOK;
+    if (UNLIKELY(storage->refLock == NULL)) {
+        return result;
+    }
+    csound->LockMutex(storage->refLock);
+    if (storage->refs != 1) {
+        csound->UnlockMutex(storage->refLock);
+        return result;
+    }
+    storage->refs = 0;
+    result = OK;
+    csound->UnlockMutex(storage->refLock);
+    return result;
+#endif
+}
+
+static inline int32_t cs_array_storage_release_ref(
+    CSOUND *csound, CS_ARRAY_STORAGE *storage)
+{
+#if defined(MSVC)
+    IGN(csound);
+    return (int32_t)InterlockedDecrement((volatile LONG *)&storage->refs);
+#elif defined(HAVE_ATOMIC_BUILTIN)
+    IGN(csound);
+    return __atomic_sub_fetch(&storage->refs, 1, __ATOMIC_ACQ_REL);
+#else
+    int32_t refs;
+    if (UNLIKELY(storage->refLock == NULL)) {
+        return NOTOK;
+    }
+    csound->LockMutex(storage->refLock);
+    refs = --storage->refs;
+    csound->UnlockMutex(storage->refLock);
+    return refs;
+#endif
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* Internal runtime entry points used by core array writers. The inline helper
+   below remains self-contained because utility plugins do not link these
+   symbols. */
+void csound_array_prepare_write(CSOUND *csound, ARRAYDAT *array,
+                                INSDS *ctx);
+void csound_array_share(CSOUND *csound, ARRAYDAT *dest, ARRAYDAT *src);
+void csound_free_array_storage(CSOUND *csound, ARRAYDAT *array);
+#ifdef __cplusplus
+}
+#endif
+
 typedef struct {
     OPDS    h;
     MYFLT   *r, *a;
@@ -32,179 +182,463 @@ static inline CS_VARIABLE *array_element_create_variable(CSOUND *csound,
                                                          const CS_TYPE *arrayType,
                                                          INSDS *ctx)
 {
+    if (arrayType == NULL || arrayType->createVariable == NULL) {
+        return NULL;
+    }
     void *typeArg = (arrayType && arrayType->userDefinedType)
                       ? (void *)arrayType : NULL;
     return arrayType->createVariable(csound, typeArg, ctx);
 }
 
-static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size, INSDS *ctx)
+static inline int32_t csound_array_element_types_compatible(
+    const CS_TYPE *destination, const CS_TYPE *source)
 {
-    size_t ss;
-    int32_t oldCount = (p->allocated > 0 && p->arrayMemberSize > 0)
-                         ? (int32_t)(p->allocated / (size_t)p->arrayMemberSize)
-                         : 0;
-    if (p->dimensions==0) {
-        p->dimensions = 1;
-        p->sizes = (int32_t*)csound->Calloc(csound, sizeof(int32_t));
+    const char *destinationName;
+    const char *sourceName;
+
+    if (destination == source) {
+        return 1;
     }
-    if (p->data == NULL) {
-        if (UNLIKELY(p->arrayType == NULL)) {
-          csound->Die(csound, "tabinit: arrayType is NULL");
-          return;
-        }
-        CS_VARIABLE* var = array_element_create_variable(csound, p->arrayType, ctx);
-        if (UNLIKELY(var == NULL)) {
-          csound->Die(csound, "tabinit: could not create array element variable");
-          return;
-        }
-        p->arrayMemberSize = var->memBlockSize;
-        int32_t allocCount = size > 0 ? size : 1;
-        ss = (size_t)p->arrayMemberSize * (size_t)allocCount;
-        p->data = (MYFLT*)csound->Calloc(csound, ss);
-        p->allocated = ss;
-        // Initialize struct elements if user-defined type
-        if (p->arrayType && p->arrayType->userDefinedType && var->initializeVariableMemory) {
-          char *base = (char*)p->data;
-          size_t blockSize = (size_t)var->memBlockSize;
-          // Batch process struct arrays
-          int32_t i = 0;
-          for (; i + 3 < allocCount; i += 4) {
-            var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
-            var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 1) * blockSize));
-            var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 2) * blockSize));
-            var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 3) * blockSize));
-          }
-          // The second loop only handles the remainder elements (0-3 elements at most)
-          for (; i < allocCount; i++) {
-            var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
-          }
-          csound->Free(csound, var);
-        }
-    } else if( (ss = (size_t)p->arrayMemberSize * (size_t)size) > p->allocated) {
-        size_t prevAllocated = p->allocated;
-        p->data = (MYFLT*) csound->ReAlloc(csound, p->data, ss);
-        memset((char*)(p->data)+prevAllocated, '\0', ss-prevAllocated);
-        p->allocated = ss;
-        // Initialize only the newly added struct elements if it's UDT
-        if (p->arrayType && p->arrayType->userDefinedType) {
-          CS_VARIABLE* var2 = array_element_create_variable(csound, p->arrayType, ctx);
-          if (var2 && var2->initializeVariableMemory) {
-            char *base = (char*)p->data;
-            size_t blockSize = (size_t)var2->memBlockSize;
-            // Batch process arrays
-            int32_t i = oldCount;
-            for (; i + 3 < size; i += 4) {
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + i * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 1) * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 2) * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 3) * blockSize));
-            }
-            // The second loop only handles the remainder elements (0-3 elements at most)
-            for (; i < size; i++) {
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + i * blockSize));
-            }
-          }
-          csound->Free(csound, var2);
-        }
+    if (source == NULL) {
+        return 0;
     }
-    if (p->dimensions==1) p->sizes[0] = size;
+    if (destination == NULL) {
+        return 1;
+    }
+    destinationName = destination->varTypeName;
+    sourceName = source->varTypeName;
+    if (destinationName == NULL || sourceName == NULL ||
+        destinationName[0] == '\0' || sourceName[0] == '\0' ||
+        destinationName[1] != '\0' || sourceName[1] != '\0') {
+        return 0;
+    }
+    /* Array channels have historically allowed i[] and k[] to connect; both
+       store MYFLT elements, while the receiving variable retains its rate. */
+    return (destinationName[0] == 'i' && sourceName[0] == 'k') ||
+           (destinationName[0] == 'k' && sourceName[0] == 'i');
 }
 
-static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p, const ARRAYDAT *tp)
+static inline int32_t csound_array_member_count(const ARRAYDAT *array,
+                                                size_t *result)
 {
-    uint32_t elemCount = 1;
-    if(p->data == tp->data) {
+    size_t count = 1;
+
+    if (result == NULL) {
+        return NOTOK;
+    }
+    *result = 0;
+    if (array == NULL || array->dimensions < 0) {
+        return NOTOK;
+    }
+    if (array->dimensions == 0) {
+        return OK;
+    }
+    if (array->sizes == NULL ||
+        (size_t)array->dimensions > SIZE_MAX / sizeof(int32_t)) {
+        return NOTOK;
+    }
+    for (int32_t i = 0; i < array->dimensions; i++) {
+        if (array->sizes[i] < 0) {
+            return NOTOK;
+        }
+        if (array->sizes[i] == 0) {
+            count = 0;
+        } else if (count != 0) {
+            if ((size_t)array->sizes[i] > SIZE_MAX / count) {
+                return NOTOK;
+            }
+            count *= (size_t)array->sizes[i];
+        }
+    }
+    *result = count;
+    return OK;
+}
+
+static inline int32_t csound_array_allocation_size(int32_t memberSize,
+                                                   size_t count,
+                                                   size_t *result)
+{
+    if (result == NULL || memberSize <= 0 ||
+        count > SIZE_MAX / (size_t)memberSize) {
+        return NOTOK;
+    }
+    *result = count * (size_t)memberSize;
+    return OK;
+}
+
+static inline void csound_array_free_elements_inline(
+    CSOUND *csound, const CS_TYPE *arrayType, MYFLT *data,
+    size_t allocated, int32_t memberSize)
+{
+    /* Empty arrays own one initialized placeholder, so teardown follows
+       allocated capacity rather than the current logical element count. */
+    if (arrayType != NULL && arrayType->freeVariableMemory != NULL &&
+        data != NULL && memberSize > 0) {
+        /* If legacy metadata is malformed, free every complete element and
+           leave only an incomplete trailing fragment to the raw-buffer free. */
+        size_t count = allocated / (size_t)memberSize;
+        for (size_t i = 0; i < count; i++) {
+            void *element = (char *)data + i * (size_t)memberSize;
+            arrayType->freeVariableMemory(csound, element);
+        }
+    }
+}
+
+static inline void cs_array_storage_destroy_inline(
+    CSOUND *csound, CS_ARRAY_STORAGE *storage)
+{
+    if (storage == NULL) {
         return;
     }
-    // Additional safety check: if p and tp are the same ARRAYDAT structure, don't modify
-    if(p == tp) {
-        return;
+    csound_array_free_elements_inline(csound, storage->arrayType,
+                                      storage->data, storage->allocated,
+                                      storage->arrayMemberSize);
+    csound->Free(csound, storage->data);
+    csound->Free(csound, storage->sizes);
+    if (storage->refLock != NULL) {
+        csound->DestroyMutex(storage->refLock);
     }
-    if (p->dimensions != tp->dimensions) {
-      p->sizes = (int32_t*)csound->ReAlloc(csound, p->sizes,
-                                           sizeof(int32_t)*tp->dimensions);
-      p->dimensions = tp->dimensions;
+    csound->Free(csound, storage);
+}
+
+static inline int32_t cs_array_storage_layout(
+    const ARRAYDAT *array, const CS_ARRAY_STORAGE *storage,
+    size_t *logicalCount, size_t *capacity, size_t *strideBytes)
+{
+    if (array == NULL || storage == NULL || logicalCount == NULL ||
+        capacity == NULL || strideBytes == NULL ||
+        storage->dimensions <= 0 ||
+        storage->dimensions != array->dimensions ||
+        storage->arrayType == NULL ||
+        !storage->arrayType->userDefinedType ||
+        storage->arrayType->copyValue == NULL || storage->data == NULL ||
+        storage->sizes != array->sizes || storage->data != array->data ||
+        storage->arrayType != array->arrayType ||
+        storage->arrayMemberSize != array->arrayMemberSize ||
+        storage->arrayMemberSize <= 0 ||
+        storage->allocated < (size_t)storage->arrayMemberSize ||
+        storage->allocated % (size_t)storage->arrayMemberSize != 0 ||
+        (array->allocated != 0 && array->allocated != storage->allocated) ||
+        csound_array_member_count(array, logicalCount) != OK) {
+        return NOTOK;
     }
 
-    for (int32_t i=0; i<tp->dimensions; i++) {
-      p->sizes[i] = tp->sizes[i];
-      elemCount *= (uint32_t)tp->sizes[i];
+    *capacity = storage->allocated / (size_t)storage->arrayMemberSize;
+    *strideBytes = (size_t)storage->arrayMemberSize;
+    return *logicalCount <= *capacity ? OK : NOTOK;
+}
+
+static inline int32_t cs_array_storage_clone(
+    CSOUND *csound, const ARRAYDAT *array, const CS_ARRAY_STORAGE *storage,
+    INSDS *ctx, size_t capacity, size_t strideBytes,
+    ARRAYDAT *clone)
+{
+    CS_VARIABLE *var;
+
+    memset(clone, 0, sizeof(*clone));
+    clone->dimensions = storage->dimensions;
+    clone->arrayMemberSize = storage->arrayMemberSize;
+    clone->arrayType = storage->arrayType;
+    clone->allocated = storage->allocated;
+    if (clone->dimensions > 0) {
+        clone->sizes = (int32_t *)csound->Malloc(
+          csound, sizeof(int32_t) * (size_t)clone->dimensions);
+        memcpy(clone->sizes, array->sizes,
+               sizeof(int32_t) * (size_t)clone->dimensions);
     }
-    if(p->arrayType == NULL) p->arrayType = tp->arrayType;
-    int32_t oldCount = (p->allocated > 0 && p->arrayMemberSize > 0)
-                         ? (int32_t)(p->allocated / (size_t)p->arrayMemberSize)
-                         : 0;
-    if (p->data == NULL) {
-      CS_VARIABLE* var = array_element_create_variable(csound, p->arrayType, NULL);
-      if (UNLIKELY(var == NULL)) {
-        csound->Die(csound, "tabinit_like: could not create array element variable");
+    clone->data = (MYFLT *)csound->Calloc(csound, clone->allocated);
+
+    var = array_element_create_variable(csound, clone->arrayType, ctx);
+    if (UNLIKELY(var == NULL || var->initializeVariableMemory == NULL)) {
+        csound->Free(csound, clone->data);
+        csound->Free(csound, clone->sizes);
+        memset(clone, 0, sizeof(*clone));
+        return NOTOK;
+    }
+    for (size_t i = 0; i < capacity; i++) {
+        void *element = (char *)clone->data + i * strideBytes;
+        var->initializeVariableMemory(csound, var, (MYFLT *)element);
+    }
+    csound->Free(csound, var);
+
+    /* Capacity slots are all initialized and may become visible after a later
+       resize, so copy them even when the current logical size is smaller. */
+    for (size_t i = 0; i < capacity; i++) {
+        size_t offset = i * strideBytes;
+        clone->arrayType->copyValue(csound, clone->arrayType,
+                                    (char *)clone->data + offset,
+                                    (char *)storage->data + offset, ctx);
+    }
+    return OK;
+}
+
+/* Detach a shared structured array before an inline array helper mutates it.
+   The first write to a shared value may allocate; later writes are in-place.
+   This stays inline because utility plugins use tabinit without linking to
+   internal Csound symbols. */
+static inline void csound_array_prepare_write_inline(CSOUND *csound,
+                                                      ARRAYDAT *array,
+                                                      INSDS *ctx)
+{
+    CS_ARRAY_STORAGE *storage;
+    ARRAYDAT clone = {0};
+    size_t logicalCount, capacity, strideBytes;
+    int32_t refs;
+
+    if (array == NULL || array->storage == NULL) {
         return;
-      }
-      p->arrayMemberSize = var->memBlockSize;
-      uint32_t allocCount = elemCount > 0 ? elemCount : 1;
-      size_t bytes = (size_t)p->arrayMemberSize * (size_t)allocCount;
-      p->data = (MYFLT*)csound->Calloc(csound, bytes);
-      p->allocated = bytes;
-      // Initialize struct elements if it's UDT
-      if (p->arrayType && p->arrayType->userDefinedType && var->initializeVariableMemory) {
-        char *base = (char*)p->data;
-        size_t blockSize = (size_t)var->memBlockSize;
-        // Batch process arrays
-        uint32_t i = 0;
-        for (; i + 3 < allocCount; i += 4) {
-          var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
-          var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 1) * blockSize));
-          var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 2) * blockSize));
-          var->initializeVariableMemory(csound, var, (MYFLT*)(base + (i + 3) * blockSize));
+    }
+
+    storage = array->storage;
+    if (UNLIKELY(cs_array_storage_layout(array, storage, &logicalCount,
+                                         &capacity, &strideBytes) != OK)) {
+        csound->Die(csound, "invalid shared structured-array storage");
+        return;
+    }
+
+    refs = cs_array_storage_ref_count(csound, storage);
+    if (UNLIKELY(refs <= 0)) {
+        csound->Die(csound, "invalid shared array reference count");
+        return;
+    }
+    if (refs == 1 && cs_array_storage_try_claim(csound, storage) == OK) {
+        /* The final view can discard the sidecar and resume direct ownership. */
+        array->arrayMemberSize = storage->arrayMemberSize;
+        array->arrayType = storage->arrayType;
+        array->sizes = storage->sizes;
+        array->data = storage->data;
+        array->allocated = storage->allocated;
+        array->storage = NULL;
+        if (storage->refLock != NULL) {
+            csound->DestroyMutex(storage->refLock);
         }
-        // The second loop only handles the remainder elements (0-3 elements at most)
-        for (; i < allocCount; i++) {
-          var->initializeVariableMemory(csound, var, (MYFLT*)(base + i * blockSize));
-        }
-      }
-      csound->Free(csound, var);
-    } else {
-      size_t bytes = (size_t)p->arrayMemberSize * (size_t)elemCount;
-      if (bytes > p->allocated) {
-        size_t prevAllocated = p->allocated;
-        p->data = (MYFLT*) csound->ReAlloc(csound, p->data, bytes);
-        memset((char*)(p->data) + prevAllocated, '\0', bytes - prevAllocated);
-        p->allocated = bytes;
-        // Initialize only the newly added struct elements if it's UDT
-        if (p->arrayType && p->arrayType->userDefinedType) {
-          CS_VARIABLE* var2 = array_element_create_variable(csound, p->arrayType, NULL);
-          if (var2 && var2->initializeVariableMemory) {
-            char *base = (char*)p->data;
-            size_t blockSize = (size_t)var2->memBlockSize;
-            // Batch process arrays
-            int32_t i = oldCount;
-            for (; (uint32_t)(i + 3) < elemCount; i += 4) {
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + i * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 1) * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 2) * blockSize));
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + (i + 3) * blockSize));
+        csound->Free(csound, storage);
+        return;
+    }
+    /* If the 1 -> 0 claim lost a race to a new reference, or another view
+       released a 2 -> 1 reference after the load above, cloning is still
+       valid: this ARRAYDAT continues to hold one live reference throughout. */
+    if (UNLIKELY(cs_array_storage_clone(csound, array, storage, ctx,
+                                        capacity, strideBytes,
+                                        &clone) != OK)) {
+        csound->Die(csound, "could not clone shared structured-array storage");
+        return;
+    }
+    refs = cs_array_storage_release_ref(csound, storage);
+    if (UNLIKELY(refs < 0)) {
+        csound_array_free_elements_inline(csound, clone.arrayType, clone.data,
+                                          clone.allocated,
+                                          clone.arrayMemberSize);
+        csound->Free(csound, clone.data);
+        csound->Free(csound, clone.sizes);
+        csound->Die(csound, "invalid shared array reference count");
+        return;
+    }
+    /* Another independently locked view may release its reference while this
+       one is being detached. The last releaser still owns final teardown. */
+    if (refs == 0) {
+        cs_array_storage_destroy_inline(csound, storage);
+    }
+    *array = clone;
+}
+
+static inline int32_t csound_array_initialize_struct_range(
+    CSOUND *csound, const CS_TYPE *arrayType, CS_VARIABLE *var,
+    MYFLT *data, int32_t memberSize, size_t begin, size_t end)
+{
+    if (arrayType == NULL || !arrayType->userDefinedType || begin == end) {
+        return OK;
+    }
+    if (var == NULL || var->initializeVariableMemory == NULL ||
+        var->memBlockSize != memberSize) {
+        return NOTOK;
+    }
+    for (size_t i = begin; i < end; i++) {
+        void *element = (char *)data + i * (size_t)memberSize;
+        var->initializeVariableMemory(csound, var, (MYFLT *)element);
+    }
+    return OK;
+}
+
+static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
+                                                   ARRAYDAT *array,
+                                                   size_t capacity,
+                                                   INSDS *ctx)
+{
+    CS_VARIABLE *var = NULL;
+    size_t oldCapacity = 0;
+    size_t bytes;
+    int32_t fresh = array->data == NULL;
+
+    if (array->arrayType == NULL || capacity == 0) {
+        return NOTOK;
+    }
+    if (fresh) {
+        var = array_element_create_variable(csound, array->arrayType, ctx);
+        if (var == NULL || var->memBlockSize <= 0 ||
+            (array->arrayType->userDefinedType &&
+             var->initializeVariableMemory == NULL)) {
+            if (var != NULL) {
+                csound->Free(csound, var);
             }
-            for (; (uint32_t)i < elemCount; i++) {
-              var2->initializeVariableMemory(csound, var2, (MYFLT*)(base + i * blockSize));
-            }
-            csound->Free(csound, var2);
-          }
+            return NOTOK;
         }
-      }
+        array->arrayMemberSize = var->memBlockSize;
+    }
+    else {
+        /* allocated == 0 marks a legacy non-owning view. Only managed
+           structured views can be detached safely before resizing. */
+        if (array->allocated == 0 || array->arrayMemberSize <= 0 ||
+            array->allocated % (size_t)array->arrayMemberSize != 0) {
+            return NOTOK;
+        }
+        oldCapacity = array->allocated / (size_t)array->arrayMemberSize;
+    }
+    if (csound_array_allocation_size(array->arrayMemberSize, capacity,
+                                     &bytes) != OK) {
+        if (var != NULL) {
+            csound->Free(csound, var);
+        }
+        return NOTOK;
+    }
+    if (!fresh && bytes <= array->allocated) {
+        return OK;
+    }
+
+    if (!fresh && array->arrayType->userDefinedType) {
+        var = array_element_create_variable(csound, array->arrayType, ctx);
+        if (var == NULL || var->initializeVariableMemory == NULL ||
+            var->memBlockSize != array->arrayMemberSize) {
+            if (var != NULL) {
+                csound->Free(csound, var);
+            }
+            return NOTOK;
+        }
+    }
+    if (fresh) {
+        array->data = (MYFLT *)csound->Calloc(csound, bytes);
+    }
+    else {
+        array->data = (MYFLT *)csound->ReAlloc(csound, array->data, bytes);
+        memset((char *)array->data + array->allocated, 0,
+               bytes - array->allocated);
+    }
+    array->allocated = bytes;
+    if (csound_array_initialize_struct_range(
+          csound, array->arrayType, var, array->data,
+          array->arrayMemberSize, oldCapacity, capacity) != OK) {
+        csound->Free(csound, var);
+        return NOTOK;
+    }
+    if (var != NULL) {
+        csound->Free(csound, var);
+    }
+    return OK;
+}
+
+static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size,
+                           INSDS *ctx)
+{
+    size_t capacity;
+
+    if (UNLIKELY(p == NULL || size < 0 || p->dimensions < 0)) {
+        csound->Die(csound, "tabinit: invalid array or size");
+        return;
+    }
+    csound_array_prepare_write_inline(csound, p, ctx);
+    if (p->dimensions == 0) {
+        p->dimensions = 1;
+    }
+    if (p->dimensions == 1 && p->sizes == NULL) {
+        p->sizes = (int32_t *)csound->Calloc(csound, sizeof(int32_t));
+    }
+    if (UNLIKELY(p->dimensions > 1 && p->sizes == NULL)) {
+        csound->Die(csound, "tabinit: multidimensional array has no sizes");
+        return;
+    }
+    capacity = size > 0 ? (size_t)size : 1;
+    if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, ctx)
+                 != OK)) {
+        csound->Die(csound, "tabinit: could not allocate array storage");
+        return;
+    }
+    if (p->dimensions == 1) {
+        p->sizes[0] = size;
+    }
+}
+
+static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p,
+                                const ARRAYDAT *tp)
+{
+    size_t elementCount;
+    size_t capacity;
+
+    if (UNLIKELY(p == NULL || tp == NULL || tp->dimensions < 0 ||
+                 csound_array_member_count(tp, &elementCount) != OK)) {
+        csound->Die(csound, "tabinit_like: invalid source array");
+        return;
+    }
+    if (p == tp) {
+        return;
+    }
+    if (p->arrayType == NULL) {
+        p->arrayType = tp->arrayType;
+    }
+    if (UNLIKELY(p->arrayType == NULL ||
+                 !csound_array_element_types_compatible(
+                   p->arrayType, tp->arrayType))) {
+        csound->Die(csound, "tabinit_like: array types do not match");
+        return;
+    }
+    csound_array_prepare_write_inline(csound, p, NULL);
+    if (p->data == tp->data) {
+        return;
+    }
+
+    if (tp->dimensions == 0) {
+        csound->Free(csound, p->sizes);
+        p->sizes = NULL;
+        p->dimensions = 0;
+    }
+    else if (p->dimensions != tp->dimensions || p->sizes == NULL) {
+        p->sizes = (int32_t *)csound->ReAlloc(
+          csound, p->sizes, sizeof(int32_t) * (size_t)tp->dimensions);
+        p->dimensions = tp->dimensions;
+    }
+    if (tp->dimensions > 0) {
+        memcpy(p->sizes, tp->sizes,
+               sizeof(int32_t) * (size_t)tp->dimensions);
+    }
+    capacity = elementCount > 0 ? elementCount : 1;
+    if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, NULL)
+                 != OK)) {
+        csound->Die(csound, "tabinit_like: could not allocate array storage");
     }
 }
 
 static inline int32_t tabcheck(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *q)
 {
-    if (p->data==NULL || p->dimensions == 0) {
+    size_t bytes;
+
+    if (UNLIKELY(p == NULL || size < 0)) {
+      return csound->PerfError(csound, q, "%s", Str("Invalid array size"));
+    }
+    /* Updating the logical size is a write even when capacity is unchanged. */
+    csound_array_prepare_write_inline(csound, p,
+                                      q != NULL ? q->insdshead : NULL);
+    if (p->data == NULL || p->dimensions == 0 || p->sizes == NULL) {
       return csound->PerfError(csound, q, "%s", Str("Array not initialised"));
     }
-    size_t s = p->arrayMemberSize*size;
-    if (s > p->allocated) { /* was arr->allocate */
+    if (UNLIKELY(csound_array_allocation_size(
+                   p->arrayMemberSize, (size_t)size, &bytes) != OK)) {
+      return csound->PerfError(csound, q, "%s",
+                               Str("Array size overflow"));
+    }
+    if (bytes > p->allocated) { /* was arr->allocate */
       return csound->PerfError(csound, q,
         Str("Array too small (allocated %zu < needed %zu), but cannot "
             "allocate during performance pass. Allocate a bigger array at init time"),
-        p->allocated, s);
+        p->allocated, bytes);
     }
     p->sizes[0] = size;
     return OK;

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -253,6 +253,7 @@ typedef struct {
   /**
    * Type definition for arrays
    */
+  struct cs_array_storage;
   struct arraydat {
     int32_t      dimensions; /* number of array dimensions */
     int32_t*     sizes;  /* size of each dimensions */
@@ -260,6 +261,12 @@ typedef struct {
     const struct cstype* arrayType; /* type of array */
     MYFLT*   data; /* data */
     size_t   allocated; /* size of allocated data */
+    /* Opaque ownership sidecar for structured arrays. Appending it preserves
+       existing member offsets but changes sizeof(ARRAYDAT), so external code
+       embedding the struct must rebuild against this header. Direct ARRAYDAT
+       constructors must initialize the field to NULL; ownership changes must
+       go through the array type callbacks rather than copying this pointer. */
+    struct cs_array_storage* storage;
   };
 
   /**

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -818,6 +818,10 @@ def runTest():
         ["udo/test_args_in.csd", "Pass-by-ref connects args correctly."],
         ["udo/test_K_type.csd", "K-type arguments work with pass-by-ref"],
         [
+            "udo/test_init_only_udo_frame_lifetime.csd",
+            "Init-only UDO frames release structured temporary values",
+        ],
+        [
             "udo/test_udo_init_only_conditional_perf_chain.csd",
             "init-only UDOs in conditionals do not install perf chains",
         ],

--- a/tests/commandline/udo/test_init_only_udo_frame_lifetime.csd
+++ b/tests/commandline/udo/test_init_only_udo_frame_lifetime.csd
@@ -1,0 +1,203 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+struct ScoreNode label:S, children:ScoreNode[]
+
+opcode CountScoreBranches(depth:i):i
+  children:ScoreNode[] init 0
+  temporary:ScoreNode init "temporary", children
+
+  if (depth == 0) then
+    result:i = 1
+  else
+    left:i = CountScoreBranches(depth - 1)
+    right:i = CountScoreBranches(depth - 1)
+    result = left + right
+  endif
+  result += lenarray(temporary.children)
+  xout result
+endop
+
+struct Annotation text:S, nested:Annotation[], catalogs:Catalog[]
+struct Catalog keys:S[], values:Annotation[], parents:Catalog[], length:i, id:i
+
+emptyAnnotations@global:Annotation[] init 0
+emptyCatalogs@global:Catalog[] init 0
+emptyKeys@global:S[] init 0
+catalogRegistry@global:Catalog[] init 1
+
+opcode MakeCatalog(id:i):Catalog
+  result:Catalog init emptyKeys, emptyAnnotations, emptyCatalogs, 0, id
+  xout result
+endop
+
+opcode ResolveCatalog(input:Catalog):Catalog
+  if (input.id >= 0) then
+    stored:Catalog = catalogRegistry[input.id]
+    if (stored.id == input.id) then
+      result:Catalog = stored
+    else
+      result:Catalog = input
+    endif
+  else
+    result:Catalog = input
+  endif
+  xout result
+endop
+
+opcode AppendCatalog(input:Catalog, key:S):Catalog
+  result:Catalog = ResolveCatalog(input)
+  keys:S[] init result.length + 1
+
+  if (result.length > 0) then
+    for index in [0 ... result.length - 1] do
+      keys[index] = result.keys[index]
+    od
+  endif
+  keys[result.length] = key
+  result.keys = keys
+  result.length += 1
+  xout result
+endop
+
+struct Section players:i
+
+opcode ForwardSections(input:Section[]):Section[]
+  xout input
+endop
+
+opcode ForwardCatalogs(input:Catalog[]):Catalog[]
+  xout input
+endop
+
+opcode IncrementCycle(source:k):k
+  result:k = 0
+  result = source + 1
+  xout result
+endop
+
+instr InitChecks
+  ; Large enough to expose retained recursive frames while keeping the
+  ; recycled case bounded by recursion depth.
+  branches:i = CountScoreBranches(18)
+  if (branches != 262144) then
+    prints "recursive init failed: expected=262144 got=%d\n", branches
+    exitnow(1)
+  endif
+
+  root:Catalog = MakeCatalog(0)
+  catalogRegistry[0] = root
+  first:Catalog = AppendCatalog(root, "violin")
+  catalogRegistry[0] = first
+  second:Catalog = AppendCatalog(first, "cello")
+
+  if (second.length != 2 || lenarray(second.keys) != 2 || \
+      strcmp(second.keys[0], "violin") != 0 || \
+      strcmp(second.keys[1], "cello") != 0) then
+    prints "returned recursive struct did not survive frame reuse\n"
+    exitnow(1)
+  endif
+
+  original:Section[] init 1
+  woodwind:Section init 1
+  original[0] = woodwind
+  copied:Section[] = ForwardSections(original)
+  brass:Section init 2
+  copied[0] = brass
+  originalValue:Section = original[0]
+  copiedValue:Section = copied[0]
+
+  if (originalValue.players != 1 || copiedValue.players != 2) then
+    prints "struct array copy-on-write failed: original=%d copied=%d\n", \
+      originalValue.players, copiedValue.players
+    exitnow(1)
+  endif
+
+  memberCopy:Section[] = ForwardSections(original)
+  memberCopy[0].players = 3
+  originalAfterMember:Section = original[0]
+  copiedAfterMember:Section = memberCopy[0]
+
+  if (originalAfterMember.players != 1 || copiedAfterMember.players != 3) then
+    prints "struct member copy-on-write failed: original=%d copied=%d\n", \
+      originalAfterMember.players, copiedAfterMember.players
+    exitnow(1)
+  endif
+
+  resized:Section[] = ForwardSections(original)
+  resized fillarray brass, brass
+  originalAfterResize:Section = original[0]
+  resizedFirst:Section = resized[0]
+  resizedSecond:Section = resized[1]
+
+  if (lenarray(original) != 1 || originalAfterResize.players != 1 || \
+      lenarray(resized) != 2 || resizedFirst.players != 2 || \
+      resizedSecond.players != 2) then
+    prints "struct array resize copy-on-write failed\n"
+    exitnow(1)
+  endif
+
+  survivor:Section[] = ForwardSections(original)
+  original[0] = brass
+  survivorValue:Section = survivor[0]
+  changedOwnerValue:Section = original[0]
+  if (survivorValue.players != 1 || changedOwnerValue.players != 2) then
+    prints "struct array owner copy-on-write failed: old=%d new=%d\n", \
+      survivorValue.players, changedOwnerValue.players
+    exitnow(1)
+  endif
+
+  nestedOriginal:Catalog[] init 1
+  nestedOriginal[0] = second
+  nestedCopy:Catalog[] = ForwardCatalogs(nestedOriginal)
+  replacement:Catalog = MakeCatalog(7)
+  nestedCopy[0] = replacement
+  preserved:Catalog = nestedOriginal[0]
+  replaced:Catalog = nestedCopy[0]
+
+  if (preserved.length != 2 || lenarray(preserved.keys) != 2 || \
+      strcmp(preserved.keys[1], "cello") != 0 || replaced.id != 7) then
+    prints "nested struct array copy-on-write failed\n"
+    exitnow(1)
+  endif
+
+  emptySections:Section[] init 0
+  emptyCopy:Section[] = ForwardSections(emptySections)
+  emptyCopy fillarray brass
+  if (lenarray(emptySections) != 0 || lenarray(emptyCopy) != 1) then
+    prints "empty struct array copy-on-write failed: old=%d new=%d\n", \
+      lenarray(emptySections), lenarray(emptyCopy)
+    exitnow(1)
+  endif
+
+  matrix:Section[][] init 2, 2
+  matrix[1][0] = brass
+  matrixValue:Section = matrix[1][0]
+  if (matrixValue.players != 2) then
+    prints "multidimensional struct array indexing failed\n"
+    exitnow(1)
+  endif
+endin
+
+instr PerformanceCheck
+  value:k init 5
+  value = IncrementCycle(value)
+  if (timeinstk() == 1 && value != 6) then
+    printks "k-rate UDO cycle 1 failed: expected=6 got=%g\n", 0, value
+    exitnowk(-1)
+  endif
+  if (timeinstk() == 2 && value != 7) then
+    printks "k-rate UDO cycle 2 failed: expected=7 got=%g\n", 0, value
+    exitnowk(-1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i "InitChecks" 0 0
+i "PerformanceCheck" 0 0.02
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
## Summary

Recursive structs exposed a lifetime problem that could not be fixed safely in only the UDO or array code.

Before this change, copies of arrays containing user-defined structs could refer to the same backing memory without recording shared ownership. An init-only UDO therefore had two unsafe choices: keep its entire frame alive after returning, or recycle it and leave escaped recursive values pointing into released storage. Csound chose the first, which was safe for small programs but allowed allocation-heavy recursive code to grow until the enclosing instrument ended.

This PR gives structured arrays an explicit ownership boundary, then uses that contract to recycle UDO frames whose work is provably complete. The changes belong together: frame reclamation is only safe after returned structured values can retain their storage independently.

## What changed

- Add an optional, reference-counted storage sidecar for arrays of user-defined structs.
- Retain and release shared structured-array storage through the normal type copy and destruction paths.
- Detach shared storage with copy-on-write before element, member, fill, or resize mutations.
- Destroy nested structured elements when their final storage owner is released.
- Recycle zero-duration, init-only UDO frames after pass-by-copy outputs have been materialized.
- Keep the existing lifecycle for UDOs that may still run or defer work, including positive or indefinite duration, `xtratim`, deinit callbacks, open files, nested instances, and rate converters.
- Preserve the existing deep-copy behavior for non-UDT arrays.

This is not a tracing garbage collector. Storage is released deterministically when its final owner goes away. Reference cycles are outside the scope of this change.

## Why the patch crosses several files

| Area | Responsibility |
| --- | --- |
| `ARRAYDAT` and array helpers | Record shared backing storage, reference counts, and copy-on-write transitions. |
| Struct operations | Copy and release recursive members without dangling nested arrays. |
| Array operations and core initializers | Apply the same ownership rules to creation, assignment, fill, resize, bus, and engine-managed arrays. |
| UDO lifecycle | Recycle only frames that cannot execute or defer cleanup after init. |
| Regression tests | Exercise returned values, nested strings, mutation isolation, resizing, empty and multidimensional arrays, and k-rate behavior. |

`ARRAYDAT` gains one optional storage pointer. The sidecar layout is identical on atomic and mutex-fallback builds, so separately built components agree on the structure layout. As with other internal layout changes, plugins embedding `ARRAYDAT` need to be rebuilt with this Csound version.

## Benchmarks

Both revisions were built as `RelWithDebInfo` with the same toolchain and measured on the same arm64 macOS host. Runs were interleaved after warmup, with no other Csound processes active. The [benchmark scripts, raw samples, environment details, and chart sources](https://gist.github.com/hlolli/b6bee7239711ccc8297b448ccdb6a483) are published separately so the measurements can be inspected without adding benchmark artifacts to the Csound source tree.

### Existing synthesis workload

The canonical `Chowning-Stria.csd` example was synthesized with `-n -d -m0`, excluding output-file I/O. The chart shows five measured runs per revision after one warmup run.

![Stria wall and CPU time](https://gist.githubusercontent.com/hlolli/b6bee7239711ccc8297b448ccdb6a483/raw/d6a8a5cc79c3bbb3b8f588415c2bdfd05f9aa3a3/stria-performance.png)

<p align="center"><em>Less is better. The observed differences are within run-to-run noise.</em></p>

| Median, 5 runs | `develop` | This branch | Difference |
| --- | ---: | ---: | ---: |
| Wall time | `15.260 s` | `15.240 s` | `-0.13%` |
| CPU time | `15.160 CPU-s` | `15.156 CPU-s` | `-0.03%` |

This benchmark is intended as a regression check, not a speedup claim. It found no measurable cost in an existing synthesis workload.

### Recursive structured workload

The allocation-heavy recursive structured workload that exposed the problem was run three times per revision. Process resident memory was sampled every 25 ms. On `develop`, every run terminated before completing. This branch completed all three runs while reaching a lower peak resident set.

![Recursive workload memory over time](https://gist.githubusercontent.com/hlolli/b6bee7239711ccc8297b448ccdb6a483/raw/d6a8a5cc79c3bbb3b8f588415c2bdfd05f9aa3a3/recursive-memory-over-time.png)

<p align="center"><em>Less is better. The branch completes the workload; develop terminates early.</em></p>

![Recursive workload resource and outcome summary](https://gist.githubusercontent.com/hlolli/b6bee7239711ccc8297b448ccdb6a483/raw/d6a8a5cc79c3bbb3b8f588415c2bdfd05f9aa3a3/recursive-workload-summary.png)

<p align="center"><em>Memory: less is better. Completion: higher is better.</em></p>

| Median, 3 runs | `develop` | This branch |
| --- | ---: | ---: |
| Peak resident memory | `308.5 MiB` before termination | `154.6 MiB` |
| Successful completion | `0 / 3` | `3 / 3` |

The peak resident set is an end-to-end process measurement, not a byte-exact count of live Csound allocations. There is deliberately no runtime comparison for this workload because `develop` aborts after roughly 1.6 seconds while the branch finishes in roughly 13 seconds. Despite doing the complete job, the branch uses about 49.9% less peak resident memory.

## Verification

- Full command-line CSD suite: `299 / 299` passed.
- Relevant C++ unit tests: `16 / 16` passed.
- The new recursive UDO regression test passes directly against the branch build.
- The non-atomic reference-count fallback compiles successfully.

The regression CSD covers recursive init-only calls, returned nested values and strings, copy-on-write element and member mutation, resize and fill, owner mutation, empty and multidimensional arrays, and k-rate UDO lifetime behavior.
