### PR TITLE
fix(parser): preserve newline suppression in nested parentheses

### DIFF
--- a/Engine/csound_orc.lex
+++ b/Engine/csound_orc.lex
@@ -93,7 +93,6 @@ RSTR            "R{"
 ERSTR           "}R"
 
 
-%s ignorenewline
 %x line
 %x sline
 %x src
@@ -536,9 +535,12 @@ ERSTR           "}R"
                   /* csound->Message(csound,"%s -> %d\n",
                                      yytext, (*lvalp)->type); */
                   return (*lvalp)->type; }
-{IDENTB}        { if (UNLIKELY(strchr(yytext, '\n')))
+{IDENTB}        { PARM->paren_depth++;
+                  if (UNLIKELY(strchr(yytext, '\n'))) {
+                       yycolumn = 1;
                        csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                             yyscanner);
+                  }
                   *strrchr(yytext, '(') = '\0';
                   *lvalp = lookup_token(csound, yytext, yyscanner);
                   return (*lvalp)->type+1; }
@@ -546,9 +548,12 @@ ERSTR           "}R"
                   /* csound->Message(csound,"%s -> %d\n",
                                      yytext, (*lvalp)->type); */
                   return (*lvalp)->type; }
-{TYPED_IDENTIFIERB} { if (UNLIKELY(strchr(yytext, '\n')))
+{TYPED_IDENTIFIERB} { PARM->paren_depth++;
+                      if (UNLIKELY(strchr(yytext, '\n'))) {
+                           yycolumn = 1;
                            csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
                                                 yyscanner);
+                      }
                       *strrchr(yytext, '(') = '\0';
                       *lvalp = lookup_token(csound, yytext, yyscanner);
                       return (*lvalp)->type+1; }
@@ -557,10 +562,11 @@ ERSTR           "}R"
                     /*csound->Message(csound,"%d\n", (*lvalp)->type);*/
                     return ((*lvalp)->type);
                 }
-{LPAREN}     { BEGIN(ignorenewline);
+{LPAREN}     { PARM->paren_depth++;
                return *yytext; }
 
-{RPAREN}     { BEGIN(INITIAL);
+{RPAREN}     { if (PARM->paren_depth > 0)
+                 PARM->paren_depth--;
                return *yytext; }
 
 {SYMBOL}     { return *yytext;}
@@ -600,18 +606,11 @@ ERSTR           "}R"
                   yyterminate();
                 }
 
-<ignorenewline>{
-  "\n" {
-    yycolumn = 1;
-    csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
-                                         yyscanner);
-  }
-}
-
 <INITIAL>"\n" { yycolumn = 1;
-                csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
-                                       yyscanner);
-                return NEWLINE; }
+                 csound_orcset_lineno(1+csound_orcget_lineno(yyscanner),
+                                      yyscanner);
+                 if (PARM->paren_depth == 0)
+                   return NEWLINE; }
 
 %%
 
@@ -762,5 +761,4 @@ uint32_t csound_orcget_last_column(void *yyscanner)
   //   struct yyguts_t *yyg  = (struct yyguts_t*)yyscanner;
     return PARM->last_column;
 }
-
 

--- a/Engine/parse_param.h
+++ b/Engine/parse_param.h
@@ -59,6 +59,7 @@ typedef struct parse_parm_s {
     uint64_t        ilocn;      /* and location */
     uint32_t        first_column;
     uint32_t        last_column;  
+    uint32_t        paren_depth;  /* suppress newlines inside parentheses */
     int             xsubstr;    /* count for substr */
 } PARSE_PARM;
 

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -591,7 +591,7 @@ TEST_F (OrcCompileTests, testColumnNumbersContinuation)
     csoundDeleteTree(csound, tree);
 }
 
-// Test column tracking inside parentheses (ignorenewline state)
+// Test column tracking inside parentheses (parenthesis depth)
 // Newlines inside parens should reset yycolumn but not return NEWLINE.
 // Note: the parser expands (100 + 200) into an implicit ##add node
 // with a temp #i0 variable, so the AST has 3 statements:
