### PR TITLE
fix for diskin2 async failure: join I/O threads before freeing instance memory

### DIFF
--- a/OOps/diskin2.c
+++ b/OOps/diskin2.c
@@ -550,9 +550,6 @@ static int32_t diskin2_reset_callback(CSOUND *csound, void *p) {
       pt = csound->QueryGlobalVariable(csound, "DISKIN_PTHREAD");
       if (pt != NULL && *pt != NULL)
         csound->JoinThread(*pt);
-      csound->DestroyGlobalVariable(csound, "DISKIN_PTHREAD");
-      csound->DestroyGlobalVariable(csound, "DISKIN_THREAD_START");
-      csound->DestroyGlobalVariable(csound, "DISKIN_INST");
     }
 #endif
     return OK;
@@ -569,9 +566,6 @@ static int32_t diskin2_reset_callback_array(CSOUND *csound, void *p) {
       pt = csound->QueryGlobalVariable(csound, "DISKIN_PTHREAD_ARRAY");
       if (pt != NULL && *pt != NULL)
         csound->JoinThread(*pt);
-      csound->DestroyGlobalVariable(csound, "DISKIN_PTHREAD_ARRAY");
-      csound->DestroyGlobalVariable(csound, "DISKIN_THREAD_START_ARRAY");
-      csound->DestroyGlobalVariable(csound, "DISKIN_INST_ARRAY");
     }
 #endif
     return OK;

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1868,14 +1868,16 @@ static void reset(CSOUND *csound) {
     ATOMIC_SET(csound->parflag,!csound->parflag);
 #endif
   }
-  csound_cleanup(csound);
-  /* call registered reset callbacks */
+  /* call registered reset callbacks before csound_cleanup so that
+     any I/O threads (e.g. diskin2 async) are joined before their
+     instance memory is freed by free_inactive_instances. */
   while (csound->reset_list != NULL) {
     resetCallback_t *p = (resetCallback_t *)csound->reset_list;
     p->func(csound, p->userData);
     csound->reset_list = (void *)p->nxt;
     free(p);
   }
+  csound_cleanup(csound);
   /* call local destructor routines of external modules */
   /* should check return value... */
   csoundDestroyModules(csound);


### PR DESCRIPTION
This may be a regression - diskin2 async test started failing again. But it may not be either. 

In reset(), csound_cleanup() was called before the registered reset callbacks. csound_cleanup() calls free_inactive_instances() which frees the DISKIN2/DISKIN2_ARRAY instance structs, but the async I/O threads (diskin_io_thread / diskin_io_thread_array) were still running and accessing that memory. The reset callbacks that join those threads ran too late.

This caused a heap-use-after-free detected by AddressSanitizer in diskin_file_read_array (diskin2.c:1251) during csound teardown.

Fix by:
- Moving the reset callback invocation before csound_cleanup() so I/O threads are stopped and joined before free_inactive_instances() reclaims their memory.
- Removing DestroyGlobalVariable calls from diskin2_reset_callback and diskin2_reset_callback_array, since csound_cleanup() still needs those globals (DISKIN_INST, DISKIN_THREAD_START, etc.) for diskin2_async_deinit_array to unlink instances from the chain. The globals are cleaned up by csoundDeleteAllGlobalVariables() later in reset().

Fix by opencode (Big Pickle).