### PR TITLE
Missing newline when no errors are found

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -530,7 +530,7 @@ int32_t csound_cleanup(CSOUND *csound)
       if(csound->perferrcnt > 0) {
         csound->ErrorMsg(csound, Str("\n%d errors in performance\n"),
                          csound->perferrcnt);
-      }
+      } else  csound->ErrorMsg(csound, "\n");
       
       /* Print unit test report if enabled */
       if (csound->oparms->runUnitTests) {


### PR DESCRIPTION
A recent PR removed printing the number of found errors when that is 0. However that also took away a newline in the stderr stream before the final msg is printed. This fixes the problem