### PR TITLE
fix: correct real-array division by complex arrays

### DIFF
--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -1211,6 +1211,24 @@ cmplx_real_diva(COMPLEXDAT *out, COMPLEXDAT *in, MYFLT *num, int32_t n) {
   }
 }
 
+static inline void
+real_cmplx_diva(COMPLEXDAT *out, MYFLT *num, COMPLEXDAT *in, int32_t n) {
+  for(int i = 0; i < n; i++) {
+    MYFLT real = in[i].real;
+    MYFLT imag = in[i].imag;
+    if(!in[i].isPolar) {
+      MYFLT den = real*real + imag*imag;
+      out[i].real = (num[i]*real)/den;
+      out[i].imag = -(num[i]*imag)/den;
+      out[i].isPolar = 0;
+    } else {
+      out[i].real = num[i]/real;
+      out[i].imag = -imag;
+      out[i].isPolar = 1;
+    }
+  }
+}
+
 int32_t complexa_div_reala(CSOUND *csound, COPS1 *p) {
   ARRAYDAT *array1, *array2;
   array2 = (ARRAYDAT *) p->b;
@@ -1233,7 +1251,7 @@ int32_t reala_div_complexa(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in1 = (COMPLEXDAT *) array2->data;
   MYFLT *in2 = (MYFLT *) array1->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
-  cmplx_real_diva(out,in1,in2,len);
+  real_cmplx_diva(out,in2,in1,len);
   return OK;
 }
 

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -12,6 +12,14 @@ if k1 != k2 then
 endif
 endop
 
+opcode assert_close,0,kkk
+kactual, kexpected, ktolerance xin
+if abs(kactual - kexpected) > ktolerance then
+ printks "assert_close error %f %f\n", 1, kactual, kexpected
+ exitnowk(-1)
+endif
+endop
+
 test@global:Complex[] init 2
 test[0] = 1,2
 test[1] = 3,4
@@ -71,11 +79,45 @@ Ca += Ra
 Ca = 2*Ca/Ca1
 endin
 
+instr 5
+kReal[] = [10]
+kRect:Complex[] = [complex(3, 4)]
+kPolar:Complex[] = [complex(5, taninv2(4, 3), 1)]
+kRectZero:Complex[] = [complex(0, 0)]
+kPolarZero:Complex[] = [complex(0, 0.5, 1)]
+kepsilon = 0.00001
+
+kResult:Complex[] = kRect / kReal
+assert_close(real(kResult[0]), 0.3, kepsilon)
+assert_close(imag(kResult[0]), 0.4, kepsilon)
+
+kResult = kReal / kRect
+assert_close(real(kResult[0]), 1.2, kepsilon)
+assert_close(imag(kResult[0]), -1.6, kepsilon)
+
+kResult = kPolar / kReal
+assert_close(real(kResult[0]), 0.3, kepsilon)
+assert_close(imag(kResult[0]), 0.4, kepsilon)
+
+kResult = kReal / kPolar
+assert_close(real(kResult[0]), 1.2, kepsilon)
+assert_close(imag(kResult[0]), -1.6, kepsilon)
+
+kResult = kReal / kRectZero
+assert(qnan(real(kResult[0])), 1)
+assert(qnan(imag(kResult[0])), 1)
+
+kResult = kReal / kPolarZero
+assert(qinf(abs(kResult[0])), 1)
+assert_close(arg(kResult[0]), -0.5, kepsilon)
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
 i2 0 1
 i3 0 1
 i4 0 1
+i5 0 1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -80,36 +80,34 @@ Ca = 2*Ca/Ca1
 endin
 
 instr 5
-kReal[] = [10]
-kRect:Complex[] = [complex(3, 4)]
-kPolar:Complex[] = [complex(5, taninv2(4, 3), 1)]
-kRectZero:Complex[] = [complex(0, 0)]
-kPolarZero:Complex[] = [complex(0, 0.5, 1)]
+kReal[] = [10, 4]
+kRect:Complex[] = [complex(3, 4), complex(-1, 2)]
+kPolar:Complex[] = [complex(5, taninv2(4, 3), 1), complex(2, -$M_PI/2, 1)]
 kepsilon = 0.00001
 
 kResult:Complex[] = kRect / kReal
 assert_close(real(kResult[0]), 0.3, kepsilon)
 assert_close(imag(kResult[0]), 0.4, kepsilon)
+assert_close(real(kResult[1]), -0.25, kepsilon)
+assert_close(imag(kResult[1]), 0.5, kepsilon)
 
 kResult = kReal / kRect
 assert_close(real(kResult[0]), 1.2, kepsilon)
 assert_close(imag(kResult[0]), -1.6, kepsilon)
+assert_close(real(kResult[1]), -0.8, kepsilon)
+assert_close(imag(kResult[1]), -1.6, kepsilon)
 
 kResult = kPolar / kReal
 assert_close(real(kResult[0]), 0.3, kepsilon)
 assert_close(imag(kResult[0]), 0.4, kepsilon)
+assert_close(real(kResult[1]), 0, kepsilon)
+assert_close(imag(kResult[1]), -0.5, kepsilon)
 
 kResult = kReal / kPolar
 assert_close(real(kResult[0]), 1.2, kepsilon)
 assert_close(imag(kResult[0]), -1.6, kepsilon)
-
-kResult = kReal / kRectZero
-assert(qnan(real(kResult[0])), 1)
-assert(qnan(imag(kResult[0])), 1)
-
-kResult = kReal / kPolarZero
-assert(qinf(abs(kResult[0])), 1)
-assert_close(arg(kResult[0]), -0.5, kepsilon)
+assert_close(real(kResult[1]), 0, kepsilon)
+assert_close(imag(kResult[1]), 2, kepsilon)
 endin
 
 </CsInstruments>


### PR DESCRIPTION
## Summary

Use a separate helper for `k[] / Complex[]` instead of routing it through the `Complex[] / k[]` implementation.

The new path matches scalar real-by-complex division: rectangular inputs use the complex conjugate over the squared magnitude, while polar inputs divide the magnitudes and negate the phase. It also keeps array zero-divisor behavior in line with the scalar overload and reads the complex input before writing the result.

This fixes the operand order without changing `Complex[] / k[]`.

Closes #2644.

## Result

For `kReal / kComplex`:

Before:

```text
real=0.300000 imag=0.400000
```

After:

```text
real=1.200000 imag=-1.600000
```