### PR TITLE
Fix non-power-of-two complex FFT lane aliasing

### DIFF
--- a/OOps/mxfft.c
+++ b/OOps/mxfft.c
@@ -973,18 +973,22 @@ void csoundInverseRealFFTnp2(CSOUND *csound, MYFLT *buf, int32_t FFTsize)
 
 void csoundInverseComplexFFTnp2(CSOUND *csound, MYFLT *buf, int32_t FFTsize)
 {
-  if (UNLIKELY(FFTsize < 2 || (FFTsize & 1))){
-      csound->Warning(csound, Str("csoundInverseRealFFTnp2(): invalid FFT size"));
+    if (UNLIKELY(FFTsize < 2 || (FFTsize & 1))) {
+      csound->Warning(csound,
+                      Str("csoundInverseComplexFFTnp2(): invalid FFT size, %d"),
+                      FFTsize);
       return;
-  }
-    fft_(csound, buf, buf, 1, FFTsize, 1, 2);
+    }
+    fft_(csound, buf, &(buf[1]), 1, FFTsize, 1, 2);
 }
 
 void csoundComplexFFTnp2(CSOUND *csound, MYFLT *buf, int32_t FFTsize)
 {
-      if (UNLIKELY(FFTsize < 2 || (FFTsize & 1))) {
-        csound->Warning(csound, Str("csoundRealFFTnp2(): invalid FFT size"));
-        return;
-      }
-      fft_(csound, buf, buf, 1, FFTsize, 1, -2);
+    if (UNLIKELY(FFTsize < 2 || (FFTsize & 1))) {
+      csound->Warning(csound,
+                      Str("csoundComplexFFTnp2(): invalid FFT size, %d"),
+                      FFTsize);
+      return;
+    }
+    fft_(csound, buf, &(buf[1]), 1, FFTsize, 1, -2);
 }

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -101,6 +101,10 @@ static int32_t init_fft_complex(CSOUND *csound, FFT *p) {
       return csound->InitError(csound, "fft: input array size (%d) is unreasonable", N);
     }
   }
+  if (UNLIKELY(N > 1 && (N & 1)))
+    return csound->InitError(csound,
+                             Str("fft: input array size (%d) must be 1 or even"),
+                             N);
 
   tabinit(csound, p->out, N, p->h.insdshead);
   size_t bytes = (size_t)N * 2u * sizeof(MYFLT);

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -1,14 +1,61 @@
 #define __BUILDING_LIBCSOUND
 #include "csoundCore.h"
 #include "csound_graph_display.h"
+#include "fftlib.h"
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <cstring>
 #include <stdio.h>
+#include <string>
 #include <thread>
 #include <vector>
 #include "gtest/gtest.h"
 #include "time.h"
+
+namespace {
+
+std::vector<MYFLT> directComplexDft(const std::vector<MYFLT>& input,
+                                    bool inverse)
+{
+    const int32_t size = static_cast<int32_t>(input.size() / 2);
+    const double direction = inverse ? 1.0 : -1.0;
+    const double scale = inverse ? 1.0 / size : 1.0;
+    const double twoPi = 2.0 * std::acos(-1.0);
+    std::vector<MYFLT> output(input.size(), FL(0.0));
+
+    for (int32_t bin = 0; bin < size; ++bin) {
+        double real = 0.0;
+        double imag = 0.0;
+        for (int32_t sample = 0; sample < size; ++sample) {
+            const double angle = direction * twoPi *
+              static_cast<double>(bin) * sample / size;
+            const double cosine = std::cos(angle);
+            const double sine = std::sin(angle);
+            const double inputReal = input[sample * 2];
+            const double inputImag = input[sample * 2 + 1];
+            real += inputReal * cosine - inputImag * sine;
+            imag += inputReal * sine + inputImag * cosine;
+        }
+        output[bin * 2] = static_cast<MYFLT>(real * scale);
+        output[bin * 2 + 1] = static_cast<MYFLT>(imag * scale);
+    }
+    return output;
+}
+
+std::string drainMessageBuffer(CSOUND *csound)
+{
+    std::string messages;
+    while (csoundGetMessageCnt(csound) > 0) {
+        const char *message = csoundGetFirstMessage(csound);
+        if (message != nullptr)
+            messages += message;
+        csoundPopFirstMessage(csound);
+    }
+    return messages;
+}
+
+}
 
 class EngineTests : public ::testing::Test {
 public:
@@ -35,6 +82,84 @@ public:
 
     CSOUND* csound {nullptr};
 };
