### PR TITLE
Return array initialization errors instead of terminating Csound

### DIFF
--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -621,7 +621,10 @@ int32_t copy_var_generic_init(CSOUND *csound, void *p)
         }
         // If the destination really is an array, make it like the source.
         if (csoundGetTypeForArg(dstArr) == &CS_VAR_TYPE_ARRAY) {
-            tabinit_like(csound, dstArr, (ARRAYDAT *)srcArr);
+            if (UNLIKELY(tabinit_like(csound, dstArr, srcArr) != OK)) {
+                return csound->InitError(
+                  csound, "could not initialize array value");
+            }
         }
 
         // Special-case: complex arrays copy immediately (no perf hook, no flag).

--- a/Engine/csound_type_system.c
+++ b/Engine/csound_type_system.c
@@ -623,7 +623,8 @@ int32_t copy_var_generic_init(CSOUND *csound, void *p)
         if (csoundGetTypeForArg(dstArr) == &CS_VAR_TYPE_ARRAY) {
             if (UNLIKELY(tabinit_like(csound, dstArr, srcArr) != OK)) {
                 return csound->InitError(
-                  csound, "could not initialize array value");
+                  csound, "%s",
+                  Str("array assignment: could not initialize destination"));
             }
         }
 

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -1578,7 +1578,9 @@ int32_t inarray_set(CSOUND *csound, INA *p){
   if(CS_ESR != csound->esr)
     return csound->InitError(csound,
                              "local sampling rate not supported\n");
-  tabinit(csound, p->tabout, csound->inchnls, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->tabout, csound->inchnls,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -2594,7 +2596,9 @@ int32_t painit(CSOUND *csound, PAINIT *p)
   if (*p->end!=FL(0.0)) {
     if (k<pargs) pargs = k;
   }
-  tabinit(csound, p->inits, pargs-start+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->inits, pargs-start+1,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   for (n=0; n<=pargs-start; n++) {
     ((MYFLT*)p->inits->data)[n] = csound->init_event->p[n+start];
   }

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -155,7 +155,8 @@ int32_t tabfill(CSOUND *csound, TABFILL *p)
   int32_t i, size;
   size_t memMyfltSize;
   MYFLT  **valp = p->iargs;
-  tabinit(csound, p->ans, nargs, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->ans, nargs, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
 
   size = p->ans->sizes[0];
   for (i=1; i<p->ans->dimensions; i++) size *= p->ans->sizes[i];
@@ -240,7 +241,8 @@ int32_t tabfillf(CSOUND* csound, TABFILLF* p)
     nextval(infile);
   } while (!feof(infile));
   flen--; // overshoots by 1
-  tabinit(csound, p->ans, flen, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->ans, flen, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   size = p->ans->sizes[0];
   for (i=1; i<p->ans->dimensions; i++) size *= p->ans->sizes[i];
   if (size<flen) flen = size;
@@ -295,7 +297,8 @@ int32_t tabsfill(CSOUND *csound, TABFILLF *p)
     if (isnan(x)) break;
     flen++;
   } while (*string!='\0');
-  tabinit(csound, p->ans, flen, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->ans, flen, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   size = p->ans->sizes[0];
   for (i=1; i<p->ans->dimensions; i++) size *= p->ans->sizes[i];
   if (size<flen) flen = size;
@@ -731,7 +734,8 @@ int32_t tabarithset(CSOUND *csound, TABARITH *p)
     if (p->ans->arrayType != source->arrayType &&
         p->ans->arrayType == p->right->arrayType)
       source = p->right;
-    tabinit_like(csound, p->ans, source);
+    if (UNLIKELY(tabinit_like(csound, p->ans, source) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
   }
   else return csound->InitError(csound, "%s",
@@ -753,7 +757,8 @@ int32_t tabarithset1(CSOUND *csound, TABARITH1 *p)
   }
 
 
-  tabinit_like(csound, p->ans, left);
+  if (UNLIKELY(tabinit_like(csound, p->ans, left) != OK))
+    return csound_array_init_resize_error(csound);
   /* When the right operand is i-rate (##add.[i, ##sub.[i, etc.),
      it is safe and correct to compute the result at init-time as well.
      This ensures k[] outputs are populated even if a perf pass does
@@ -779,7 +784,8 @@ int32_t tabarithset2(CSOUND *csound, TABARITH2 *p)
     return OK;
   }
 
-  tabinit_like(csound, p->ans, right);
+  if (UNLIKELY(tabinit_like(csound, p->ans, right) != OK))
+    return csound_array_init_resize_error(csound);
 
 
   return OK;
@@ -970,7 +976,8 @@ int32_t tabaiadd(CSOUND *csound, TABARITH1 *p)
   ARRAYDAT *ans = p->ans;
   ARRAYDAT *l   = p->left;
   MYFLT r       = *p->right;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
   return tabiadd(csound, ans, l, r, p);
 }
 
@@ -1004,7 +1011,8 @@ int32_t tabaddinkk(CSOUND *csound, TABARITHIN *p)
   int32_t sizer    = r->sizes[0];
   int32_t i;
 
-  tabinit_like(csound, ans, r);
+  if (UNLIKELY(tabinit_like(csound, ans, r) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(ans->data == NULL || r->data==NULL))
     return csound->PerfError(csound, &(p->h),
@@ -1285,7 +1293,8 @@ int32_t tabsubinkk(CSOUND *csound, TABARITHIN *p)
   int32_t sizer    = r->sizes[0];
   int32_t i;
 
-  tabinit_like(csound, ans, r);
+  if (UNLIKELY(tabinit_like(csound, ans, r) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
   if (UNLIKELY(ans->data == NULL || r->data==NULL))
     return csound->PerfError(csound, &(p->h),
                              "%s", Str("array-variable not initialised"));
@@ -1323,7 +1332,8 @@ int32_t tabmulinkk(CSOUND *csound, TABARITHIN *p)
   int32_t sizer    = r->sizes[0];
   int32_t i;
 
-  tabinit_like(csound, ans, r);
+  if (UNLIKELY(tabinit_like(csound, ans, r) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(ans->data == NULL || r->data==NULL))
     return csound->PerfError(csound, &(p->h),
@@ -1731,7 +1741,8 @@ int32_t tabdivinkk(CSOUND *csound, TABARITHIN *p)
   int32_t sizer    = r->sizes[0];
   int32_t i;
 
-  tabinit_like(csound, ans, r);
+  if (UNLIKELY(tabinit_like(csound, ans, r) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
   if (UNLIKELY(ans->data == NULL || r->data==NULL))
     return csound->PerfError(csound, &(p->h),
                              "%s", Str("array-variable not initialised"));
@@ -1754,7 +1765,8 @@ int32_t tabaisub(CSOUND *csound, TABARITH1 *p)
   MYFLT r       = *p->right;
   int32_t sizel = l->sizes[0];
   int32_t i;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(ans->data == NULL || l->data== NULL))
     return csound->PerfError(csound, &(p->h),
@@ -1776,7 +1788,8 @@ int32_t tabiasub(CSOUND *csound, TABARITH2 *p)
   MYFLT r     = *p->left;
   int32_t sizel = l->sizes[0];
   int32_t i;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(ans->data == NULL || l->data== NULL))
     return csound->PerfError(csound, &(p->h),
@@ -1835,7 +1848,8 @@ int32_t tabaimult(CSOUND *csound, TABARITH1 *p)
   ARRAYDAT *ans = p->ans;
   ARRAYDAT *l   = p->left;
   MYFLT r       = *p->right;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
   return tabimult(csound, ans, l, r, p);
 }
 
@@ -1845,7 +1859,8 @@ int32_t tabiamult(CSOUND *csound, TABARITH2 *p)
   ARRAYDAT *ans = p->ans;
   ARRAYDAT *l   = p->right;
   MYFLT r       = *p->left;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
   return tabimult(csound, ans, l, r, p);
 }
 
@@ -1857,7 +1872,8 @@ int32_t tabaidiv(CSOUND *csound, TABARITH1 *p)
   MYFLT r       = *p->right;
   int32_t sizel = l->sizes[0];
   int32_t i;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(r==FL(0.0)))
     return csound->PerfError(csound, &(p->h),
@@ -1882,7 +1898,8 @@ int32_t tabiadiv(CSOUND *csound, TABARITH2 *p)
   MYFLT r     = *p->left;
   int32_t sizel    = l->sizes[0];
   int32_t i;
-  tabinit_like(csound, ans, l);
+  if (UNLIKELY(tabinit_like(csound, ans, l) != OK))
+    return csound_array_perf_resize_error(csound, &p->h);
 
   if (UNLIKELY(ans->data == NULL || l->data== NULL))
     return csound->PerfError(csound, &(p->h),
@@ -3533,7 +3550,9 @@ int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
   }
 
   // Allocate backing store sized like the source total element count
-  tabinit(csound, p->dst, get_array_total_size(p->src), p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->dst, get_array_total_size(p->src),
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -3769,9 +3788,11 @@ int32_t tabgen(CSOUND *csound, TABGEN *p)
                              (long long)sz64);
   int32_t size = (int32_t)sz64;
 
-  tabinit(csound, p->tab, size, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, size, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
   }
   data =  p->tab->data;
   for (i=0; i < size; i++) {
@@ -3794,7 +3815,8 @@ int32_t ftab2tabi(CSOUND *csound, TABCOPY *p)
     return csound->InitError(csound, "%s", Str("No table for copy2ftab"));
   fsize = ftp->flen;
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, fsize, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->tab, fsize, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->tab->sizes[0] = fsize;
   }
   tlen = p->tab->sizes[0];
@@ -3828,9 +3850,15 @@ int32_t ftab2tab(CSOUND *csound, TABCOPY *p)
 
 int32_t trim_i(CSOUND *csound, TRIM *p)
 {
-  int32_t size = (int)(*p->size);
-  tabinit(csound, p->tab, size, p->h.insdshead);
-  p->tab->sizes[0] = size;
+  MYFLT requestedSize = *p->size;
+  if (UNLIKELY(isnan(requestedSize) || requestedSize < FL(0.0) ||
+               requestedSize > (MYFLT)INT32_MAX)) {
+    return csound->InitError(csound, "%s", Str("Invalid array size"));
+  }
+  int32_t size = (int32_t)requestedSize;
+  if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK)) {
+    return csound->InitError(csound, "%s", Str("Invalid array size"));
+  }
   return OK;
 }
 
@@ -3849,7 +3877,13 @@ int32_t trim_prepare(CSOUND *csound, TRIM *p)
 
 int32_t trim(CSOUND *csound, TRIM *p)
 {
-  int32_t size = (int)(*p->size);
+  MYFLT requestedSize = *p->size;
+  if (UNLIKELY(isnan(requestedSize) || requestedSize < FL(0.0) ||
+               requestedSize > (MYFLT)INT32_MAX)) {
+    return csound->PerfError(csound, &p->h, "%s",
+                             Str("Invalid array size"));
+  }
+  int32_t size = (int32_t)requestedSize;
   int32_t n = tabcheck(csound, p->tab, size, &(p->h));
   if (n != OK) return n;
   p->tab->sizes[0] = size;
@@ -3880,7 +3914,8 @@ int32_t tabslice(CSOUND *csound, TABSLICE *p) {
   if (UNLIKELY(inc<=0))
     return csound->InitError(csound, "%s",
                              Str("slice increment must be positive"));
-  tabinit(csound, p->tab, size, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
 
   for (i = start, destIndex = 0; i < end + 1; i+=inc, destIndex++) {
     p->tab->arrayType->copyValue(csound, p->tab->arrayType,
@@ -3904,7 +3939,8 @@ int32_t tabmap_set(CSOUND *csound, TABMAP *p)
 
   size = p->tabin->sizes[0];
   if (UNLIKELY(p->tab->data==NULL)) {
-    tabinit(csound, p->tab, size, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->tab->sizes[0] = size;
   }
   else size = size < p->tab->sizes[0] ? size : p->tab->sizes[0];
@@ -3968,7 +4004,8 @@ int32_t tablength(CSOUND *csound, TABQUERY1 *p)
 
 int32_t asig2array_init(CSOUND *csound, A2ARR *p) {
   int32_t nsmps = CS_KSMPS;
-  tabinit(csound, p->res, nsmps, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->res, nsmps, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 

--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -3520,10 +3520,9 @@ int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
   if (UNLIKELY(p->src == NULL || p->dst == NULL))
     return csound->InitError(csound, "tabcopyk_init: null src/dst");
 
-  if (p->dst->arrayType == NULL)
-    p->dst->arrayType = p->src->arrayType;
-
   if (p->src->arrayType && p->src->arrayType->userDefinedType) {
+    if (p->dst->arrayType == NULL)
+      p->dst->arrayType = p->src->arrayType;
     if (UNLIKELY(p->src->arrayType != p->dst->arrayType))
       return csound->InitError(csound, "%s",
                                Str("array-variable types do not match"));
@@ -3537,21 +3536,7 @@ int32_t tabcopyk_init(CSOUND *csound, TABCPY *p) {
     return OK;
   }
 
-  // Propagate dimensions and sizes so downstream ops can rely on them
-  if (p->src->dimensions > 0) {
-    int32_t dim = p->src->dimensions;
-    p->dst->dimensions = dim;
-    if (p->dst->sizes != NULL) {
-      csound->Free(csound, p->dst->sizes);
-      p->dst->sizes = NULL;
-    }
-    p->dst->sizes = (int32_t*) csound->Malloc(csound, sizeof(int32_t) * dim);
-    memcpy(p->dst->sizes, p->src->sizes, sizeof(int32_t) * dim);
-  }
-
-  // Allocate backing store sized like the source total element count
-  if (UNLIKELY(tabinit(csound, p->dst, get_array_total_size(p->src),
-                       p->h.insdshead) != OK))
+  if (UNLIKELY(tabinit_like(csound, p->dst, p->src) != OK))
     return csound_array_init_resize_error(csound);
   return OK;
 }
@@ -3850,14 +3835,12 @@ int32_t ftab2tab(CSOUND *csound, TABCOPY *p)
 
 int32_t trim_i(CSOUND *csound, TRIM *p)
 {
-  MYFLT requestedSize = *p->size;
-  if (UNLIKELY(isnan(requestedSize) || requestedSize < FL(0.0) ||
-               requestedSize > (MYFLT)INT32_MAX)) {
+  int32_t size;
+  if (UNLIKELY(csound_array_size_to_int32(*p->size, &size) != OK)) {
     return csound->InitError(csound, "%s", Str("Invalid array size"));
   }
-  int32_t size = (int32_t)requestedSize;
   if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK)) {
-    return csound->InitError(csound, "%s", Str("Invalid array size"));
+    return csound_array_init_resize_error(csound);
   }
   return OK;
 }
@@ -3877,13 +3860,11 @@ int32_t trim_prepare(CSOUND *csound, TRIM *p)
 
 int32_t trim(CSOUND *csound, TRIM *p)
 {
-  MYFLT requestedSize = *p->size;
-  if (UNLIKELY(isnan(requestedSize) || requestedSize < FL(0.0) ||
-               requestedSize > (MYFLT)INT32_MAX)) {
+  int32_t size;
+  if (UNLIKELY(csound_array_size_to_int32(*p->size, &size) != OK)) {
     return csound->PerfError(csound, &p->h, "%s",
                              Str("Invalid array size"));
   }
-  int32_t size = (int32_t)requestedSize;
   int32_t n = tabcheck(csound, p->tab, size, &(p->h));
   if (n != OK) return n;
   p->tab->sizes[0] = size;

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1721,7 +1721,9 @@ int32_t chnget_array_opcode_init_i(CSOUND* csound, CHNGETARRAY* p)
   p->arraySize = arr->sizes[0];
   p->channels = (STRINGDAT*) arr->data;
 
-  tabinit(csound, p->arrayDat, p->arraySize, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->arrayDat, p->arraySize,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
 
   int32_t err;
   MYFLT* fp;
@@ -1779,7 +1781,9 @@ int32_t chnget_array_opcode_init(CSOUND* csound, CHNGETARRAY* p)
   p->channels = (STRINGDAT*) arr->data;
   p->channelPtrs = (MYFLT **) csound->Malloc(csound, p->arraySize*sizeof(MYFLT*));
   // VL: surely an array of pointers?
-  tabinit(csound, p->arrayDat, p->arraySize,  p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->arrayDat, p->arraySize,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
 
   int32_t err;
   int32_t channelType;
@@ -2536,15 +2540,15 @@ static int32_t init_chn_array(CSOUND* csound, CHNGET* p, int32_t type) {
   if(adat->data == NULL) {
     if(adat_chn->data == NULL)
       return csound->InitError(csound, "array channel not allocated\n");
-    else tabinit_like(csound, adat, adat_chn);
-
+    else if (UNLIKELY(tabinit_like(csound, adat, adat_chn) != OK))
+      return csound_array_init_resize_error(csound);
   }
 
   if(adat_chn->data == NULL) {
     if(adat->data == NULL)
       return csound->InitError(csound, "array variable not allocated\n");
-    else tabinit_like(csound, adat_chn, adat);
-
+    else if (UNLIKELY(tabinit_like(csound, adat_chn, adat) != OK))
+      return csound_array_init_resize_error(csound);
   }
   return OK;
 }
@@ -2680,7 +2684,8 @@ int32_t chn_opcode_init_ARRAY(CSOUND *csound, CHN_OPCODE_ARRAY *p)
 
   adat->arrayType = (CS_TYPE *)
     csoundGetTypeWithVarTypeName(csound->typePool, p->type->data);
-  tabinit(csound, adat, siz, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, adat, siz, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -2978,7 +2983,10 @@ ARRAYDAT *csoundInitArrayChannel(CSOUND *csound, const char *name,
 
     adat->arrayType = (CS_TYPE *)
       csoundGetTypeWithVarTypeName(csound->typePool, type);
-    tabinit(csound, adat, siz, NULL);
+    if (UNLIKELY(tabinit(csound, adat, siz, NULL) != OK)) {
+      csound->ErrorMsg(csound, "%s", Str("Could not resize array channel"));
+      return NULL;
+    }
   }
   return adat;
 }

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -2502,6 +2502,50 @@ int32_t outvalsetSgo(CSOUND *csound, OUTVAL *p)
 }
 
 /* ARRAY channels implementation - VL 7.08.24 */
+static int32_t prepare_array_channel(CSOUND *csound, ARRAYDAT *prepared,
+                                     const CS_TYPE *elementType,
+                                     int32_t dimensions,
+                                     const int32_t *sizes, INSDS *ctx)
+{
+  size_t totalSize = 1;
+
+  if (UNLIKELY(prepared == NULL || elementType == NULL ||
+               dimensions <= 0 || sizes == NULL ||
+               (size_t)dimensions > SIZE_MAX / sizeof(int32_t)))
+    return NOTOK;
+
+  prepared->arrayType = elementType;
+  prepared->dimensions = dimensions;
+  prepared->sizes = (int32_t *)csound->Calloc(
+    csound, (size_t)dimensions * sizeof(int32_t));
+  if (UNLIKELY(prepared->sizes == NULL))
+    return NOTOK;
+
+  for (int32_t i = 0; i < dimensions; i++) {
+    if (UNLIKELY(sizes[i] < 0 ||
+                 (sizes[i] != 0 &&
+                  totalSize > (size_t)INT32_MAX / (size_t)sizes[i]))) {
+      csound_free_array_storage(csound, prepared);
+      return NOTOK;
+    }
+    prepared->sizes[i] = sizes[i];
+    totalSize *= (size_t)sizes[i];
+  }
+  if (UNLIKELY(tabinit(csound, prepared, (int32_t)totalSize, ctx) != OK)) {
+    csound_free_array_storage(csound, prepared);
+    return NOTOK;
+  }
+  return OK;
+}
+
+static void publish_array_channel(CSOUND *csound, ARRAYDAT *destination,
+                                  ARRAYDAT *prepared)
+{
+  csound_free_array_storage(csound, destination);
+  *destination = *prepared;
+  memset(prepared, 0, sizeof(*prepared));
+}
+
 static inline int32_t copy_array(CSOUND *csound, ARRAYDAT *out,
                                  const ARRAYDAT *in, spin_lock_t *lock,
                                  CSOUND_ARRAY_COPY_MODE mode)
@@ -2661,8 +2705,12 @@ int32_t chnset_opcode_init_ARRAY(CSOUND *csound, CHNGET *p)
 /* chn opcode (array channel) */
 int32_t chn_opcode_init_ARRAY(CSOUND *csound, CHN_OPCODE_ARRAY *p)
 {
+  ARRAYDAT prepared = {0};
   ARRAYDAT *adat;
-  int32_t   type, mode, err, siz = 0, i;
+  const CS_TYPE *elementType;
+  int32_t *sizes;
+  size_t dimensionCount;
+  int32_t type, mode, err, dimensions;
 
   mode = (int32_t) MYFLT2LRND(*(p->imode));
   if (UNLIKELY(mode < 1 || mode > 3))
@@ -2675,17 +2723,39 @@ int32_t chn_opcode_init_ARRAY(CSOUND *csound, CHN_OPCODE_ARRAY *p)
   err = csoundGetChannelPtr(csound, (void **) &adat, (char*) p->iname->data, type);
   if (UNLIKELY(err))
     return print_chn_err(p, err);
-  adat->dimensions = (int32_t) p->idim->sizes[0];
-  adat->sizes = (int32_t *) csound->Calloc(csound,
-                                           adat->dimensions*sizeof(int32_t));
-  siz = (adat->sizes[0] = (int32_t) MYFLT2LRND(p->idim->data[0]));
-  for(i = 1; i < adat->dimensions; i++)
-    siz *= (adat->sizes[i] = (int32_t) MYFLT2LRND(p->idim->data[i]));
 
-  adat->arrayType = (CS_TYPE *)
-    csoundGetTypeWithVarTypeName(csound->typePool, p->type->data);
-  if (UNLIKELY(tabinit(csound, adat, siz, p->h.insdshead) != OK))
+  if (UNLIKELY(p->idim == NULL || p->idim->data == NULL ||
+               p->idim->dimensions != 1 || p->idim->sizes == NULL ||
+               csound_array_member_count(p->idim, &dimensionCount) != OK ||
+               dimensionCount == 0 || dimensionCount > INT32_MAX))
+    return csound->InitError(csound, "%s",
+                             Str("invalid array channel dimensions"));
+  dimensions = (int32_t)dimensionCount;
+  sizes = (int32_t *)csound->Malloc(
+    csound, dimensionCount * sizeof(int32_t));
+  if (UNLIKELY(sizes == NULL))
     return csound_array_init_resize_error(csound);
+  for (int32_t i = 0; i < dimensions; i++) {
+    double size = (double)p->idim->data[i];
+    double roundedSize = nearbyint(size);
+    if (UNLIKELY(isnan(size) || size < 0.0 ||
+                 roundedSize >= (double)INT32_MAX + 1.0)) {
+      csound->Free(csound, sizes);
+      return csound->InitError(csound, "%s",
+                               Str("invalid array channel dimensions"));
+    }
+    sizes[i] = (int32_t)roundedSize;
+  }
+  elementType = csoundGetTypeWithVarTypeName(
+    csound->typePool, p->type->data);
+  if (UNLIKELY(prepare_array_channel(
+                 csound, &prepared, elementType, dimensions, sizes,
+                 p->h.insdshead) != OK)) {
+    csound->Free(csound, sizes);
+    return csound_array_init_resize_error(csound);
+  }
+  csound->Free(csound, sizes);
+  publish_array_channel(csound, adat, &prepared);
   return OK;
 }
 
@@ -2963,7 +3033,9 @@ int32_t csoundGetPvsChannel(CSOUND *csound, const char *name,
 ARRAYDAT *csoundInitArrayChannel(CSOUND *csound, const char *name,
                                  const char *type, int32_t dimensions,
                                  const int32_t *sizes) {
-  int32_t i, siz = 0, err;
+  ARRAYDAT prepared = {0};
+  const CS_TYPE *elementType;
+  int32_t err;
   ARRAYDAT *adat;
 
   err = csoundGetChannelPtr(csound, (void **) &adat, name,
@@ -2974,19 +3046,15 @@ ARRAYDAT *csoundInitArrayChannel(CSOUND *csound, const char *name,
   if(err != CSOUND_SUCCESS) return NULL;
 
   if(adat->data == NULL) {
-    adat->dimensions = dimensions;
-    adat->sizes = (int32_t *) csound->Calloc(csound,
-                                             dimensions*sizeof(int32_t));
-    siz = (adat->sizes[0] = sizes[0]);
-    for(i = 1; i < adat->dimensions; i++)
-      siz *= (adat->sizes[i] = sizes[i]);
-
-    adat->arrayType = (CS_TYPE *)
-      csoundGetTypeWithVarTypeName(csound->typePool, type);
-    if (UNLIKELY(tabinit(csound, adat, siz, NULL) != OK)) {
+    elementType = type != NULL
+      ? csoundGetTypeWithVarTypeName(csound->typePool, type) : NULL;
+    if (UNLIKELY(prepare_array_channel(
+                   csound, &prepared, elementType, dimensions, sizes,
+                   NULL) != OK)) {
       csound->ErrorMsg(csound, "%s", Str("Could not resize array channel"));
       return NULL;
     }
+    publish_array_channel(csound, adat, &prepared);
   }
   return adat;
 }

--- a/OOps/compile_ops.c
+++ b/OOps/compile_ops.c
@@ -276,7 +276,10 @@ int32_t readOSC_perf(CSOUND *csound, ROSC *p) {
 #include "arrays.h"
 
 int32_t readOSCarray_init(CSOUND *csound, ROSCA *p) {
-  tabinit(csound, p->out, (int32_t) strlen(p->type->data), p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out,
+                       (int32_t)strlen(p->type->data),
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 

--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -678,7 +678,8 @@ int32_t cops_init(CSOUND *csound, COPS1 *p) {
       return csound->InitError(csound, "array unitialised\n");
     size = aa->sizes[0];
   }
-  tabinit(csound, p->out, size, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, size, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -1416,7 +1417,9 @@ int32_t cops_init_r(CSOUND *csound, COPS1 *p) {
     if(IS_ARRAY_ARG(p->out)) {
       int32_t size = ((ARRAYDAT *)p->a)->sizes ? ((ARRAYDAT *)p->a)->sizes[0] : 0;
       if (size <= 0) size = CS_KSMPS; /* fallback to ksmps for audio-like arrays */
-      tabinit(csound, p->out, size, p->h.insdshead);
+      if (UNLIKELY(tabinit(csound, p->out, size,
+                           p->h.insdshead) != OK))
+        return csound_array_init_resize_error(csound);
     } else {
       int32_t inSize = ((ARRAYDAT *)p->a)->sizes ? ((ARRAYDAT *)p->a)->sizes[0] : 0;
       if(inSize < CS_KSMPS)
@@ -1555,7 +1558,8 @@ int32_t cops_init_a(CSOUND *csound, COPS1 *p) {
       size = aa->sizes[0] < ab->sizes[0] ? aa->sizes[0] : ab->sizes[0];
     }
   }
-  tabinit(csound, p->out, size, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, size, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -1665,7 +1669,9 @@ int32_t quadosc_init(CSOUND *csound, QUADOSC *p) {
     p->rphs = 1.0;
     p->iphs = 0;
   }
-  tabinit(csound, p->out, CS_KSMPS, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, CS_KSMPS,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 

--- a/OOps/lpred.c
+++ b/OOps/lpred.c
@@ -753,7 +753,8 @@ int32_t lpred_alloc(CSOUND *csound, LPREDA *p) {
     p->setup = csound->LPsetup(csound,N,p->M);
     if(p->buf.auxp == NULL || Nbytes > p->buf.size)
       csound->AuxAlloc(csound, Nbytes, &p->buf);
-    tabinit(csound,p->out,p->M, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, p->M, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->ft = ft;
     return OK;
   }
@@ -811,7 +812,8 @@ int32_t lpred_alloc2(CSOUND *csound, LPREDA2 *p) {
     csound->AuxAlloc(csound, Nbytes, &p->buf);
   if(p->cbuf.auxp == NULL || Nbytes > p->cbuf.size)
     csound->AuxAlloc(csound, Nbytes, &p->cbuf);
-  tabinit(csound,p->out,p->M, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, p->M, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->cp = 1;
   p->bp = 0;
   return OK;
@@ -1021,7 +1023,8 @@ int32_t pvscoefs_init(CSOUND *csound, PVSCFS *p) {
     csound->AuxAlloc(csound, Nbytes, &p->buf);
   if(p->coef.auxp == NULL || Mbytes > p->coef.size)
     csound->AuxAlloc(csound, Mbytes, &p->coef);
-  tabinit(csound,p->out,p->M, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, p->M, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->framecount = 0;
   p->mod = *p->imod;
   p->framecount = 0;
@@ -1060,7 +1063,8 @@ int32_t pvscoefs(CSOUND *csound, PVSCFS *p){
 int32_t coef2parm_init(CSOUND *csound, CF2P *p) {
   p->M = p->in->sizes[0];
   p->setup = csound->LPsetup(csound,0,p->M);
-  tabinit(csound,p->out,p->M, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, p->M, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->sum = 0.0;
   return OK;
 }

--- a/OOps/midiops.c
+++ b/OOps/midiops.c
@@ -858,7 +858,9 @@ int32_t savectrl_init(CSOUND *csound, SAVECTRL *p)
       if (ctlno < FL(0.0) || ctlno > FL(127.0))
         return csound->InitError(csound, Str("Value out of range [0,127]\n"));
     }
-    tabinit(csound, p->arr, 2+2*nargs, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->arr, 2+2*nargs,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->arr->data[0] = nargs;    /* length */
     p->arr->data[1] = chnl+1;   /* channel */
     for (i=0, j=2; i<nargs; i++, j+=2) {
@@ -1093,4 +1095,3 @@ int32_t printpresets_init1(CSOUND *csound, PRINTPRESETS *p)
     if (p->fout==NULL) return NOTOK;
     return OK;
 }
-

--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -174,7 +174,8 @@ int32_t commandline_args_init(CSOUND *csound, ARGV_OP *p)
 {
   int32_t count = csoundGetCommandLineArgCount(csound);
 
-  tabinit(csound, p->args, count, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->args, count, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   for (int32_t index = 0; index < count; index++) {
     const char *argument = csoundGetCommandLineArg(csound, index);
     STRINGDAT source = {

--- a/OOps/structs.c
+++ b/OOps/structs.c
@@ -616,7 +616,9 @@ int32_t struct_array_get(CSOUND *csound, STRUCT_ARRAY_GET* dat)
       return csound->InitError(csound,
                                "Invalid struct array dimensions");
     }
-    tabinit(csound, arrayDat, (int32_t)totalSize, dat->h.insdshead);
+    if (UNLIKELY(tabinit(csound, arrayDat, (int32_t)totalSize,
+                         dat->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
   }
   if (UNLIKELY(struct_array_flat_index(csound, &dat->h,
                                        "struct_array_get", arrayDat,

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1255,7 +1255,9 @@ static int32_t OSC_alist_init(CSOUND *csound, OSCLISTENA *p)
                                            strlen((char*) p->dest->data) + 1);
     strcpy(p->c.saved_path, (char*) p->dest->data);
     /* check for a valid argument list */
-    tabinit(csound, p->args, n= (int32_t)strlen((char*) p->type->data), p->h.insdshead);
+    n = (int32_t)strlen((char *)p->type->data);
+    if (UNLIKELY(tabinit(csound, p->args, n, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     strcpy(p->c.saved_types, (char*) p->type->data);
     for (i = 0; i < n; i++) {
       switch (p->c.saved_types[i]) {

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -1236,8 +1236,10 @@ static int32_t OSC_ahandler(const char *path, const char *types,
 
 static int32_t OSC_alist_init(CSOUND *csound, OSCLISTENA *p)
 {
-    //void  *x;
-    int32_t   i, n;
+    int32_t i, n;
+    const char *path = (const char *)p->dest->data;
+    const char *types = (const char *)p->type->data;
+    size_t pathLength, typeLength;
 
     OSC_GLOBALS *pp =
       (OSC_GLOBALS*) csound->QueryGlobalVariable(csound, "_OSC_globals");
@@ -1251,16 +1253,12 @@ static int32_t OSC_alist_init(CSOUND *csound, OSCLISTENA *p)
     if (UNLIKELY(p->port == NULL || p->port->thread == NULL ||
                  p->port->mutex_ == NULL))
       return csound->InitError(csound, "%s", Str("invalid handle"));
-    p->c.saved_path = (char*) csound->Malloc(csound,
-                                           strlen((char*) p->dest->data) + 1);
-    strcpy(p->c.saved_path, (char*) p->dest->data);
-    /* check for a valid argument list */
-    n = (int32_t)strlen((char *)p->type->data);
-    if (UNLIKELY(tabinit(csound, p->args, n, p->h.insdshead) != OK))
-      return csound_array_init_resize_error(csound);
-    strcpy(p->c.saved_types, (char*) p->type->data);
+    typeLength = strlen(types);
+    if (UNLIKELY(typeLength >= ARG_CNT))
+      return csound->InitError(csound, "%s", Str("too many OSC types"));
+    n = (int32_t)typeLength;
     for (i = 0; i < n; i++) {
-      switch (p->c.saved_types[i]) {
+      switch (types[i]) {
       case 'c':
       case 'd':
       case 'f':
@@ -1271,6 +1269,12 @@ static int32_t OSC_alist_init(CSOUND *csound, OSCLISTENA *p)
         return csound->InitError(csound, "%s", Str("invalid type"));
       }
     }
+    if (UNLIKELY(tabinit(csound, p->args, n, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
+    pathLength = strlen(path);
+    p->c.saved_path = (char*)csound->Malloc(csound, pathLength + 1);
+    memcpy(p->c.saved_path, path, pathLength + 1);
+    memcpy(p->c.saved_types, types, typeLength + 1);
     csound->LockMutex(p->port->mutex_);
     p->c.nxt = p->port->oplst;
     p->port->oplst = (void*) &p->c;

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -51,7 +51,8 @@ int32_t init_autocorr(CSOUND *csound, AUTOCORR *p) {
     csound->AuxAlloc(csound, fn*sizeof(MYFLT), &p->mem);
   p->N = N;
   p->FN = fn;
-  tabinit(csound, p->out,N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -123,7 +124,8 @@ static int32_t init_fft_complex_common(CSOUND *csound, FFT *p,
                              Str("fft: input array size (%d) must be 1 or even"),
                              N);
 
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   size_t bytes = (size_t)N * 2u * sizeof(MYFLT);
   csound->AuxAlloc(csound, bytes, &p->mem);
   return OK;
@@ -202,7 +204,8 @@ static int32_t init_rfft_r2c(CSOUND *csound, FFT *p) {
                              Str("rfft: only one-dimensional arrays allowed"));
   if (UNLIKELY(validate_real_fft_size(csound, "rfft", N) != OK))
     return NOTOK;
-  tabinit(csound, p->out, N/2+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N/2+1, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
   csound->AuxAlloc(csound, sizeof(MYFLT)*N, &p->mem);
   return OK;
@@ -239,7 +242,8 @@ static int32_t init_rfft_c2r(CSOUND *csound, FFT *p) {
   int32_t N = 2*(M - 1);
   if (UNLIKELY(validate_real_fft_size(csound, "rifft", N) != OK))
     return NOTOK;
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
   csound->AuxAlloc(csound, sizeof(MYFLT)*N, &p->mem);
   return OK;
@@ -271,7 +275,8 @@ static int32_t init_rfft(CSOUND *csound, FFT *p) {
                              Str("rfft: only one-dimensional arrays allowed"));
   if (UNLIKELY(validate_real_fft_size(csound, "rfft", N) != OK))
     return NOTOK;
-  tabinit(csound, p->out,N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
   return OK;
 }
@@ -299,7 +304,8 @@ static int32_t init_rifft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(validate_real_fft_size(csound, "rifft", N) != OK))
     return NOTOK;
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -324,7 +330,8 @@ static int32_t init_rfftmult(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
   if (UNLIKELY(N != p->in2->sizes[0]))
     return csound->InitError(csound, "%s", Str("array sizes do not match\n"));
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -340,7 +347,8 @@ static int32_t initialise_fft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("fft: only one-dimensional arrays allowed"));
-  tabinit(csound,p->out,N2, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N2, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -365,7 +373,8 @@ static int32_t init_ifft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("fftinv: only one-dimensional arrays allowed"));
-  tabinit(csound, p->out, N2, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N2, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -386,7 +395,8 @@ static int32_t init_recttopol(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -425,7 +435,9 @@ static int32_t init_poltorect2(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "array not initialised\n");
   if (LIKELY(p->in2->sizes[0] == p->in->sizes[0])) {
     int32_t   N = p->in2->sizes[0];
-    tabinit(csound, p->out, N*2 - 2, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, N*2 - 2,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
   } else return csound->InitError(csound,
                                   Str("in array sizes do not match: %d and %d\n"),
@@ -454,7 +466,8 @@ static int32_t init_mags(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N/2+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N/2+1, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -485,7 +498,9 @@ static int32_t perf_phs(CSOUND *csound, FFT *p) {
 static int32_t init_logarray(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
-  tabinit(csound, p->out, p->in->sizes[0], p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, p->in->sizes[0],
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   if (LIKELY(*((MYFLT *)p->in2)))
     p->b = 1/log(*((MYFLT *)p->in2));
   else
@@ -513,7 +528,8 @@ static int32_t init_rtoc(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N*2, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N*2, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -540,7 +556,8 @@ static int32_t init_ctor(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t   N = p->in->sizes[0];
-  tabinit(csound, p->out, N/2, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N/2, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -569,7 +586,8 @@ static int32_t init_window(CSOUND *csound, FFT *p) {
   int32_t   N = p->in->sizes[0];
   int32_t   i,type = (int32_t) *p->f;
   MYFLT *w;
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   if (p->mem.auxp == 0 || p->mem.size < N*sizeof(MYFLT))
     csound->AuxAlloc(csound, N*sizeof(MYFLT), &p->mem);
   w = (MYFLT *) p->mem.auxp;
@@ -618,7 +636,8 @@ typedef struct _pvsceps {
 static int32_t pvsceps_init(CSOUND *csound, PVSCEPS *p) {
   int32_t N = p->fin->N;
   p->setup = csound->RealFFTSetup(csound, N/2, FFT_FWD);
-  tabinit(csound, p->out, N/2+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N/2+1, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->lastframe = 0;
   return OK;
 }
@@ -654,7 +673,8 @@ static int32_t init_ceps(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "%s",
                              Str("FFT size too small (min 64 samples)\n"));
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
-  tabinit(csound, p->out, N+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N+1, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 
@@ -682,7 +702,8 @@ static int32_t init_iceps(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "array not initialised\n");
   int32_t N = p->in->sizes[0]-1;
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
-  tabinit(csound, p->out, N+1, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N+1, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   N++;
   if (p->mem.auxp == NULL || p->mem.size < N*sizeof(MYFLT))
     csound->AuxAlloc(csound, N*sizeof(MYFLT), &p->mem);
@@ -707,7 +728,8 @@ static int32_t rows_init(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "array not initialised\n");
   if (p->in->dimensions == 2) {
     int32_t siz = p->in->sizes[1];
-    tabinit(csound, p->out, siz, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, siz, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
   }
   else
@@ -844,7 +866,8 @@ static int32_t cols_init(CSOUND *csound, FFT *p) {
     return csound->InitError(csound, "array not initialised\n");
   if (LIKELY(p->in->dimensions == 2)) {
     int32_t siz = p->in->sizes[0];
-    tabinit(csound, p->out, siz, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, siz, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
   }
   else
@@ -1009,7 +1032,8 @@ static int32_t shiftin_init(CSOUND *csound, FFT *p) {
 
   int32_t sizs = CS_KSMPS;
   if(p->out->sizes[0] < sizs)
-    tabinit(csound, p->out, sizs, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, sizs, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
   p->n = 0;
   return OK;
 }
@@ -1063,7 +1087,8 @@ static int32_t unwrap_set(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t N = p->in->sizes[0];
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   if(*((MYFLT *)p->in2) != FL(0)) {
     csound->AuxAlloc(csound, N*sizeof(float), &p->mem);
     memset(p->mem.auxp, 0, N*sizeof(float));
@@ -1102,7 +1127,8 @@ static int32_t init_dct(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("dct: only one-dimensional arrays allowed"));
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->setup =  csound->DCTSetup(csound,N,FFT_FWD);
   return OK;
 }
@@ -1129,7 +1155,8 @@ static int32_t init_dctinv(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("dctinv: only one-dimensional arrays allowed"));
-  tabinit(csound, p->out, N, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   p->setup =  csound->DCTSetup(csound,N,FFT_INV);
   return OK;
 }
@@ -1179,7 +1206,8 @@ static int32_t mfb_init(CSOUND *csound, MFB *p) {
   int32_t   L = *p->len;
   int32_t N = p->in->sizes[0];
   if (LIKELY(L < N)) {
-    tabinit(csound, p->out, L, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, L, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
   }
   else
     return csound->InitError(csound, "%s",
@@ -1299,7 +1327,8 @@ static int32_t interleave_i (CSOUND *csound, INTERL *p) {
      p->c->dimensions == 1 &&
      p->b->sizes[0] == p->c->sizes[0]) {
     int32_t len = p->b->sizes[0], i,j;
-    tabinit(csound, p->a, len*2, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->a, len*2, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     for(i = 0, j = 0; i < len; i++,j+=2) {
       p->a->data[j] =  p->b->data[i];
       p->a->data[j+1] = p->c->data[i];
@@ -1324,8 +1353,9 @@ static int32_t deinterleave_i (CSOUND *csound, INTERL *p) {
     return csound->InitError(csound, "array not initialised\n");
   if(p->c->dimensions == 1) {
     int32_t len = p->c->sizes[0]/2, i,j;
-    tabinit(csound, p->a, len, p->h.insdshead);
-    tabinit(csound, p->b, len, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->a, len, p->h.insdshead) != OK ||
+                 tabinit(csound, p->b, len, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     for(i = 0, j = 0; i < len; i++,j+=2) {
       p->a->data[i] =  p->c->data[j];
       p->b->data[i] = p->c->data[j+1];

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -1352,14 +1352,34 @@ static int32_t deinterleave_i (CSOUND *csound, INTERL *p) {
   if(p->c->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   if(p->c->dimensions == 1) {
+    const CS_TYPE *arrayContainerType = csound->GetType(csound, "[");
+    ARRAYDAT preparedA = {0}, preparedB = {0};
     int32_t len = p->c->sizes[0]/2, i,j;
-    if (UNLIKELY(tabinit(csound, p->a, len, p->h.insdshead) != OK ||
-                 tabinit(csound, p->b, len, p->h.insdshead) != OK))
+
+    if (UNLIKELY(p->a == p->b))
+      return csound->InitError(csound, "%s",
+                               Str("array outputs must be distinct"));
+    if (UNLIKELY(arrayContainerType == NULL ||
+                 arrayContainerType->freeVariableMemory == NULL))
       return csound_array_init_resize_error(csound);
-    for(i = 0, j = 0; i < len; i++,j+=2) {
-      p->a->data[i] =  p->c->data[j];
-      p->b->data[i] = p->c->data[j+1];
+    preparedA.arrayType = p->a->arrayType;
+    preparedB.arrayType = p->b->arrayType;
+    if (UNLIKELY(tabinit(csound, &preparedA, len,
+                         p->h.insdshead) != OK ||
+                 tabinit(csound, &preparedB, len,
+                         p->h.insdshead) != OK)) {
+      arrayContainerType->freeVariableMemory(csound, &preparedA);
+      arrayContainerType->freeVariableMemory(csound, &preparedB);
+      return csound_array_init_resize_error(csound);
     }
+    for(i = 0, j = 0; i < len; i++,j+=2) {
+      preparedA.data[i] = p->c->data[j];
+      preparedB.data[i] = p->c->data[j+1];
+    }
+    arrayContainerType->freeVariableMemory(csound, p->a);
+    arrayContainerType->freeVariableMemory(csound, p->b);
+    *p->a = preparedA;
+    *p->b = preparedB;
     return OK;
   }
   return csound->InitError(csound, "%s", Str("array inputs not in correct format\n"));

--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -107,7 +107,9 @@ typedef struct {
 
 static int32_t linlinarr1_init(CSOUND *csound, LINLINARR1 *p) {
     int32_t numitems = p->xs->sizes[0];
-    tabinit(csound, p->ys, numitems, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->ys, numitems,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     CHECKARR1D(p->xs);
     CHECKARR1D(p->ys);
     return OK;
@@ -160,7 +162,9 @@ blendarray_init(CSOUND *csound, BLENDARRAY *p) {
     int32_t numitemsA = p->A->sizes[0];
     int32_t numitemsB = p->B->sizes[0];
     int32_t numitems = numitemsA < numitemsB ? numitemsA : numitemsB;
-    tabinit(csound, p->out, numitems, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, numitems,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->numitems = numitems;
     return OK;
 }
@@ -386,7 +390,9 @@ static int32_t
 ftom_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     p->freqA4 = csound->GetA4(csound);
     p->rnd = (int)*p->irnd;
-    tabinit(csound, p->outarr, p->inarr->sizes[0], p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->outarr, p->inarr->sizes[0],
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->skip = 0;
     ftom_arr(csound, p);
     p->skip = 1;
@@ -417,7 +423,9 @@ mtof_arr(CSOUND *csound, PITCHCONV_ARR *p) {
 static int32_t
 mtof_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     p->freqA4 = csound->GetA4(csound);
-    tabinit(csound, p->outarr, p->inarr->sizes[0], p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->outarr, p->inarr->sizes[0],
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->skip = 0;
     mtof_arr(csound, p);
     p->skip = 1;
@@ -892,7 +900,10 @@ typedef struct {
 
 
 static int32_t bpf_K_Km_init(CSOUND *csound, BPF_K_Km *p) {
-  tabinit(csound, p->out, p->in->sizes[0], p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, p->in->sizes[0],
+                         p->h.insdshead) != OK)) {
+        return csound_array_init_resize_error(csound);
+    }
     p->lastidx = -1;
     int32_t datalen = p->INOCOUNT - 1;
     if(datalen % 2)
@@ -902,7 +913,8 @@ static int32_t bpf_K_Km_init(CSOUND *csound, BPF_K_Km *p) {
     if(datalen >= BPF_MAXPOINTS)
         return INITERR(Str("bpf: too many pargs (max=256)"));
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
 }
 
@@ -1371,7 +1383,8 @@ cmp_init(CSOUND *csound, Cmp *p) {
 static int32_t
 cmparray1_init(CSOUND *csound, Cmp_array1 *p) {
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
@@ -1389,7 +1402,8 @@ cmparray2_init(CSOUND *csound, Cmp_array2 *p) {
 
     // make sure that we can put the result in `out`,
     // grow the array if necessary
-    tabinit(csound, p->out, N, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
@@ -1402,7 +1416,8 @@ cmparray2_init(CSOUND *csound, Cmp_array2 *p) {
 static int32_t
 cmp2array1_init(CSOUND *csound, Cmp2_array1 *p) {
     int32_t N = p->in->sizes[0];
-    tabinit(csound, p->out, N, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
 
     char *op1 = (char*)p->op1->data;
     int64_t op1size = p->op1->size - 1;
@@ -1871,7 +1886,9 @@ tab2array_init(CSOUND *csound, TAB2ARRAY *p) {
     if(numitems < 0) {
         return PERFERR(Str("tab2array: cannot copy a negative number of items"));
     }
-    tabinit(csound, p->out, numitems, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, numitems,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->numitems = numitems;
     return OK;
 }
@@ -2496,7 +2513,9 @@ array_binop_init(CSOUND *csound, BINOP_AAA *p) {
     for(i=0; i<p->in1->dimensions; i++) {
         numitems *= p->in1->sizes[i];
     }
-    tabinit(csound, p->out, numitems, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, numitems,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     p->numitems = numitems;
     return OK;
 }

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -919,7 +919,9 @@ static int32_t infile_set_A(CSOUND *csound, INFILEA *p)
   if (p->f.async == 1)
     csound->FSeekAsync(csound,p->f.fd, p->currpos*p->f.nchnls, SEEK_SET);
 
-  tabinit(csound, p->tabout, p->chn, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->tabout, p->chn,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   return OK;
 }
 

--- a/Opcodes/fout.c
+++ b/Opcodes/fout.c
@@ -920,8 +920,10 @@ static int32_t infile_set_A(CSOUND *csound, INFILEA *p)
     csound->FSeekAsync(csound,p->f.fd, p->currpos*p->f.nchnls, SEEK_SET);
 
   if (UNLIKELY(tabinit(csound, p->tabout, p->chn,
-                       p->h.insdshead) != OK))
+                       p->h.insdshead) != OK)) {
+    fout_deinit(csound, &p->f);
     return csound_array_init_resize_error(csound);
+  }
   return OK;
 }
 

--- a/Opcodes/ftsamplebank.cpp
+++ b/Opcodes/ftsamplebank.cpp
@@ -235,7 +235,9 @@ static int32_t directory(CSOUND *csound, DIR_STRUCT *p) {
   }
 
   int32_t numberOfFiles = (int32_t) fileNames.size();
-  tabinit(csound, p->outArr, numberOfFiles, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->outArr, numberOfFiles,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   STRINGDAT *strings = (STRINGDAT *)p->outArr->data;
 
   for (int32_t i = 0; i < numberOfFiles; i++) {

--- a/Opcodes/loscilx.c
+++ b/Opcodes/loscilx.c
@@ -389,7 +389,9 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
       sf->loopEnd = tmp;
     }
     p->nChannels = sf->nChannels;
-    tabinit(csound, p->arr, p->nChannels, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->arr, p->nChannels,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     dataPtr = (void*) &(sf->data[0]);
     p->curPos = loscilx_convert_phase(sf->startOffs);
     p->curLoopMode = sf->loopMode - 1;
@@ -416,7 +418,9 @@ static int32_t loscilxa_opcode_init(CSOUND *csound, LOSCILXA_OPCODE *p)
     if (ftp == NULL)
       return NOTOK;
     p->nChannels = ftp->nchanls;
-    tabinit(csound, p->arr, p->nChannels, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->arr, p->nChannels,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     dataPtr = (void*) &(ftp->ftable[0]);
     p->curPos = (int_least64_t) 0;
     switch ((int32_t) ftp->loopmode1) {

--- a/Opcodes/pan2.c
+++ b/Opcodes/pan2.c
@@ -168,7 +168,8 @@ static int32_t pan2arr_set(CSOUND *csound, PAN2ARR *p) {
     if (UNLIKELY(type <0 || type > 3))
       return csound->InitError(csound, "%s", Str("Unknown panning type"));
     // p->lastpan = -FL(1.0);
-    tabinit(csound, p->out, 2, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, 2, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
 }
 

--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -1674,7 +1674,9 @@ static int32_t hilbert_array_init(CSOUND *csound, HILBA *p) {
     p->off = 0;
     p->N = N;
     p->hop = h;
-    tabinit(csound, p->out, CS_KSMPS, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, CS_KSMPS,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     for(int k=0; k < CS_KSMPS; k++)
       ((COMPLEXDAT *)p->out->data)[k].isPolar = 0;  
     return OK;

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -782,14 +782,32 @@ static int32_t scsnsmap(CSOUND *csound, PSCSNMAP *p)
 
 static int32_t scsnmapV_init(CSOUND *csound, PSCSNMAPV *p)
 {
+    const CS_TYPE *arrayContainerType = csound->GetType(csound, "[");
+    ARRAYDAT preparedPosition = {0}, preparedVelocity = {0};
+
     /* Get corresponding update */
     p->p = listget(csound, (int32_t)*p->i_id);
     if (p->p == NULL) return NOTOK;
-    if (UNLIKELY(tabinit(csound, p->k_pos, (p->p)->len,
-                         p->h.insdshead) != OK ||
-                 tabinit(csound, p->k_vel, (p->p)->len,
-                         p->h.insdshead) != OK))
+    if (UNLIKELY(p->k_pos == p->k_vel))
+      return csound->InitError(csound, "%s",
+                               Str("array outputs must be distinct"));
+    if (UNLIKELY(arrayContainerType == NULL ||
+                 arrayContainerType->freeVariableMemory == NULL))
       return csound_array_init_resize_error(csound);
+    preparedPosition.arrayType = p->k_pos->arrayType;
+    preparedVelocity.arrayType = p->k_vel->arrayType;
+    if (UNLIKELY(tabinit(csound, &preparedPosition, (p->p)->len,
+                         p->h.insdshead) != OK ||
+                 tabinit(csound, &preparedVelocity, (p->p)->len,
+                         p->h.insdshead) != OK)) {
+      arrayContainerType->freeVariableMemory(csound, &preparedPosition);
+      arrayContainerType->freeVariableMemory(csound, &preparedVelocity);
+      return csound_array_init_resize_error(csound);
+    }
+    arrayContainerType->freeVariableMemory(csound, p->k_pos);
+    arrayContainerType->freeVariableMemory(csound, p->k_vel);
+    *p->k_pos = preparedPosition;
+    *p->k_vel = preparedVelocity;
     return OK;
 }
 

--- a/Opcodes/scansyn.c
+++ b/Opcodes/scansyn.c
@@ -785,8 +785,11 @@ static int32_t scsnmapV_init(CSOUND *csound, PSCSNMAPV *p)
     /* Get corresponding update */
     p->p = listget(csound, (int32_t)*p->i_id);
     if (p->p == NULL) return NOTOK;
-    tabinit(csound, p->k_pos,(p->p)->len, p->h.insdshead);
-    tabinit(csound, p->k_vel,(p->p)->len, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->k_pos, (p->p)->len,
+                         p->h.insdshead) != OK ||
+                 tabinit(csound, p->k_vel, (p->p)->len,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     return OK;
 }
 

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -690,7 +690,9 @@ static int32_t init_raw_osc(CSOUND *csound, RAWOSC *p)
       memset(buf, 0, MTU);
     }
     if(p->sout->data == NULL)
-      tabinit(csound, p->sout, 2, p->h.insdshead);
+      if (UNLIKELY(tabinit(csound, p->sout, 2,
+                           p->h.insdshead) != OK))
+        return csound_array_init_resize_error(csound);
 
   return OK;
 }

--- a/Opcodes/ugsc.c
+++ b/Opcodes/ugsc.c
@@ -744,7 +744,9 @@ static int32_t hilbertset_array(CSOUND *csound, HILBERTA *p)
       p->xnm1[j] = p->ynm1[j] = FL(0.0);
       p->coef[j] = -(MYFLT)beta;
     }
-    tabinit(csound, p->out, CS_KSMPS, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->out, CS_KSMPS,
+                         p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     for(int k=0; k < CS_KSMPS; k++)
       ((COMPLEXDAT *)p->out->data)[k].isPolar = 0;  
     return OK;
@@ -818,4 +820,3 @@ int32_t ugsc_init_(CSOUND *csound)
                                  (int32_t
                                   ) (sizeof(localops) / sizeof(OENTRY)));
 }
-

--- a/Opcodes/vbap.c
+++ b/Opcodes/vbap.c
@@ -1916,7 +1916,9 @@ int32_t vbap_init_a(CSOUND *csound, VBAPA *p)
                              "%s", Str("vbap system NOT configured.\nMissing"
                                        " vbaplsinit opcode in orchestra?"));
   //printf("**** size = %d\n", p->q.ls_set_am);
-  tabinit(csound,  p->tabout, p->q.ls_set_am, p->h.insdshead);
+  if (UNLIKELY(tabinit(csound, p->tabout, p->q.ls_set_am,
+                       p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
   cnt = p->q.number = p->tabout->sizes[0];
   csound->AuxAlloc(csound, p->q.ls_set_am * sizeof(LS_SET), &p->q.aux);
   if (UNLIKELY(p->q.aux.auxp == NULL)) {
@@ -3066,4 +3068,3 @@ static OENTRY vbap_localops[] = {
 };
 
 LINKAGE_BUILTIN(vbap_localops)
-

--- a/Top/opcode.c
+++ b/Top/opcode.c
@@ -1267,7 +1267,8 @@ int32_t create_opcode_array(CSOUND *csound, OPARRAY *p) {
     OENTRY *entry =
      ref->entries->entries[n < ref->entries->count ? n : ref->entries->count-1];
     n  = *p->n;
-    tabinit(csound, p->r, n, p->h.insdshead);
+    if (UNLIKELY(tabinit(csound, p->r, n, p->h.insdshead) != OK))
+      return csound_array_init_resize_error(csound);
     obj = (OPCODEOBJ *) p->r->data;
     for(i = 0; i < n; i++) {
       if(obj[i].dataspace == NULL || obj[i].size < entry->dsblksiz) {
@@ -1469,8 +1470,10 @@ int32_t opcode_array_init(CSOUND *csound, OPRUN *p) {
       array = (ARRAYDAT *) p->args[i];
       if(array->dimensions > 1)
         return csound->InitError(csound, "only 1-dim arrays are allowed\n");
-      if(array->dimensions == 0 || n > array->sizes[0])
-        tabinit(csound, array, n, p->h.insdshead);
+      if (array->dimensions == 0 || n > array->sizes[0]) {
+        if (UNLIKELY(tabinit(csound, array, n, p->h.insdshead) != OK))
+          return csound_array_init_resize_error(csound);
+      }
   }
   for(i = 0; i < n; i++) {
     size_t size;

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -23,6 +23,7 @@
 #ifndef __ARRAY_H__
 #define __ARRAY_H__
 
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -190,8 +191,10 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
                                                    INSDS *ctx)
 {
     CS_VARIABLE *var = NULL;
+    MYFLT *newData;
     size_t oldCapacity = 0;
     size_t bytes;
+    int32_t memberSize = array->arrayMemberSize;
     int32_t fresh = array->data == NULL;
 
     if (array->arrayType == NULL || capacity == 0) {
@@ -207,7 +210,7 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
             }
             return NOTOK;
         }
-        array->arrayMemberSize = var->memBlockSize;
+        memberSize = var->memBlockSize;
     }
     else {
         /* allocated == 0 marks a legacy non-owning view. Only managed
@@ -229,7 +232,7 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
         }
         oldCapacity = array->allocated / (size_t)array->arrayMemberSize;
     }
-    if (csound_array_allocation_size(array->arrayMemberSize, capacity,
+    if (csound_array_allocation_size(memberSize, capacity,
                                      &bytes) != OK) {
         if (var != NULL) {
             csound->Free(csound, var);
@@ -243,7 +246,7 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
     if (!fresh && array->arrayType->userDefinedType) {
         var = array_element_create_variable(csound, array->arrayType, ctx);
         if (var == NULL || var->initializeVariableMemory == NULL ||
-            var->memBlockSize != array->arrayMemberSize) {
+            var->memBlockSize != memberSize) {
             if (var != NULL) {
                 csound->Free(csound, var);
             }
@@ -251,19 +254,38 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
         }
     }
     if (fresh) {
-        array->data = (MYFLT *)csound->Calloc(csound, bytes);
+        newData = (MYFLT *)csound->Calloc(csound, bytes);
+        if (UNLIKELY(newData == NULL)) {
+            csound->Free(csound, var);
+            return NOTOK;
+        }
+        if (UNLIKELY(csound_array_initialize_struct_range(
+                       csound, array->arrayType, var, newData, memberSize,
+                       oldCapacity, capacity) != OK)) {
+            csound->Free(csound, newData);
+            csound->Free(csound, var);
+            return NOTOK;
+        }
+        array->arrayMemberSize = memberSize;
+        array->data = newData;
+        array->allocated = bytes;
     }
     else {
-        array->data = (MYFLT *)csound->ReAlloc(csound, array->data, bytes);
-        memset((char *)array->data + array->allocated, 0,
+        newData = (MYFLT *)csound->ReAlloc(csound, array->data, bytes);
+        if (UNLIKELY(newData == NULL)) {
+            csound->Free(csound, var);
+            return NOTOK;
+        }
+        array->data = newData;
+        memset((char *)newData + array->allocated, 0,
                bytes - array->allocated);
-    }
-    array->allocated = bytes;
-    if (csound_array_initialize_struct_range(
-          csound, array->arrayType, var, array->data,
-          array->arrayMemberSize, oldCapacity, capacity) != OK) {
-        csound->Free(csound, var);
-        return NOTOK;
+        array->allocated = bytes;
+        if (UNLIKELY(csound_array_initialize_struct_range(
+                       csound, array->arrayType, var, newData, memberSize,
+                       oldCapacity, capacity) != OK)) {
+            csound->Free(csound, var);
+            return NOTOK;
+        }
     }
     if (var != NULL) {
         csound->Free(csound, var);
@@ -317,6 +339,8 @@ static inline int32_t tabinit_like(CSOUND *csound, ARRAYDAT *p,
                                    const ARRAYDAT *tp)
 {
     int32_t *newSizes = NULL;
+    const CS_TYPE *originalArrayType;
+    const CS_TYPE *targetArrayType;
     size_t elementCount;
     size_t capacity;
 
@@ -328,12 +352,12 @@ static inline int32_t tabinit_like(CSOUND *csound, ARRAYDAT *p,
     if (p == tp) {
         return OK;
     }
-    if (p->arrayType == NULL) {
-        p->arrayType = tp->arrayType;
-    }
-    if (UNLIKELY(p->arrayType == NULL ||
+    originalArrayType = p->arrayType;
+    targetArrayType = originalArrayType != NULL
+      ? originalArrayType : tp->arrayType;
+    if (UNLIKELY(targetArrayType == NULL ||
                  !csound_array_element_types_compatible(
-                   p->arrayType, tp->arrayType))) {
+                   targetArrayType, tp->arrayType))) {
         return NOTOK;
     }
     if (tp->dimensions > 0 &&
@@ -347,17 +371,21 @@ static inline int32_t tabinit_like(CSOUND *csound, ARRAYDAT *p,
                sizeof(int32_t) * (size_t)tp->dimensions);
     }
     if (UNLIKELY(csound_array_prepare_write(csound, p, NULL) != OK)) {
+        p->arrayType = originalArrayType;
         csound->Free(csound, newSizes);
         return NOTOK;
     }
     if (p->data == tp->data) {
+        p->arrayType = targetArrayType;
         csound->Free(csound, newSizes);
         return OK;
     }
 
     capacity = elementCount > 0 ? elementCount : 1;
+    p->arrayType = targetArrayType;
     if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, NULL)
                  != OK)) {
+        p->arrayType = originalArrayType;
         csound->Free(csound, newSizes);
         return NOTOK;
     }
@@ -385,10 +413,23 @@ static inline int32_t csound_array_init_resize_error(CSOUND *csound)
 }
 
 static inline int32_t csound_array_perf_resize_error(CSOUND *csound,
-                                                      OPDS *ctx)
+                                                     OPDS *ctx)
 {
     return csound->PerfError(csound, ctx, "%s",
                              Str("Could not resize array"));
+}
+
+static inline int32_t csound_array_size_to_int32(MYFLT requestedSize,
+                                                 int32_t *size)
+{
+    double value = (double)requestedSize;
+
+    if (size == NULL || isnan(value) || value < 0.0 ||
+        value >= (double)INT32_MAX + 1.0) {
+        return NOTOK;
+    }
+    *size = (int32_t)value;
+    return OK;
 }
 
 static inline int32_t tabcheck(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *q)

--- a/include/arrays.h
+++ b/include/arrays.h
@@ -271,53 +271,62 @@ static inline int32_t csound_array_ensure_capacity(CSOUND *csound,
     return OK;
 }
 
-static inline void tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size,
-                           INSDS *ctx)
+/* Resize an array. Return NOTOK without publishing a new logical size when
+   validation, detachment, or allocation fails. */
+static inline int32_t tabinit(CSOUND *csound, ARRAYDAT *p, int32_t size,
+                              INSDS *ctx)
 {
+    int32_t *newSizes = NULL;
     size_t capacity;
 
     if (UNLIKELY(p == NULL || size < 0 || p->dimensions < 0)) {
-        csound->Die(csound, "tabinit: invalid array or size");
-        return;
-    }
-    if (UNLIKELY(csound_array_prepare_write(csound, p, ctx) != OK)) {
-        csound->Die(csound, "tabinit: could not detach shared array");
-        return;
-    }
-    if (p->dimensions == 0) {
-        p->dimensions = 1;
-    }
-    if (p->dimensions == 1 && p->sizes == NULL) {
-        p->sizes = (int32_t *)csound->Calloc(csound, sizeof(int32_t));
+        return NOTOK;
     }
     if (UNLIKELY(p->dimensions > 1 && p->sizes == NULL)) {
-        csound->Die(csound, "tabinit: multidimensional array has no sizes");
-        return;
+        return NOTOK;
+    }
+    if (p->dimensions <= 1 && p->sizes == NULL) {
+        newSizes = (int32_t *)csound->Calloc(csound, sizeof(int32_t));
+        if (UNLIKELY(newSizes == NULL)) {
+            return NOTOK;
+        }
+    }
+    if (UNLIKELY(csound_array_prepare_write(csound, p, ctx) != OK)) {
+        csound->Free(csound, newSizes);
+        return NOTOK;
     }
     capacity = size > 0 ? (size_t)size : 1;
     if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, ctx)
                  != OK)) {
-        csound->Die(csound, "tabinit: could not allocate array storage");
-        return;
+        csound->Free(csound, newSizes);
+        return NOTOK;
     }
-    if (p->dimensions == 1) {
+    if (newSizes != NULL) {
+        p->sizes = newSizes;
+    }
+    if (p->dimensions <= 1) {
+        p->dimensions = 1;
         p->sizes[0] = size;
     }
+    return OK;
 }
 
-static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p,
-                                const ARRAYDAT *tp)
+/* Match another array's layout. Return NOTOK without publishing partial size
+   metadata when validation, detachment, or allocation fails. */
+static inline int32_t tabinit_like(CSOUND *csound, ARRAYDAT *p,
+                                   const ARRAYDAT *tp)
 {
+    int32_t *newSizes = NULL;
     size_t elementCount;
     size_t capacity;
 
-    if (UNLIKELY(p == NULL || tp == NULL || tp->dimensions < 0 ||
+    if (UNLIKELY(p == NULL || tp == NULL || p->dimensions < 0 ||
+                 tp->dimensions < 0 ||
                  csound_array_member_count(tp, &elementCount) != OK)) {
-        csound->Die(csound, "tabinit_like: invalid source array");
-        return;
+        return NOTOK;
     }
     if (p == tp) {
-        return;
+        return OK;
     }
     if (p->arrayType == NULL) {
         p->arrayType = tp->arrayType;
@@ -325,36 +334,61 @@ static inline void tabinit_like(CSOUND *csound, ARRAYDAT *p,
     if (UNLIKELY(p->arrayType == NULL ||
                  !csound_array_element_types_compatible(
                    p->arrayType, tp->arrayType))) {
-        csound->Die(csound, "tabinit_like: array types do not match");
-        return;
+        return NOTOK;
+    }
+    if (tp->dimensions > 0 &&
+        (p->dimensions != tp->dimensions || p->sizes == NULL)) {
+        newSizes = (int32_t *)csound->Calloc(
+          csound, sizeof(int32_t) * (size_t)tp->dimensions);
+        if (UNLIKELY(newSizes == NULL)) {
+            return NOTOK;
+        }
+        memcpy(newSizes, tp->sizes,
+               sizeof(int32_t) * (size_t)tp->dimensions);
     }
     if (UNLIKELY(csound_array_prepare_write(csound, p, NULL) != OK)) {
-        csound->Die(csound, "tabinit_like: could not detach shared array");
-        return;
+        csound->Free(csound, newSizes);
+        return NOTOK;
     }
     if (p->data == tp->data) {
-        return;
+        csound->Free(csound, newSizes);
+        return OK;
     }
 
+    capacity = elementCount > 0 ? elementCount : 1;
+    if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, NULL)
+                 != OK)) {
+        csound->Free(csound, newSizes);
+        return NOTOK;
+    }
     if (tp->dimensions == 0) {
         csound->Free(csound, p->sizes);
         p->sizes = NULL;
         p->dimensions = 0;
     }
-    else if (p->dimensions != tp->dimensions || p->sizes == NULL) {
-        p->sizes = (int32_t *)csound->ReAlloc(
-          csound, p->sizes, sizeof(int32_t) * (size_t)tp->dimensions);
+    else if (newSizes != NULL) {
+        csound->Free(csound, p->sizes);
+        p->sizes = newSizes;
         p->dimensions = tp->dimensions;
+        newSizes = NULL;
     }
-    if (tp->dimensions > 0) {
+    else {
         memcpy(p->sizes, tp->sizes,
                sizeof(int32_t) * (size_t)tp->dimensions);
     }
-    capacity = elementCount > 0 ? elementCount : 1;
-    if (UNLIKELY(csound_array_ensure_capacity(csound, p, capacity, NULL)
-                 != OK)) {
-        csound->Die(csound, "tabinit_like: could not allocate array storage");
-    }
+    return OK;
+}
+
+static inline int32_t csound_array_init_resize_error(CSOUND *csound)
+{
+    return csound->InitError(csound, "%s", Str("Could not resize array"));
+}
+
+static inline int32_t csound_array_perf_resize_error(CSOUND *csound,
+                                                      OPDS *ctx)
+{
+    return csound->PerfError(csound, ctx, "%s",
+                             Str("Could not resize array"));
 }
 
 static inline int32_t tabcheck(CSOUND *csound, ARRAYDAT *p, int32_t size, OPDS *q)

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -351,9 +351,15 @@ public:
 template <typename T> class Vector : ARRAYDAT {
 
 public:
+  /** Initialise the container.
+   */
+  void init(Csound *csound, int32_t size, INSDS *ctx) {
+    (void)init_checked(csound, size, ctx);
+  }
+
   /** Initialise the container and return OK or NOTOK.
    */
-  int32_t init(Csound *csound, int32_t size, INSDS *ctx) {
+  int32_t init_checked(Csound *csound, int32_t size, INSDS *ctx) {
     return tabinit(csound, this, size, ctx);
   }
 

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -351,10 +351,10 @@ public:
 template <typename T> class Vector : ARRAYDAT {
 
 public:
-  /** Initialise the container
+  /** Initialise the container and return OK or NOTOK.
    */
-  void init(Csound *csound, int32_t size, INSDS *ctx) {
-    tabinit(csound, this, size, ctx);
+  int32_t init(Csound *csound, int32_t size, INSDS *ctx) {
+    return tabinit(csound, this, size, ctx);
   }
 
   /** Return writable data without allocating while detaching shared storage.

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -351,15 +351,9 @@ public:
 template <typename T> class Vector : ARRAYDAT {
 
 public:
-  /** Initialise the container.
-   */
-  void init(Csound *csound, int32_t size, INSDS *ctx) {
-    (void)init_checked(csound, size, ctx);
-  }
-
   /** Initialise the container and return OK or NOTOK.
    */
-  int32_t init_checked(Csound *csound, int32_t size, INSDS *ctx) {
+  int32_t init(Csound *csound, int32_t size, INSDS *ctx) {
     return tabinit(csound, this, size, ctx);
   }
 

--- a/tests/c/channel_tests.cpp
+++ b/tests/c/channel_tests.cpp
@@ -318,6 +318,40 @@ TEST_F (ChannelTests, ArrayDataSetterRejectsManagedElements)
     EXPECT_EQ(originalString, currentString);
 }
 
+TEST_F (ChannelTests, InvalidArrayChannelShapeDoesNotPublishMetadata)
+{
+    const int32_t invalidSizes[] = {-1};
+    const int32_t validSizes[] = {2};
+    void *channelPointer = nullptr;
+
+    ASSERT_EQ(CSOUND_SUCCESS, csoundGetChannelPtr(
+      csound, &channelPointer, "array-shape",
+      CSOUND_ARRAY_CHANNEL | CSOUND_INPUT_CHANNEL |
+      CSOUND_OUTPUT_CHANNEL));
+    ARRAYDAT *array = static_cast<ARRAYDAT *>(channelPointer);
+    ASSERT_NE(nullptr, array);
+    const int32_t oldDimensions = array->dimensions;
+    int32_t *const oldSizes = array->sizes;
+    const CS_TYPE *const oldArrayType = array->arrayType;
+    MYFLT *const oldData = array->data;
+    const size_t oldAllocated = array->allocated;
+
+    EXPECT_EQ(nullptr, csoundInitArrayChannel(
+      csound, "array-shape", "k", 1, invalidSizes));
+    EXPECT_EQ(oldDimensions, array->dimensions);
+    EXPECT_EQ(oldSizes, array->sizes);
+    EXPECT_EQ(oldArrayType, array->arrayType);
+    EXPECT_EQ(oldData, array->data);
+    EXPECT_EQ(oldAllocated, array->allocated);
+
+    EXPECT_EQ(array, csoundInitArrayChannel(
+      csound, "array-shape", "k", 1, validSizes));
+    EXPECT_EQ(1, array->dimensions);
+    ASSERT_NE(nullptr, array->sizes);
+    EXPECT_EQ(2, array->sizes[0]);
+    EXPECT_NE(nullptr, array->data);
+}
+
 const char orc6[] = "chn_k \"chan\", 3, 2, 0.5, 0, 1, 10, 10, 50, 100\n"
         "chn_k \"chan2\", 3, 2, 0.5, 0, 1, 10, 10, 50, 100, \"testattr\"\n"
         "chn_k \"chan3\", 3, 2, 0.5, 0, 1\n"

--- a/tests/c/csound_type_system_test.cpp
+++ b/tests/c/csound_type_system_test.cpp
@@ -241,6 +241,76 @@ TEST_F (TypeSystemTests, testIndependentArrayCopyReportsTypeMismatch)
     EXPECT_EQ(0u, destination.allocated);
 }
 
+TEST_F (TypeSystemTests, testTabinitRejectsNegativeSizeWithoutMutation)
+{
+    ARRAYDAT array{};
+
+    array.arrayType = &CS_VAR_TYPE_I;
+    ASSERT_EQ(OK, tabinit(csound, &array, 2, nullptr));
+    ASSERT_NE(nullptr, array.data);
+    ASSERT_NE(nullptr, array.sizes);
+    array.data[0] = FL(11.0);
+    MYFLT *const data = array.data;
+    int32_t *const sizes = array.sizes;
+    const size_t allocated = array.allocated;
+
+    EXPECT_EQ(NOTOK, tabinit(csound, &array, -1, nullptr));
+    EXPECT_EQ(data, array.data);
+    EXPECT_EQ(sizes, array.sizes);
+    EXPECT_EQ(allocated, array.allocated);
+    EXPECT_EQ(1, array.dimensions);
+    EXPECT_EQ(2, array.sizes[0]);
+    EXPECT_EQ(FL(11.0), array.data[0]);
+
+    csound_free_array_storage(csound, &array);
+}
+
+TEST_F (TypeSystemTests, testTabinitStorageFailureLeavesArrayReusable)
+{
+    ARRAYDAT array{};
+
+    EXPECT_EQ(NOTOK, tabinit(csound, &array, 2, nullptr));
+    EXPECT_EQ(0, array.dimensions);
+    EXPECT_EQ(nullptr, array.sizes);
+    EXPECT_EQ(nullptr, array.data);
+    EXPECT_EQ(0u, array.allocated);
+
+    array.arrayType = &CS_VAR_TYPE_I;
+    ASSERT_EQ(OK, tabinit(csound, &array, 2, nullptr));
+    EXPECT_EQ(1, array.dimensions);
+    EXPECT_EQ(2, array.sizes[0]);
+    EXPECT_NE(nullptr, array.data);
+
+    csound_free_array_storage(csound, &array);
+}
+
+TEST_F (TypeSystemTests, testTabinitLikeRejectsInvalidSourceWithoutMutation)
+{
+    ARRAYDAT source{};
+    ARRAYDAT destination{};
+
+    destination.arrayType = &CS_VAR_TYPE_I;
+    ASSERT_EQ(OK, tabinit(csound, &destination, 2, nullptr));
+    ASSERT_NE(nullptr, destination.data);
+    ASSERT_NE(nullptr, destination.sizes);
+    destination.data[0] = FL(13.0);
+    MYFLT *const data = destination.data;
+    int32_t *const sizes = destination.sizes;
+    const size_t allocated = destination.allocated;
+    source.arrayType = &CS_VAR_TYPE_I;
+    source.dimensions = -1;
+
+    EXPECT_EQ(NOTOK, tabinit_like(csound, &destination, &source));
+    EXPECT_EQ(data, destination.data);
+    EXPECT_EQ(sizes, destination.sizes);
+    EXPECT_EQ(allocated, destination.allocated);
+    EXPECT_EQ(1, destination.dimensions);
+    EXPECT_EQ(2, destination.sizes[0]);
+    EXPECT_EQ(FL(13.0), destination.data[0]);
+
+    csound_free_array_storage(csound, &destination);
+}
+
 TEST_F (TypeSystemTests, testConcurrentStructuredArrayCopiesShareOneStorage)
 {
     constexpr int32_t readerCount = 8;

--- a/tests/c/csound_type_system_test.cpp
+++ b/tests/c/csound_type_system_test.cpp
@@ -311,6 +311,38 @@ TEST_F (TypeSystemTests, testTabinitLikeRejectsInvalidSourceWithoutMutation)
     csound_free_array_storage(csound, &destination);
 }
 
+TEST_F (TypeSystemTests, testTabinitLikeFailureLeavesUntypedArrayUnchanged)
+{
+    CS_TYPE invalidElementType{};
+    int32_t sourceSizes[] = {1};
+    MYFLT sourceData = FL(0.0);
+    ARRAYDAT source{};
+    ARRAYDAT destination{};
+
+    source.arrayType = &invalidElementType;
+    source.dimensions = 1;
+    source.sizes = sourceSizes;
+    source.data = &sourceData;
+
+    EXPECT_EQ(NOTOK, tabinit_like(csound, &destination, &source));
+    EXPECT_EQ(nullptr, destination.arrayType);
+    EXPECT_EQ(0, destination.dimensions);
+    EXPECT_EQ(nullptr, destination.sizes);
+    EXPECT_EQ(0, destination.arrayMemberSize);
+    EXPECT_EQ(nullptr, destination.data);
+    EXPECT_EQ(0u, destination.allocated);
+    EXPECT_EQ(nullptr, destination.storage);
+}
+
+TEST_F (TypeSystemTests, testTrimRejectsInt32MaxPlusOne)
+{
+    MYFLT requestedSize = (MYFLT)2147483648.0;
+    int32_t size = 1;
+
+    EXPECT_EQ(NOTOK, csound_array_size_to_int32(requestedSize, &size));
+    EXPECT_EQ(1, size);
+}
+
 TEST_F (TypeSystemTests, testConcurrentStructuredArrayCopiesShareOneStorage)
 {
     constexpr int32_t readerCount = 8;

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -484,6 +484,36 @@ TEST_F (EngineTests, testScoreRewind)
     ASSERT_TRUE(csoundPerformKsmps(csound) == 0); 
 }
 
+TEST_F (EngineTests, testInvalidTrimDoesNotStopFollowingInstrument)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 1000
+      ksmps = 10
+      nchnls = 1
+
+      instr 1
+        values:i[] init 1
+        trim values, -1
+      endin
+
+      instr 2
+        chnset 1, "continued"
+      endin
+    )", 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 0\ni 2 0.01 0\n", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    for (int32_t cycle = 0; cycle < 4; ++cycle) {
+      if (csoundPerformKsmps(csound) != CSOUND_SUCCESS)
+        break;
+    }
+
+    int32_t error = 0;
+    EXPECT_EQ(csoundGetControlChannel(csound, "continued", &error), FL(1.0));
+    EXPECT_EQ(error, CSOUND_SUCCESS);
+}
+
 TEST_F (EngineTests, testCommandLineArgumentsApi)
 {
     char firstArgument[] = "concert.orc";

--- a/util/mkir.c
+++ b/util/mkir.c
@@ -263,7 +263,8 @@ static int32_t deconv_init(CSOUND *csound, DECONV *p) {
   int32_t fftlen;
   p->len = p->swp->sizes[0];
   fftlen = p->len*2;
-  tabinit_like(csound, p->outp, p->swp);
+  if (UNLIKELY(tabinit_like(csound, p->outp, p->swp) != OK))
+    return csound_array_init_resize_error(csound);
   p->in = (MYFLT *) csound->Calloc(csound, sizeof(MYFLT)*fftlen);
   p->sw = (MYFLT *) csound->Calloc(csound, sizeof(MYFLT)*fftlen);
   return OK;


### PR DESCRIPTION
tabinit() and tabinit_like() called Die() when validation, detachment, or allocation failed. This stopped the whole engine for errors that an opcode could report and handle.

This change makes both helpers return OK or NOTOK. It delays logical size updates until storage is ready and updates all in-tree callers to report the right init or performance error. It also validates trim sizes before converting them to integers.

Tests cover invalid sizes, unchanged and reusable arrays after failure, and confirm that an init error deletes only the bad note while later instruments still run.

Closes #2621.