### PR TITLE
Check expected-failure diagnostics

### DIFF
--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2911,25 +2911,25 @@ int32_t verify_opcode(CSOUND* csound, TREE* root, TYPE_TABLE* typeTable) {
                          root->value->last_column);
     csound->Free(csound, name);
     name = strip_extension(csound, root->value->lexeme);
-    csoundMessage(csound, Str("Found:\n  %s %s %s\n"),
-                  leftArgString ? leftArgString : "", name,
-                  rightArgString ? rightArgString : "");
+    csoundMessageS(csound, CSOUNDMSG_ERROR, Str("Found:\n  %s %s %s\n"),
+                   leftArgString ? leftArgString : "", name,
+                   rightArgString ? rightArgString : "");
     csound->Free(csound, name);
-    csoundMessage(csound, Str("\nCandidates:\n"));
+    csoundMessageS(csound, CSOUNDMSG_ERROR, Str("\nCandidates:\n"));
 
     for (i = 0; i < entries->count; i++) {
       OENTRY *entry = entries->entries[i];
       name = strip_extension(csound, entry->opname);
-      csoundMessage(csound, "  %s %s %s\n", entry->outypes, name,
-                    entry->intypes);
+      csoundMessageS(csound, CSOUNDMSG_ERROR, "  %s %s %s\n",
+                     entry->outypes, name, entry->intypes);
       csound->Free(csound, name);
     }
 
-    csoundMessage(csound, Str("\nLine: %d "
-                              " columns %d-%d\n"),
-                  root->line,
-                  root->value->first_column,
-                  root->value->last_column);
+    csoundMessageS(csound, CSOUNDMSG_ERROR, Str("\nLine: %d "
+                                                " columns %d-%d\n"),
+                   root->line,
+                   root->value->first_column,
+                   root->value->last_column);
     do_baktrace(csound, root->locn);
 
     csound->Free(csound, leftArgString);

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -99,6 +99,7 @@ if(Python3_Interpreter_FOUND)
 
   add_custom_target(csdtest-harness-tests
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_harness.py
+    VERBATIM
   )
   add_dependencies(csdtests csdtest-harness-tests)
   add_dependencies(csdtests-verbose csdtest-harness-tests)

--- a/tests/commandline/CMakeLists.txt
+++ b/tests/commandline/CMakeLists.txt
@@ -96,7 +96,12 @@ if(Python3_Interpreter_FOUND)
       VERBATIM
     )
   endif()
+
+  add_custom_target(csdtest-harness-tests
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_harness.py
+  )
+  add_dependencies(csdtests csdtest-harness-tests)
+  add_dependencies(csdtests-verbose csdtest-harness-tests)
 else()
   message(STATUS "Python3 not found; not creating commandline test targets.")
 endif()
-

--- a/tests/commandline/arrays/test_opcode_array_managed_input_fail.csd
+++ b/tests/commandline/arrays/test_opcode_array_managed_input_fail.csd
@@ -10,23 +10,11 @@ nchnls = 1
 
 struct Sample value:k
 
-opcode EchoSample(input:Sample):Sample
-  xout input
-endop
-
 opcode SampleValue(input:Sample):k
   xout input.value
 endop
 
 instr 1
-  definition:OpcodeDef init "EchoSample"
-  objects:Opcode[] create definition, 1
-  input:Sample[] init 1
-  output:Sample[] init 1
-  output run objects, input
-endin
-
-instr 2
   definition:OpcodeDef init "SampleValue"
   objects:Opcode[] create definition, 1
   input:Sample[] init 1
@@ -37,6 +25,5 @@ endin
 </CsInstruments>
 <CsScore>
 i 1 0 0.1
