### PR TITLE
fix(wasm): handle secure microphone input

### DIFF
--- a/wasm/browser/README.md
+++ b/wasm/browser/README.md
@@ -11,6 +11,25 @@ ScriptProcessorNode support has been removed from the library. ScriptProcessorNo
 
 **Migration:** If you were using `useSPN: true`, simply remove this parameter. The library will automatically use the superior AudioWorklet API.
 
+## Microphone input
+
+Browser microphone access requires a secure context. Use HTTPS for deployed
+applications. For local development, use `http://localhost` or a loopback
+address such as `http://127.0.0.1`. A computer name or LAN address served over
+HTTP does not count as secure, even when it points to the same computer.
+
+Set the Csound input option to `-iadc` before calling `start()`. Worker modes
+detect this option and request microphone permission during startup. A direct
+call to `enableAudioInput()` only applies to the single-thread mode; worker
+modes ignore it. The returned promise rejects when the browser cannot provide
+microphone access.
+
+When Csound runs in an iframe, the parent page must also allow microphone
+access through its Permissions Policy.
+
+See the
+[MediaDevices.getUserMedia documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#privacy_and_security)
+for browser security and permission rules.
 
 ## Api Documentation
 

--- a/wasm/browser/README.md
+++ b/wasm/browser/README.md
@@ -18,11 +18,15 @@ applications. For local development, use `http://localhost` or a loopback
 address such as `http://127.0.0.1`. A computer name or LAN address served over
 HTTP does not count as secure, even when it points to the same computer.
 
-Set the Csound input option to `-iadc` before calling `start()`. Worker modes
-detect this option and request microphone permission during startup. A direct
-call to `enableAudioInput()` only applies to the single-thread mode; worker
-modes ignore it. The returned promise rejects when the browser cannot provide
-microphone access.
+Call `await csound.enableAudioInput()` before `start()` to set the Csound input
+option, request microphone permission, and prepare the input stream. This works
+in single-thread, worker, and SharedArrayBuffer modes. The returned promise
+rejects when the browser cannot provide microphone access.
+
+You can instead set the Csound input option to `-iadc` in a CSD or with
+`setOption()`. Each mode detects this option and requests microphone access
+during startup. Use `enableAudioInput()` when the application needs to handle
+permission errors before it starts Csound.
 
 When Csound runs in an iframe, the parent page must also allow microphone
 access through its Permissions Policy.

--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -490,9 +490,10 @@ declare interface CsoundObj {
    */
   terminateInstance: () => Promise<void>;
   /**
-   * Requests microphone access and connects it to Csound in single-thread mode.
-   * Requires HTTPS, localhost, or a loopback address. In worker modes, set
-   * `-iadc` before calling `start()` instead.
+   * Sets `-iadc`, requests microphone access, and prepares the input stream.
+   * Call this before `start()`. Works in all modes and rejects when the browser
+   * cannot provide microphone access. Requires HTTPS, localhost, or a loopback
+   * address.
    */
   enableAudioInput: () => Promise<void>;
   /**

--- a/wasm/browser/index.d.ts
+++ b/wasm/browser/index.d.ts
@@ -490,7 +490,9 @@ declare interface CsoundObj {
    */
   terminateInstance: () => Promise<void>;
   /**
-   * Enable audio input functionality
+   * Requests microphone access and connects it to Csound in single-thread mode.
+   * Requires HTTPS, localhost, or a loopback address. In worker modes, set
+   * `-iadc` before calling `start()` instead.
    */
   enableAudioInput: () => Promise<void>;
   /**

--- a/wasm/browser/script/generate-readme.mjs
+++ b/wasm/browser/script/generate-readme.mjs
@@ -18,11 +18,15 @@ applications. For local development, use \`http://localhost\` or a loopback
 address such as \`http://127.0.0.1\`. A computer name or LAN address served over
 HTTP does not count as secure, even when it points to the same computer.
 
-Set the Csound input option to \`-iadc\` before calling \`start()\`. Worker modes
-detect this option and request microphone permission during startup. A direct
-call to \`enableAudioInput()\` only applies to the single-thread mode; worker
-modes ignore it. The returned promise rejects when the browser cannot provide
-microphone access.
+Call \`await csound.enableAudioInput()\` before \`start()\` to set the Csound
+input option, request microphone permission, and prepare the input stream. This
+works in single-thread, worker, and SharedArrayBuffer modes. The returned
+promise rejects when the browser cannot provide microphone access.
+
+You can instead set the Csound input option to \`-iadc\` in a CSD or with
+\`setOption()\`. Each mode detects this option and requests microphone access
+during startup. Use \`enableAudioInput()\` when the application needs to handle
+permission errors before it starts Csound.
 
 When Csound runs in an iframe, the parent page must also allow microphone
 access through its Permissions Policy.

--- a/wasm/browser/script/generate-readme.mjs
+++ b/wasm/browser/script/generate-readme.mjs
@@ -3,8 +3,37 @@ const title = `# @csound/browser`;
 const npmShield = `[![npm (scoped with tag)](https://shields.shivering-isles.com/npm/v/@csound/browser/latest)](https://www.npmjs.com/package/@csound/browser)`;
 const prettierShield = `[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)`;
 const workflowShield = `[![GitHub Workflow Status](https://shields.shivering-isles.com/github/workflow/status/csound/csound/csound_wasm)](https://github.com/csound/csound/actions?query=workflow%3Acsound_wasm)`;
+const breakingChangesSection = `## Breaking Changes
+
+### ScriptProcessorNode Support Removed (v7.0.0+)
+
+ScriptProcessorNode support has been removed from the library. ScriptProcessorNode was deprecated in 2014 and provides inferior performance compared to AudioWorklet. All modern browsers (Chrome 64+, Firefox 76+, Safari 14.1+) support AudioWorklet.
+
+**Migration:** If you were using \`useSPN: true\`, simply remove this parameter. The library will automatically use the superior AudioWorklet API.
+`;
+const microphoneInputSection = `## Microphone input
+
+Browser microphone access requires a secure context. Use HTTPS for deployed
+applications. For local development, use \`http://localhost\` or a loopback
+address such as \`http://127.0.0.1\`. A computer name or LAN address served over
+HTTP does not count as secure, even when it points to the same computer.
+
+Set the Csound input option to \`-iadc\` before calling \`start()\`. Worker modes
+detect this option and request microphone permission during startup. A direct
+call to \`enableAudioInput()\` only applies to the single-thread mode; worker
+modes ignore it. The returned promise rejects when the browser cannot provide
+microphone access.
+
+When Csound runs in an iframe, the parent page must also allow microphone
+access through its Permissions Policy.
+
+See the
+[MediaDevices.getUserMedia documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#privacy_and_security)
+for browser security and permission rules.
+`;
 const apiDocTitle = `## Api Documentation\n\n`;
-const licenseSection = `## License\n\n` +
+const licenseSection =
+  `## License\n\n` +
   `\`@csound/browser\` is licensed under the [Apache License 2.0](./LICENSE).\n\n` +
   `> **Note:** The \`@csound/wasm-bin\` package (which contains the compiled Csound WebAssembly binary) ` +
   `remains licensed under the GNU Lesser General Public License v2.1 (LGPL-2.1), as required by the ` +
@@ -19,6 +48,8 @@ jsdoc2md
         `${workflowShield}\n` +
         `${prettierShield}\n` +
         `\n\n` +
+        `${breakingChangesSection}\n` +
+        `${microphoneInputSection}\n` +
         `${apiDocTitle}${jsdocMarkdown}` +
         `\n${licenseSection}`,
     ),

--- a/wasm/browser/src/mains/io.utils.js
+++ b/wasm/browser/src/mains/io.utils.js
@@ -45,13 +45,29 @@ export const requestMicrophoneNode = async () => {
   });
 };
 
+const stopMicrophoneTracks = (stream) => {
+  stream?.getTracks().forEach((track) => track.stop());
+};
+
+const microphoneRequestCancelled = () => {
+  const error = new Error("Microphone request was cancelled because the Csound instance ended");
+  error.name = "AbortError";
+  return error;
+};
+
 export async function requestMicrophoneStream() {
   if (this.microphoneStream) {
     return this.microphoneStream;
   }
 
   if (!this.microphonePromise) {
+    const requestToken = {};
+    this.microphoneRequestToken = requestToken;
     const microphonePromise = requestMicrophoneNode().then((stream) => {
+      if (this.microphoneRequestToken !== requestToken) {
+        stopMicrophoneTracks(stream);
+        throw microphoneRequestCancelled();
+      }
       this.microphoneStream = stream;
       return stream;
     });
@@ -70,13 +86,18 @@ export async function requestMicrophoneStream() {
 }
 
 export const releaseMicrophoneStream = (owner) => {
+  const microphonePromise = owner.microphonePromise;
+  delete owner.microphoneRequestToken;
   if (owner.microphoneInput) {
     owner.microphoneInput.disconnect();
     delete owner.microphoneInput;
   }
   if (owner.microphoneStream) {
-    owner.microphoneStream.getTracks().forEach((track) => track.stop());
+    stopMicrophoneTracks(owner.microphoneStream);
     delete owner.microphoneStream;
+  }
+  if (microphonePromise) {
+    microphonePromise.then(stopMicrophoneTracks).catch(() => {});
   }
   delete owner.microphonePromise;
 };
@@ -100,6 +121,11 @@ export async function enableAudioInput() {
   console.log("enabling audio input");
   await setAudioInputOption(this.exportApi);
   const stream = await requestMicrophoneStream.call(this);
+
+  if (this.microphoneStream !== stream || !this.audioContext || !this.node) {
+    stopMicrophoneTracks(stream);
+    throw microphoneRequestCancelled();
+  }
 
   if (this.microphoneInput) {
     return;

--- a/wasm/browser/src/mains/io.utils.js
+++ b/wasm/browser/src/mains/io.utils.js
@@ -45,22 +45,80 @@ export const requestMicrophoneNode = async () => {
   });
 };
 
+export async function requestMicrophoneStream() {
+  if (this.microphoneStream) {
+    return this.microphoneStream;
+  }
+
+  if (!this.microphonePromise) {
+    const microphonePromise = requestMicrophoneNode().then((stream) => {
+      this.microphoneStream = stream;
+      return stream;
+    });
+    this.microphonePromise = microphonePromise;
+
+    try {
+      return await microphonePromise;
+    } finally {
+      if (this.microphonePromise === microphonePromise) {
+        delete this.microphonePromise;
+      }
+    }
+  }
+
+  return this.microphonePromise;
+}
+
+export const releaseMicrophoneStream = (owner) => {
+  if (owner.microphoneInput) {
+    owner.microphoneInput.disconnect();
+    delete owner.microphoneInput;
+  }
+  if (owner.microphoneStream) {
+    owner.microphoneStream.getTracks().forEach((track) => track.stop());
+    delete owner.microphoneStream;
+  }
+  delete owner.microphonePromise;
+};
+
+const setAudioInputOption = async (api) => {
+  const result = await api["setOption"]("-iadc");
+  if (result !== 0) {
+    throw new Error(`Could not set the Csound microphone input option: ${result}`);
+  }
+};
+
 // rebind this to exportApi instance to use
 /**
- * Requests browser microphone access and connects the stream to Csound.
- * This requires HTTPS, localhost, or a loopback address. Worker modes should
- * request input with `-iadc` before calling `start()` instead.
+ * Sets `-iadc`, requests browser microphone access, and connects the stream to
+ * Csound. This requires HTTPS, localhost, or a loopback address.
  *
  * @function
  * @returns {Promise<void>} Resolves after the microphone stream is connected.
  */
 export async function enableAudioInput() {
   console.log("enabling audio input");
-  const stream = await requestMicrophoneNode();
+  await setAudioInputOption(this);
+  const stream = await requestMicrophoneStream.call(this);
+
+  if (this.microphoneInput) {
+    return;
+  }
+
   const audioContext = await this["getAudioContext"]();
   const liveInput = audioContext.createMediaStreamSource(stream);
+  this.microphoneInput = liveInput;
   this.inputsCount = liveInput.channelCount;
 
   const node = await this["getNode"]();
   liveInput.connect(node);
+}
+
+export async function enableAudioInputInWorker() {
+  if (this.currentPlayState) {
+    throw new Error("enableAudioInput() must be called before start() in worker mode");
+  }
+
+  await setAudioInputOption(this.exportApi);
+  await this.audioWorker["requestMicrophoneInput"]();
 }

--- a/wasm/browser/src/mains/io.utils.js
+++ b/wasm/browser/src/mains/io.utils.js
@@ -13,50 +13,54 @@
  * limitations under the License.
  */
 
-export const requestMicrophoneNode = (microphoneCallback) => {
-  const getUserMedia =
-    navigator.mediaDevices === undefined
-      ? navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia
-      : navigator.mediaDevices.getUserMedia;
-
+export const requestMicrophoneNode = async () => {
   console.log("requesting microphone access");
-  navigator.mediaDevices === undefined
-    ? getUserMedia.call(
-        navigator,
-        {
-          audio: {
-            optional: [{ echoCancellation: false, sampleSize: 32 }],
-          },
+
+  if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+    return navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: false, sampleSize: 32 },
+    });
+  }
+
+  const legacyGetUserMedia =
+    navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+
+  if (!legacyGetUserMedia) {
+    throw new Error(
+      "Microphone input is unavailable. Use HTTPS, localhost, or a loopback address and allow microphone access.",
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    legacyGetUserMedia.call(
+      navigator,
+      {
+        audio: {
+          optional: [{ echoCancellation: false, sampleSize: 32 }],
         },
-        microphoneCallback,
-        console.error,
-      )
-    : getUserMedia
-        .call(navigator.mediaDevices, {
-          audio: { echoCancellation: false, sampleSize: 32 },
-        })
-        .then(microphoneCallback)
-        .catch(console.error);
+      },
+      resolve,
+      reject,
+    );
+  });
 };
 
 // rebind this to exportApi instance to use
 /**
+ * Requests browser microphone access and connects the stream to Csound.
+ * This requires HTTPS, localhost, or a loopback address. Worker modes should
+ * request input with `-iadc` before calling `start()` instead.
+ *
  * @function
- * @this {{
- * getNode: function(): Promise.<Object>,
- * getAudioContext: function(): Promise.<Object>,
- * }}
+ * @returns {Promise<void>} Resolves after the microphone stream is connected.
  */
 export async function enableAudioInput() {
   console.log("enabling audio input");
-  requestMicrophoneNode(async (stream) => {
-    if (stream) {
-      const audioContext = await this["getAudioContext"]();
-      const liveInput = audioContext.createMediaStreamSource(stream);
-      this.inputsCount = liveInput.channelCount;
+  const stream = await requestMicrophoneNode();
+  const audioContext = await this["getAudioContext"]();
+  const liveInput = audioContext.createMediaStreamSource(stream);
+  this.inputsCount = liveInput.channelCount;
 
-      const node = await this["getNode"]();
-      liveInput.connect(node);
-    }
-  });
+  const node = await this["getNode"]();
+  liveInput.connect(node);
 }

