### PR TITLE
Fix polar type loss in complex array scalar addition

### DIFF
--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -745,8 +745,8 @@ int32_t complex_div_scalar(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_sc_add(COMPLEXDAT *out, COMPLEXDAT *in, MYFLT num, int32_t n) {
   for(int i = 0; i < n; i++) {
+    out[i].isPolar = in[i].isPolar;
     if(!in[i].isPolar) {
-      out[i].isPolar = in[i].isPolar;
       out[i].real = in[i].real + num;
       out[i].imag = in[i].imag;
     } else {

--- a/tests/commandline/complex_array_test.csd
+++ b/tests/commandline/complex_array_test.csd
@@ -14,6 +14,14 @@ if k1 != k2 then
 endif
 endop
 
+opcode assert_close,0,kkk
+kActual, kExpected, kTolerance xin
+if abs(kActual - kExpected) > kTolerance then
+ printks "assert_close error %.9f %.9f\n", 1, kActual, kExpected
+ exitnowk(-1)
+endif
+endop
+
 instr 1
  sig:Complex[] hilbert oscili(p4,p5)
  mod:Complex[] = oscili(0.5,100,-1,0.25), oscili(0.5,100,-1)
@@ -109,11 +117,42 @@ endif
 turnoff
 endin
 
+instr 4
+kRectInput:Complex[] = [complex(0, 2, 0)]
+kPolarInput:Complex[] = [complex(2, $M_PI/2, 1)]
+kRectLeft:Complex[] = kRectInput + 1
+kRectRight:Complex[] = 1 + kRectInput
+kPolarLeft:Complex[] = kPolarInput + 1
+kPolarRight:Complex[] = 1 + kPolarInput
+kTolerance = 0.00001
+
+assert_close(real(kRectLeft[0]), 1, kTolerance)
+assert_close(imag(kRectLeft[0]), 2, kTolerance)
+assert_close(abs(kRectLeft[0]), sqrt(5), kTolerance)
+assert_close(arg(kRectLeft[0]), taninv2(2, 1), kTolerance)
+
+assert_close(real(kRectRight[0]), 1, kTolerance)
+assert_close(imag(kRectRight[0]), 2, kTolerance)
+assert_close(abs(kRectRight[0]), sqrt(5), kTolerance)
+assert_close(arg(kRectRight[0]), taninv2(2, 1), kTolerance)
+
+assert_close(real(kPolarLeft[0]), 1, kTolerance)
+assert_close(imag(kPolarLeft[0]), 2, kTolerance)
+assert_close(abs(kPolarLeft[0]), sqrt(5), kTolerance)
+assert_close(arg(kPolarLeft[0]), taninv2(2, 1), kTolerance)
+
+assert_close(real(kPolarRight[0]), 1, kTolerance)
+assert_close(imag(kPolarRight[0]), 2, kTolerance)
+assert_close(abs(kPolarRight[0]), sqrt(5), kTolerance)
+assert_close(arg(kPolarRight[0]), taninv2(2, 1), kTolerance)
+turnoff
+endin
+
 </CsInstruments>
 <CsScore>
+i4 0 1
 i3 0 1
 i2 0 1
 i1 0 1 0.5 400
 </CsScore>
 </CsoundSynthesizer>
-


### PR DESCRIPTION
Closes #2645

`Complex[] + k` converted polar values to a new magnitude and phase but did not mark the result as polar. Later reads treated those fields as real and imaginary values. The same helper handles `k + Complex[]`.

This change copies the input storage type before scalar addition. It also extends the existing complex array test to cover both operand orders with rectangular and polar arrays.

Before:

```text
real=2.236068 imag=1.107149 abs=2.495151 arg=0.459746
```

After:

```text
real=1.000000 imag=2.000000 abs=2.236068 arg=1.107149
```