### PR TITLE
Fix representation flags in Complex array conversions

### DIFF
--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -1495,11 +1495,13 @@ int32_t complex_array_complex(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in = (COMPLEXDAT *)((ARRAYDAT *)p->a)->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
     if(!in[i].isPolar) out[i] = in[i];
     else {
-      out[i].real = in[i].real*COS(in[i].imag);
-      out[i].imag = in[i].real*SIN(in[i].imag);
+      MYFLT magnitude = in[i].real;
+      MYFLT phase = in[i].imag;
+      out[i].real = magnitude*COS(phase);
+      out[i].imag = magnitude*SIN(phase);
+      out[i].isPolar = 0;
     }
   }
   return OK;

--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -1477,11 +1477,13 @@ int32_t complex_array_polar(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in = (COMPLEXDAT *)((ARRAYDAT *)p->a)->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
     if(in[i].isPolar) out[i] = in[i];
     else {
-      out[i].real = HYPOT(in[i].real, in[i].imag);
-      out[i].imag = ATAN2(in[i].imag, in[i].real);
+      MYFLT real = in[i].real;
+      MYFLT imag = in[i].imag;
+      out[i].real = HYPOT(real, imag);
+      out[i].imag = ATAN2(imag, real);
+      out[i].isPolar = 1;
     }
   }
   return OK;

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -126,6 +126,22 @@ assert_close(real(Cpolar[1]), real(Csource[1]), kepsilon)
 assert_close(imag(Cpolar[1]), imag(Csource[1]), kepsilon)
 endin
 
+instr 7
+Csource:Complex[] = [complex(5, taninv2(4, 3), 1), complex(-2, 7)]
+Crect:Complex[] = complex(Csource)
+kepsilon = 0.00001
+
+assert_close(real(Crect[0]), 3, kepsilon)
+assert_close(imag(Crect[0]), 4, kepsilon)
+assert_close(abs(Crect[0]), 5, kepsilon)
+assert_close(arg(Crect[0]), taninv2(4, 3), kepsilon)
+
+assert_close(real(Crect[1]), -2, kepsilon)
+assert_close(imag(Crect[1]), 7, kepsilon)
+assert_close(abs(Crect[1]), sqrt(53), kepsilon)
+assert_close(arg(Crect[1]), taninv2(7, -2), kepsilon)
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -134,5 +150,6 @@ i3 0 1
 i4 0 1
 i5 0 1
 i6 0 1
+i7 0 1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -110,6 +110,22 @@ assert_close(real(kResult[1]), 0, kepsilon)
 assert_close(imag(kResult[1]), 2, kepsilon)
 endin
 
+instr 6
+Csource:Complex[] = [complex(3,4), polar(complex(3,4))]
+Cpolar:Complex[] = polar(Csource)
+kepsilon = 0.00001
+
+assert_close(abs(Cpolar[0]), abs(Csource[0]), kepsilon)
+assert_close(arg(Cpolar[0]), arg(Csource[0]), kepsilon)
+assert_close(real(Cpolar[0]), real(Csource[0]), kepsilon)
+assert_close(imag(Cpolar[0]), imag(Csource[0]), kepsilon)
+
+assert_close(abs(Cpolar[1]), abs(Csource[1]), kepsilon)
+assert_close(arg(Cpolar[1]), arg(Csource[1]), kepsilon)
+assert_close(real(Cpolar[1]), real(Csource[1]), kepsilon)
+assert_close(imag(Cpolar[1]), imag(Csource[1]), kepsilon)
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -117,5 +133,6 @@ i2 0 1
 i3 0 1
 i4 0 1
 i5 0 1
+i6 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
## Summary

Fix both `Complex[]` conversion overloads so each result's representation flag matches its stored values:

- `polar(Complex[])` marks converted rectangular values as polar and leaves values that are already polar unchanged.
- `complex(Complex[])` marks converted polar values as rectangular and leaves values that are already rectangular unchanged.

Both conversions read the source fields before writing the result, so they also work when input and output share storage.

## Result

For `[complex(3, 4)]` converted with `polar()`:

```text
Before: abs=5.085261 arg=0.183376 real=5.000000 imag=0.927295
After:  abs=5.000000 arg=0.927295 real=3.000000 imag=4.000000
```

For `[complex(5, taninv2(4, 3), 1)]` converted with `complex()`:

```text
Before: real=-1.960931 imag=-2.270407 abs=3.000000 arg=4.000000
After:  real=3.000000 imag=4.000000 abs=5.000000 arg=0.927295
```

## Tests

- `ninja -C build`
- `build/csound tests/commandline/test_complex_numbers.csd`

The command-line test covers both conversion directions and values that already use the target representation.

Closes #2639.
Closes #2640.