### PR TITLE
Enforce real FFT array size contract

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -152,6 +152,14 @@ static int32_t perf_fft_complex(CSOUND *csound, FFT *p) {
   return OK;
 }
 
+static int32_t validate_real_fft_size(CSOUND *csound, const char *opcode,
+                                      int32_t size) {
+  if (UNLIKELY(size < 2 || (size & 1)))
+    return csound->InitError(csound, "%s: %s", opcode,
+                             Str("transform size must be even and at least 2"));
+  return OK;
+}
+
 static int32_t init_rfft_r2c(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
@@ -159,12 +167,14 @@ static int32_t init_rfft_r2c(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("rfft: only one-dimensional arrays allowed"));
+  if (UNLIKELY(validate_real_fft_size(csound, "rfft", N) != OK))
+    return NOTOK;
   tabinit(csound, p->out, N/2+1, p->h.insdshead);
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
   csound->AuxAlloc(csound, sizeof(MYFLT)*N, &p->mem);
   return OK;
 }
-// NB: outputs are NOT packed (N+1 size)
+// Typed output has N / 2 + 1 unpacked complex bins.
 static int32_t perf_rfft_r2c(CSOUND *csound, FFT *p) {
   int32_t N = p->in->sizes[0];
   MYFLT *tmp = (MYFLT *)p->mem.auxp;
@@ -184,17 +194,23 @@ static int32_t perf_rfft_r2c(CSOUND *csound, FFT *p) {
 static int32_t init_rfft_c2r(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
-  int32_t   N = 2*(p->in->sizes[0] - 1);
+  int32_t M = p->in->sizes[0];
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
-                             Str("rfft: only one-dimensional arrays allowed"));
+                             Str("rifft: only one-dimensional arrays allowed"));
+  if (UNLIKELY(M < 2))
+    return csound->InitError(csound, "%s",
+                             Str("rifft: input spectrum must contain at least 2 bins"));
+  int32_t N = 2*(M - 1);
+  if (UNLIKELY(validate_real_fft_size(csound, "rifft", N) != OK))
+    return NOTOK;
   tabinit(csound, p->out, N, p->h.insdshead);
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
   csound->AuxAlloc(csound, sizeof(MYFLT)*N, &p->mem);
   return OK;
 }
 
-// NB: these expect NOT packed (N+1 size) inputs
+// M unpacked complex bins produce 2 * (M - 1) real samples.
 static int32_t perf_rfft_c2r(CSOUND *csound, FFT *p) {
   int32_t N = p->out->sizes[0];
   MYFLT *tmp = (MYFLT *)p->mem.auxp;
@@ -216,6 +232,8 @@ static int32_t init_rfft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("rfft: only one-dimensional arrays allowed"));
+  if (UNLIKELY(validate_real_fft_size(csound, "rfft", N) != OK))
+    return NOTOK;
   tabinit(csound, p->out,N, p->h.insdshead);
   p->setup = csound->RealFFTSetup(csound, N, FFT_FWD);
   return OK;
@@ -241,6 +259,8 @@ static int32_t init_rifft(CSOUND *csound, FFT *p) {
   if (UNLIKELY(p->in->dimensions > 1))
     return csound->InitError(csound, "%s",
                              Str("rifft: only one-dimensional arrays allowed"));
+  if (UNLIKELY(validate_real_fft_size(csound, "rifft", N) != OK))
+    return NOTOK;
   p->setup = csound->RealFFTSetup(csound, N, FFT_INV);
   tabinit(csound, p->out, N, p->h.insdshead);
   return OK;

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -187,11 +187,12 @@ protected:
 };
 
 static int32_t realFFTSetupCalls;
+static void *(*realFFTSetup)(CSOUND *, int32_t, int32_t);
 
-static void *countRealFFTSetup(CSOUND *, int32_t, int32_t)
+static void *countRealFFTSetup(CSOUND *csound, int32_t size, int32_t direction)
 {
     ++realFFTSetupCalls;
-    return nullptr;
+    return realFFTSetup(csound, size, direction);
 }
 
 TEST_P(InvalidRealFFTSizeTests, RejectsBeforeBackendSetup)
@@ -205,6 +206,7 @@ TEST_P(InvalidRealFFTSizeTests, RejectsBeforeBackendSetup)
     ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
 
     realFFTSetupCalls = 0;
