### PR TITLE
Fix mixed-representation Complex[] arithmetic

### DIFF
--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -981,14 +981,21 @@ int32_t complexa_minus_complex(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_cmplx_proda(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT *num, int32_t n) {
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real*num[i].real - in[i].imag*num[i].imag;
-      out[i].imag = in[i].imag*num[i].real + in[i].real*num[i].imag;
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num[i];
+    COMPLEXDAT result;
+    if(left.isPolar && right.isPolar) {
+      result.real = left.real*right.real;
+      result.imag = left.imag + right.imag;
+      result.isPolar = 1;
     } else {
-      out[i].real = in[i].real*num[i].real;
-      out[i].imag = in[i].imag + num[i].imag;
+      if(left.isPolar) left = complex(&left);
+      if(right.isPolar) right = complex(&right);
+      result.real = left.real*right.real - left.imag*right.imag;
+      result.imag = left.imag*right.real + left.real*right.imag;
+      result.isPolar = 0;
     }
+    out[i] = result;
   }
 }
 
@@ -1020,17 +1027,24 @@ int32_t complexa_mulin(CSOUND *csound, COPS1 *p) {
 
 static inline void
 cmplx_cmplx_diva(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT* num, int32_t n) {
-  MYFLT d;
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      d = num[i].real*num[i].real + num[i].imag*num[i].imag;
-      out[i].real = (in[i].real*num[i].real + in[i].imag*num[i].imag)/d;
-      out[i].imag = (in[i].imag*num[i].real - in[i].real*num[i].imag)/d;
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num[i];
+    COMPLEXDAT result;
+    if(left.isPolar && right.isPolar) {
+      result.real = left.real/right.real;
+      result.imag = left.imag - right.imag;
+      result.isPolar = 1;
     } else {
-      out[i].real = in[i].real/num[i].real;
-      out[i].imag = in[i].imag - num[i].imag;
+      MYFLT d;
+      if(left.isPolar) left = complex(&left);
+      if(right.isPolar) right = complex(&right);
+      d = right.real*right.real + right.imag*right.imag;
+      result.real = (left.real*right.real + left.imag*right.imag)/d;
+      result.imag = (left.imag*right.real - left.real*right.imag)/d;
+      result.isPolar = 0;
     }
+    out[i] = result;
   }
 }
 
@@ -1061,19 +1075,16 @@ int32_t complexa_divin(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_cmplx_adda(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT* num, int32_t n) {
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real + num[i].real;
-      out[i].imag = in[i].imag + num[i].imag;
-    } else {
-      MYFLT re, im;
-      re = COS(in[i].imag)*in[i].real;
-      im = SIN(in[i].imag)*in[i].real;
-      re += num[i].real;
-      im += num[i].imag;
-      out[i].real = HYPOT(re,im);
-      out[i].imag = ATAN2(im,re);
-    }
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num[i];
+    COMPLEXDAT result;
+    int32_t isPolar = left.isPolar && right.isPolar;
+    if(left.isPolar) left = complex(&left);
+    if(right.isPolar) right = complex(&right);
+    result.real = left.real + right.real;
+    result.imag = left.imag + right.imag;
+    result.isPolar = 0;
+    out[i] = isPolar ? polar(&result) : result;
   }
 }
 
@@ -1104,19 +1115,16 @@ int32_t complexa_addin(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_cmplx_suba(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT* num, int32_t n) {
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real - num[i].real;
-      out[i].imag = in[i].imag - num[i].imag;
-    } else {
-      MYFLT re, im;
-      re = COS(in[i].imag)*in[i].real;
-      im = SIN(in[i].imag)*in[i].real;
-      re -= num[i].real;
-      im -= num[i].imag;
-      out[i].real = HYPOT(re,im);
-      out[i].imag = ATAN2(im,re);
-    }
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num[i];
+    COMPLEXDAT result;
+    int32_t isPolar = left.isPolar && right.isPolar;
+    if(left.isPolar) left = complex(&left);
+    if(right.isPolar) right = complex(&right);
+    result.real = left.real - right.real;
+    result.imag = left.imag - right.imag;
+    result.isPolar = 0;
+    out[i] = isPolar ? polar(&result) : result;
   }
 }
 

