### PR TITLE
shorten 64 to 32 warning fix

### DIFF
--- a/InOut/rtjack.c
+++ b/InOut/rtjack.c
@@ -397,7 +397,7 @@ static void openJackStreams(RtJackGlobals *p)
     csound->GetSystemSr(csound, jack_sr);
     if (O->msglevel || O->odebug)
       csound->Message(csound, "system sr: %f\n", csound->GetSystemSr(csound, 0));
-    if(p->sampleRate < 0) p->sampleRate = jack_sr;
+    if(p->sampleRate < 0) p->sampleRate = (int32_t) jack_sr;
 
     /* check consistency of parameters */
     if (UNLIKELY(p->nChannels < 1 || p->nChannels > 255))


### PR DESCRIPTION
Code is not passing my strict warning flags - shortening 64 to 32. This fixes the problem