@@ -599,7 +599,7 @@ TEST_F (OrcCompileTests, testColumnNumbersContinuation)
 TEST_F (OrcCompileTests, testColumnNumbersIgnoreNewline)
 {
     const char *orc = "instr 1\n"
-                      "k1 = (100 +\n"      // line 2: ( triggers ignorenewline
+                      "k1 = (100 +\n"      // line 2: ( increments parenthesis depth
                       " 200)\n"             // line 3: 200 at cols 2-4
                       "k2 = 300\n"          // line 4: k2 at cols 1-2
                       "endin\n";

--- a/tests/commandline/test_commandline_args.csd
+++ b/tests/commandline/test_commandline_args.csd
@@ -12,12 +12,16 @@ instr 1
     exitnow(1)
   endif
 
-  if (strcmp(Sarguments[0], "concert.orc") != 0 || \
-      strcmp(Sarguments[1], "first violin") != 0 || \
-      strcmp(Sarguments[2], "--logfile=ignored") != 0 || \
-      strcmp(Sarguments[3], "") != 0) then
-    prints "argv values failed: '%s', '%s', '%s', '%s'\n", \
+  if (
+    strcmp(Sarguments[0], "concert.orc") != 0 ||
+    strcmp(Sarguments[1], "first violin") != 0 ||
+    strcmp(Sarguments[2], "--logfile=ignored") != 0 ||
+    strcmp(Sarguments[3], "") != 0
+  ) then
+    prints(
+      "argv values failed: '%s', '%s', '%s', '%s'\n",
       Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    )
     exitnow(1)
   endif
 endin

--- a/tests/commandline/test_commandline_overrides_csoptions_args.csd
+++ b/tests/commandline/test_commandline_overrides_csoptions_args.csd
@@ -12,12 +12,16 @@ instr 1
     exitnow(1)
   endif
 
-  if (strcmp(Sarguments[0], "concert.orc") != 0 || \
-      strcmp(Sarguments[1], "first violin") != 0 || \
-      strcmp(Sarguments[2], "--logfile=ignored") != 0 || \
-      strcmp(Sarguments[3], "") != 0) then
-    prints "command line did not override CsOptions: '%s', '%s', '%s', '%s'\n", \
+  if (
+    strcmp(Sarguments[0], "concert.orc") != 0 ||
+    strcmp(Sarguments[1], "first violin") != 0 ||
+    strcmp(Sarguments[2], "--logfile=ignored") != 0 ||
+    strcmp(Sarguments[3], "") != 0
+  ) then
+    prints(
+      "command line did not override CsOptions: '%s', '%s', '%s', '%s'\n",
       Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    )
     exitnow(1)
   endif
 endin

--- a/tests/commandline/test_csoptions_args.csd
+++ b/tests/commandline/test_csoptions_args.csd
@@ -12,12 +12,16 @@ instr 1
     exitnow(1)
   endif
 
-  if (strcmp(Sarguments[0], "options.orc") != 0 || \
-      strcmp(Sarguments[1], "viola section") != 0 || \
-      strcmp(Sarguments[2], "--from=csoptions") != 0 || \
-      strcmp(Sarguments[3], "") != 0) then
-    prints "argv values failed: '%s', '%s', '%s', '%s'\n", \
+  if (
+    strcmp(Sarguments[0], "options.orc") != 0 ||
+    strcmp(Sarguments[1], "viola section") != 0 ||
+    strcmp(Sarguments[2], "--from=csoptions") != 0 ||
+    strcmp(Sarguments[3], "") != 0
+  ) then
+    prints(
+      "argv values failed: '%s', '%s', '%s', '%s'\n",
       Sarguments[0], Sarguments[1], Sarguments[2], Sarguments[3]
+    )
     exitnow(1)
   endif
 endin

--- a/tests/commandline/test_newlines_within_function_calls.csd
+++ b/tests/commandline/test_newlines_within_function_calls.csd
@@ -16,6 +16,38 @@ prints(
   "Test: %d\n", 
   1))
 