--- a/OOps/complex_ops.c
+++ b/OOps/complex_ops.c
@@ -830,14 +830,21 @@ int32_t complex_minus_scalar(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_cmplx_prod(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT num, int32_t n) {
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real*num.real - in[i].imag*num.imag;
-      out[i].imag = in[i].imag*num.real + in[i].real*num.imag;
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num;
+    COMPLEXDAT result;
+    if(left.isPolar && right.isPolar) {
+      result.real = left.real*right.real;
+      result.imag = left.imag + right.imag;
+      result.isPolar = 1;
     } else {
-      out[i].real = in[i].real*num.real;
-      out[i].imag = in[i].imag + num.imag;
+      if(left.isPolar) left = complex(&left);
+      if(right.isPolar) right = complex(&right);
+      result.real = left.real*right.real - left.imag*right.imag;
+      result.imag = left.imag*right.real + left.real*right.imag;
+      result.isPolar = 0;
     }
+    out[i] = result;
   }
 }
 
@@ -866,17 +873,24 @@ int32_t complex_x_complex(CSOUND *csound, COPS1 *p) {
 
 static inline void
 cmplx_cmplx_div(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT num, int32_t n) {
-  MYFLT d;
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      d = num.real*num.real + num.imag*num.imag;
-      out[i].real = (in[i].real*num.real + in[i].imag*num.imag)/d;
-      out[i].imag = (in[i].imag*num.real - in[i].real*num.imag)/d;
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num;
+    COMPLEXDAT result;
+    if(left.isPolar && right.isPolar) {
+      result.real = left.real/right.real;
+      result.imag = left.imag - right.imag;
+      result.isPolar = 1;
     } else {
-      out[i].real = in[i].real/num.real;
-      out[i].imag = in[i].imag - num.imag;
+      MYFLT d;
+      if(left.isPolar) left = complex(&left);
+      if(right.isPolar) right = complex(&right);
+      d = right.real*right.real + right.imag*right.imag;
+      result.real = (left.real*right.real + left.imag*right.imag)/d;
+      result.imag = (left.imag*right.real - left.real*right.imag)/d;
+      result.isPolar = 0;
     }
+    out[i] = result;
   }
 }
 
@@ -894,19 +908,16 @@ int32_t complex_div_complex(CSOUND *csound, COPS1 *p) {
 static inline void
 cmplx_cmplx_add(COMPLEXDAT *out, COMPLEXDAT *in, COMPLEXDAT num, int32_t n) {
   for(int i = 0; i < n; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real + num.real;
-      out[i].imag = in[i].imag + num.imag;
-    } else {
-      MYFLT re, im;
-      re = COS(in[i].imag)*in[i].real;
-      im = SIN(in[i].imag)*in[i].real;
-      re += num.real;
-      im += num.imag;
-      out[i].real = HYPOT(re,im);
-      out[i].imag = ATAN2(im,re);
-    }
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num;
+    COMPLEXDAT result;
+    int32_t isPolar = left.isPolar && right.isPolar;
+    if(left.isPolar) left = complex(&left);
+    if(right.isPolar) right = complex(&right);
+    result.real = left.real + right.real;
+    result.imag = left.imag + right.imag;
+    result.isPolar = 0;
+    out[i] = isPolar ? polar(&result) : result;
   }
 }
 
@@ -936,19 +947,16 @@ int32_t complex_minus_complexa(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in = (COMPLEXDAT *) array->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
   for(int i = 0; i < len; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = num.real - in[i].real;
-      out[i].imag = num.imag - in[i].imag;
-    } else {
-      MYFLT re, im;
-      re = COS(in[i].imag)*in[i].real;
-      im = SIN(in[i].imag)*in[i].real;
-      re = num.real - re;
-      im = num.imag - im;
-      out[i].real = HYPOT(re,im);
-      out[i].imag = ATAN2(im,re);
-    }
+    COMPLEXDAT left = num;
+    COMPLEXDAT right = in[i];
+    COMPLEXDAT result;
+    int32_t isPolar = left.isPolar && right.isPolar;
+    if(left.isPolar) left = complex(&left);
+    if(right.isPolar) right = complex(&right);
+    result.real = left.real - right.real;
+    result.imag = left.imag - right.imag;
+    result.isPolar = 0;
+    out[i] = isPolar ? polar(&result) : result;
   }
   return OK;
 }
