### PR TITLE
Add init-time typed FFT transforms

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -148,6 +148,13 @@ static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
   return OK;
 }
 
+/* Complex[] signatures do not retain a rate, so the shared form runs both phases. */
+static int32_t fft_complex_i(CSOUND *csound, FFT *p) {
+  if (LIKELY(init_fft_complex(csound, p) == OK))
+    return perf_fft_complex(csound, p);
+  else return NOTOK;
+}
+
 static int32_t init_rfft_r2c(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
@@ -177,6 +184,12 @@ static int32_t perf_rfft_r2c(CSOUND *csound, FFT *p) {
   return OK;
 }
 
+static int32_t rfft_r2c_i(CSOUND *csound, FFT *p) {
+  if (LIKELY(init_rfft_r2c(csound, p) == OK))
+    return perf_rfft_r2c(csound, p);
+  else return NOTOK;
+}
+
 static int32_t init_rfft_c2r(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
@@ -203,6 +216,12 @@ static int32_t perf_rfft_c2r(CSOUND *csound, FFT *p) {
   csound->RealFFT(csound,p->setup,tmp);
   memcpy(p->out->data,tmp,N*sizeof(MYFLT));
   return OK;
+}
+
+static int32_t rfft_c2r_i(CSOUND *csound, FFT *p) {
+  if (LIKELY(init_rfft_c2r(csound, p) == OK))
+    return perf_rfft_c2r(csound, p);
+  else return NOTOK;
 }
 
 static int32_t init_rfft(CSOUND *csound, FFT *p) {
@@ -1289,15 +1308,23 @@ static OENTRY arrayvars_localops[] =
   {
     { "nxtpow2", sizeof(INOUT), 0, "i", "i", (SUBR)nxtpow2},
     { "fft", sizeof(FFT), 0, ":Complex;[]",":Complex;[]o",
-      (SUBR) init_fft_complex, (SUBR) perf_fft_complex, NULL},
+      (SUBR) fft_complex_i, (SUBR) perf_fft_complex, NULL},
     { "fft", sizeof(FFT), 0, ":Complex;[]","k[]",
       (SUBR) init_fft_complex, (SUBR) perf_fft_complex, NULL},
+    { "fft", sizeof(FFT), 0, ":Complex;[]","i[]",
+      (SUBR) fft_complex_i, NULL, NULL},
     { "fft", sizeof(FFT), 0, "k[]",":Complex;[]",
       (SUBR) init_fft_complex, (SUBR) perf_fft_complex, NULL},
+    { "fft", sizeof(FFT), 0, "i[]",":Complex;[]",
+      (SUBR) fft_complex_i, NULL, NULL},
     { "rfft", sizeof(FFT), 0, ":Complex;[]","k[]",
       (SUBR) init_rfft_r2c, (SUBR) perf_rfft_r2c, NULL},
+    { "rfft", sizeof(FFT), 0, ":Complex;[]","i[]",
+      (SUBR) rfft_r2c_i, NULL, NULL},
     { "rifft", sizeof(FFT), 0, "k[]", ":Complex;[]",
       (SUBR) init_rfft_c2r, (SUBR) perf_rfft_c2r, NULL},
+    { "rifft", sizeof(FFT), 0, "i[]", ":Complex;[]",
+      (SUBR) rfft_c2r_i, NULL, NULL},
     { "rfft", sizeof(FFT), 0, "k[]","k[]",
       (SUBR) init_rfft, (SUBR) perf_rfft, NULL},
     {"rfft", sizeof(FFT), 0, "i[]","i[]",

--- a/tests/commandline/fft_array_test.csd
+++ b/tests/commandline/fft_array_test.csd
@@ -1,11 +1,20 @@
 <CsoundSynthesizer>
 <CsOptions>
--n
+-n -d -m0
 </CsOptions>
 <CsInstruments>
 
 nchnls = 1
 0dbfs = 1
+
+opcode assert_close_i, 0, iii
+ iActual, iExpected, iTolerance xin
+ iDifference = abs(iActual - iExpected)
+ if qnan(iDifference) != 0 || iDifference > iTolerance then
+  prints "assert_close_i failed: actual=%f expected=%f\n", iActual, iExpected
+  exitnow(-1)
+ endif
+endop
 
 instr 1
  kArr[] genarray_i 0,1023
@@ -13,10 +22,50 @@ instr 1
  kArr fft spec
 endin
 
+instr 2
+ iComplexInput:Complex[] = [complex(1, 0), complex(0, 1), \
+                            complex(-1, 0), complex(0, -1)]
+ iRealInput[] = [1, 0, 0, 0]
+
+ iComplexForward:Complex[] = fft(iComplexInput)
+ iRealForward:Complex[] = fft(iRealInput)
+ iComplexInverse:Complex[] = fft(iComplexInput, 1)
+ iRealInverse[] = fft(iRealForward)
+
+ if lenarray(iComplexForward) != 4 || lenarray(iRealForward) != 4 || \
+    lenarray(iComplexInverse) != 4 || lenarray(iRealInverse) != 4 then
+  prints "typed init fft returned an invalid array size\n"
+  exitnow(-1)
+ endif
+
+ iTolerance = 0.000001
+ iIndex = 0
+ while iIndex < 4 do
+  iExpectedForward = iIndex == 1 ? 4 : 0
+  iExpectedInverse = iIndex == 3 ? 1 : 0
+  iExpectedRealInverse = iIndex == 0 ? 1 : 0
+
+  iComplexForwardReal = real(iComplexForward[iIndex])
+  iComplexForwardImag = imag(iComplexForward[iIndex])
+  iRealForwardReal = real(iRealForward[iIndex])
+  iRealForwardImag = imag(iRealForward[iIndex])
+  iComplexInverseReal = real(iComplexInverse[iIndex])
+  iComplexInverseImag = imag(iComplexInverse[iIndex])
+
+  assert_close_i(iComplexForwardReal, iExpectedForward, iTolerance)
+  assert_close_i(iComplexForwardImag, 0, iTolerance)
+  assert_close_i(iRealForwardReal, 1, iTolerance)
+  assert_close_i(iRealForwardImag, 0, iTolerance)
+  assert_close_i(iComplexInverseReal, iExpectedInverse, iTolerance)
+  assert_close_i(iComplexInverseImag, 0, iTolerance)
+  assert_close_i(iRealInverse[iIndex], iExpectedRealInverse, iTolerance)
+  iIndex += 1
+ od
+endin
+
 </CsInstruments>
 <CsScore>
-i1 0 1 
+i1 0 1
+i2 0 0
 </CsScore>
 </CsoundSynthesizer>
-
-

--- a/tests/commandline/rfft_array_test.csd
+++ b/tests/commandline/rfft_array_test.csd
@@ -1,11 +1,20 @@
 <CsoundSynthesizer>
 <CsOptions>
--n
+-n -d -m0
 </CsOptions>
 <CsInstruments>
 
 nchnls = 1
 0dbfs = 1
+
+opcode assert_close_i, 0, iii
+ iActual, iExpected, iTolerance xin
+ iDifference = abs(iActual - iExpected)
+ if qnan(iDifference) != 0 || iDifference > iTolerance then
+  prints "assert_close_i failed: actual=%f expected=%f\n", iActual, iExpected
+  exitnow(-1)
+ endif
+endop
 
 instr 1
  kArr[] genarray_i 0,1023
@@ -13,10 +22,37 @@ instr 1
  kArr rifft spec
 endin
 
+instr 2
+ iInput[] = [1, 0, 0, 0]
+ iSpectrum:Complex[] = rfft(iInput)
+ iOutput[] = rifft(iSpectrum)
+
+ if lenarray(iSpectrum) != 3 || lenarray(iOutput) != 4 then
+  prints "typed init rfft returned an invalid array size\n"
+  exitnow(-1)
+ endif
+
+ iTolerance = 0.000001
+ iIndex = 0
+ while iIndex < lenarray(iSpectrum) do
+  iSpectrumReal = real(iSpectrum[iIndex])
+  iSpectrumImag = imag(iSpectrum[iIndex])
+  assert_close_i(iSpectrumReal, 1, iTolerance)
+  assert_close_i(iSpectrumImag, 0, iTolerance)
+  iIndex += 1
+ od
+
+ iIndex = 0
+ while iIndex < lenarray(iOutput) do
+  iExpected = iIndex == 0 ? 1 : 0
+  assert_close_i(iOutput[iIndex], iExpected, iTolerance)
+  iIndex += 1
+ od
+endin
+
 </CsInstruments>
 <CsScore>
-i1 0 1 
+i1 0 1
+i2 0 0
 </CsScore>
 </CsoundSynthesizer>
-
-


### PR DESCRIPTION
## Summary

Typed `Complex[]` FFT opcodes only allocated their outputs during init. They did not run the transform until the first control pass, and the typed real-input and real-output init forms were missing.

Run the typed complex transform during init and add init-only overloads for `fft(i[])`, `rfft(i[])`, and `rifft(Complex[])`. The existing control callbacks stay in place.

Closes #2677

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
0dbfs = 1

instr 1
  iComplex:Complex[] = [complex(1, 0), complex(0, 0), \
                        complex(0, 0), complex(0, 0)]
  iReal[] = [1, 0, 0, 0]

  iFFT:Complex[] = fft(iComplex)
  iRFFT:Complex[] = rfft(iReal)

  iFFT0 = real(iFFT[0])
  iFFT1 = real(iFFT[1])
  iFFT2 = real(iFFT[2])
  iFFT3 = real(iFFT[3])
  iRFFT0 = real(iRFFT[0])
  iRFFT1 = real(iRFFT[1])
  iRFFT2 = real(iRFFT[2])

  prints "fft:  %.6f %.6f %.6f %.6f\n", \
         iFFT0, iFFT1, iFFT2, iFFT3
  prints "rfft: %.6f %.6f %.6f\n", iRFFT0, iRFFT1, iRFFT2
endin
</CsInstruments>
<CsScore>
i 1 0 0
</CsScore>
</CsoundSynthesizer>
```

Before:

```text
fft:  0.000000 0.000000 0.000000 0.000000
rfft: 0.000000 0.000000 0.000000
```

After:

```text
fft:  1.000000 1.000000 1.000000 1.000000
rfft: 1.000000 1.000000 1.000000
```