-i 2 0 0.1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/arrays/test_opcode_array_managed_output_fail.csd
+++ b/tests/commandline/arrays/test_opcode_array_managed_output_fail.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+sr = 1000
+ksmps = 10
+nchnls = 1
+
+struct Sample value:k
+
+opcode EchoSample(input:Sample):Sample
+  xout input
+endop
+
+instr 1
+  definition:OpcodeDef init "EchoSample"
+  objects:Opcode[] create definition, 1
+  input:Sample[] init 1
+  output:Sample[] init 1
+  output run objects, input
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -6,6 +6,7 @@
 import logging
 import locale
 import os
+import re
 import shlex
 import shutil
 import stat
@@ -46,6 +47,15 @@ def setup_logging():
 
 logger = setup_logging()
 
+WINDOWS_EXCEPTION_EXIT_MIN = 0xC0000000
+
+
+def is_normal_nonzero_exit(return_code):
+    """Reject signal exits and Windows exception status codes."""
+    if return_code <= 0:
+        return False
+    return os.name != "nt" or return_code < WINDOWS_EXCEPTION_EXIT_MIN
+
 
 class Test:
     def __init__(self, fileName, description="", expected=True):
@@ -55,10 +65,22 @@ class Test:
 
 
 class TestResult:
-    """Container for test execution results with ordering information."""
+    """Container for test results and optional stderr diagnostic checks.
+
+    A string in the third test entry is an expected stderr substring. A
+    compiled regular expression in that entry matches stderr with search().
+    Both forms also require a normal nonzero process exit.
+    """
 
     def __init__(
-        self, test_index, test_data, return_code, cs_output, execution_time, error=None
+        self,
+        test_index,
+        test_data,
+        return_code,
+        cs_output,
+        execution_time,
+        error=None,
+        stderr_output=None,
     ):
         self.test_index = test_index
         self.test_data = test_data
@@ -68,16 +90,38 @@ class TestResult:
         self.error = error
         self.filename = test_data[0]
         self.description = test_data[1]
+        self.expected = test_data[2] if len(test_data) >= 3 else 0
         self.expected_result = (
-            1 if len(test_data) == 3 or self.filename in expectedFailures else 0
+            1
+            if self.filename in expectedFailures
+            else 0 if self.expected in (None, False, 0, "") else 1
         )
+        self.stderr_output = cs_output if stderr_output is None else stderr_output
+
+    @property
+    def expected_stderr(self):
+        """Return the expected stderr substring or regular expression."""
+        if self.expected_result != 0 and isinstance(self.expected, (str, re.Pattern)):
+            return self.expected
+        return None
+
+    @property
+    def stderr_matches(self):
+        """Check the diagnostic for an expected-failure test."""
+        if self.expected_stderr is None:
+            return True
+        if isinstance(self.expected_stderr, str):
+            return self.expected_stderr in self.stderr_output
+        return self.expected_stderr.search(self.stderr_output) is not None
 
     @property
     def passed(self):
         """Check if test passed based on return code and expected result."""
         if self.error is not None:
             return False
-        return (self.return_code == 0) == (self.expected_result == 0)
+        if self.expected_result == 0:
+            return self.return_code == 0
+        return is_normal_nonzero_exit(self.return_code) and self.stderr_matches
 
     @property
     def status_line(self):
@@ -94,6 +138,16 @@ class TestResult:
         output += (
             f"\tReturn Code: {self.return_code}\tExpected: {self.expected_result}\n"
         )
+        if self.expected_stderr is not None:
+            if isinstance(self.expected_stderr, str):
+                diagnostic = repr(self.expected_stderr)
+                kind = "substring"
+            else:
+                diagnostic = repr(self.expected_stderr.pattern)
+                kind = "regular expression"
+            output += f"\tExpected stderr {kind}: {diagnostic}\n"
+            if not self.stderr_matches:
+                output += "\tExpected diagnostic was not found in captured stderr\n"
         if self.error:
             output += f"\tError: {self.error}\n"
         if verbose and self.execution_time:
