### PR TITLE
Fix polar handling in typed FFT opcodes

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -74,6 +74,14 @@ typedef struct _fft {
   AUXCH mem;
 } FFT;
 
+static inline MYFLT complex_rect_real(const COMPLEXDAT *value) {
+  return value->isPolar ? value->real * COS(value->imag) : value->real;
+}
+
+static inline MYFLT complex_rect_imag(const COMPLEXDAT *value) {
+  return value->isPolar ? value->real * SIN(value->imag) : value->imag;
+}
+
 static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
@@ -124,8 +132,8 @@ static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
   COMPLEXDAT *c = (COMPLEXDAT *) p->in->data;
   if(p->in->arrayType == csound->GetType(csound, "Complex")) {
     for(int32_t i = 0, j = 0; j < N; i+=2, j++) {
-      tmp[i] = c[j].real;
-      tmp[i+1] = c[j].imag;
+      tmp[i] = complex_rect_real(&c[j]);
+      tmp[i+1] = complex_rect_imag(&c[j]);
     }
   } else {
     MYFLT *re = p->in->data;
@@ -142,6 +150,7 @@ static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
     for(int32_t i = 0, j = 0; j < N; i+=2, j++) {
       c[j].real = tmp[i];
       c[j].imag = tmp[i+1];
+      c[j].isPolar = 0;
     }
   } else {
     MYFLT *re = p->out->data;
@@ -175,9 +184,11 @@ static int32_t perf_rfft_r2c(CSOUND *csound, FFT *p) {
     c[j].real = tmp[i];
     if(j) c[j].imag = tmp[i+1];
     else c[j].imag = 0.;
+    c[j].isPolar = 0;
   }
   c[N>>1].real = tmp[1];
   c[N>>1].imag =  0.;
+  c[N>>1].isPolar = 0;
   return OK;
 }
 
