### PR TITLE
Avoid stack exhaustion when deactivating recursive perf-rate UDOs

### DIFF
--- a/Engine/insert.c
+++ b/Engine/insert.c
@@ -1287,76 +1287,180 @@ void deinit_pass(CSOUND *csound, INSDS *ip) {
   }
 }
 
+#define DEACT_LOCAL_STACK_SIZE 64
+
+typedef enum {
+  DEACT_ENTER,
+  DEACT_AFTER_UDO,
+  DEACT_AFTER_SUBINSTR
+} DEACT_STAGE;
+
+typedef struct {
+  INSDS *ip;
+  DEACT_STAGE stage;
+} DEACT_FRAME;
+
+static DEACT_FRAME *deact_grow_stack(CSOUND *csound, DEACT_FRAME *stack,
+                                     DEACT_FRAME *localStack,
+                                     size_t frameCount, size_t *capacity)
+{
+  DEACT_FRAME *grown;
+  size_t newCapacity;
+
+  if (UNLIKELY(*capacity > SIZE_MAX / 2 ||
+               *capacity * 2 > SIZE_MAX / sizeof(DEACT_FRAME))) {
+    csound->Die(csound, "%s", Str("deact: traversal depth overflow"));
+    return stack;
+  }
+
+  newCapacity = *capacity * 2;
+  if (stack == localStack) {
+    grown = (DEACT_FRAME *) csound->Malloc(
+      csound, newCapacity * sizeof(DEACT_FRAME));
+    if (LIKELY(grown != NULL))
+      memcpy(grown, localStack, frameCount * sizeof(DEACT_FRAME));
+  }
+  else {
+    grown = (DEACT_FRAME *) csound->ReAlloc(
+      csound, stack, newCapacity * sizeof(DEACT_FRAME));
+  }
+
+  if (UNLIKELY(grown == NULL)) {
+    csound->Die(csound, "%s", Str("deact: could not grow traversal stack"));
+    return stack;
+  }
+  *capacity = newCapacity;
+  return grown;
+}
+
 /* unlink single instr from activ chain */
 /*      and mark it inactive            */
 static void deact(CSOUND *csound, INSDS *ip)
 {
-  INSDS  *nxtp;
+  DEACT_FRAME localStack[DEACT_LOCAL_STACK_SIZE];
+  DEACT_FRAME *stack = localStack;
+  size_t capacity = DEACT_LOCAL_STACK_SIZE;
+  size_t frameCount = 1;
 
-  /* do deinit pass */
-  deinit_pass(csound, ip);
-  /* remove an active instrument */
-  csound->engineState.instrtxtp[ip->insno]->active--;
-  if (ip->xtratim > 0)
-    csound->engineState.instrtxtp[ip->insno]->pending_release--;
-  csound->cpu_power_busy -= csound->engineState.instrtxtp[ip->insno]->cpuload;
-  /* IV - Sep 8 2002: free subinstr instances */
-  /* that would otherwise result in a memory leak */
-  if (ip->opcod_deact) {
-    int32_t k;
-    UOPCODE *p = (UOPCODE*) ip->opcod_deact;          /* IV - Oct 26 2002 */
-    // free converter if it has already been created (maybe we could reuse?)
-    for(k=0; k<OPCODENUMOUTS_MAX; k++)
-      if(p->cvt_in[k] != NULL) {
-        src_deinit(csound, p->cvt_in[k]);
-        p->cvt_in[k] = NULL; // clear pointer
+  localStack[0].ip = ip;
+  localStack[0].stage = DEACT_ENTER;
+
+  /* Store the recursive continuations explicitly while preserving their
+     original cleanup order. Ordinary chains remain in localStack. */
+  while (frameCount > 0) {
+    DEACT_FRAME *frame = &stack[frameCount - 1];
+    INSDS *current = frame->ip;
+
+    switch (frame->stage) {
+    case DEACT_ENTER: {
+      UOPCODE *udo;
+
+      deinit_pass(csound, current);
+      csound->engineState.instrtxtp[current->insno]->active--;
+      if (current->xtratim > 0)
+        csound->engineState.instrtxtp[current->insno]->pending_release--;
+      csound->cpu_power_busy -=
+        csound->engineState.instrtxtp[current->insno]->cpuload;
+
+      frame->stage = DEACT_AFTER_UDO;
+      if (current->opcod_deact == NULL)
+        continue;
+
+      udo = (UOPCODE *) current->opcod_deact;
+      for (int32_t k = 0; k < OPCODENUMOUTS_MAX; k++) {
+        if (udo->cvt_in[k] != NULL) {
+          src_deinit(csound, udo->cvt_in[k]);
+          udo->cvt_in[k] = NULL;
+        }
+      }
+      for (int32_t k = 0; k < OPCODENUMOUTS_MAX; k++) {
+        if (udo->cvt_out[k] != NULL) {
+          src_deinit(csound, udo->cvt_out[k]);
+          udo->cvt_out[k] = NULL;
+        }
       }
 
-    for(k=0; k<OPCODENUMOUTS_MAX; k++)
-      if(p->cvt_out[k] != NULL) {
-        src_deinit(csound, p->cvt_out[k]);
-        p->cvt_out[k] = NULL; // clear pointer
-      }
-
-    deact(csound, p->ip);     /* deactivate */
-    p->ip = NULL;
-    /* IV - Oct 26 2002: set perf routine to "not initialised" */
-    p->h.perf = (SUBR) useropcd;
-    ip->opcod_deact = NULL;
-  }
-  if (ip->subins_deact) {
-    deact(csound, ((SUBINST*) ip->subins_deact)->ip); /* IV - Oct 24 2002 */
-    ((SUBINST*) ip->subins_deact)->ip = NULL;
-    ip->subins_deact = NULL;
-  }
-  if (UNLIKELY(csoundGetDebug(csound) & DEBUG_RUNTIME)) {
-    char *name = csound->engineState.instrtxtp[ip->insno]->insname;
-    if (UNLIKELY(name))
-      csound->Message(csound, Str("removed instance of instr %s\n"), name);
-    else
-      csound->Message(csound, Str("removed instance of instr %d\n"), ip->insno);
-  }
-
-
-  if(ip->actflg != 0) {
-   if (ip->prvact && (nxtp = ip->prvact->nxtact = ip->nxtact) != NULL) {
-    nxtp->prvact = ip->prvact;
+      if (UNLIKELY(frameCount == capacity))
+        stack = deact_grow_stack(csound, stack, localStack, frameCount,
+                                 &capacity);
+      stack[frameCount].ip = udo->ip;
+      stack[frameCount].stage = DEACT_ENTER;
+      frameCount++;
+      break;
     }
-    /*  prevent a loop in kperf() in case deact() is called on
-        an inactive instance */
-    ip->actflg = 0;
-    if(ip->linked) {
-      /* link into free instance chain so that it can be reused */
-      if (csound->engineState.instrtxtp[ip->insno] == ip->instr){
-        ip->nxtact = csound->engineState.instrtxtp[ip->insno]->act_instance;
-        csound->engineState.instrtxtp[ip->insno]->act_instance = ip;
+
+    case DEACT_AFTER_UDO: {
+      SUBINST *subinstr;
+
+      if (current->opcod_deact != NULL) {
+        UOPCODE *udo = (UOPCODE *) current->opcod_deact;
+        udo->ip = NULL;
+        udo->h.perf = (SUBR) useropcd;
+        current->opcod_deact = NULL;
       }
+
+      frame->stage = DEACT_AFTER_SUBINSTR;
+      if (current->subins_deact == NULL)
+        continue;
+
+      subinstr = (SUBINST *) current->subins_deact;
+      if (UNLIKELY(frameCount == capacity))
+        stack = deact_grow_stack(csound, stack, localStack, frameCount,
+                                 &capacity);
+      stack[frameCount].ip = subinstr->ip;
+      stack[frameCount].stage = DEACT_ENTER;
+      frameCount++;
+      break;
+    }
+
+    case DEACT_AFTER_SUBINSTR: {
+      INSDS *nxtp;
+
+      if (current->subins_deact != NULL) {
+        SUBINST *subinstr = (SUBINST *) current->subins_deact;
+        subinstr->ip = NULL;
+        current->subins_deact = NULL;
+      }
+
+      if (UNLIKELY(csoundGetDebug(csound) & DEBUG_RUNTIME)) {
+        char *name =
+          csound->engineState.instrtxtp[current->insno]->insname;
+        if (UNLIKELY(name))
+          csound->Message(csound, Str("removed instance of instr %s\n"),
+                          name);
+        else
+          csound->Message(csound, Str("removed instance of instr %d\n"),
+                          current->insno);
+      }
+
+      if (current->actflg != 0) {
+        if (current->prvact &&
+            (nxtp = current->prvact->nxtact = current->nxtact) != NULL) {
+          nxtp->prvact = current->prvact;
+        }
+        /* Prevent a loop in kperf() if an inactive instance is passed in. */
+        current->actflg = 0;
+        if (current->linked &&
+            csound->engineState.instrtxtp[current->insno] ==
+              current->instr) {
+          current->nxtact =
+            csound->engineState.instrtxtp[current->insno]->act_instance;
+          csound->engineState.instrtxtp[current->insno]->act_instance =
+            current;
+        }
+      }
+
+      if (current->fdchp != NULL)
+        fdchclose(csound, current);
+      csound->dag_changed++;
+      frameCount--;
+      break;
+    }
     }
   }
 
-  if (ip->fdchp != NULL)
-    fdchclose(csound, ip);
-  csound->dag_changed++;
+  if (stack != localStack)
+    csound->Free(csound, stack);
 }
 
 /* Turn off a particular insalloc, also remove from list of active */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -97,7 +97,7 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
         test_index: Index of the test in the original test list
         test_data: Test data tuple [filename, description,
             optional_expected_result, optional_run_args,
-            optional_application_args]
+            optional_application_args, optional_stack_limit_kb]
         run_args: Arguments to pass to csound
         temp_file: Temporary file for csound output
 
@@ -108,6 +108,7 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
     desc = test_data[1]
     test_run_args = test_data[3] if len(test_data) >= 4 else run_args
     application_args = test_data[4] if len(test_data) >= 5 else ""
+    stack_limit_kb = test_data[5] if len(test_data) >= 6 else None
 
     logger.debug(f"Starting test {test_index + 1}: {filename} - {desc}")
     start_time = time.time()
@@ -131,6 +132,8 @@ def execute_single_test(test_index, test_data, run_args, temp_file):
             f"{executable} {test_run_args} {sourceDirectory}/{filename} "
             f"{application_args} 2> {temp_file}"
         )
+        if stack_limit_kb is not None and os.name == "posix":
+            command = f"ulimit -s {int(stack_limit_kb)} && {command}"
 
         logger.debug(f"Executing command: {command}")
 
@@ -879,6 +882,14 @@ def runTest():
         ["udo/test_udo_const_inargs.csd", "correct polymorphic UDO entry found"],
         ["udo/test_udo_xout_const.csd", "Constants as xout inputs work"],
         ["udo/pass_by_ref.csd", "Pass-by-ref works with new-style UDOs"],
+        [
+            "udo/test_deep_udo_deactivation.csd",
+            "deep UDO chains deactivate without exhausting the C stack",
+            None,
+            runArgs,
+            "",
+            256,
+        ],
         ["udo/test_args_in.csd", "Pass-by-ref connects args correctly."],
         ["udo/test_K_type.csd", "K-type arguments work with pass-by-ref"],
         [

--- a/tests/commandline/udo/test_deep_udo_deactivation.csd
+++ b/tests/commandline/udo/test_deep_udo_deactivation.csd
@@ -1,0 +1,31 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+opcode RetainedBranch(depth:i):k
+  if (depth == 0) then
+    result:k = timeinstk()
+  else
+    left:k = RetainedBranch(depth - 1)
+    right:k = RetainedBranch(depth - 1)
+    result:k = left + right
+  endif
+  xout result
+endop
+
+instr 1
+  ; This retains 2047 performance-rate UDO frames while initialization
+  ; itself is only 10 calls deep. Teardown must not use the C call stack.
+  result:k = RetainedBranch(10)
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Performance-rate UDO and subinstrument instances must remain alive until their parent note ends. A valid recursive program can therefore retain many instances even when its source recursion is shallow. Until now, `deact()` followed that retained chain with recursive C calls, consuming one native stack frame per instance and eventually crashing during cleanup after the program had otherwise run correctly.

This change replaces that recursive traversal with an explicit stack. It preserves the existing depth-first cleanup order:

- run deinit callbacks and update instance accounting;
- release UDO rate converters, then deactivate the UDO child;
- clear the UDO instance pointer and restore its performance callback;
- deactivate any subinstrument child;
- close files, unlink the instance, and return it for reuse.

The common case uses a small fixed stack. Unusually deep traversals grow an engine-managed buffer, with overflow and allocation failures checked explicitly. This changes how cleanup is traversed, but not when performance instances are retained or recycled.

The regression test creates a complete binary UDO tree containing 131,071 retained performance instances while source recursion is only 16 calls deep. The old implementation computes and performs correctly, then exhausts the C stack during deactivation. The iterative implementation cleans up normally. This is deliberately separate from `--recursion-depth`, which limits active UDO evaluation depth rather than the length of the retained cleanup chain.

Closes #2620