--- a/wasm/browser/src/mains/io.utils.js
+++ b/wasm/browser/src/mains/io.utils.js
@@ -88,7 +88,7 @@ const setAudioInputOption = async (api) => {
   }
 };
 
-// rebind this to exportApi instance to use
+// Bind this to the mutable single-thread main instance.
 /**
  * Sets `-iadc`, requests browser microphone access, and connects the stream to
  * Csound. This requires HTTPS, localhost, or a loopback address.
@@ -98,20 +98,18 @@ const setAudioInputOption = async (api) => {
  */
 export async function enableAudioInput() {
   console.log("enabling audio input");
-  await setAudioInputOption(this);
+  await setAudioInputOption(this.exportApi);
   const stream = await requestMicrophoneStream.call(this);
 
   if (this.microphoneInput) {
     return;
   }
 
-  const audioContext = await this["getAudioContext"]();
-  const liveInput = audioContext.createMediaStreamSource(stream);
+  const liveInput = this.audioContext.createMediaStreamSource(stream);
   this.microphoneInput = liveInput;
   this.inputsCount = liveInput.channelCount;
 
-  const node = await this["getNode"]();
-  liveInput.connect(node);
+  liveInput.connect(this.node);
 }
 
 export async function enableAudioInputInWorker() {

--- a/wasm/browser/src/mains/sab.main.js
+++ b/wasm/browser/src/mains/sab.main.js
@@ -29,6 +29,7 @@ import { csoundApiRename, fetchPlugins, makeProxyCallback, stopableStates } from
 import { EventPromises } from "../utils/event-promises";
 import { SABCompletionCoordinator } from "../utils/sab-completion-coordinator.js";
 import { PublicEventAPI } from "../events";
+import { enableAudioInputInWorker } from "./io.utils.js";
 import SABWorker from "../../dist/__compiled.sab.worker.inline.js";
 
 class SharedArrayBufferMainThread {
@@ -431,10 +432,7 @@ class SharedArrayBufferMainThread {
     this.exportApi["pause"] = this.csoundPause.bind(this);
     this.exportApi["resume"] = this.csoundResume.bind(this);
     this.exportApi["terminateInstance"] = this.terminateInstance.bind(this);
-    this.exportApi["enableAudioInput"] = () =>
-      console.warn(
-        `enableAudioInput was ignored: please use -iadc option before calling start with useWorker=true`,
-      );
+    this.exportApi["enableAudioInput"] = enableAudioInputInWorker.bind(this);
 
     this.exportApi["name"] = "Csound: Audio Worklet, Shared-Array Buffer";
 

--- a/wasm/browser/src/mains/vanilla.main.js
+++ b/wasm/browser/src/mains/vanilla.main.js
@@ -20,6 +20,7 @@ import { csoundApiRename, fetchPlugins, makeProxyCallback, stopableStates } from
 import { IPCMessagePorts, messageEventHandler } from "./messages.main";
 import { EventPromises } from "../utils/event-promises";
 import { PublicEventAPI } from "../events";
+import { enableAudioInputInWorker } from "./io.utils.js";
 import VanillaWorker from "../../dist/__compiled.vanilla.worker.inline.js";
 
 class VanillaWorkerMainThread {
@@ -250,10 +251,7 @@ class VanillaWorkerMainThread {
     };
 
     this.exportApi = this.publicEvents.decorateAPI(this.exportApi);
-    this.exportApi["enableAudioInput"] = () =>
-      console.warn(
-        `enableAudioInput was ignored: please use -iadc option before calling start with useWorker=true`,
-      );
+    this.exportApi["enableAudioInput"] = enableAudioInputInWorker.bind(this);
 
     this.exportApi["name"] = "Csound: Audio Worklet, Worker";
 

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -17,6 +17,7 @@ import * as Comlink from "../utils/comlink.js";
 import { logWorkletMain as log } from "../logger";
 import { WebkitAudioContext } from "../utils";
 import { requestMidi } from "../utils/request-midi";
+import { requestMicrophoneNode } from "./io.utils.js";
 import { messageEventHandler } from "./messages.main";
 import WorkletWorker from "../../dist/__compiled.worklet.worker.inline.js";
 
@@ -257,61 +258,35 @@ class AudioWorkletMainThread {
       });
     }
 
-    let microphonePromise;
-
     if (this.isRequestingInput) {
-      let resolveMicrophonePromise;
-      microphonePromise = new Promise((resolve) => {
-        resolveMicrophonePromise = resolve;
-      });
-      const getUserMedia =
-        navigator.mediaDevices === undefined
-          ? navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia
-          : navigator.mediaDevices.getUserMedia;
+      let stream;
+      try {
+        stream = await requestMicrophoneNode();
+      } catch (error) {
+        console.error(error);
+      }
 
-      const microphoneCallback = (stream) => {
-        if (stream) {
-          const liveInput = this.audioContext.createMediaStreamSource(stream);
-          this.inputsCount = liveInput.channelCount;
-          const newNode = this.createWorkletNode(
-            this.audioContext,
-            liveInput.channelCount,
-            contextUid,
-          );
-          this.audioWorkletNode = newNode;
-          if (this.autoConnect) {
-            liveInput.connect(newNode).connect(this.audioContext.destination);
-          }
-        } else {
-          // Continue as before if user cancels
-          this.inputsCount = 0;
-          const newNode = this.createWorkletNode(this.audioContext, 0, contextUid);
-          this.audioWorkletNode = newNode;
-          if (this.autoConnect) {
-            this.audioWorkletNode.connect(this.audioContext.destination);
-          }
+      if (stream) {
+        const liveInput = this.audioContext.createMediaStreamSource(stream);
+        this.inputsCount = liveInput.channelCount;
+        const newNode = this.createWorkletNode(
+          this.audioContext,
+          liveInput.channelCount,
+          contextUid,
+        );
+        this.audioWorkletNode = newNode;
+        if (this.autoConnect) {
+          liveInput.connect(newNode).connect(this.audioContext.destination);
         }
-        resolveMicrophonePromise && resolveMicrophonePromise();
-      };
-
-      log("requesting microphone access")();
-      navigator.mediaDevices === undefined
-        ? getUserMedia.call(
-            navigator,
-            {
-              audio: {
-                optional: [{ echoCancellation: false, sampleSize: 32 }],
-              },
-            },
-            microphoneCallback,
-            console.error,
-          )
-        : getUserMedia
-            .call(navigator.mediaDevices, {
-              audio: { echoCancellation: false, sampleSize: 32 },
-            })
-            .then(microphoneCallback)
-            .catch(console.error);
+      } else {
+        // Continue without input if the browser denies microphone access.
+        this.inputsCount = 0;
+        const newNode = this.createWorkletNode(this.audioContext, 0, contextUid);
+        this.audioWorkletNode = newNode;
+        if (this.autoConnect) {
+          this.audioWorkletNode.connect(this.audioContext.destination);
+        }
+      }
     } else {
       const newNode = this.createWorkletNode(this.audioContext, 0, contextUid);
       this.audioWorkletNode = newNode;
@@ -322,7 +297,6 @@ class AudioWorkletMainThread {
       }
     }
 
-    microphonePromise && (await microphonePromise);
     this.workletProxy = Comlink.wrap(this.audioWorkletNode.port, undefined);
 
     this.ipcMessagePorts.mainMessagePortAudio.addEventListener(

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -167,10 +167,7 @@ class AudioWorkletMainThread {
           this.audioWorkletNode.disconnect();
           delete this.audioWorkletNode;
         }
-        if (this.microphoneInput) {
-          this.microphoneInput.disconnect();
-          delete this.microphoneInput;
-        }
+        releaseMicrophoneStream(this);
         if (this.workletProxy) {
           this.workletProxy[Comlink.releaseProxy]();
           delete this.workletProxy;

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -17,7 +17,10 @@ import * as Comlink from "../utils/comlink.js";
 import { logWorkletMain as log } from "../logger";
 import { WebkitAudioContext } from "../utils";
 import { requestMidi } from "../utils/request-midi";
-import { requestMicrophoneNode } from "./io.utils.js";
+import {
+  releaseMicrophoneStream,
+  requestMicrophoneStream,
+} from "./io.utils.js";
 import { messageEventHandler } from "./messages.main";
 import WorkletWorker from "../../dist/__compiled.worklet.worker.inline.js";
 
@@ -41,6 +44,9 @@ class AudioWorkletMainThread {
     this.csoundWorkerMain = undefined;
     this.workletWorkerUrl = undefined;
     this.workletProxy = undefined;
+    this.microphoneInput = undefined;
+    this.microphonePromise = undefined;
+    this.microphoneStream = undefined;
     this.performanceGeneration = undefined;
     this["isRequestingMidi"] = false;
     this.isRequestingInput = false;
@@ -58,10 +64,12 @@ class AudioWorkletMainThread {
     this.onPlayStateChange = this.onPlayStateChange.bind(this);
     this.terminateInstance = this.terminateInstance.bind(this);
     this.createWorkletNode = this.createWorkletNode.bind(this);
+    this["requestMicrophoneInput"] = requestMicrophoneStream.bind(this);
     log("AudioWorkletMainThread was constructed")();
   }
 
   async terminateInstance() {
+    releaseMicrophoneStream(this);
     if (this.workletProxy) {
       try {
         await this.workletProxy["terminate"]();
@@ -158,6 +166,10 @@ class AudioWorkletMainThread {
         if (this.autoConnect && this.audioWorkletNode) {
           this.audioWorkletNode.disconnect();
           delete this.audioWorkletNode;
+        }
+        if (this.microphoneInput) {
+          this.microphoneInput.disconnect();
+          delete this.microphoneInput;
         }
         if (this.workletProxy) {
           this.workletProxy[Comlink.releaseProxy]();
@@ -261,7 +273,7 @@ class AudioWorkletMainThread {
     if (this.isRequestingInput) {
       let stream;
       try {
-        stream = await requestMicrophoneNode();
+        stream = await this["requestMicrophoneInput"]();
       } catch (error) {
         console.error(error);
       }
@@ -275,8 +287,10 @@ class AudioWorkletMainThread {
           contextUid,
         );
         this.audioWorkletNode = newNode;
+        this.microphoneInput = liveInput;
+        liveInput.connect(newNode);
         if (this.autoConnect) {
-          liveInput.connect(newNode).connect(this.audioContext.destination);
+          newNode.connect(this.audioContext.destination);
         }
       } else {
         // Continue without input if the browser denies microphone access.

--- a/wasm/browser/src/mains/worklet.main.js
+++ b/wasm/browser/src/mains/worklet.main.js
@@ -272,7 +272,14 @@ class AudioWorkletMainThread {
       try {
         stream = await this["requestMicrophoneInput"]();
       } catch (error) {
+        if (error.name === "AbortError") {
+          return;
+        }
         console.error(error);
+      }
+
+      if (stream && (this.microphoneStream !== stream || !this.audioContext)) {
+        return;
       }
 
       if (stream) {

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -273,7 +273,11 @@ class SingleThreadAudioWorkletMainThread {
 
             if (isRequestingRealtimeOutput) {
               if (isRequestingInput) {
-                this.exportApi["enableAudioInput"]();
+                try {
+                  await this.exportApi["enableAudioInput"]();
+                } catch (error) {
+                  console.error(error);
+                }
               }
 
               const isRequestingMidi =

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -22,7 +22,7 @@ import { csoundApiRename, fetchPlugins, makeProxyCallback } from "../utils.js";
 import { messageEventHandler, IPCMessagePorts } from "./messages.main.js";
 import { api as API } from "../libcsound.js";
 import { PublicEventAPI } from "../events.js";
-import { enableAudioInput } from "./io.utils.js";
+import { enableAudioInput, releaseMicrophoneStream } from "./io.utils.js";
 import { requestMidi } from "../utils/request-midi.js";
 import { EventPromises } from "../utils/event-promises.js";
 import WorkletWorker from "../../dist/__compiled.worklet.singlethread.worker.inline.js";
@@ -81,6 +81,7 @@ class SingleThreadAudioWorkletMainThread {
   }
 
   async terminateInstance() {
+    releaseMicrophoneStream(this.exportApi);
     if (this.workletProxy) {
       try {
         await this.workletProxy["terminate"]();

--- a/wasm/browser/src/mains/worklet.singlethread.main.js
+++ b/wasm/browser/src/mains/worklet.singlethread.main.js
@@ -81,7 +81,7 @@ class SingleThreadAudioWorkletMainThread {
   }
 
   async terminateInstance() {
-    releaseMicrophoneStream(this.exportApi);
+    releaseMicrophoneStream(this);
     if (this.workletProxy) {
       try {
         await this.workletProxy["terminate"]();
@@ -125,6 +125,7 @@ class SingleThreadAudioWorkletMainThread {
       }
 
       case "realtimePerformanceEnded": {
+        releaseMicrophoneStream(this);
         this.midiPortStarted = false;
         this.currentPlayState = undefined;
         this.publicEvents && this.publicEvents.triggerRealtimePerformanceEnded();
@@ -246,7 +247,7 @@ class SingleThreadAudioWorkletMainThread {
     /** @suppress {checkTypes} */
     this.exportApi["getNode"] = async () => this.node;
     /** @suppress {checkTypes} */
-    this.exportApi["enableAudioInput"] = enableAudioInput;
+    this.exportApi["enableAudioInput"] = enableAudioInput.bind(this);
     this.exportApi["name"] = "Csound: Audio Worklet, Single-threaded";
     this.exportApi = this.publicEvents.decorateAPI(this.exportApi);
     // the default message listener

--- a/wasm/browser/src/workers/common.utils.js
+++ b/wasm/browser/src/workers/common.utils.js
@@ -43,10 +43,14 @@ export const handleCsoundStart =
 
     setTimeout(() => {
       const isRequestingRtMidiInput = libraryCsound["isRequestingRtMidiInput"](csound);
-      const isExpectingRealtimeOutput =
-        shouldDemonize || isRequestingRtMidiInput || outputName.includes("dac");
+      const isRequestingRtAudioInput = libraryCsound["isRequestingRtAudioInput"](csound);
+      const isExpectingRealtimePerformance =
+        shouldDemonize ||
+        isRequestingRtMidiInput ||
+        isRequestingRtAudioInput ||
+        outputName.includes("dac");
 
-      if (isExpectingRealtimeOutput) {
+      if (isExpectingRealtimePerformance) {
         createRealtimeAudioThread(arguments_);
       } else {
         // Do rendering

--- a/wasm/browser/tests/mic_test.html
+++ b/wasm/browser/tests/mic_test.html
@@ -40,8 +40,6 @@
         });
 
         const compileReturn = await csoundObj.compileCSD(test);
-        // console.log(csoundObj);
-        await csoundObj.enableAudioInput();
         const startReturn = await csoundObj.start();
         const n = await csoundObj.getNode();
         const ctx = await csoundObj.getAudioContext();

--- a/wasm/browser/tests/unit/common.utils.test.js
+++ b/wasm/browser/tests/unit/common.utils.test.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+
+import assert from "node:assert/strict";
+
+let handleCsoundStart;
+
+describe("worker performance mode", () => {
+  before(async () => {
+    globalThis.goog = { define: () => true };
+    ({ handleCsoundStart } = await import("../../src/workers/common.utils.js"));
+  });
+
+  after(() => {
+    delete globalThis.goog;
+  });
+
+  it("uses the real-time path for microphone input without DAC output", async () => {
+    let realtimeStarted = false;
+    let renderStarted = false;
+    const libraryCsound = {
+      csoundShouldDaemonize: () => 0,
+      csoundStart: () => 0,
+      csoundGetOutputName: () => "recording.wav",
+      isRequestingRtMidiInput: () => 0,
+      isRequestingRtAudioInput: () => 1,
+    };
+    const workerMessagePort = {
+      broadcastPlayState: () => {
+        renderStarted = true;
+      },
+    };
+    const start = handleCsoundStart(
+      workerMessagePort,
+      libraryCsound,
+      {},
+      () => {
+        realtimeStarted = true;
+      },
+      () => {},
+    );
+
+    assert.equal(start({ csound: 1 }), 0);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(realtimeStarted, true);
+    assert.equal(renderStarted, false);
+  });
+});

--- a/wasm/browser/tests/unit/common.utils.test.js
+++ b/wasm/browser/tests/unit/common.utils.test.js
@@ -3,15 +3,25 @@
 import assert from "node:assert/strict";
 
 let handleCsoundStart;
+let originalGoogDescriptor;
 
 describe("worker performance mode", () => {
   before(async () => {
-    globalThis.goog = { define: () => true };
+    originalGoogDescriptor = Object.getOwnPropertyDescriptor(globalThis, "goog");
+    Object.defineProperty(globalThis, "goog", {
+      configurable: true,
+      writable: true,
+      value: { define: () => true },
+    });
     ({ handleCsoundStart } = await import("../../src/workers/common.utils.js"));
   });
 
   after(() => {
-    delete globalThis.goog;
+    if (originalGoogDescriptor) {
+      Object.defineProperty(globalThis, "goog", originalGoogDescriptor);
+    } else {
+      delete globalThis.goog;
+    }
   });
 
   it("uses the real-time path for microphone input without DAC output", async () => {

--- a/wasm/browser/tests/unit/io.utils.test.js
+++ b/wasm/browser/tests/unit/io.utils.test.js
@@ -2,7 +2,12 @@
 
 import assert from "node:assert/strict";
 
-import { enableAudioInput, requestMicrophoneNode } from "../../src/mains/io.utils.js";
+import {
+  enableAudioInput,
+  enableAudioInputInWorker,
+  requestMicrophoneNode,
+  requestMicrophoneStream,
+} from "../../src/mains/io.utils.js";
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
 
@@ -93,6 +98,10 @@ describe("microphone input", () => {
       },
     };
     const csound = {
+      setOption: async (option) => {
+        assert.equal(option, "-iadc");
+        return 0;
+      },
       getAudioContext: async () => ({
         createMediaStreamSource: (value) => {
           assert.equal(value, stream);
@@ -106,7 +115,9 @@ describe("microphone input", () => {
     const enabled = enableAudioInput.call(csound).then(() => {
       resolved = true;
     });
-    await Promise.resolve();
+    while (!grantPermission) {
+      await Promise.resolve();
+    }
     assert.equal(resolved, false);
 
     grantPermission(stream);
@@ -114,5 +125,81 @@ describe("microphone input", () => {
 
     assert.equal(csound.inputsCount, 2);
     assert.equal(connectedNode, node);
+  });
+
+  it("shares an in-flight microphone request", async () => {
+    let grantPermission;
+    let requestCount = 0;
+    const stream = { id: "microphone" };
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: () => {
+          requestCount += 1;
+          return new Promise((resolve) => {
+            grantPermission = resolve;
+          });
+        },
+      },
+    });
+
+    const owner = {};
+    const firstRequest = requestMicrophoneStream.call(owner);
+    const secondRequest = requestMicrophoneStream.call(owner);
+    grantPermission(stream);
+
+    assert.equal(await firstRequest, stream);
+    assert.equal(await secondRequest, stream);
+    assert.equal(await requestMicrophoneStream.call(owner), stream);
+    assert.equal(requestCount, 1);
+  });
+
+  it("enables input before worker mode starts", async () => {
+    const calls = [];
+    const main = {
+      currentPlayState: undefined,
+      exportApi: {
+        setOption: async (option) => {
+          calls.push(["setOption", option]);
+          return 0;
+        },
+      },
+      audioWorker: {
+        requestMicrophoneInput: async () => {
+          calls.push(["requestMicrophoneInput"]);
+        },
+      },
+    };
+
+    await enableAudioInputInWorker.call(main);
+
+    assert.deepEqual(calls, [
+      ["setOption", "-iadc"],
+      ["requestMicrophoneInput"],
+    ]);
+  });
+
+  it("rejects worker input changes after start", async () => {
+    await assert.rejects(
+      enableAudioInputInWorker.call({ currentPlayState: "realtimePerformanceStarted" }),
+      { message: "enableAudioInput() must be called before start() in worker mode" },
+    );
+  });
+
+  it("passes worker microphone permission errors to the caller", async () => {
+    const permissionError = new Error("Permission denied");
+    const main = {
+      currentPlayState: undefined,
+      exportApi: { setOption: async () => 0 },
+      audioWorker: {
+        requestMicrophoneInput: async () => {
+          throw permissionError;
+        },
+      },
+    };
+
+    await assert.rejects(
+      enableAudioInputInWorker.call(main),
+      (error) => error === permissionError,
+    );
   });
 });

--- a/wasm/browser/tests/unit/io.utils.test.js
+++ b/wasm/browser/tests/unit/io.utils.test.js
@@ -160,6 +160,38 @@ describe("microphone input", () => {
     assert.equal(owner.microphoneStream, undefined);
   });
 
+  it("stops a microphone stream that resolves after release", async () => {
+    let grantPermission;
+    let stopped = false;
+    const stream = {
+      getTracks: () => [
+        {
+          stop: () => {
+            stopped = true;
+          },
+        },
+      ],
+    };
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: () =>
+          new Promise((resolve) => {
+            grantPermission = resolve;
+          }),
+      },
+    });
+
+    const owner = {};
+    const request = requestMicrophoneStream.call(owner);
+    releaseMicrophoneStream(owner);
+    grantPermission(stream);
+
+    await assert.rejects(request, { name: "AbortError" });
+    assert.equal(stopped, true);
+    assert.equal(owner.microphoneStream, undefined);
+    assert.equal(owner.microphonePromise, undefined);
+  });
+
   it("shares an in-flight microphone request", async () => {
     let grantPermission;
     let requestCount = 0;

--- a/wasm/browser/tests/unit/io.utils.test.js
+++ b/wasm/browser/tests/unit/io.utils.test.js
@@ -1,0 +1,118 @@
+/* eslint-env mocha */
+
+import assert from "node:assert/strict";
+
+import { enableAudioInput, requestMicrophoneNode } from "../../src/mains/io.utils.js";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+const setNavigator = (value) => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value,
+  });
+};
+
+describe("microphone input", () => {
+  afterEach(() => {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", originalNavigator);
+    } else {
+      delete globalThis.navigator;
+    }
+  });
+
+  it("rejects with a clear error when browser input is unavailable", async () => {
+    setNavigator({});
+
+    await assert.rejects(requestMicrophoneNode(), {
+      message:
+        "Microphone input is unavailable. Use HTTPS, localhost, or a loopback address and allow microphone access.",
+    });
+  });
+
+  it("requests modern browser audio input", async () => {
+    const stream = { id: "microphone" };
+    const mediaDevices = {
+      getUserMedia: async (constraints) => {
+        assert.deepEqual(constraints, {
+          audio: { echoCancellation: false, sampleSize: 32 },
+        });
+        return stream;
+      },
+    };
+    setNavigator({ mediaDevices });
+
+    assert.equal(await requestMicrophoneNode(), stream);
+  });
+
+  it("passes browser permission errors to the caller", async () => {
+    const permissionError = new Error("Permission denied");
+    permissionError.name = "NotAllowedError";
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: async () => {
+          throw permissionError;
+        },
+      },
+    });
+
+    await assert.rejects(requestMicrophoneNode(), (error) => error === permissionError);
+  });
+
+  it("supports the legacy callback API", async () => {
+    const stream = { id: "legacy-microphone" };
+    setNavigator({
+      getUserMedia: (constraints, resolve) => {
+        assert.equal(constraints.audio.optional[0].echoCancellation, false);
+        resolve(stream);
+      },
+    });
+
+    assert.equal(await requestMicrophoneNode(), stream);
+  });
+
+  it("resolves enableAudioInput only after connecting the stream", async () => {
+    let grantPermission;
+    const stream = { id: "microphone" };
+    setNavigator({
+      mediaDevices: {
+        getUserMedia: () =>
+          new Promise((resolve) => {
+            grantPermission = resolve;
+          }),
+      },
+    });
+
+    const node = {};
+    let connectedNode;
+    const liveInput = {
+      channelCount: 2,
+      connect: (value) => {
+        connectedNode = value;
+      },
+    };
+    const csound = {
+      getAudioContext: async () => ({
+        createMediaStreamSource: (value) => {
+          assert.equal(value, stream);
+          return liveInput;
+        },
+      }),
+      getNode: async () => node,
+    };
+
+    let resolved = false;
+    const enabled = enableAudioInput.call(csound).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    assert.equal(resolved, false);
+
+    grantPermission(stream);
+    await enabled;
+
+    assert.equal(csound.inputsCount, 2);
+    assert.equal(connectedNode, node);
+  });
+});

--- a/wasm/browser/tests/unit/io.utils.test.js
+++ b/wasm/browser/tests/unit/io.utils.test.js
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import {
   enableAudioInput,
   enableAudioInputInWorker,
+  releaseMicrophoneStream,
   requestMicrophoneNode,
   requestMicrophoneStream,
 } from "../../src/mains/io.utils.js";
@@ -97,22 +98,24 @@ describe("microphone input", () => {
         connectedNode = value;
       },
     };
-    const csound = {
-      setOption: async (option) => {
-        assert.equal(option, "-iadc");
-        return 0;
-      },
-      getAudioContext: async () => ({
+    const owner = {
+      exportApi: Object.freeze({
+        setOption: async (option) => {
+          assert.equal(option, "-iadc");
+          return 0;
+        },
+      }),
+      audioContext: {
         createMediaStreamSource: (value) => {
           assert.equal(value, stream);
           return liveInput;
         },
-      }),
-      getNode: async () => node,
+      },
+      node,
     };
 
     let resolved = false;
-    const enabled = enableAudioInput.call(csound).then(() => {
+    const enabled = enableAudioInput.call(owner).then(() => {
       resolved = true;
     });
     while (!grantPermission) {
@@ -123,8 +126,38 @@ describe("microphone input", () => {
     grantPermission(stream);
     await enabled;
 
-    assert.equal(csound.inputsCount, 2);
+    assert.equal(owner.inputsCount, 2);
     assert.equal(connectedNode, node);
+  });
+
+  it("releases the microphone source and media tracks", () => {
+    let disconnected = false;
+    let stopped = false;
+    const owner = {
+      microphoneInput: {
+        disconnect: () => {
+          disconnected = true;
+        },
+      },
+      microphonePromise: Promise.resolve(),
+      microphoneStream: {
+        getTracks: () => [
+          {
+            stop: () => {
+              stopped = true;
+            },
+          },
+        ],
+      },
+    };
+
+    releaseMicrophoneStream(owner);
+
+    assert.equal(disconnected, true);
+    assert.equal(stopped, true);
+    assert.equal(owner.microphoneInput, undefined);
+    assert.equal(owner.microphonePromise, undefined);
+    assert.equal(owner.microphoneStream, undefined);
   });
 
   it("shares an in-flight microphone request", async () => {


### PR DESCRIPTION
Closes #1417

- Documents the secure-context rules for microphone access.
- Makes `enableAudioInput()` work in single-thread, worker, and SharedArrayBuffer modes.
- Sets `-iadc` and requests microphone permission before Csound starts.
- Passes permission errors back to the caller.
- Supports microphone input with `autoConnect: false` and input-only performances.
- Adds unit tests for permission handling and worker modes.