@@ -961,19 +969,16 @@ int32_t complexa_minus_complex(CSOUND *csound, COPS1 *p) {
   COMPLEXDAT *in = (COMPLEXDAT *) array->data;
   COMPLEXDAT *out = (COMPLEXDAT *) p->out->data;
   for(int i = 0; i < len; i++) {
-    out[i].isPolar = in[i].isPolar;
-    if(!in[i].isPolar) {
-      out[i].real = in[i].real - num.real;
-      out[i].imag = in[i].imag - num.imag;
-    } else {
-      MYFLT re, im;
-      re = COS(in[i].imag)*in[i].real;
-      im = SIN(in[i].imag)*in[i].real;
-      re -= num.real;
-      im -= num.imag;
-      out[i].real = HYPOT(re,im);
-      out[i].imag = ATAN2(im,re);
-    }
+    COMPLEXDAT left = in[i];
+    COMPLEXDAT right = num;
+    COMPLEXDAT result;
+    int32_t isPolar = left.isPolar && right.isPolar;
+    if(left.isPolar) left = complex(&left);
+    if(right.isPolar) right = complex(&right);
+    result.real = left.real - right.real;
+    result.imag = left.imag - right.imag;
+    result.isPolar = 0;
+    out[i] = isPolar ? polar(&result) : result;
   }
   return OK;
 }

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -12,6 +12,14 @@ if k1 != k2 then
 endif
 endop
 
+opcode assert_close,0,kkk
+kactual, kexpected, ktolerance xin
+if abs(kactual - kexpected) > ktolerance then
+ printks "assert_close error %f %f\n", 1, kactual, kexpected
+ exitnowk(-1)
+endif
+endop
+
 test@global:Complex[] init 2
 test[0] = 1,2
 test[1] = 3,4
@@ -71,11 +79,60 @@ Ca += Ra
 Ca = 2*Ca/Ca1
 endin
 
+instr 5
+kARect:Complex = complex(1, 2)
+kAPolar:Complex = complex(sqrt(5), taninv2(2, 1), 1)
+kBRect:Complex = complex(3, -4)
+kBPolar:Complex = complex(5, taninv2(-4, 3), 1)
+kLeft:Complex[] = [kARect, kARect, kAPolar, kAPolar]
+kRight:Complex[] = [kBRect, kBPolar, kBRect, kBPolar]
+kepsilon = 0.00001
+
+kAdd:Complex[] = kLeft + kRight
+kSub:Complex[] = kLeft - kRight
+kMul:Complex[] = kLeft * kRight
+kDiv:Complex[] = kLeft / kRight
+kIndex = 0
+while kIndex < 4 do
+ assert_close(real(kAdd[kIndex]), 4, kepsilon)
+ assert_close(imag(kAdd[kIndex]), -2, kepsilon)
+ assert_close(real(kSub[kIndex]), -2, kepsilon)
+ assert_close(imag(kSub[kIndex]), 6, kepsilon)
+ assert_close(real(kMul[kIndex]), 11, kepsilon)
+ assert_close(imag(kMul[kIndex]), 2, kepsilon)
+ assert_close(real(kDiv[kIndex]), -0.2, kepsilon)
+ assert_close(imag(kDiv[kIndex]), 0.4, kepsilon)
+ kIndex += 1
+od
+
+kAdd = kRight
+kSub = kRight
+kMul = kRight
+kDiv = kRight
+kAdd += kLeft
+kSub -= kLeft
+kMul *= kLeft
+kDiv /= kLeft
+kIndex = 0
+while kIndex < 4 do
+ assert_close(real(kAdd[kIndex]), 4, kepsilon)
+ assert_close(imag(kAdd[kIndex]), -2, kepsilon)
+ assert_close(real(kSub[kIndex]), 2, kepsilon)
+ assert_close(imag(kSub[kIndex]), -6, kepsilon)
+ assert_close(real(kMul[kIndex]), 11, kepsilon)
+ assert_close(imag(kMul[kIndex]), 2, kepsilon)
+ assert_close(real(kDiv[kIndex]), -1, kepsilon)
+ assert_close(imag(kDiv[kIndex]), -2, kepsilon)
+ kIndex += 1
+od
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
 i2 0 1
 i3 0 1
 i4 0 1
+i5 0 1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_complex_numbers.csd
+++ b/tests/commandline/test_complex_numbers.csd
@@ -14,7 +14,8 @@ endop
 
 opcode assert_close,0,kkk
 kactual, kexpected, ktolerance xin
