### PR TITLE
fix(wasm): coordinate SAB performance completion

### DIFF
--- a/wasm/browser/package.json
+++ b/wasm/browser/package.json
@@ -52,8 +52,9 @@
     "build:readme": "node --experimental-modules script/generate-readme.mjs > README.md",
     "build:tools": "node compile-tools.js",
     "test:types": "node tests/types/run.cjs",
-    "test:ci": "npm run test:types && node tests/selenium_runner.js",
-    "test:ci:firefox": "npm run test:types && node tests/selenium_runner_firefox.js",
+    "test:unit": "mocha \"tests/unit/**/*.test.js\"",
+    "test:ci": "npm run test:types && npm run test:unit && node tests/selenium_runner.js",
+    "test:ci:firefox": "npm run test:types && npm run test:unit && node tests/selenium_runner_firefox.js",
     "test:open": "node tests/server.cjs"
   },
   "devDependencies": {

--- a/wasm/browser/src/mains/messages.main.js
+++ b/wasm/browser/src/mains/messages.main.js
@@ -32,7 +32,10 @@ export const messageEventHandler = (worker) => (event) => {
       worker.publicEvents.triggerDebugCallback();
     }
   } else if (event.data["playStateChange"] && worker && worker["onPlayStateChange"]) {
-    worker["onPlayStateChange"](event.data["playStateChange"]);
+    worker["onPlayStateChange"](
+      event.data["playStateChange"],
+      event.data["performanceGeneration"],
+    );
   }
 };
 

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -65,6 +65,9 @@ class SharedArrayBufferMainThread {
     this.callbackBuffer = {};
     this.performanceEndState = undefined;
     this.stopReleaseReceived = false;
+    // End state and stop release arrive on different ports. A generation keeps
+    // late messages from an earlier run from completing the current one.
+    this.performanceGeneration = 0;
 
     this.audioStateBuffer = new SharedArrayBuffer(
       initialSharedState.length * Int32Array.BYTES_PER_ELEMENT,
@@ -171,12 +174,25 @@ class SharedArrayBufferMainThread {
     this.stopReleaseReceived = false;
   }
 
-  markPerformanceEndState(playState) {
+  isCurrentPerformanceGeneration(performanceGeneration) {
+    return (
+      performanceGeneration === undefined ||
+      performanceGeneration === this.performanceGeneration
+    );
+  }
+
+  markPerformanceEndState(playState, performanceGeneration) {
+    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
+      return;
+    }
     this.performanceEndState = playState;
     this.finishPerformanceEnd();
   }
 
-  markStopReleaseReceived() {
+  markStopReleaseReceived(performanceGeneration) {
+    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
+      return;
+    }
     this.stopReleaseReceived = true;
     this.finishPerformanceEnd();
   }
@@ -198,9 +214,12 @@ class SharedArrayBufferMainThread {
     this.eventPromises && this.eventPromises.releaseStopPromise();
   }
 
-  async onPlayStateChange(newPlayState) {
+  async onPlayStateChange(newPlayState, performanceGeneration) {
     if (this === undefined) {
       console.log("Failed to announce playstatechange", newPlayState);
+      return;
+    }
+    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
       return;
     }
     this.currentPlayState = newPlayState;
@@ -276,7 +295,7 @@ class SharedArrayBufferMainThread {
       console.error(error);
     }
     if (performanceEndState) {
-      this.markPerformanceEndState(performanceEndState);
+      this.markPerformanceEndState(performanceEndState, performanceGeneration);
     }
   }
 
@@ -334,6 +353,10 @@ class SharedArrayBufferMainThread {
     log(`(postMessage) making a message channel from SABMain to SABWorker via workerMessagePort`)();
 
     this.ipcMessagePorts.sabMainCallbackReply.addEventListener("message", (event) => {
+      if (event.data && event.data["type"] === "releaseStop") {
+        this.markStopReleaseReceived(event.data["performanceGeneration"]);
+        return;
+      }
       switch (event.data) {
         case "poll": {
           if (this.ipcMessagePorts && this.ipcMessagePorts.sabMainCallbackReply) {
@@ -351,7 +374,7 @@ class SharedArrayBufferMainThread {
           break;
         }
         case "releaseStop": {
-          this.markStopReleaseReceived();
+          this.markStopReleaseReceived(this.performanceGeneration);
           break;
         }
         case "releasePause": {
@@ -472,6 +495,7 @@ class SharedArrayBufferMainThread {
             if (this.eventPromises.isWaiting("start")) {
               return -1;
             } else {
+              this.performanceGeneration += 1;
               this.resetPerformanceEndSignals();
               this.eventPromises.createStartPromise();
 
@@ -481,6 +505,7 @@ class SharedArrayBufferMainThread {
               startPayload["audioStreamOut"] = audioStreamOut;
               startPayload["midiBuffer"] = midiBuffer;
               startPayload["csound"] = csoundInstance;
+              startPayload["performanceGeneration"] = this.performanceGeneration;
 
               const startResult = await proxyCallback(startPayload);
 

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -63,6 +63,8 @@ class SharedArrayBufferMainThread {
 
     this.callbackId = 0;
     this.callbackBuffer = {};
+    this.performanceEndState = undefined;
+    this.stopReleaseReceived = false;
 
     this.audioStateBuffer = new SharedArrayBuffer(
       initialSharedState.length * Int32Array.BYTES_PER_ELEMENT,
@@ -164,6 +166,38 @@ class SharedArrayBufferMainThread {
     }
   }
 
+  resetPerformanceEndSignals() {
+    this.performanceEndState = undefined;
+    this.stopReleaseReceived = false;
+  }
+
+  markPerformanceEndState(playState) {
+    this.performanceEndState = playState;
+    this.finishPerformanceEnd();
+  }
+
+  markStopReleaseReceived() {
+    this.stopReleaseReceived = true;
+    this.finishPerformanceEnd();
+  }
+
+  finishPerformanceEnd() {
+    if (!this.performanceEndState || !this.stopReleaseReceived) {
+      return;
+    }
+
+    // Logs and play-state changes share one ordered port. releaseStop uses a
+    // second port, so wait for both before exposing completion to callers.
+    const performanceEndState = this.performanceEndState;
+    this.resetPerformanceEndSignals();
+    if (performanceEndState === "renderEnded") {
+      this.publicEvents && this.publicEvents.triggerRenderEnded();
+    } else {
+      this.publicEvents && this.publicEvents.triggerRealtimePerformanceEnded();
+    }
+    this.eventPromises && this.eventPromises.releaseStopPromise();
+  }
+
   async onPlayStateChange(newPlayState) {
     if (this === undefined) {
       console.log("Failed to announce playstatechange", newPlayState);
@@ -174,6 +208,7 @@ class SharedArrayBufferMainThread {
       // prevent late timers from calling terminated fn
       return;
     }
+    let performanceEndState;
     switch (newPlayState) {
       case "realtimePerformanceStarted": {
         log(
@@ -216,6 +251,7 @@ class SharedArrayBufferMainThread {
         if (userProvidedNchnlsInput > -1) {
           Atomics.store(this.audioStatePointer, AUDIO_STATE.NCHNLS_I, userProvidedNchnlsInput);
         }
+        performanceEndState = newPlayState;
         break;
       }
       case "renderStarted": {
@@ -225,8 +261,7 @@ class SharedArrayBufferMainThread {
       }
       case "renderEnded": {
         log(`event: renderEnded received, beginning cleanup`)();
-        this.publicEvents.triggerRenderEnded();
-        this.eventPromises && this.eventPromises.releaseStopPromise();
+        performanceEndState = newPlayState;
         break;
       }
       default: {
@@ -239,6 +274,9 @@ class SharedArrayBufferMainThread {
       await this.audioWorker.onPlayStateChange(newPlayState);
     } catch (error) {
       console.error(error);
+    }
+    if (performanceEndState) {
+      this.markPerformanceEndState(performanceEndState);
     }
   }
 
@@ -313,11 +351,7 @@ class SharedArrayBufferMainThread {
           break;
         }
         case "releaseStop": {
-          this.onPlayStateChange(
-            this.currentPlayState === "renderStarted" ? "renderEnded" : "realtimePerformanceEnded",
-          );
-          this.publicEvents && this.publicEvents.triggerRealtimePerformanceEnded();
-          this.eventPromises && this.eventPromises.releaseStopPromise();
+          this.markStopReleaseReceived();
           break;
         }
         case "releasePause": {
@@ -438,6 +472,7 @@ class SharedArrayBufferMainThread {
             if (this.eventPromises.isWaiting("start")) {
               return -1;
             } else {
+              this.resetPerformanceEndSignals();
               this.eventPromises.createStartPromise();
 
               const startPayload = {};

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -279,6 +279,7 @@ class SharedArrayBufferMainThread {
         break;
       }
       case "renderEnded": {
+        this.eventPromises.createStopPromise();
         log(`event: renderEnded received, beginning cleanup`)();
         performanceEndState = newPlayState;
         break;

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -27,6 +27,7 @@ import {
 import { logSABMain as log } from "../logger";
 import { csoundApiRename, fetchPlugins, makeProxyCallback, stopableStates } from "../utils";
 import { EventPromises } from "../utils/event-promises";
+import { SABCompletionCoordinator } from "../utils/sab-completion-coordinator.js";
 import { PublicEventAPI } from "../events";
 import SABWorker from "../../dist/__compiled.sab.worker.inline.js";
 
@@ -63,11 +64,12 @@ class SharedArrayBufferMainThread {
 
     this.callbackId = 0;
     this.callbackBuffer = {};
-    this.performanceEndState = undefined;
-    this.stopReleaseReceived = false;
     // End state and stop release arrive on different ports. A generation keeps
     // late messages from an earlier run from completing the current one.
     this.performanceGeneration = 0;
+    this.performanceCompletion = new SABCompletionCoordinator((performanceEndState) =>
+      this.finishPerformanceEnd(performanceEndState),
+    );
 
     this.audioStateBuffer = new SharedArrayBuffer(
       initialSharedState.length * Int32Array.BYTES_PER_ELEMENT,
@@ -152,7 +154,7 @@ class SharedArrayBufferMainThread {
 
       Atomics.store(this.audioStatePointer, AUDIO_STATE.IS_PAUSED, 1);
       await this.eventPromises.waitForPause();
-      this.onPlayStateChange("realtimePerformancePaused");
+      this.onPlayStateChange("realtimePerformancePaused", this.performanceGeneration);
       return 0;
     }
   }
@@ -165,47 +167,27 @@ class SharedArrayBufferMainThread {
     ) {
       Atomics.store(this.audioStatePointer, AUDIO_STATE.IS_PAUSED, 0);
       Atomics.notify(this.audioStatePointer, AUDIO_STATE.IS_PAUSED);
-      this.onPlayStateChange("realtimePerformanceResumed");
+      this.onPlayStateChange("realtimePerformanceResumed", this.performanceGeneration);
     }
-  }
-
-  resetPerformanceEndSignals() {
-    this.performanceEndState = undefined;
-    this.stopReleaseReceived = false;
-  }
-
-  isCurrentPerformanceGeneration(performanceGeneration) {
-    return (
-      performanceGeneration === undefined ||
-      performanceGeneration === this.performanceGeneration
-    );
   }
 
   markPerformanceEndState(playState, performanceGeneration) {
-    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
-      return;
-    }
-    this.performanceEndState = playState;
-    this.finishPerformanceEnd();
+    this.performanceCompletion.markEnd(playState, performanceGeneration);
   }
 
   markStopReleaseReceived(performanceGeneration) {
-    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
+    if (!this.performanceCompletion.canAccept(performanceGeneration)) {
       return;
     }
-    this.stopReleaseReceived = true;
-    this.finishPerformanceEnd();
+    // Either completion signal can arrive first. Establish the stop barrier
+    // before recording this one so a new run cannot reset partial state.
+    this.eventPromises.createStopPromise();
+    this.performanceCompletion.markStopReleased(performanceGeneration);
   }
 
-  finishPerformanceEnd() {
-    if (!this.performanceEndState || !this.stopReleaseReceived) {
-      return;
-    }
-
+  finishPerformanceEnd(performanceEndState) {
     // Logs and play-state changes share one ordered port. releaseStop uses a
     // second port, so wait for both before exposing completion to callers.
-    const performanceEndState = this.performanceEndState;
-    this.resetPerformanceEndSignals();
     if (performanceEndState === "renderEnded") {
       this.publicEvents && this.publicEvents.triggerRenderEnded();
     } else {
@@ -219,7 +201,7 @@ class SharedArrayBufferMainThread {
       console.log("Failed to announce playstatechange", newPlayState);
       return;
     }
-    if (!this.isCurrentPerformanceGeneration(performanceGeneration)) {
+    if (!this.performanceCompletion.canAccept(performanceGeneration)) {
       return;
     }
     this.currentPlayState = newPlayState;
@@ -291,7 +273,7 @@ class SharedArrayBufferMainThread {
 
     // forward the message from worker to the audioWorker
     try {
-      await this.audioWorker.onPlayStateChange(newPlayState);
+      await this.audioWorker.onPlayStateChange(newPlayState, performanceGeneration);
     } catch (error) {
       console.error(error);
     }
@@ -498,7 +480,7 @@ class SharedArrayBufferMainThread {
               return -1;
             } else {
               this.performanceGeneration += 1;
-              this.resetPerformanceEndSignals();
+              this.performanceCompletion.begin(this.performanceGeneration);
               this.eventPromises.createStartPromise();
 
               const startPayload = {};

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -374,7 +374,8 @@ class SharedArrayBufferMainThread {
           break;
         }
         case "releaseStop": {
-          this.markStopReleaseReceived(this.performanceGeneration);
+          // Untagged releases cannot be attributed to a performance. Current
+          // workers always send the object payload handled above.
           break;
         }
         case "releasePause": {

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -40,6 +40,7 @@ class AudioWorkletMainThread {
     this.csoundWorkerMain = undefined;
     this.workletWorkerUrl = undefined;
     this.workletProxy = undefined;
+    this.performanceGeneration = undefined;
     this["isRequestingMidi"] = false;
     this.isRequestingInput = false;
 
@@ -91,6 +92,7 @@ class AudioWorkletMainThread {
     processorOptions["inputsCount"] = inputsCount;
     processorOptions["outputsCount"] = this.outputsCount;
     processorOptions["ksmps"] = this.ksmps;
+    processorOptions["performanceGeneration"] = this.performanceGeneration;
     processorOptions["maybeSharedArrayBuffer"] =
       this.csoundWorkerMain.hasSharedArrayBuffer && this.csoundWorkerMain.audioStatePointer;
     processorOptions["maybeSharedArrayBufferAudioIn"] =
@@ -107,7 +109,19 @@ class AudioWorkletMainThread {
     return audioNode;
   }
 
-  async onPlayStateChange(newPlayState) {
+  async onPlayStateChange(newPlayState, performanceGeneration) {
+    // Old AudioWorklet processors can still post on the shared message port
+    // after a replacement node starts. Only the current SAB run may act here.
+    if (
+      this.csoundWorkerMain &&
+      this.csoundWorkerMain.hasSharedArrayBuffer &&
+      performanceGeneration !== this.csoundWorkerMain.performanceGeneration
+    ) {
+      return;
+    }
+    if (newPlayState === "realtimePerformanceStarted") {
+      this.performanceGeneration = performanceGeneration;
+    }
     this.currentPlayState = newPlayState;
 
     switch (newPlayState) {

--- a/wasm/browser/src/utils/sab-completion-coordinator.js
+++ b/wasm/browser/src/utils/sab-completion-coordinator.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) The Csound Developers
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class SABCompletionCoordinator {
+  constructor(onComplete) {
+    /** @type {function(string): void} */
+    this.onComplete = onComplete;
+    /** @type {number} */
+    this.generation = 0;
+    /** @type {string|undefined} */
+    this.endState = undefined;
+    /** @type {boolean} */
+    this.stopReleased = false;
+    /** @type {boolean} */
+    this.completed = false;
+    this.begin(0);
+  }
+
+  begin(generation) {
+    this.generation = generation;
+    this.endState = undefined;
+    this.stopReleased = false;
+    this.completed = false;
+  }
+
+  isCurrent(generation) {
+    return generation === this.generation;
+  }
+
+  canAccept(generation) {
+    return this.isCurrent(generation) && !this.completed;
+  }
+
+  markEnd(endState, generation) {
+    if (!this.canAccept(generation)) {
+      return false;
+    }
+    if (!this.endState) {
+      this.endState = endState;
+    }
+    return this.finish();
+  }
+
+  markStopReleased(generation) {
+    if (!this.canAccept(generation)) {
+      return false;
+    }
+    this.stopReleased = true;
+    return this.finish();
+  }
+
+  finish() {
+    if (!this.endState || !this.stopReleased || this.completed) {
+      return false;
+    }
+
+    // Latch before invoking application code so re-entrant or replayed
+    // signals cannot expose completion more than once for this generation.
+    this.completed = true;
+    this.onComplete(this.endState);
+    return true;
+  }
+}

--- a/wasm/browser/src/workers/common.utils.js
+++ b/wasm/browser/src/workers/common.utils.js
@@ -50,7 +50,10 @@ export const handleCsoundStart =
         createRealtimeAudioThread(arguments_);
       } else {
         // Do rendering
-        workerMessagePort.broadcastPlayState("renderStarted");
+        workerMessagePort.broadcastPlayState(
+          "renderStarted",
+          arguments_["performanceGeneration"],
+        );
         if (renderFunction) {
           renderFunction(arguments_);
         } else {

--- a/wasm/browser/src/workers/common.utils.js
+++ b/wasm/browser/src/workers/common.utils.js
@@ -92,5 +92,5 @@ export const renderFunction =
       }
     }
 
-    workerMessagePort.broadcastPlayState("renderEnded");
+    workerMessagePort.broadcastPlayState("renderEnded", payload["performanceGeneration"]);
   };

--- a/wasm/browser/src/workers/sab.worker.js
+++ b/wasm/browser/src/workers/sab.worker.js
@@ -80,6 +80,7 @@ const sabCreateRealtimeAudioThread =
     const audioStreamOut = argumentz["audioStreamOut"];
     const midiBuffer = argumentz["midiBuffer"];
     const csound = argumentz["csound"];
+    const performanceGeneration = argumentz["performanceGeneration"];
 
     const audioStatePointer = new Int32Array(audioStateBuffer);
 
@@ -145,7 +146,10 @@ const sabCreateRealtimeAudioThread =
       );
     }
 
-    workerMessagePort.broadcastPlayState("realtimePerformanceStarted");
+    workerMessagePort.broadcastPlayState(
+      "realtimePerformanceStarted",
+      performanceGeneration,
+    );
     // Let's notify the audio-worker that performance has started
     Atomics.store(audioStatePointer, AUDIO_STATE.IS_PERFORMING, 1);
 
@@ -172,9 +176,12 @@ const sabCreateRealtimeAudioThread =
           libraryCsound.csoundPerformKsmps(csound);
         }
         log(`triggering realtimePerformanceEnded event`)();
-        workerMessagePort.broadcastPlayState("realtimePerformanceEnded");
+        workerMessagePort.broadcastPlayState(
+          "realtimePerformanceEnded",
+          performanceGeneration,
+        );
         log(`End of realtimePerformance loop!`)();
-        releaseStop();
+        releaseStop(performanceGeneration);
         return true;
       } else {
         return false;
@@ -327,9 +334,12 @@ const sabCreateRealtimeAudioThread =
 const initMessagePort = ({ port }) => {
   const workerMessagePort = new MessagePortState();
   workerMessagePort.post = (messageLog) => port.postMessage({ log: messageLog });
-  workerMessagePort.broadcastPlayState = (playStateChange) => {
+  workerMessagePort.broadcastPlayState = (playStateChange, performanceGeneration) => {
     const payload = {};
     payload["playStateChange"] = playStateChange;
+    if (performanceGeneration !== undefined) {
+      payload["performanceGeneration"] = performanceGeneration;
+    }
     port.postMessage(payload);
   };
   workerMessagePort.broadcastSabUnlocked = () => port.postMessage({ sabWorker: "unlocked" });
@@ -384,6 +394,7 @@ const renderFunction =
   async (argumentz) => {
     const audioStateBuffer = argumentz["audioStateBuffer"];
     const csound = argumentz["csound"];
+    const performanceGeneration = argumentz["performanceGeneration"];
     const audioStatePointer = new Int32Array(audioStateBuffer);
     Atomics.store(audioStatePointer, AUDIO_STATE.IS_RENDERING, 1);
     workerMessagePort.broadcastSabUnlocked();
@@ -408,8 +419,8 @@ const renderFunction =
       }
     }
     Atomics.store(audioStatePointer, AUDIO_STATE.IS_RENDERING, 0);
-    workerMessagePort.broadcastPlayState("renderEnded");
-    releaseStop();
+    workerMessagePort.broadcastPlayState("renderEnded", performanceGeneration);
+    releaseStop(performanceGeneration);
   };
 
 /** @export */
@@ -422,7 +433,12 @@ const initialize = async (payload) => {
   log(`initializing SABWorker and WASM`)();
   const workerMessagePort = initMessagePort({ port: messagePort });
   const callbacksRequest = () => callbackPort.postMessage("poll");
-  const releaseStop = () => callbackPort.postMessage("releaseStop");
+  const releaseStop = (performanceGeneration) => {
+    const payload = {};
+    payload["type"] = "releaseStop";
+    payload["performanceGeneration"] = performanceGeneration;
+    callbackPort.postMessage(payload);
+  };
   const releasePause = () => callbackPort.postMessage("releasePause");
   const releaseResumed = () => callbackPort.postMessage("releaseResumed");
 

--- a/wasm/browser/src/workers/worklet.worker.js
+++ b/wasm/browser/src/workers/worklet.worker.js
@@ -30,6 +30,7 @@ const activeNodes = new Map();
  * @this {{
  * workerMessagePort: Object,
  * bufferLength: number,
+ * performanceGeneration: (number|undefined),
  * }}
  */
 function processSharedArrayBuffer(inputs, outputs) {
@@ -128,7 +129,10 @@ function processSharedArrayBuffer(inputs, outputs) {
       // means a fatal situation and browser
       // may crash
       this.workerMessagePort.post("FATAL: 100 buffers failed in a row");
-      this.workerMessagePort.broadcastPlayState("realtimePerformanceEnded");
+      this.workerMessagePort.broadcastPlayState(
+        "realtimePerformanceEnded",
+        this.performanceGeneration,
+      );
       return false;
     }
   }
@@ -223,7 +227,10 @@ function processVanillaBuffers(inputs, outputs) {
       // means a fatal situation and browser
       // may crash
       this.workerMessagePort.post("FATAL: 100 buffers failed in a row");
-      this.workerMessagePort.broadcastPlayState("realtimePerformanceEnded");
+      this.workerMessagePort.broadcastPlayState(
+        "realtimePerformanceEnded",
+        this.performanceGeneration,
+      );
       return false;
     }
   }
@@ -252,11 +259,13 @@ class CsoundWorkletProcessor extends AudioWorkletProcessor {
     const inputsCount = processorOptions["inputsCount"];
     const outputsCount = processorOptions["outputsCount"];
     const ksmps = processorOptions["ksmps"];
+    const performanceGeneration = processorOptions["performanceGeneration"];
     const maybeSharedArrayBuffer = processorOptions["maybeSharedArrayBuffer"];
     const maybeSharedArrayBufferAudioIn = processorOptions["maybeSharedArrayBufferAudioIn"];
     const maybeSharedArrayBufferAudioOut = processorOptions["maybeSharedArrayBufferAudioOut"];
 
     this.workerMessagePort = undefined;
+    this.performanceGeneration = performanceGeneration;
     this.startPromiz = undefined;
     this.audioFramePort = undefined;
     this.audioInputPort = undefined;
@@ -380,12 +389,18 @@ class CsoundWorkletProcessor extends AudioWorkletProcessor {
 
   pause() {
     this.isPaused = true;
-    this.workerMessagePort.broadcastPlayState("realtimePerformancePaused");
+    this.workerMessagePort.broadcastPlayState(
+      "realtimePerformancePaused",
+      this.performanceGeneration,
+    );
   }
 
   resume() {
     this.isPaused = false;
-    this.workerMessagePort.broadcastPlayState("realtimePerformanceResumed");
+    this.workerMessagePort.broadcastPlayState(
+      "realtimePerformanceResumed",
+      this.performanceGeneration,
+    );
   }
 
   terminate() {
@@ -423,9 +438,12 @@ function initMessagePort(payload) {
     payload["log"] = logMessage;
     port.postMessage(payload);
   };
-  workerMessagePort.broadcastPlayState = (playStateChange) => {
+  workerMessagePort.broadcastPlayState = (playStateChange, performanceGeneration) => {
     const payload = {};
     payload["playStateChange"] = playStateChange;
+    if (performanceGeneration !== undefined) {
+      payload["performanceGeneration"] = performanceGeneration;
+    }
     port.postMessage(payload);
   };
 

--- a/wasm/browser/tests/unit/sab-completion-coordinator.test.js
+++ b/wasm/browser/tests/unit/sab-completion-coordinator.test.js
@@ -1,0 +1,175 @@
+/* eslint-env mocha */
+
+import assert from "node:assert/strict";
+
+import { SABCompletionCoordinator } from "../../src/utils/sab-completion-coordinator.js";
+
+const createCoordinator = (generation = 1) => {
+  const completedStates = [];
+  const coordinator = new SABCompletionCoordinator((endState) => completedStates.push(endState));
+  coordinator.begin(generation);
+
+  return { completedStates, coordinator };
+};
+
+describe("SABCompletionCoordinator", () => {
+  it("completes after the end state followed by the stop release", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded", 1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("completes after the stop release followed by the end state", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("realtimePerformanceEnded", 1);
+    assert.deepEqual(completedStates, ["realtimePerformanceEnded"]);
+  });
+
+  it("ignores stale generations", () => {
+    const { completedStates, coordinator } = createCoordinator(2);
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("renderEnded", 2);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markStopReleased(2);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("ignores undefined generations", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded");
+    coordinator.markStopReleased();
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("renderEnded", 1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("discards a partial end state when a new generation begins", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.begin(2);
+    coordinator.markStopReleased(2);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("renderEnded", 2);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("discards a partial stop release when a new generation begins", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markStopReleased(1);
+    coordinator.begin(2);
+    coordinator.markEnd("renderEnded", 2);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markStopReleased(2);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("completes only once when a full signal pair is replayed", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(1);
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(1);
+
+    assert.deepEqual(completedStates, ["renderEnded"]);
+    assert.equal(coordinator.canAccept(1), false);
+  });
+
+  it("clears the completion latch for a new generation", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(1);
+    coordinator.begin(2);
+    coordinator.markStopReleased(2);
+    coordinator.markEnd("realtimePerformanceEnded", 2);
+
+    assert.deepEqual(completedStates, ["renderEnded", "realtimePerformanceEnded"]);
+  });
+
+  it("latches completion before invoking a re-entrant callback", () => {
+    let completionCount = 0;
+
+    function onComplete() {
+      completionCount += 1;
+      coordinator.markEnd("renderEnded", 1);
+      coordinator.markStopReleased(1);
+    }
+
+    const coordinator = new SABCompletionCoordinator(onComplete);
+    coordinator.begin(1);
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(1);
+
+    assert.equal(completionCount, 1);
+  });
+
+  it("does not complete early or twice for duplicate end signals", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markEnd("renderEnded", 1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  it("does not complete early or twice for duplicate stop-release signals", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markStopReleased(1);
+    coordinator.markStopReleased(1);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("renderEnded", 1);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+
+  for (const endState of ["renderEnded", "realtimePerformanceEnded"]) {
+    it(`reports the ${endState} terminal state`, () => {
+      const { completedStates, coordinator } = createCoordinator();
+
+      coordinator.markEnd(endState, 1);
+      coordinator.markStopReleased(1);
+
+      assert.deepEqual(completedStates, [endState]);
+    });
+  }
+
+  it("ignores an old end handler that resumes after a new generation begins", () => {
+    const { completedStates, coordinator } = createCoordinator();
+
+    coordinator.markStopReleased(1);
+    coordinator.begin(2);
+    coordinator.markEnd("renderEnded", 1);
+    coordinator.markStopReleased(2);
+    assert.deepEqual(completedStates, []);
+
+    coordinator.markEnd("renderEnded", 2);
+    assert.deepEqual(completedStates, ["renderEnded"]);
+  });
+});


### PR DESCRIPTION
## Summary

This extracts the SAB completion work from #2603 so it can be reviewed independently of UDO recycling and structured-array ownership.

- Wait for both worker release and terminal play-state completion.
- Scope completion signals to the active performance run.
- Prevent delayed signals from an earlier run from completing a newer run.