### PR TITLE
fix: clear polar flag after complex array conversion

### DIFF
--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -1475,11 +1475,13 @@ int32_t complex_array_complex(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in = (COMPLEXDAT *)((ARRAYDAT *)p->a)->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
     if(!in[i].isPolar) out[i] = in[i];
     else {
-      out[i].real = in[i].real*COS(in[i].imag);
-      out[i].imag = in[i].real*SIN(in[i].imag);
+      MYFLT magnitude = in[i].real;
+      MYFLT phase = in[i].imag;
+      out[i].real = magnitude*COS(phase);
+      out[i].imag = magnitude*SIN(phase);
+      out[i].isPolar = 0;
     }
   }
   return OK;

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -12,6 +12,14 @@ if k1 != k2 then
 endif
 endop
 
+opcode assert_close,0,kkk
+kactual, kexpected, ktolerance xin
+if abs(kactual - kexpected) > ktolerance then
+ printks "assert_close error %f %f\n", 1, kactual, kexpected
+ exitnowk(-1)
+endif
+endop
+
 test@global:Complex[] init 2
 test[0] = 1,2
 test[1] = 3,4
@@ -71,11 +79,28 @@ Ca += Ra
 Ca = 2*Ca/Ca1
 endin
 
+instr 5
+Csource:Complex[] = [complex(5, taninv2(4, 3), 1), complex(-2, 7)]
+Crect:Complex[] = complex(Csource)
+kepsilon = 0.00001
+
+assert_close(real(Crect[0]), 3, kepsilon)
+assert_close(imag(Crect[0]), 4, kepsilon)
+assert_close(abs(Crect[0]), 5, kepsilon)
+assert_close(arg(Crect[0]), taninv2(4, 3), kepsilon)
+
+assert_close(real(Crect[1]), -2, kepsilon)
+assert_close(imag(Crect[1]), 7, kepsilon)
+assert_close(abs(Crect[1]), sqrt(53), kepsilon)
+assert_close(arg(Crect[1]), taninv2(7, -2), kepsilon)
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
 i2 0 1
 i3 0 1
 i4 0 1
+i5 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
## Summary

Fix `complex(Complex[])` so each converted value is marked as rectangular. The conversion reads the polar values before it writes the result, which also keeps it correct if the input and output share storage.

This makes the array overload match the scalar conversion. Calls such as `real`, `imag`, `abs`, and `arg` now interpret converted array items correctly, while items that were already rectangular stay unchanged.

Closes #2640.

## Result

Before:

```text
real=-1.960931 imag=-2.270407 abs=3.000000 arg=4.000000
```

After:

```text
real=3.000000 imag=4.000000 abs=5.000000 arg=0.927295
```