+    realFFTSetup = csound->RealFFTSetup;
     csound->RealFFTSetup = countRealFFTSetup;
     EXPECT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
     EXPECT_EQ(realFFTSetupCalls, 0);

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -161,6 +161,124 @@ TEST_F (EngineTests, testTypedComplexFftRejectsOddSize)
               std::string::npos);
 }
 
+struct InvalidRealFFTSizeCase {
+    const char *name;
+    const char *statement;
+    const char *error;
+};
+
+class InvalidRealFFTSizeTests
+    : public ::testing::TestWithParam<InvalidRealFFTSizeCase> {
+protected:
+    void SetUp() override
+    {
+        csound = csoundCreate(nullptr, nullptr);
+        ASSERT_NE(csound, nullptr);
+        csoundCreateMessageBuffer(csound, 0);
+        ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        csoundDestroy(csound);
+    }
+
+    CSOUND *csound {nullptr};
+};
+
+static int32_t realFFTSetupCalls;
+
+static void *countRealFFTSetup(CSOUND *, int32_t, int32_t)
+{
+    ++realFFTSetupCalls;
+    return nullptr;
+}
+
+TEST_P(InvalidRealFFTSizeTests, RejectsBeforeBackendSetup)
+{
+    const InvalidRealFFTSizeCase &test = GetParam();
+    std::string orchestra = "instr 1\n";
+    orchestra += test.statement;
+    orchestra += "\nendin\n";
+    ASSERT_EQ(csoundCompileOrc(csound, orchestra.c_str(), 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 0", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    realFFTSetupCalls = 0;
+    csound->RealFFTSetup = countRealFFTSetup;
+    EXPECT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+    EXPECT_EQ(realFFTSetupCalls, 0);
+
+    std::string messages;
+    while (csoundGetMessageCnt(csound)) {
+        const char *message = csoundGetFirstMessage(csound);
+        if (message != nullptr)
+            messages += message;
+        csoundPopFirstMessage(csound);
+    }
+    EXPECT_NE(messages.find(test.error), std::string::npos)
+        << "Expected error text not found in:\n" << messages;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ArrayOpcodes, InvalidRealFFTSizeTests,
+    ::testing::Values(
+        InvalidRealFFTSizeCase{
+            "TypedForwardEmpty",
+            "kInput[] init 0\nkSpectrum:Complex[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "TypedForwardOne",
+            "kInput[] init 1\nkSpectrum:Complex[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "TypedForwardOdd",
+            "kInput[] init 5\nkSpectrum:Complex[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "TypedInverseEmpty",
+            "kSpectrum:Complex[] init 0\nkOutput[] rifft kSpectrum",
+            "rifft: input spectrum must contain at least 2 bins"},
+        InvalidRealFFTSizeCase{
+            "TypedInverseOne",
+            "kSpectrum:Complex[] init 1\nkOutput[] rifft kSpectrum",
+            "rifft: input spectrum must contain at least 2 bins"},
+        InvalidRealFFTSizeCase{
+            "PackedForwardEmpty",
+            "kInput[] init 0\nkOutput[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedForwardOne",
+            "kInput[] init 1\nkOutput[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedForwardOdd",
+            "kInput[] init 5\nkOutput[] rfft kInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedInitForwardOdd",
+            "iInput[] init 5\niOutput[] rfft iInput",
+            "rfft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedInverseEmpty",
+            "kInput[] init 0\nkOutput[] rifft kInput",
+            "rifft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedInverseOne",
+            "kInput[] init 1\nkOutput[] rifft kInput",
+            "rifft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedInverseOdd",
+            "kInput[] init 5\nkOutput[] rifft kInput",
+            "rifft: transform size must be even and at least 2"},
+        InvalidRealFFTSizeCase{
+            "PackedInitInverseOdd",
+            "iInput[] init 5\niOutput[] rifft iInput",
+            "rifft: transform size must be even and at least 2"}),
+    [](const ::testing::TestParamInfo<InvalidRealFFTSizeCase> &info) {
+        return info.param.name;
+    });
+
 TEST_F (EngineTests, testUdpServer)
 {
     csoundSetIsGraphable(csound, 1);

--- a/tests/commandline/test_rfft.csd
+++ b/tests/commandline/test_rfft.csd
@@ -5,16 +5,51 @@
 <CsInstruments>
 
 instr 1
-test:k[] = [1, 2, 3, 4, 5, 6, 7, 8]
-spec:Complex[] = rfft(test)
-res:k[] = rifft(spec)
+test6:k[] = [1, 2, 3, 4, 5, 6]
+spec6:Complex[] = rfft(test6)
+res6:k[] = rifft(spec6)
+if lenarray(spec6) != 4 || lenarray(res6) != 6 then
+  printks "wrong array size in six-sample rfft/rifft\n", 1
+  exitnowk(-1)
+endif
 n:k = 0
-while n < lenarray(test) do
- if int(res[n]) != int(test[n]) then
-   printks "error in rfft/rifft\n", 1
-   exitnowk(-1)
- endif
- n += 1
+while n < lenarray(test6) do
+  if abs(res6[n] - test6[n]) > 0.0001 then
+    printks "error in six-sample rfft/rifft\n", 1
+    exitnowk(-1)
+  endif
+  n += 1
+od
+
+packed6:k[] = rfft(test6)
+packedRes6:k[] = rifft(packed6)
+if lenarray(packed6) != 6 || lenarray(packedRes6) != 6 then
+  printks "wrong array size in packed six-sample rfft/rifft\n", 1
+  exitnowk(-1)
+endif
+n = 0
+while n < lenarray(test6) do
+  if abs(packedRes6[n] - test6[n]) > 0.0001 then
+    printks "error in packed six-sample rfft/rifft\n", 1
+    exitnowk(-1)
+  endif
+  n += 1
+od
+
+test8:k[] = [1, 2, 3, 4, 5, 6, 7, 8]
+spec8:Complex[] = rfft(test8)
+res8:k[] = rifft(spec8)
+if lenarray(spec8) != 5 || lenarray(res8) != 8 then
+  printks "wrong array size in eight-sample rfft/rifft\n", 1
+  exitnowk(-1)
+endif
+n = 0
+while n < lenarray(test8) do
+  if abs(res8[n] - test8[n]) > 0.0001 then
+    printks "error in eight-sample rfft/rifft\n", 1
+    exitnowk(-1)
+  endif
+  n += 1
 od
 turnoff
 endin


### PR DESCRIPTION
## Summary

Reject real FFT array transform sizes that are odd or smaller than two before setup or allocation. This covers the typed `Complex[]` and packed numeric forms of `rfft` and `rifft`.

Typed `rifft` also rejects inputs with fewer than two bins. Even non-power-of-two sizes, such as six, keep working.

## Root cause

The array init paths passed invalid lengths to the real FFT backend. Typed `rfft` then packed odd arrays in pairs and read `tmp[i + 1]` past the scratch buffer on the last pass. Typed `rifft` cannot recover an odd source length from a half spectrum, since `M` bins map to the even length `2 * (M - 1)`.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  kInput[] = [1, 0, 0, 0, 0]
  kSpectrum:Complex[] = rfft(kInput)
  kRoundTrip[] = rifft(kSpectrum)

  printf "sizes: input=%d spectrum=%d roundtrip=%d\n", 1, \
         lenarray(kInput), lenarray(kSpectrum), lenarray(kRoundTrip)
  printf "bins: %.6f%+.6fi %.6f%+.6fi %.6f%+.6fi\n", 1, \
         real(kSpectrum[0]), imag(kSpectrum[0]), \
         real(kSpectrum[1]), imag(kSpectrum[1]), \
         real(kSpectrum[2]), imag(kSpectrum[2])
  turnoff
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before

Csound continues with mismatched array sizes:

```text
sizes: input=5 spectrum=3 roundtrip=4
bins: 1.000000+0.000000i 0.000000+0.000000i 0.000000+0.000000i
```

An AddressSanitizer build also reports a heap-buffer-overflow in `perf_rfft_r2c()`.

## After

Csound rejects the invalid size during init:

```text
INIT ERROR in instr 1 (opcode rfft) line 13: rfft: transform size must be even and at least 2
1 errors in performance
```

The error occurs before the transform backend runs or scratch memory is allocated.

Closes #2676