+iGrouped = (
+  1 +
+  2
+)
+prints "Grouped expression: %d\n", iGrouped
+
+iNested = (
+  1 +
+  (
+    2 +
+    3
+  ) +
+  4
+)
+prints "Nested expression: %d\n", iNested
+
+iFunction = int(
+  1 +
+  2
+)
+prints "Function expression: %d\n", iFunction
+
+iNestedFunction = (
+  1 +
+  int(
+    2 +
+    3
+  ) +
+  4
+)
+prints "Nested function expression: %d\n", iNestedFunction
+
 endin
 
 </CsInstruments>
@@ -26,4 +58,3 @@ e
 
 </CsScore>
 </CsoundSynthesizer>
-

--- a/tests/commandline/test_newlines_within_function_calls.csd
+++ b/tests/commandline/test_newlines_within_function_calls.csd
@@ -48,6 +48,21 @@ iNestedFunction = (
 )
 prints "Nested function expression: %d\n", iNestedFunction
 
+; Nested string delimiters and parentheses must not affect the outer call.
+prints(
+  {{
+Nested extended string with parentheses:
+{{inner (text)}}
+}}
+)
+
+prints(
+  R{
+Nested raw string with parentheses:
+R{inner (text)}R
+}R
+)
+
 endin
 
 </CsInstruments>

--- a/tests/commandline/udo/pass_by_ref.csd
+++ b/tests/commandline/udo/pass_by_ref.csd
@@ -192,11 +192,21 @@ opcode LowpassByReference(input:a, coefficient1:k, coefficient2:k):a
 endop
 
 
-opcode RecursiveLowpassByReference(signal:a, coefficient1:k, coefficient2:k, \
-                                   depth:p, count:p):a
+opcode RecursiveLowpassByReference(
+    signal:a,
+    coefficient1:k,
+    coefficient2:k,
+    depth:p,
+    count:p
+):a
     if (count < depth) then
-        signal = RecursiveLowpassByReference(signal, coefficient1, \
-                                             coefficient2, depth, count + 1)
+        signal = RecursiveLowpassByReference(
+            signal,
+            coefficient1,
+            coefficient2,
+            depth,
+            count + 1
+        )
     endif
     xout LowpassByReference(signal, coefficient1, coefficient2)
 endop
@@ -590,8 +600,12 @@ instr 37
     input:a = oscili(0.5, 220)
     coefficient:k = linseg(0.2, p3, 0.8)
     byCopy:a RecursiveLowpassByCopy input, coefficient, 1 - coefficient, 10
-    byReference:a = RecursiveLowpassByReference(input, coefficient, \
-                                                 1 - coefficient, 10)
+    byReference:a = RecursiveLowpassByReference(
+        input,
+        coefficient,
+        1 - coefficient,
+        10
+    )
     difference:a = byCopy - byReference
     peakError:k peak difference
     outputPeak:k peak byCopy

--- a/tests/regression/conditional.csd
+++ b/tests/regression/conditional.csd
@@ -5,9 +5,11 @@
 instr 1
  i_value = 0
  i_value2 = 0
- i_value = (i_value2 == 0) ? i_value :\
-           (i_value < 0) ? (1 / floor(i_value)) :\
-           (i_value > 0) ? (1 / ceil(i_value)) : 0
+ i_value = (
+   (i_value2 == 0) ? i_value :
+   (i_value < 0) ? (1 / floor(i_value)) :
+   (i_value > 0) ? (1 / ceil(i_value)) : 0
+ )
 
  print i_value
 endin


### PR DESCRIPTION
Csound already suppresses newlines inside parenthesized expressions, but the lexer previously tracked this with a single `ignorenewline` state.

That breaks for nested parentheses because encountering any `)` restores normal newline handling, even when an outer parenthesis is still open. Function and opcode-call  tokens also consume their opening `(` directly, bypassing the existing lexer state.

This change:

- Replaces the lexer state with a per-parser parenthesis depth counter.
- Tracks opening parentheses consumed by function and opcode-call tokens.
- Resumes emitting `NEWLINE` only after the outermost parenthesis closes.
- Extends the existing newline parser test with grouped, nested, function-call, and nested-function expressions.