### PR TITLE
Add typed Complex[] overloads to fftinv

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -74,16 +74,20 @@ typedef struct _fft {
   AUXCH mem;
 } FFT;
 
-static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
+static int32_t init_fft_complex_common(CSOUND *csound, FFT *p,
+                                       int32_t inverse) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
   int32_t N = p->in->sizes[0];
   if (UNLIKELY(p->in->dimensions > 1))
-    return csound->InitError(csound, "%s",
+    return csound->InitError(csound, "%s", inverse ?
+                             Str("fftinv: only one-dimensional arrays allowed") :
                              Str("fft: only one-dimensional arrays allowed"));
   /* Sanity checks: prevent pathological sizes and integer overflows */
   if (UNLIKELY(N <= 0))
-    return csound->InitError(csound, "%s", Str("fft: input array size must be > 0"));
+    return csound->InitError(csound, "%s", inverse ?
+                             Str("fftinv: input array size must be > 0") :
+                             Str("fft: input array size must be > 0"));
   /* Cap to a conservative upper bound to avoid overflow in allocations */
   const int32_t MAX_REASONABLE_N = (1 << 24); /* ~16M elements */
   if (UNLIKELY(N > MAX_REASONABLE_N)) {
@@ -95,10 +99,14 @@ static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
         if (p->in->sizes && p->in->dimensions == 1)
           p->in->sizes[0] = N;
       } else {
-        return csound->InitError(csound, "fft: input array size (%d) is unreasonable", N);
+        return csound->InitError(csound, inverse ?
+                                 Str("fftinv: input array size (%d) is unreasonable") :
+                                 Str("fft: input array size (%d) is unreasonable"), N);
       }
     } else {
-      return csound->InitError(csound, "fft: input array size (%d) is unreasonable", N);
+      return csound->InitError(csound, inverse ?
+                               Str("fftinv: input array size (%d) is unreasonable") :
+                               Str("fft: input array size (%d) is unreasonable"), N);
     }
   }
   if (UNLIKELY(N > 1 && (N & 1)))
@@ -109,6 +117,13 @@ static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
   tabinit(csound, p->out, N, p->h.insdshead);
   size_t bytes = (size_t)N * 2u * sizeof(MYFLT);
   csound->AuxAlloc(csound, bytes, &p->mem);
+  return OK;
+}
+
+static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
+  int32_t result = init_fft_complex_common(csound, p, 0);
+  if (UNLIKELY(result != OK))
+    return result;
   if(p->out->arrayType == csound->GetType(csound, "Complex")
      && p->in->arrayType == csound->GetType(csound, "Complex"))
     p->b = *((MYFLT *)p->in2);
@@ -118,14 +133,27 @@ static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
   return OK;
 }
 
+static int32_t init_ifft_complex(CSOUND *csound, FFT *p) {
+  int32_t result = init_fft_complex_common(csound, p, 1);
+  if (UNLIKELY(result != OK))
+    return result;
+  p->b = 1;
+  return OK;
+}
+
 static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
   int32_t N = p->in->sizes[0];
   MYFLT *tmp = (MYFLT *)p->mem.auxp;
   COMPLEXDAT *c = (COMPLEXDAT *) p->in->data;
   if(p->in->arrayType == csound->GetType(csound, "Complex")) {
     for(int32_t i = 0, j = 0; j < N; i+=2, j++) {
-      tmp[i] = c[j].real;
-      tmp[i+1] = c[j].imag;
+      if(c[j].isPolar) {
+        tmp[i] = c[j].real*COS(c[j].imag);
+        tmp[i+1] = c[j].real*SIN(c[j].imag);
+      } else {
+        tmp[i] = c[j].real;
+        tmp[i+1] = c[j].imag;
+      }
     }
   } else {
     MYFLT *re = p->in->data;
@@ -142,6 +170,7 @@ static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
     for(int32_t i = 0, j = 0; j < N; i+=2, j++) {
       c[j].real = tmp[i];
       c[j].imag = tmp[i+1];
+      c[j].isPolar = 0;
     }
   } else {
     MYFLT *re = p->out->data;
@@ -1316,6 +1345,11 @@ static OENTRY arrayvars_localops[] =
      (SUBR) initialise_fft, (SUBR) perf_fft, NULL},
     {"fft", sizeof(FFT), 0, "i[]","i[]",
      (SUBR) fft_i, NULL, NULL},