@@ -199,11 +210,13 @@ static int32_t perf_rfft_c2r(CSOUND *csound, FFT *p) {
   int32_t N = p->out->sizes[0];
   MYFLT *tmp = (MYFLT *)p->mem.auxp;
   COMPLEXDAT *c = (COMPLEXDAT *) p->in->data;
-  for(int32_t i = 0, j = 0; i < N; i+=2, j++) {
-    tmp[i] = c[j].real;
-    if(j) tmp[i+1] = c[j].imag;
+  int32_t halfN = N >> 1;
+  tmp[0] = complex_rect_real(&c[0]);
+  for(int32_t j = 1; j < halfN; j++) {
+    tmp[j << 1] = complex_rect_real(&c[j]);
+    tmp[(j << 1) + 1] = complex_rect_imag(&c[j]);
   }
-  tmp[1] = c[N>>1].real;
+  tmp[1] = complex_rect_real(&c[halfN]);
   csound->RealFFT(csound,p->setup,tmp);
   memcpy(p->out->data,tmp,N*sizeof(MYFLT));
   return OK;

--- a/tests/commandline/fft_array_test.csd
+++ b/tests/commandline/fft_array_test.csd
@@ -37,6 +37,72 @@ instr 1
     assert_close(imag(kRoundTrip[kIndex]), kIndex == 1 ? 2 : 0, 0.00001)
     kIndex += 1
   od
+
+  kTolerance = 0.00001
+  kRectInput:Complex[] = [complex(1, 0), complex(0, 1), \
+                          complex(-1, 0), complex(0, -1)]
+  kPolarInput:Complex[] = [complex(1, 0, 1), \
+                           complex(1, $M_PI / 2, 1), \
+                           complex(1, $M_PI, 1), \
+                           complex(1, -$M_PI / 2, 1)]
+
+  kRectForward:Complex[] fft kRectInput
+  kPolarForward:Complex[] fft kPolarInput
+  kRectInverse:Complex[] fft kRectInput, 1
+  kPolarInverse:Complex[] fft kPolarInput, 1
+  kRectInverseReal[] fft kRectInput
+  kPolarInverseReal[] fft kPolarInput
+
+  kIndex = 0
+  while kIndex < lenarray(kRectInput) do
+    assert_close(real(kPolarForward[kIndex]), real(kRectForward[kIndex]), \
+                 kTolerance)
+    assert_close(imag(kPolarForward[kIndex]), imag(kRectForward[kIndex]), \
+                 kTolerance)
+    assert_close(real(kPolarInverse[kIndex]), real(kRectInverse[kIndex]), \
+                 kTolerance)
+    assert_close(imag(kPolarInverse[kIndex]), imag(kRectInverse[kIndex]), \
+                 kTolerance)
+    assert_close(real(kRectForward[kIndex]), kIndex == 1 ? 4 : 0, \
+                 kTolerance)
+    assert_close(imag(kRectForward[kIndex]), 0, kTolerance)
+    assert_close(real(kRectInverse[kIndex]), kIndex == 3 ? 1 : 0, \
+                 kTolerance)
+    assert_close(imag(kRectInverse[kIndex]), 0, kTolerance)
+    assert_close(kPolarInverseReal[kIndex], kRectInverseReal[kIndex], \
+                 kTolerance)
+    assert_close(kRectInverseReal[kIndex], kIndex == 3 ? 1 : 0, \
+                 kTolerance)
+    kIndex += 1
+  od
+
+  kNegative:Complex[] = [complex(-1, 0), complex(0, 0), \
+                          complex(0, 0), complex(0, 0)]
+  kReusedForward:Complex[] = [complex(1, 0, 1), complex(1, 0, 1), \
+                              complex(1, 0, 1), complex(1, 0, 1)]
+  kReusedInverse:Complex[] = [complex(1, 0, 1), complex(1, 0, 1), \
+                              complex(1, 0, 1), complex(1, 0, 1)]
+  kReusedForward fft kNegative
+  kReusedInverse fft kNegative, 1
+
+  kNegativeReal[] = [-1, 0, 0, 0]
+  kReusedRealInput:Complex[] = [complex(1, 0, 1), complex(1, 0, 1), \
+                                complex(1, 0, 1), complex(1, 0, 1)]
+  kReusedRealInput fft kNegativeReal
+
+  kIndex = 0
+  while kIndex < lenarray(kNegative) do
+    assert_close(real(kReusedForward[kIndex]), -1, kTolerance)
+    assert_close(imag(kReusedForward[kIndex]), 0, kTolerance)
+    assert_close(abs(arg(kReusedForward[kIndex])), $M_PI, kTolerance)
+    assert_close(real(kReusedInverse[kIndex]), -0.25, kTolerance)
+    assert_close(imag(kReusedInverse[kIndex]), 0, kTolerance)
+    assert_close(abs(arg(kReusedInverse[kIndex])), $M_PI, kTolerance)
+    assert_close(real(kReusedRealInput[kIndex]), -1, kTolerance)
+    assert_close(imag(kReusedRealInput[kIndex]), 0, kTolerance)
+    assert_close(abs(arg(kReusedRealInput[kIndex])), $M_PI, kTolerance)
+    kIndex += 1
+  od
   turnoff
 endin
 

--- a/tests/commandline/rfft_array_test.csd
+++ b/tests/commandline/rfft_array_test.csd
@@ -1,22 +1,66 @@
 <CsoundSynthesizer>
 <CsOptions>
--n
+-n -d -m0
 </CsOptions>
 <CsInstruments>
 
+sr = 48000
+ksmps = 32
 nchnls = 1
 0dbfs = 1
 
+opcode assert_close, 0, kkk
+  kActual, kExpected, kTolerance xin
+  kDifference = abs(kActual - kExpected)
+  if qnan(kDifference) != 0 || kDifference > kTolerance then
+    printks "assert_close failed: actual=%f expected=%f difference=%f\n", \
+            1, kActual, kExpected, kDifference
+    exitnowk(-1)
+  endif
+endop
+
 instr 1
- kArr[] genarray_i 0,1023
- spec:Complex[] rfft kArr
- kArr rifft spec
+  kTolerance = 0.00001
+  kRectSpectrum:Complex[] = [complex(1, sqrt(3)), complex(0, 1), \
+                             complex(-2, 2 * sqrt(3))]
+  kPolarSpectrum:Complex[] = [complex(2, $M_PI / 3, 1), \
+                              complex(1, $M_PI / 2, 1), \
+                              complex(4, 2 * $M_PI / 3, 1)]
+  kRectOutput[] rifft kRectSpectrum
+  kPolarOutput[] rifft kPolarSpectrum
+  kExpectedOutput[] = [-0.25, 0.25, -0.25, 1.25]
+
+  kIndex = 0
+  while kIndex < lenarray(kExpectedOutput) do
+    assert_close(kRectOutput[kIndex], kExpectedOutput[kIndex], kTolerance)
+    assert_close(kPolarOutput[kIndex], kExpectedOutput[kIndex], kTolerance)
+    kIndex += 1
+  od
+
+  kInput[] = [-2, 1, 0, 0]
+  kExpectedSpectrum:Complex[] = [complex(-1, 0), complex(-2, -1), \
+                                 complex(-3, 0)]
+  kReusedSpectrum:Complex[] = [complex(1, 0, 1), complex(1, 0, 1), \
+                               complex(1, 0, 1)]
+  kReusedSpectrum rfft kInput
+
+  kIndex = 0
+  while kIndex < lenarray(kExpectedSpectrum) do
+    assert_close(real(kReusedSpectrum[kIndex]), \
+                 real(kExpectedSpectrum[kIndex]), kTolerance)
+    assert_close(imag(kReusedSpectrum[kIndex]), \
+                 imag(kExpectedSpectrum[kIndex]), kTolerance)
+    assert_close(abs(kReusedSpectrum[kIndex]), \
+                 abs(kExpectedSpectrum[kIndex]), kTolerance)
+    assert_close(arg(kReusedSpectrum[kIndex]), \
+                 arg(kExpectedSpectrum[kIndex]), kTolerance)
+    kIndex += 1
+  od
+  turnoff
 endin
 
 </CsInstruments>
 <CsScore>
-i1 0 1 
+i1 0 1
 </CsScore>
 </CsoundSynthesizer>
-
-


### PR DESCRIPTION
Closes #2646.

## What changed

Typed `fft` and `rifft` now convert polar `Complex[]` values to rectangular parts before the transform. Typed `fft` and `rfft` also mark every complex output bin as rectangular, including reused arrays and the separate `rfft` Nyquist bin.

The typed paths had copied the stored `real` and `imag` fields without checking `isPolar`. Output paths then overwrote those fields without always clearing `isPolar`, so later complex operations could read rectangular FFT data as magnitude and phase.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  kRect:Complex[] = [complex(0, 1), complex(0, 0), \
                     complex(0, 0), complex(0, 0)]
  kPolar:Complex[] = [complex(1, $M_PI / 2, 1), complex(0, 0, 1), \
                      complex(0, 0, 1), complex(0, 0, 1)]
  kRectFFT:Complex[] fft kRect
  kPolarFFT:Complex[] fft kPolar

  kRectHalf:Complex[] = [complex(0, 0), complex(0, 1), complex(0, 0)]
  kPolarHalf:Complex[] = [complex(0, 0, 1), \
                          complex(1, $M_PI / 2, 1), complex(0, 0, 1)]
  kRectTime[] rifft kRectHalf
  kPolarTime[] rifft kPolarHalf

  kInput[] = [-2, 1, 0, 0]
  kReused:Complex[] = [complex(1, 0, 1), complex(1, 0, 1), \
                       complex(1, 0, 1)]
  kReused rfft kInput

  printf "fft rect:  %.6f %+.6fi\n", 1, \
         real(kRectFFT[0]), imag(kRectFFT[0])
  printf "fft polar: %.6f %+.6fi\n", 1, \
         real(kPolarFFT[0]), imag(kPolarFFT[0])
  printf "rifft rect:  %.6f %.6f %.6f %.6f\n", 1, \
         kRectTime[0], kRectTime[1], kRectTime[2], kRectTime[3]
  printf "rifft polar: %.6f %.6f %.6f %.6f\n", 1, \
         kPolarTime[0], kPolarTime[1], kPolarTime[2], kPolarTime[3]
  printf "reused rfft: abs(DC)=%.6f bin1=%.6f %+.6fi abs(Nyq)=%.6f\n", 1, \
         abs(kReused[0]), real(kReused[1]), imag(kReused[1]), \
         abs(kReused[2])
  turnoff
endin
</CsInstruments>
<CsScore>
i1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

```text
fft rect:  0.000000 +1.000000i
fft polar: 1.000000 +1.570796i
rifft rect:  0.000000 -0.500000 0.000000 0.500000
rifft polar: 0.500000 -0.785398 -0.500000 0.785398
reused rfft: abs(DC)=-1.000000 bin1=-1.080605 +1.682942i abs(Nyq)=-3.000000
```

## After

```text
fft rect:  0.000000 +1.000000i
fft polar: 0.000000 +1.000000i
rifft rect:  0.000000 -0.500000 0.000000 0.500000
rifft polar: 0.000000 -0.500000 0.000000 0.500000
reused rfft: abs(DC)=1.000000 bin1=-2.000000 -1.000000i abs(Nyq)=3.000000
```