@@ -171,7 +225,7 @@ def execute_single_test(test_index, test_data, run_args, working_directory=None)
     Args:
         test_index: Index of the test in the original test list
         test_data: Test data tuple [filename, description,
-            optional_expected_result, optional_run_args,
+            optional_expected_result_or_stderr_pattern, optional_run_args,
             optional_application_args, optional_stack_limit_kb]
         run_args: Arguments to pass to csound
     Returns:
@@ -254,7 +308,13 @@ def execute_single_test(test_index, test_data, run_args, working_directory=None)
                     error=f"Test timed out after {test_timeout} seconds",
                 )
 
-            cs_output = collect_process_output(stderr_file, result.stdout)
+            stderr_file.flush()
+            stderr_file.seek(0)
+            stderr_output = decode_process_output(stderr_file.read())
+            cs_output = stderr_output
+            stdout_text = decode_process_output(result.stdout)
+            if stdout_text:
+                cs_output += "\n[STDOUT CAPTURED]:\n" + stdout_text
 
         execution_time = time.time() - start_time
 
@@ -262,7 +322,14 @@ def execute_single_test(test_index, test_data, run_args, working_directory=None)
             f"Completed test {test_index + 1}: {filename} in {execution_time:.2f}s"
         )
 
-        return TestResult(test_index, test_data, return_code, cs_output, execution_time)
+        return TestResult(
+            test_index,
+            test_data,
+            return_code,
+            cs_output,
+            execution_time,
+            stderr_output=stderr_output,
+        )
 
     except Exception as e:
         execution_time = time.time() - start_time
@@ -729,7 +796,7 @@ def runTest():
         [
             "test_opcode_getp_managed_fail.csd",
             "reject managed opcode-object output access",
-            1,
+            "getp does not support managed outputs",
         ],
         ["test_sa.csd", "test sample accurate mode"],
         ["test_overload_selection.csd", "test wrong annotation case"],
@@ -835,14 +902,22 @@ def runTest():
             "k-rate writes use prepared struct-array copy storage",
         ],
         [
-            "arrays/test_opcode_array_managed_fail.csd",
-            "reject managed scalar transfers through Opcode arrays",
-            1,
+            "arrays/test_opcode_array_managed_output_fail.csd",
+            "reject managed output transfers through Opcode arrays",
+            # Keep a regex entry in the live suite to cover both supported forms.
+            re.compile(
+                r"Opcode\[\] run does not support managed array output elements"
+            ),
+        ],
+        [
+            "arrays/test_opcode_array_managed_input_fail.csd",
+            "reject managed input transfers through Opcode arrays",
+            "Opcode[] run does not support managed array input elements",
         ],
         [
             "arrays/test_chncleararray_managed_fail.csd",
             "reject byte-wise clearing of managed array channels",
-            1,
+            "chncleararray: channel 'instrument-records' has managed elements",
         ],
         ["complex_array_test.csd", "testing complex array ops"],
         ["test_array_channels.csd", "testing bus channels holding arrays"],