+    /* Named inverse aliases for the typed fft(input, 1) forms. */
+    { "fftinv", sizeof(FFT), 0, ":Complex;[]", ":Complex;[]",
+      (SUBR) init_ifft_complex, (SUBR) perf_fft_complex, NULL},
+    { "fftinv", sizeof(FFT), 0, "k[]", ":Complex;[]",
+      (SUBR) init_ifft_complex, (SUBR) perf_fft_complex, NULL},
     {"fftinv", sizeof(FFT), 0, "k[]","k[]",
      (SUBR) init_ifft, (SUBR) perf_ifft, NULL},
     {"fftinv", sizeof(FFT), 0, "i[]","i[]",

--- a/tests/commandline/fft_array_test.csd
+++ b/tests/commandline/fft_array_test.csd
@@ -37,6 +37,64 @@ instr 1
     assert_close(imag(kRoundTrip[kIndex]), kIndex == 1 ? 2 : 0, 0.00001)
     kIndex += 1
   od
+
+  kRectInput:Complex[] = [complex(1, 2), complex(-3, 0.5), \
+                          complex(0, -1), complex(2, -4)]
+  kPolarInput:Complex[] = [polar(kRectInput[0]), polar(kRectInput[1]), \
+                           polar(kRectInput[2]), polar(kRectInput[3])]
+  kRectSpectrum:Complex[] = fft(kRectInput)
+  kPolarSpectrum:Complex[] = [polar(kRectSpectrum[0]), \
+                              polar(kRectSpectrum[1]), \
+                              polar(kRectSpectrum[2]), \
+                              polar(kRectSpectrum[3])]
+  kPolarInputSpectrum:Complex[] = fft(kPolarInput)
+
+  kRectOutput:Complex[] = fftinv(kRectSpectrum)
+  kFlagOutput:Complex[] = fft(kRectSpectrum, 1)
+  kPolarOutput:Complex[] = fftinv(kPolarSpectrum)
+  kPolarInputOutput:Complex[] = fftinv(kPolarInputSpectrum)
+
+  kIndex = 0
+  while kIndex < lenarray(kRectInput) do
+    kExpectedReal = real(kRectInput[kIndex])
+    kExpectedImag = imag(kRectInput[kIndex])
+    assert_close(real(kRectOutput[kIndex]), kExpectedReal, 0.00001)
+    assert_close(imag(kRectOutput[kIndex]), kExpectedImag, 0.00001)
+    assert_close(real(kFlagOutput[kIndex]), kExpectedReal, 0.00001)
+    assert_close(imag(kFlagOutput[kIndex]), kExpectedImag, 0.00001)
+    assert_close(real(kPolarOutput[kIndex]), kExpectedReal, 0.00001)
+    assert_close(imag(kPolarOutput[kIndex]), kExpectedImag, 0.00001)
+    assert_close(real(kPolarInputOutput[kIndex]), kExpectedReal, 0.00001)
+    assert_close(imag(kPolarInputOutput[kIndex]), kExpectedImag, 0.00001)
+    kIndex += 1
+  od
+
+  kUnitSpectrum:Complex[] = [complex(1, 0), complex(1, 0), \
+                             complex(1, 0), complex(1, 0)]
+  kComplexOutput:Complex[] = fftinv(kUnitSpectrum)
+  kRealOutput[] = fftinv(kUnitSpectrum)
+  kFftRealOutput[] = fft(kUnitSpectrum)
+  assert_close(real(kComplexOutput[0]), 1, 0.00001)
+  assert_close(imag(kComplexOutput[0]), 0, 0.00001)
+  assert_close(kRealOutput[0], 1, 0.00001)
+  assert_close(kFftRealOutput[0], 1, 0.00001)
+  kIndex = 1
+  while kIndex < lenarray(kUnitSpectrum) do
+    assert_close(real(kComplexOutput[kIndex]), 0, 0.00001)
+    assert_close(imag(kComplexOutput[kIndex]), 0, 0.00001)
+    assert_close(kRealOutput[kIndex], 0, 0.00001)
+    assert_close(kFftRealOutput[kIndex], 0, 0.00001)
+    kIndex += 1
+  od
+
+  kRealInput[] = [1, 2, 3, 4]
+  kRealSpectrum:Complex[] = fft(kRealInput)
+  kRealRoundTrip[] = fftinv(kRealSpectrum)
+  kIndex = 0
+  while kIndex < lenarray(kRealInput) do
+    assert_close(kRealRoundTrip[kIndex], kRealInput[kIndex], 0.00001)
+    kIndex += 1
+  od
   turnoff
 endin
 


### PR DESCRIPTION
Closes #2649.

## Summary

`fft` already supports typed complex inverse transforms through its direction flag, but `fftinv` only had the old numeric-array forms. Add named inverse overloads for both complex and real results:

```csound
kComplexOutput:Complex[] = fftinv(kSpectrum)
kRealOutput[] = fftinv(kSpectrum)
```

Both overloads use the same transform path, sign, and scale as `fft(kSpectrum, 1)`. Polar input items are converted to their complex values before the transform, and typed outputs are marked as rectangular. This makes the named form work with either complex storage form and keeps its results in line with the existing typed API.

## Reproducer

```csd
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  kSpectrum:Complex[] = [
    complex(1, 0),
    complex(1, 0),
    complex(1, 0),
    complex(1, 0)
  ]

  kSignal:Complex[] = fftinv(kSpectrum)

  printf "output: %.6f %.6f %.6f %.6f\n", 1, real(kSignal[0]), real(kSignal[1]), real(kSignal[2]), real(kSignal[3])
  turnoff
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

```text
Unable to find opcode entry for 'fftinv'

Found:
  Complex[] fftinv Complex[]

Candidates:
  k[] fftinv k[]
  i[] fftinv i[]
```

## After

```text
output: 1.000000 0.000000 0.000000 0.000000
```

The named opcode now states the transform direction without changing the transform itself.