### PR TITLE
fix: resolve taninv2 i-array overload

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -622,7 +622,7 @@ const OENTRY opcodlst_1[] = {
    (SUBR)tabarithset1, (SUBR)tabarkpow },
   {"##pow.a[k[", sizeof(TABARITH), 0, "a[]", "a[]k[]",
    (SUBR)tabarithset, (SUBR)tabarkrpw },
-  { "taninvx2.Ai", sizeof(TABARITH), 0, "i[]", "i[]i[]",
+  { "taninv2.Ai", sizeof(TABARITH), 0, "i[]", "i[]i[]",
     (SUBR)taninv2_Ai  },
   { "taninv2.Ak", sizeof(TABARITH), 0, "k[]", "k[]k[]",
     (SUBR)tabarithset,

--- a/tests/commandline/test_iarr_operators.csd
+++ b/tests/commandline/test_iarr_operators.csd
@@ -144,10 +144,21 @@ instr arraytests
 endin
 schedule(arraytests, 0, 1)
 
+instr arraytesttaninv2
+  iY[] fillarray 1, 1
+  iX[] fillarray 1, -1
+  iResult[] = taninv2(iY, iX)
+  if abs(iResult[0] - $M_PI/4) > 0.000001 || \
+     abs(iResult[1] - 3*$M_PI/4) > 0.000001 then
+    prints "taninv2 i-array result mismatch\n"
+    exitnow(-1)
+  endif
+endin
+schedule(arraytesttaninv2, 0, 1)
+
 </CsInstruments>
 <CsScore>
 f 0 1
 </CsScore>
 </CsoundSynthesizer>
-
 


### PR DESCRIPTION
Closes #2652.

## Summary

The init-rate array entry used the internal name `taninvx2.Ai`, so calls to `taninv2(i[], i[])` could not select it. Register the entry as `taninv2.Ai` and extend the existing init-array operator test with quadrant checks.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>

sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  iY[] fillarray 1, 1
  iX[] fillarray 1, -1

  iResult[] = taninv2(iY, iX)
  printarray iResult
endin

</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

Csound exits with status 1:

```text
syntax error, Unable to find opcode entry for 'taninv2'
  with matching argument types
Found:
  i[] taninv2 i[]i[]

Candidates:
  k[] taninv2 k[]k[]
  a[] taninv2 a[]a[]
  i taninv2 ii
  k taninv2 kk
  a taninv2 aa
```

## After

Csound exits with status 0 and prints:

```text
0.7854 2.3562
```