@@ -926,7 +1001,7 @@ def runTest():
         [
             "structs/test_struct_init_partial_member_fails.csd",
             "fail when struct init provides only some members",
-            "fail",
+            ":Point; init c",
         ],
         [
             "structs/test_string_array_direct_member_index.csd",
@@ -939,7 +1014,7 @@ def runTest():
         [
             "structs/test_struct_arate_members_negative.csd",
             "fail when a-rate struct members are initialized with constants",
-            "fail",
+            ":AudioBus; init cc",
         ],
         ["test_exitnowk.csd", "perf-time exitnow opcode"],
         ["test_udt_channel.csd", "testing user-defined type channel"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -48,6 +48,7 @@ def setup_logging():
 logger = setup_logging()
 
 WINDOWS_EXCEPTION_EXIT_MIN = 0xC0000000
+REGEX_TYPE = type(re.compile(""))
 
 
 def is_normal_nonzero_exit(return_code):
@@ -101,7 +102,7 @@ class TestResult:
     @property
     def expected_stderr(self):
         """Return the expected stderr substring or regular expression."""
-        if self.expected_result != 0 and isinstance(self.expected, (str, re.Pattern)):
+        if self.expected_result != 0 and isinstance(self.expected, (str, REGEX_TYPE)):
             return self.expected
         return None
 

--- a/tests/commandline/test_harness.py
+++ b/tests/commandline/test_harness.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+HARNESS_PATH = Path(__file__).with_name("test.py")
+SPEC = importlib.util.spec_from_file_location("csound_commandline_tests", HARNESS_PATH)
+HARNESS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HARNESS)
+
+
+class TestResultTests(unittest.TestCase):
+    def result(self, expected, return_code, stderr, error=None, output=None):
+        return HARNESS.TestResult(
+            0,
+            ["failure.csd", "expected failure", expected],
+            return_code,
+            stderr if output is None else output,
+            0.01,
+            error=error,
+            stderr_output=stderr,
+        )
+
+    def test_expected_failure_matches_stderr_substring(self):
+        self.assertTrue(self.result("wanted diagnostic", 1, "wanted diagnostic").passed)
+
+    def test_unrelated_failure_does_not_pass(self):
+        result = self.result("wanted diagnostic", 1, "unrelated parse error")
+
+        self.assertFalse(result.passed)
+        self.assertIn(
+            "Expected diagnostic was not found", result.get_formatted_output(1)
+        )
+
+    def test_expected_failure_matches_stderr_regular_expression(self):
+        expected = re.compile(r"managed array (input|output) elements")
+
+        self.assertTrue(
+            self.result(expected, 1, "managed array input elements").passed
+        )
+
+    def test_diagnostic_is_checked_only_in_stderr(self):
+        result = self.result(
+            "wanted diagnostic",
+            1,
+            "other stderr",
+            output="captured stdout: wanted diagnostic",
+        )
+
+        self.assertFalse(result.passed)
+
+    def test_timeout_cannot_pass_as_an_expected_failure(self):
+        result = self.result(1, -1, "", error="Test timed out")
+
+        self.assertFalse(result.passed)
+
+    def test_signal_cannot_pass_as_an_expected_failure(self):
+        result = self.result(1, -6, "assertion failed")
+
+        self.assertFalse(result.passed)
+
+    def test_windows_exception_cannot_pass_as_an_expected_failure(self):
+        result = self.result(1, 0xC0000005, "access violation")
+
+        with mock.patch.object(HARNESS.os, "name", "nt"):
+            self.assertFalse(result.passed)
+
+    def test_empty_diagnostic_does_not_match_every_failure(self):
+        result = self.result("", 1, "unrelated parse error")
+
+        self.assertFalse(result.passed)
+        self.assertIsNone(result.expected_stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make command-line expected-failure tests check the error they were meant to produce.

A test entry can now provide a stderr substring or regular expression. The test passes only when Csound exits normally with a nonzero status and stderr matches that diagnostic. Harness errors, signals, Windows exception statuses, and unrelated failures do not satisfy the check.

The managed `Opcode[]` input and output failures now use separate CSD files and distinct diagnostics, so each test reaches and checks one failure path.

Opcode-resolution details now use the error message channel. This keeps the full report on stderr on both Windows and POSIX systems.

## Why

A nonzero exit code alone cannot show that a negative test reached the intended code. An unrelated parser error, assertion, or crash could otherwise leave the test green. Checking stderr makes these tests more precise and gives useful output when the expected message is missing.

Keeping separate failure cases also prevents one error from hiding another path and makes each regression test easier to understand. Consistent error routing gives command-line users and tools the full diagnostic through the standard error stream on every supported system.

## Compatibility

Existing numeric expected-failure entries keep their current behavior. Tests can adopt diagnostic checks when their expected messages are stable.

Addresses the expected-failure test portion of #2623.