-if abs(kactual - kexpected) > ktolerance then
+kdifference = abs(kactual - kexpected)
+if qnan(kdifference) != 0 || kdifference > ktolerance then
  printks "assert_close error %f %f\n", 1, kactual, kexpected
  exitnowk(-1)
 endif
@@ -127,6 +128,40 @@ while kIndex < 4 do
 od
 endin
 
+instr 6
+kARect:Complex = complex(1, 2)
+kAPolar:Complex = complex(sqrt(5), taninv2(2, 1), 1)
+kBPolar:Complex = complex(5, taninv2(-4, 3), 1)
+kValues:Complex[] = [kARect, kAPolar]
+kepsilon = 0.00001
+
+kAddLeft:Complex[] = kValues + kBPolar
+kAddRight:Complex[] = kBPolar + kValues
+kSubLeft:Complex[] = kValues - kBPolar
+kSubRight:Complex[] = kBPolar - kValues
+kMulLeft:Complex[] = kValues * kBPolar
+kMulRight:Complex[] = kBPolar * kValues
+kDiv:Complex[] = kValues / kBPolar
+kIndex = 0
+while kIndex < 2 do
+ assert_close(real(kAddLeft[kIndex]), 4, kepsilon)
+ assert_close(imag(kAddLeft[kIndex]), -2, kepsilon)
+ assert_close(real(kAddRight[kIndex]), 4, kepsilon)
+ assert_close(imag(kAddRight[kIndex]), -2, kepsilon)
+ assert_close(real(kSubLeft[kIndex]), -2, kepsilon)
+ assert_close(imag(kSubLeft[kIndex]), 6, kepsilon)
+ assert_close(real(kSubRight[kIndex]), 2, kepsilon)
+ assert_close(imag(kSubRight[kIndex]), -6, kepsilon)
+ assert_close(real(kMulLeft[kIndex]), 11, kepsilon)
+ assert_close(imag(kMulLeft[kIndex]), 2, kepsilon)
+ assert_close(real(kMulRight[kIndex]), 11, kepsilon)
+ assert_close(imag(kMulRight[kIndex]), 2, kepsilon)
+ assert_close(real(kDiv[kIndex]), -0.2, kepsilon)
+ assert_close(imag(kDiv[kIndex]), 0.4, kepsilon)
+ kIndex += 1
+od
+endin
+
 </CsInstruments>
 <CsScore>
 i1 0 1
@@ -134,5 +169,6 @@ i2 0 1
 i3 0 1
 i4 0 1
 i5 0 1
+i6 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Closes #2647.

## Summary

The complex array helpers chose their arithmetic path from the left item alone. When the right item used polar storage, the code read its magnitude and phase as real and imaginary parts. The result then depended on how an equal value was stored.

Check both items before each operation. Mixed pairs now convert to rectangular form, while pairs that are both polar keep the same result form as scalar complex arithmetic. Copying both input items before writing also keeps the in-place forms safe.

The existing complex-number test now covers all four rectangular and polar storage pairs for addition, subtraction, multiplication, and division, including reversed and in-place operations.

## Reproducer

```csd
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  kRect:Complex[] = [complex(1, 2)]
  kPolar:Complex[] = [complex(sqrt(5), taninv2(2, 1), 1)]

  kAdd:Complex[] = kRect + kPolar
  kSub:Complex[] = kRect - kPolar
  kMul:Complex[] = kRect * kPolar
  kDiv:Complex[] = kRect / kPolar

  printf "add=(%.6f, %.6f)\n", 1, real(kAdd[0]), imag(kAdd[0])
  printf "sub=(%.6f, %.6f)\n", 1, real(kSub[0]), imag(kSub[0])
  printf "mul=(%.6f, %.6f)\n", 1, real(kMul[0]), imag(kMul[0])
  printf "div=(%.6f, %.6f)\n", 1, real(kDiv[0]), imag(kDiv[0])
  turnoff
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

```text
add=(3.236068, 3.107149)
sub=(-1.236068, 0.892851)
mul=(0.021771, 5.579285)
div=(0.714829, 0.540493)
```

## After

```text
add=(2.000000, 4.000000)
sub=(-0.000000, 0.000000)
mul=(-3.000000, 4.000000)
div=(1.000000, 0.000000)
```

Equal complex values now produce equal array results whether they use rectangular or polar storage.