### PR TITLE
ci: add placeholder WASM test workflow

### DIFF
--- a/.github/workflows/csound_wasm_tests.yml
+++ b/.github/workflows/csound_wasm_tests.yml
@@ -1,0 +1,14 @@
+name: Csound WASM command-line tests
+
+on:
+  workflow_run:
+    workflows: ["csound_wasm"]
+    types: [completed]
+
+jobs:
+  commandline-tests:
+    name: CSD tests with Wasmtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo true


### PR DESCRIPTION
A side-pr, needed for https://github.com/csound/csound/pull/2606/changes so that the workflow exists on develop and then it can be triggered on pushes to PR targeting develop