### PR TITLE
fix: resolve a[] -= k overload

### DIFF
--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -487,7 +487,7 @@ const OENTRY opcodlst_1[] = {
 
   {"##subin.[ak", sizeof(TABARITHIN), 0, "a[]", "k[]",
    NULL, (SUBR)tabarkrsbin },
-  {"##subdin.[aks", sizeof(TABARITHIN), 0, "a[]", "k",
+  {"##subin.[aks", sizeof(TABARITHIN), 0, "a[]", "k",
    NULL, (SUBR)tabaksubin },
 
   {"##mul.[p", sizeof(TABARITH1), 0, "i[]", "i[]i",

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -487,7 +487,7 @@ const OENTRY opcodlst_1[] = {
 
   {"##subin.[ak", sizeof(TABARITHIN), 0, "a[]", "k[]",
    NULL, (SUBR)tabarkrsbin },
-  {"##subin.[aks", sizeof(TABARITHIN), 0, "a[]", "k",
+  {"##subin.[aks", sizeof(TABARITHIN1), 0, "a[]", "k",
    NULL, (SUBR)tabaksubin },
 
   {"##mul.[p", sizeof(TABARITH1), 0, "i[]", "i[]i",

--- a/tests/commandline/arrays/array_a_arithm.csd
+++ b/tests/commandline/arrays/array_a_arithm.csd
@@ -43,6 +43,18 @@ instr 5
  outch p4, aOutArr[p4-1]
 endin
 
+instr 6
+ aValues[] init 1
+ aValues[0] = 5
+ kAmount = 2
+ aValues -= kAmount
+ kValue downsamp aValues[0]
+ if kValue != 3 then
+  printks "a[] -= k expected 3, got %f\n", 0, kValue
+  exitnowk(-1)
+ endif
+endin
+
 </CsInstruments>
 <CsScore>
 i 1 0 16
@@ -54,5 +66,6 @@ i 4 8 2 1
 i 4 10 2 2
 i 5 12 2 1
 i 5 14 2 2
+i 6 0 .1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Closes #2655.

## Summary

The `a[] -= k` entry was registered as `##subdin.[aks`, so the parser could not select it for the `##subin` operator. Register it under the correct name and extend the existing audio-array arithmetic test with a value check.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  aValues[] init 1
  aValues[0] = 5
  kAmount = 2

  aValues -= kAmount
  out aValues[0]
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

Csound exits with status 1:

```text
syntax error, Unable to find opcode entry for '##subin'
  with matching argument types
Found:
  a[] ##subin k
```

## After

Csound exits with status 0 and reports the constant output:

```text
overall amps: 3.00000
```