+
+TEST_F (EngineTests, testComplexFftMatchesDirectDft)
+{
+    const std::vector<std::vector<MYFLT>> inputs = {
+      {FL(1.0), FL(0.5), FL(-2.0), FL(1.25), FL(0.75), FL(-0.5),
+       FL(3.0), FL(-1.5), FL(-0.25), FL(2.0), FL(1.5), FL(-0.75)},
+      {FL(1.0), FL(0.5), FL(-2.0), FL(1.25), FL(0.75), FL(-0.5),
+       FL(3.0), FL(-1.5), FL(-0.25), FL(2.0), FL(1.5), FL(-0.75),
+       FL(0.5), FL(1.75), FL(-1.0), FL(-0.25)}
+    };
+    const double tolerance =
+      sizeof(MYFLT) == sizeof(float) ? 0.0001 : 1.0e-10;
+
+    for (const auto& input : inputs) {
+        const int32_t size = static_cast<int32_t>(input.size() / 2);
+        const auto expectedForward = directComplexDft(input, false);
+        auto actualForward = input;
+        if (size == 6)
+            csoundComplexFFTnp2(csound, actualForward.data(), size);
+        else
+            csound->ComplexFFT(csound, actualForward.data(), size);
+
+        for (size_t i = 0; i < actualForward.size(); ++i)
+            EXPECT_NEAR(actualForward[i], expectedForward[i], tolerance)
+              << "FFT size " << size << ", component " << i;
+
+        const auto expectedInverse = directComplexDft(actualForward, true);
+        auto actualInverse = actualForward;
+        if (size == 6)
+            csoundInverseComplexFFTnp2(csound, actualInverse.data(), size);
+        else
+            csound->InverseComplexFFT(csound, actualInverse.data(), size);
+
+        for (size_t i = 0; i < actualInverse.size(); ++i) {
+            EXPECT_NEAR(actualInverse[i], expectedInverse[i], tolerance)
+              << "inverse FFT size " << size << ", component " << i;
+            EXPECT_NEAR(actualInverse[i], input[i], tolerance)
+              << "round trip size " << size << ", component " << i;
+        }
+    }
+}
+
+TEST_F (EngineTests, testComplexFftReportsUnsupportedSizes)
+{
+    MYFLT buffer[] = {
+      FL(1.0), FL(1.0), FL(2.0), FL(-1.0), FL(0.5), FL(2.0)
+    };
+    drainMessageBuffer(csound);
+
+    csoundComplexFFTnp2(csound, buffer, 3);
+    csoundInverseComplexFFTnp2(csound, buffer, 3);
+
+    const std::string messages = drainMessageBuffer(csound);
+    EXPECT_NE(messages.find("csoundComplexFFTnp2(): invalid FFT size, 3"),
+              std::string::npos);
+    EXPECT_NE(messages.find("csoundInverseComplexFFTnp2(): invalid FFT size, 3"),
+              std::string::npos);
+}
+
+TEST_F (EngineTests, testTypedComplexFftRejectsOddSize)
+{
+    csoundSetOption(csound, "-n");
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      instr 1
+        kInput:Complex[] = [complex(1, 1), complex(2, -1), complex(0.5, 2)]
+        kSpectrum:Complex[] = fft(kInput)
+        turnoff
+      endin
+    )", 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 0.01", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    EXPECT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    const std::string messages = drainMessageBuffer(csound);
+    EXPECT_NE(messages.find(
+                "fft: input array size (3) must be 1 or even"),
+              std::string::npos);
+}
 
 TEST_F (EngineTests, testUdpServer)
 {

--- a/tests/commandline/fft_array_test.csd
+++ b/tests/commandline/fft_array_test.csd
@@ -1,22 +1,47 @@
 <CsoundSynthesizer>
 <CsOptions>
--n
+-n -d -m0
 </CsOptions>
 <CsInstruments>
 
+sr = 48000
+ksmps = 1
 nchnls = 1
 0dbfs = 1
 
+opcode assert_close, 0, kkk
+  kActual, kExpected, kTolerance xin
+  kDifference = abs(kActual - kExpected)
+  if qnan(kDifference) != 0 || kDifference > kTolerance then
+    printks "assert_close failed: actual=%f expected=%f difference=%f\n", \
+            1, kActual, kExpected, kDifference
+    exitnowk(-1)
+  endif
+endop
+
 instr 1
- kArr[] genarray_i 0,1023
- spec:Complex[] fft kArr
- kArr fft spec
+  kInput:Complex[] = [complex(0, 0), complex(1, 2), \
+                      complex(0, 0), complex(0, 0), \
+                      complex(0, 0), complex(0, 0)]
+  kSpectrum:Complex[] = fft(kInput)
+  kRoundTrip:Complex[] = fft(kSpectrum, 1)
+
+  kIndex = 0
+  while kIndex < lenarray(kInput) do
+    kAngle = 2 * $M_PI * kIndex / lenarray(kInput)
+    kExpectedReal = cos(kAngle) + 2 * sin(kAngle)
+    kExpectedImag = 2 * cos(kAngle) - sin(kAngle)
+    assert_close(real(kSpectrum[kIndex]), kExpectedReal, 0.00001)
+    assert_close(imag(kSpectrum[kIndex]), kExpectedImag, 0.00001)
+    assert_close(real(kRoundTrip[kIndex]), kIndex == 1 ? 1 : 0, 0.00001)
+    assert_close(imag(kRoundTrip[kIndex]), kIndex == 1 ? 2 : 0, 0.00001)
+    kIndex += 1
+  od
+  turnoff
 endin
 
 </CsInstruments>
 <CsScore>
-i1 0 1 
+i1 0 1
 </CsScore>
 </CsoundSynthesizer>
-
-


### PR DESCRIPTION
Closes #2675.

## Summary

Fix non-power-of-two complex FFTs so the FFT core receives separate real and imaginary lanes. The forward and inverse helpers passed `buf` as both lane pointers, which aliased the lanes, erased imaginary output, and broke round trips.

The typed-array `fft` opcode now rejects unsupported odd lengths with an error that includes the rejected size. Power-of-two FFTs keep their existing path.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 1
nchnls = 1
0dbfs = 1

instr 1
  kInput:Complex[] = [complex(0, 0), complex(1, 0), \
                      complex(0, 0), complex(0, 0), \
                      complex(0, 0), complex(0, 0)]

  kSpectrum:Complex[] = fft(kInput)
  kRoundTrip:Complex[] = fft(kSpectrum, 1)

  printf "fft bin 1: %.6f %+.6fi\n", 1, \
         real(kSpectrum[1]), imag(kSpectrum[1])
  printf "round trip: %.6f %.6f %.6f %.6f %.6f %.6f\n", 1, \
         real(kRoundTrip[0]), real(kRoundTrip[1]), \
         real(kRoundTrip[2]), real(kRoundTrip[3]), \
         real(kRoundTrip[4]), real(kRoundTrip[5])
  turnoff
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

### Before

```text
fft bin 1: -0.366025 +0.000000i
round trip: 0.020335 -0.026416 0.121278 0.020833 0.025053 0.047249
```

### After

```text
fft bin 1: 0.500000 -0.866025i
round trip: 0.000000 1.000000 0.000000 0.000000 -0.000000 -0.000000
```