### PR TITLE
Preserve struct array read phases

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1233,8 +1233,9 @@ static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
                                                TREE* tree,
                                                TYPE_TABLE* typeTable)
 {
-  /* Direct k variables already have init storage. An i-indexed array read
-     lowers to ##array_get_init. Other computed k values only run at perf. */
+  /* Direct k variables already have init storage, and struct member reads
+     have an init callback. An i-indexed array read lowers to
+     ##array_get_init. Other computed k values only run at perf. */
   while (tree != NULL) {
     char* argType =
       (is_expression_node(tree) || tree->type == STRUCT_EXPR)
@@ -1246,7 +1247,7 @@ static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
     if (argType != NULL) {
       csound->Free(csound, argType);
     }
-    if ((isKRate && tree->type != T_IDENT &&
+    if ((isKRate && tree->type != T_IDENT && tree->type != STRUCT_EXPR &&
          !(tree->type == T_ARRAY &&
            !array_has_k_rate_index(csound, tree->right, typeTable))) ||
         tree_has_perf_only_k_rate_value(csound, tree->left, typeTable) ||

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -34,12 +34,6 @@
 ORCTOKEN *make_token(CSOUND *, char *, void *);
 ORCTOKEN *make_label(CSOUND *, char *, void *);
 
-enum {
-  EXPRESSION_PERF_CONTEXT = 0,
-  EXPRESSION_INIT_CONTEXT,
-  EXPRESSION_EXPLICIT_INIT_CONTEXT
-};
-
 static TREE *create_boolean_expression(CSOUND*, TREE*, int32_t,  uint64_t,
                                        TYPE_TABLE*, int32_t);
 static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
@@ -47,9 +41,6 @@ static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
 static int32_t struct_expr_has_array_root(TREE* structExpr);
 static int32_t array_has_k_rate_index(CSOUND* csound, TREE* indexExpr,
                                       TYPE_TABLE* typeTable);
-static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
-                                               TREE* tree,
-                                               TYPE_TABLE* typeTable);
 TREE* expand_struct_array_member_read(CSOUND* csound,
                                       TREE* structExpr,
                                       int32_t line,
@@ -57,11 +48,6 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                                       TYPE_TABLE* typeTable,
                                       int32_t initContext);
 static TREE *create_synthetic_label(CSOUND *csound, int32 count);
-
-static int32_t expression_context_has_init(int32_t expressionContext)
-{
-  return expressionContext != EXPRESSION_PERF_CONTEXT;
-}
 
 static int32_t opcode_uses_expression_types_only(const char* name)
 {
@@ -82,21 +68,9 @@ static int32_t opcode_is_init_only_value_consumer(OENTRY* entry)
   if (!strcmp(name, "xout") || opcode_uses_expression_types_only(name)) {
     return 0;
   }
-  /* Keep this test conservative. A two-phase opcode may use init only for
-     setup or may read its inputs in both phases. The latter needs a getter
-     with both callbacks; an init-only getter could read a provisional index
-     or suppress later updates. */
+  /* A two-phase opcode may use init only for setup. Keep its expressions in
+     performance context so k-indexed reads follow the array rate contract. */
   return entry->perf == NULL;
-}
-
-static char* struct_array_get_opcode_name(int32_t expressionContext,
-                                          int32_t hasKRateIndex)
-{
-  if (expression_context_has_init(expressionContext) &&
-      hasKRateIndex) {
-    return "##array_get_struct_init";
-  }
-  return "##array_get_struct";
 }
 
 static TREE* tree_tail(TREE* node) {
@@ -580,11 +554,11 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
                                                      initContext);
   if (root->type == T_FUNCTION && root->value != NULL &&
       opcode_uses_expression_types_only(root->value->lexeme)) {
-    childContext = EXPRESSION_PERF_CONTEXT;
+    childContext = 0;
   }
   if (root->type == T_ARRAY &&
-      expression_context_has_init(initContext) &&
-      tree_has_perf_only_k_rate_value(csound, root->right, typeTable)) {
+      initContext &&
+      array_has_k_rate_index(csound, root->right, typeTable)) {
     char* elementType = get_arg_type2(csound, root, typeTable);
     const CS_TYPE* elementCsType =
       elementType == NULL
@@ -598,8 +572,8 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
     }
     if (elementIsStruct) {
       synterr(csound,
-              Str("struct array index requires performance-rate evaluation "
-                  "during init, line %d\n"),
+              Str("struct array index must be i-rate during init; "
+                  "convert the index explicitly, line %d\n"),
               line);
       return NULL;
     }
@@ -773,7 +747,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       int32_t hasKRateIndex =
         array_has_k_rate_index(csound, root->right, typeTable);
       int32_t initArrayRead =
-        expression_context_has_init(initContext) && !hasKRateIndex;
+        initContext && !hasKRateIndex;
 
       // Handle struct member access or other complex left expressions
       if (array_target_missing_lexeme(root)) {
@@ -786,9 +760,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
         elementCsType =
           csoundGetTypeWithVarTypeName(csound->typePool, elementType);
         if (elementCsType != NULL && elementCsType->userDefinedType) {
-          strNcpy(op,
-                  struct_array_get_opcode_name(initContext, hasKRateIndex),
-                  80);
+          strNcpy(op, "##array_get_struct", 80);
         }
         else {
           strNcpy(op, initArrayRead ? "##array_get_init" : "##array_get", 80);
@@ -818,9 +790,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       if (var->subType) {
           // Generic array or struct array
           if (var->subType->userDefinedType) {
-            strNcpy(op,
-                    struct_array_get_opcode_name(initContext, hasKRateIndex),
-                    80);
+            strNcpy(op, "##array_get_struct", 80);
           } else {
             strNcpy(op, initArrayRead ? "##array_get_init" : "##array_get",
                     80);
@@ -1260,36 +1230,6 @@ static int32_t array_has_k_rate_index(CSOUND* csound, TREE* indexExpr,
   return 0;
 }
 
-static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
-                                               TREE* tree,
-                                               TYPE_TABLE* typeTable)
-{
-  /* Direct k variables already have init storage, and struct member reads
-     have an init callback. An i-indexed array read lowers to
-     ##array_get_init. Other computed k values only run at perf. */
-  while (tree != NULL) {
-    char* argType =
-      (is_expression_node(tree) || tree->type == STRUCT_EXPR)
-        ? get_arg_type2(csound, tree, typeTable)
-        : NULL;
-    int32_t isKRate =
-      argType != NULL && (argType[0] == 'k' || argType[0] == 'K');
-
-    if (argType != NULL) {
-      csound->Free(csound, argType);
-    }
-    if ((isKRate && tree->type != STRUCT_EXPR &&
-         !(tree->type == T_ARRAY &&
-           !array_has_k_rate_index(csound, tree->right, typeTable))) ||
-        tree_has_perf_only_k_rate_value(csound, tree->left, typeTable) ||
-        tree_has_perf_only_k_rate_value(csound, tree->right, typeTable)) {
-      return 1;
-    }
-    tree = tree->next;
-  }
-  return 0;
-}
-
 static int32_t tree_has_k_rate_array_index(CSOUND* csound, TREE* tree,
                                            TYPE_TABLE* typeTable)
 {
@@ -1441,13 +1381,9 @@ static TREE* create_struct_array_get_call(CSOUND* csound,
                                           int32_t line,
                                           uint64_t locn,
                                           const char* outArg,
-                                          TREE* arrayExpr,
-                                          int32_t initContext,
-                                          int32_t hasKRateIndex)
+                                          TREE* arrayExpr)
 {
-  TREE* getOp = create_opcode_token(
-    csound,
-    struct_array_get_opcode_name(initContext, hasKRateIndex));
+  TREE* getOp = create_opcode_token(csound, "##array_get_struct");
   getOp->type = T_OPCALL;
   getOp->line = line;
   getOp->locn = locn;
@@ -1562,9 +1498,7 @@ int expand_struct_array_member_assignment(CSOUND* csound,
                    create_struct_array_get_call(csound, current->line,
                                                 current->locn,
                                                 structTemps[0],
-                                                path.arrayExpr,
-                                                initContext,
-                                                path.hasKRateIndex));
+                                                path.arrayExpr));
 
   for (i = 0; i < path.memberCount - 1; i++) {
     structTemps[i + 1] = create_out_arg(csound,
@@ -1637,12 +1571,10 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   if (!resolve_struct_array_member_path(csound, structExpr, typeTable, &path)) {
     return NULL;
   }
-  if (expression_context_has_init(initContext) &&
-      tree_has_perf_only_k_rate_value(csound, path.arrayExpr->right,
-                                      typeTable)) {
+  if (initContext && path.hasKRateIndex) {
     synterr(csound,
-            Str("struct array index requires performance-rate evaluation "
-                "during init, line %d\n"),
+            Str("struct array index must be i-rate during init; "
+                "convert the index explicitly, line %d\n"),
             line);
     return NULL;
   }
@@ -1654,9 +1586,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   readOps = tree_append(readOps,
                            create_struct_array_get_call(csound, line, locn,
                                                         currentStructArg,
-                                                        path.arrayExpr,
-                                                        initContext,
-                                                        path.hasKRateIndex));
+                                                        path.arrayExpr));
 
   for (i = 0; i < path.memberCount - 1; i++) {
     char* nextStructArg = create_out_arg(csound,
@@ -1718,12 +1648,9 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
   TREE* currentArg = current->right;
   OENTRY* statementEntry = (OENTRY*)current->markup;
   int32_t initContext =
-    current->value != NULL && current->value->lexeme != NULL &&
-    strcmp(current->value->lexeme, "init") == 0
-      ? EXPRESSION_EXPLICIT_INIT_CONTEXT
-      : (opcode_is_init_only_value_consumer(statementEntry)
-           ? EXPRESSION_INIT_CONTEXT
-           : EXPRESSION_PERF_CONTEXT);
+    (current->value != NULL && current->value->lexeme != NULL &&
+     strcmp(current->value->lexeme, "init") == 0) ||
+    opcode_is_init_only_value_consumer(statementEntry);
 
   current->next = NULL;
 

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -34,6 +34,12 @@
 ORCTOKEN *make_token(CSOUND *, char *, void *);
 ORCTOKEN *make_label(CSOUND *, char *, void *);
 
+enum {
+  EXPRESSION_PERF_CONTEXT = 0,
+  EXPRESSION_INIT_CONTEXT,
+  EXPRESSION_EXPLICIT_INIT_CONTEXT
+};
+
 static TREE *create_boolean_expression(CSOUND*, TREE*, int32_t,  uint64_t,
                                        TYPE_TABLE*, int32_t);
 static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
@@ -41,6 +47,9 @@ static TREE *create_expression(CSOUND *, TREE *, int32_t,  uint64_t,
 static int32_t struct_expr_has_array_root(TREE* structExpr);
 static int32_t array_has_k_rate_index(CSOUND* csound, TREE* indexExpr,
                                       TYPE_TABLE* typeTable);
+static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
+                                               TREE* tree,
+                                               TYPE_TABLE* typeTable);
 TREE* expand_struct_array_member_read(CSOUND* csound,
                                       TREE* structExpr,
                                       int32_t line,
@@ -48,6 +57,21 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
                                       TYPE_TABLE* typeTable,
                                       int32_t initContext);
 static TREE *create_synthetic_label(CSOUND *csound, int32 count);
+
+static int32_t expression_context_has_init(int32_t expressionContext)
+{
+  return expressionContext != EXPRESSION_PERF_CONTEXT;
+}
+
+static char* struct_array_get_opcode_name(int32_t expressionContext,
+                                          int32_t hasKRateIndex)
+{
+  if (expressionContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+      hasKRateIndex) {
+    return "##array_get_struct_init";
+  }
+  return "##array_get_struct";
+}
 
 static TREE* tree_tail(TREE* node) {
   TREE* t = node;
@@ -527,6 +551,28 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   if (root->type=='?') return create_cond_expression(csound, root, line,
                                                      locn, typeTable,
                                                      initContext);
+  if (root->type == T_ARRAY &&
+      initContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+      tree_has_perf_only_k_rate_value(csound, root->right, typeTable)) {
+    char* elementType = get_arg_type2(csound, root, typeTable);
+    const CS_TYPE* elementCsType =
+      elementType == NULL
+        ? NULL
+        : csoundGetTypeWithVarTypeName(csound->typePool, elementType);
+    int32_t elementIsStruct =
+      elementCsType != NULL && elementCsType->userDefinedType;
+
+    if (elementType != NULL) {
+      csound->Free(csound, elementType);
+    }
+    if (elementIsStruct) {
+      synterr(csound,
+              Str("struct array index requires performance-rate evaluation "
+                  "during init, line %d\n"),
+              line);
+      return NULL;
+    }
+  }
   memset(op, 0, 80);
   if (root->left != NULL) {
     expandedArgs = expand_expression_arg_list(csound, root->left, &anchor,
@@ -693,19 +739,29 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   case T_ARRAY:
     {
       char* outype;
+      int32_t hasKRateIndex =
+        array_has_k_rate_index(csound, root->right, typeTable);
       int32_t initArrayRead =
-        initContext &&
-        !array_has_k_rate_index(csound, root->right, typeTable);
+        expression_context_has_init(initContext) && !hasKRateIndex;
 
       // Handle struct member access or other complex left expressions
       if (array_target_missing_lexeme(root)) {
         char* elementType = get_arg_type2(csound, root, typeTable);
+        const CS_TYPE* elementCsType;
         if (elementType == NULL) {
           return NULL;
         }
 
-        // Set the operation to array_get (struct members are always plain arrays)
-        strNcpy(op, initArrayRead ? "##array_get_init" : "##array_get", 80);
+        elementCsType =
+          csoundGetTypeWithVarTypeName(csound->typePool, elementType);
+        if (elementCsType != NULL && elementCsType->userDefinedType) {
+          strNcpy(op,
+                  struct_array_get_opcode_name(initContext, hasKRateIndex),
+                  80);
+        }
+        else {
+          strNcpy(op, initArrayRead ? "##array_get_init" : "##array_get", 80);
+        }
 
         // Use the element type directly (it's already the type of array[index])
         outarg = create_out_arg(csound, elementType,
@@ -731,7 +787,9 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
       if (var->subType) {
           // Generic array or struct array
           if (var->subType->userDefinedType) {
-            strNcpy(op, "##array_get_struct", 80);
+            strNcpy(op,
+                    struct_array_get_opcode_name(initContext, hasKRateIndex),
+                    80);
           } else {
             strNcpy(op, initArrayRead ? "##array_get_init" : "##array_get",
                     80);
@@ -1171,6 +1229,35 @@ static int32_t array_has_k_rate_index(CSOUND* csound, TREE* indexExpr,
   return 0;
 }
 
+static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
+                                               TREE* tree,
+                                               TYPE_TABLE* typeTable)
+{
+  /* Direct k variables already have init storage. An i-indexed array read
+     lowers to ##array_get_init. Other computed k values only run at perf. */
+  while (tree != NULL) {
+    char* argType =
+      (is_expression_node(tree) || tree->type == STRUCT_EXPR)
+        ? get_arg_type2(csound, tree, typeTable)
+        : NULL;
+    int32_t isKRate =
+      argType != NULL && (argType[0] == 'k' || argType[0] == 'K');
+
+    if (argType != NULL) {
+      csound->Free(csound, argType);
+    }
+    if ((isKRate && tree->type != T_IDENT &&
+         !(tree->type == T_ARRAY &&
+           !array_has_k_rate_index(csound, tree->right, typeTable))) ||
+        tree_has_perf_only_k_rate_value(csound, tree->left, typeTable) ||
+        tree_has_perf_only_k_rate_value(csound, tree->right, typeTable)) {
+      return 1;
+    }
+    tree = tree->next;
+  }
+  return 0;
+}
+
 static int32_t tree_has_k_rate_array_index(CSOUND* csound, TREE* tree,
                                            TYPE_TABLE* typeTable)
 {
@@ -1322,9 +1409,13 @@ static TREE* create_struct_array_get_call(CSOUND* csound,
                                           int32_t line,
                                           uint64_t locn,
                                           const char* outArg,
-                                          TREE* arrayExpr)
+                                          TREE* arrayExpr,
+                                          int32_t initContext,
+                                          int32_t hasKRateIndex)
 {
-  TREE* getOp = create_opcode_token(csound, "##array_get_struct");
+  TREE* getOp = create_opcode_token(
+    csound,
+    struct_array_get_opcode_name(initContext, hasKRateIndex));
   getOp->type = T_OPCALL;
   getOp->line = line;
   getOp->locn = locn;
@@ -1439,7 +1530,9 @@ int expand_struct_array_member_assignment(CSOUND* csound,
                    create_struct_array_get_call(csound, current->line,
                                                 current->locn,
                                                 structTemps[0],
-                                                path.arrayExpr));
+                                                path.arrayExpr,
+                                                initContext,
+                                                path.hasKRateIndex));
 
   for (i = 0; i < path.memberCount - 1; i++) {
     structTemps[i + 1] = create_out_arg(csound,
@@ -1512,6 +1605,15 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   if (!resolve_struct_array_member_path(csound, structExpr, typeTable, &path)) {
     return NULL;
   }
+  if (initContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+      tree_has_perf_only_k_rate_value(csound, path.arrayExpr->right,
+                                      typeTable)) {
+    synterr(csound,
+            Str("struct array index requires performance-rate evaluation "
+                "during init, line %d\n"),
+            line);
+    return NULL;
+  }
 
   currentStructArg = create_out_arg(csound,
                                     path.rootStructType->varTypeName,
@@ -1520,7 +1622,9 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   readOps = tree_append(readOps,
                            create_struct_array_get_call(csound, line, locn,
                                                         currentStructArg,
-                                                        path.arrayExpr));
+                                                        path.arrayExpr,
+                                                        initContext,
+                                                        path.hasKRateIndex));
 
   for (i = 0; i < path.memberCount - 1; i++) {
     char* nextStructArg = create_out_arg(csound,
@@ -1581,7 +1685,15 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
   TREE* previousArg = NULL;
   TREE* currentArg = current->right;
   OENTRY* statementEntry = (OENTRY*)current->markup;
-  int32_t initContext = statementEntry != NULL && statementEntry->perf == NULL;
+  /* Some init-only opcodes, such as xout and printtype, do not consume the
+     expression value at init. Only an explicit init needs the strict getter. */
+  int32_t initContext =
+    current->value != NULL && current->value->lexeme != NULL &&
+    strcmp(current->value->lexeme, "init") == 0
+      ? EXPRESSION_EXPLICIT_INIT_CONTEXT
+      : (statementEntry != NULL && statementEntry->perf == NULL
+           ? EXPRESSION_INIT_CONTEXT
+           : EXPRESSION_PERF_CONTEXT);
 
   current->next = NULL;
 
@@ -1603,25 +1715,26 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
                                                        currentArg->locn,
                                                        typeTable,
                                                        initContext);
-      if (expanded) {
-        anchor = tree_append(anchor, expanded);
-        last = tree_tail(anchor);
-        char* newArg = last->left->value->lexeme;
-        newArgTree = create_ans_token(csound, newArg);
-
-        nextArg = currentArg->next;
-        csound->Free(csound, currentArg);
-
-        if (previousArg == NULL) {
-          current->right = newArgTree;
-        }
-        else {
-          previousArg->next = newArgTree;
-        }
-        newArgTree->next = nextArg;
-        currentArg = newArgTree;
-        continue;
+      if (expanded == NULL) {
+        return NULL;
       }
+      anchor = tree_append(anchor, expanded);
+      last = tree_tail(anchor);
+      char* newArg = last->left->value->lexeme;
+      newArgTree = create_ans_token(csound, newArg);
+
+      nextArg = currentArg->next;
+      csound->Free(csound, currentArg);
+
+      if (previousArg == NULL) {
+        current->right = newArgTree;
+      }
+      else {
+        previousArg->next = newArgTree;
+      }
+      newArgTree->next = nextArg;
+      currentArg = newArgTree;
+      continue;
     }
 
     if (is_expression_node(currentArg) ||

--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -63,10 +63,36 @@ static int32_t expression_context_has_init(int32_t expressionContext)
   return expressionContext != EXPRESSION_PERF_CONTEXT;
 }
 
+static int32_t opcode_uses_expression_types_only(const char* name)
+{
+  return name != NULL &&
+    (!strcmp(name, "printtype") || !strcmp(name, "print_type") ||
+     !strcmp(name, "typeof") || !strcmp(name, "typecheck"));
+}
+
+static int32_t opcode_is_init_only_value_consumer(OENTRY* entry)
+{
+  const char* name;
+
+  if (entry == NULL || entry->init == NULL || entry->opname == NULL) {
+    return 0;
+  }
+  name = entry->opname;
+  /* xout wires UDO outputs; type-only opcodes inspect metadata. */
+  if (!strcmp(name, "xout") || opcode_uses_expression_types_only(name)) {
+    return 0;
+  }
+  /* Keep this test conservative. A two-phase opcode may use init only for
+     setup or may read its inputs in both phases. The latter needs a getter
+     with both callbacks; an init-only getter could read a provisional index
+     or suppress later updates. */
+  return entry->perf == NULL;
+}
+
 static char* struct_array_get_opcode_name(int32_t expressionContext,
                                           int32_t hasKRateIndex)
 {
-  if (expressionContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+  if (expression_context_has_init(expressionContext) &&
       hasKRateIndex) {
     return "##array_get_struct_init";
   }
@@ -546,13 +572,18 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   TREE *opTree;
   OENTRIES* opentries;
   CS_VARIABLE* var;
+  int32_t childContext = initContext;
 
   /* HANDLE SUB EXPRESSIONS */
   if (root->type=='?') return create_cond_expression(csound, root, line,
                                                      locn, typeTable,
                                                      initContext);
+  if (root->type == T_FUNCTION && root->value != NULL &&
+      opcode_uses_expression_types_only(root->value->lexeme)) {
+    childContext = EXPRESSION_PERF_CONTEXT;
+  }
   if (root->type == T_ARRAY &&
-      initContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+      expression_context_has_init(initContext) &&
       tree_has_perf_only_k_rate_value(csound, root->right, typeTable)) {
     char* elementType = get_arg_type2(csound, root, typeTable);
     const CS_TYPE* elementCsType =
@@ -577,7 +608,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   if (root->left != NULL) {
     expandedArgs = expand_expression_arg_list(csound, root->left, &anchor,
                                               line, locn, typeTable,
-                                              initContext);
+                                              childContext);
     if (expandedArgs == NULL) {
       return NULL;
     }
@@ -586,7 +617,7 @@ static TREE *create_expression(CSOUND *csound, TREE *root, int32_t line,
   if (root->right != NULL) {
     expandedArgs = expand_expression_arg_list(csound, root->right, &anchor,
                                               line, locn, typeTable,
-                                              initContext);
+                                              childContext);
     if (expandedArgs == NULL) {
       return NULL;
     }
@@ -1247,7 +1278,7 @@ static int32_t tree_has_perf_only_k_rate_value(CSOUND* csound,
     if (argType != NULL) {
       csound->Free(csound, argType);
     }
-    if ((isKRate && tree->type != T_IDENT && tree->type != STRUCT_EXPR &&
+    if ((isKRate && tree->type != STRUCT_EXPR &&
          !(tree->type == T_ARRAY &&
            !array_has_k_rate_index(csound, tree->right, typeTable))) ||
         tree_has_perf_only_k_rate_value(csound, tree->left, typeTable) ||
@@ -1606,7 +1637,7 @@ TREE* expand_struct_array_member_read(CSOUND* csound,
   if (!resolve_struct_array_member_path(csound, structExpr, typeTable, &path)) {
     return NULL;
   }
-  if (initContext == EXPRESSION_EXPLICIT_INIT_CONTEXT &&
+  if (expression_context_has_init(initContext) &&
       tree_has_perf_only_k_rate_value(csound, path.arrayExpr->right,
                                       typeTable)) {
     synterr(csound,
@@ -1686,13 +1717,11 @@ TREE* expand_statement(CSOUND* csound, TREE* current, TYPE_TABLE* typeTable)
   TREE* previousArg = NULL;
   TREE* currentArg = current->right;
   OENTRY* statementEntry = (OENTRY*)current->markup;
-  /* Some init-only opcodes, such as xout and printtype, do not consume the
-     expression value at init. Only an explicit init needs the strict getter. */
   int32_t initContext =
     current->value != NULL && current->value->lexeme != NULL &&
     strcmp(current->value->lexeme, "init") == 0
       ? EXPRESSION_EXPLICIT_INIT_CONTEXT
-      : (statementEntry != NULL && statementEntry->perf == NULL
+      : (opcode_is_init_only_value_consumer(statementEntry)
            ? EXPRESSION_INIT_CONTEXT
            : EXPRESSION_PERF_CONTEXT);
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -4022,6 +4022,12 @@ TREE* verify_tree(CSOUND * csound, TREE *root, TYPE_TABLE* typeTable)
       }
       if (is_statement_expansion_required(current)) {
         current = expand_statement(csound, current, typeTable);
+        if (current == NULL) {
+          cs_cons_free_complete(csound, activeLoopStack);
+          cs_cons_free(csound, typeTable->labelList);
+          typeTable->labelList = parentLabelList;
+          return NULL;
+        }
         if (previous != NULL) {
           previous->next = current;
         }

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -883,7 +883,10 @@ const OENTRY opcodlst_1[] = {
   { "##array_get_struct", sizeof(STRUCT_ARRAY_GET), 0, ".", ".[]m",
     (SUBR)struct_array_get_init, NULL, NULL },
   { "##array_get_struct", sizeof(STRUCT_ARRAY_GET), 0, ".", ".[]z",
-    (SUBR)struct_array_get_init, (SUBR)struct_array_get, NULL },
+    NULL, (SUBR)struct_array_get, NULL },
+  /* Explicit aggregate init uses this entry without changing perf reads. */
+  { "##array_get_struct_init", sizeof(STRUCT_ARRAY_GET), 0, ".", ".[]z",
+    (SUBR)struct_array_get_init, NULL, NULL },
   { "##member_get", sizeof(STRUCT_GET), 0, ".", ".i", (SUBR)struct_member_get_init_and_perf, (SUBR)struct_member_get, NULL },
   { "##member_get_init", sizeof(STRUCT_GET), 0, ".", ".i",
     (SUBR)struct_member_get_init_and_perf, NULL, NULL },

--- a/Engine/entry.c
+++ b/Engine/entry.c
@@ -884,9 +884,6 @@ const OENTRY opcodlst_1[] = {
     (SUBR)struct_array_get_init, NULL, NULL },
   { "##array_get_struct", sizeof(STRUCT_ARRAY_GET), 0, ".", ".[]z",
     NULL, (SUBR)struct_array_get, NULL },
-  /* Explicit aggregate init uses this entry without changing perf reads. */
-  { "##array_get_struct_init", sizeof(STRUCT_ARRAY_GET), 0, ".", ".[]z",
-    (SUBR)struct_array_get_init, NULL, NULL },
   { "##member_get", sizeof(STRUCT_GET), 0, ".", ".i", (SUBR)struct_member_get_init_and_perf, (SUBR)struct_member_get, NULL },
   { "##member_get_init", sizeof(STRUCT_GET), 0, ".", ".i",
     (SUBR)struct_member_get_init_and_perf, NULL, NULL },

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -327,6 +327,7 @@ endin
         }
         csoundPopFirstMessage(csound);
     }
+    csoundDestroyMessageBuffer(csound);
     EXPECT_NE(std::string::npos, messages.find("VALUE=37.000000"))
         << messages;
 }

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -269,6 +269,68 @@ endin
     ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
+TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexInitConsumer)
+{
+    const char *instrument = R"(
+struct Box value:i
+
+opcode PrintAt(items:Box[], index:k):void
+  printfi "VALUE=%f\n", 1, items[index + 0].value
+endop
+
+instr 1
+  box:Box init 37
+  boxes:Box[] fillarray box
+  index:k init 0
+  PrintAt(boxes, index)
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testInitOnlyConsumerReadsKIndexStructMember)
+{
+    const char *instrument = R"(
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+struct Box value:i
+
+opcode PrintAt(items:Box[], index:k):void
+  printfi "VALUE=%f\n", 1, items[index].value
+endop
+
+instr 1
+  box:Box init 37
+  boxes:Box[] fillarray box
+  index:k init 0
+  PrintAt(boxes, index)
+endin
+)";
+
+    csoundCreateMessageBuffer(csound, 0);
+    csoundSetOption(csound, "-n");
+    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+    csoundReadScore(csound, "i 1 0 0.01\n");
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+    while (csoundPerformKsmps(csound) == CSOUND_SUCCESS) {
+    }
+
+    std::string messages;
+    while (csoundGetMessageCnt(csound) > 0) {
+        const char *message = csoundGetFirstMessage(csound);
+        if (message != nullptr) {
+            messages += message;
+        }
+        csoundPopFirstMessage(csound);
+    }
+    EXPECT_NE(std::string::npos, messages.find("VALUE=37.000000"))
+        << messages;
+}
+
 TEST_F (OrcCompileTests, testReuse)
 {
     int32_t result;

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -235,6 +235,40 @@ TEST_F (OrcCompileTests, testNestedExpressionFailurePropagates)
     ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
+TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexAggregateInit)
+{
+    const char *instrument = R"(
+struct Box value:i
+
+instr 1
+  box:Box init 37
+  boxes:Box[] fillarray box
+  index:k init 0
+  copy:Box init boxes[index + 0]
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexNestedAggregateInit)
+{
+    const char *instrument = R"(
+struct Inner value:i
+struct Outer inner:Inner
+
+instr 1
+  inner:Inner init 37
+  outer:Outer init inner
+  outers:Outer[] fillarray outer
+  index:k init 0
+  copy:Inner init outers[index + 0].inner
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
 TEST_F (OrcCompileTests, testReuse)
 {
     int32_t result;

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -235,7 +235,24 @@ TEST_F (OrcCompileTests, testNestedExpressionFailurePropagates)
     ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
-TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexAggregateInit)
+TEST_F (OrcCompileTests, testRejectsKRateIndexStructAggregateInit)
+{
+    const char *instrument = R"(
+struct Box value:i
+
+instr 1
+  first:Box init 10
+  second:Box init 20
+  boxes:Box[] fillarray first, second
+  index:k = 1
+  copy:Box init boxes[index]
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testRejectsKRateExpressionStructAggregateInit)
 {
     const char *instrument = R"(
 struct Box value:i
@@ -251,7 +268,62 @@ endin
     ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
-TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexNestedAggregateInit)
+TEST_F (OrcCompileTests, testRejectsKInitializedOutputStructAggregateInit)
+{
+    const char *instrument = R"(
+struct Box value:i
+
+opcode InitializedIndex, K, 0
+  index:k init 1
+  xout index
+endop
+
+instr 1
+  first:Box init 10
+  second:Box init 20
+  boxes:Box[] fillarray first, second
+  copy:Box init boxes[InitializedIndex()]
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testRejectsKRateStructMemberAggregateInit)
+{
+    const char *instrument = R"(
+struct Box value:i
+struct Selection index:k
+
+instr 1
+  box:Box init 37
+  boxes:Box[] fillarray box
+  selection:Selection init 0
+  copy:Box init boxes[selection.index]
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testRejectsKArrayElementStructAggregateInit)
+{
+    const char *instrument = R"(
+struct Box value:i
+
+instr 1
+  box:Box init 37
+  boxes:Box[] fillarray box
+  indices:k[] fillarray 0
+  index:i init 0
+  copy:Box init boxes[indices[index]]
+endin
+)";
+
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
+}
+
+TEST_F (OrcCompileTests, testRejectsKRateIndexNestedStructAggregateInit)
 {
     const char *instrument = R"(
 struct Inner value:i
@@ -262,41 +334,16 @@ instr 1
   outer:Outer init inner
   outers:Outer[] fillarray outer
   index:k init 0
-  copy:Inner init outers[index + 0].inner
+  copy:Inner init outers[index].inner
 endin
 )";
 
     ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
-TEST_F (OrcCompileTests, testRejectsPerfOnlyKIndexInitConsumer)
+TEST_F (OrcCompileTests, testRejectsKRateIndexInitConsumer)
 {
     const char *instrument = R"(
-struct Box value:i
-
-opcode PrintAt(items:Box[], index:k):void
-  printfi "VALUE=%f\n", 1, items[index + 0].value
-endop
-
-instr 1
-  box:Box init 37
-  boxes:Box[] fillarray box
-  index:k init 0
-  PrintAt(boxes, index)
-endin
-)";
-
-    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
-}
-
-TEST_F (OrcCompileTests, testInitOnlyConsumerReadsKIndexStructMember)
-{
-    const char *instrument = R"(
-sr = 44100
-ksmps = 32
-nchnls = 2
-0dbfs = 1
-
 struct Box value:i
 
 opcode PrintAt(items:Box[], index:k):void
@@ -311,25 +358,7 @@ instr 1
 endin
 )";
 
-    csoundCreateMessageBuffer(csound, 0);
-    csoundSetOption(csound, "-n");
-    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
-    csoundReadScore(csound, "i 1 0 0.01\n");
-    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
-    while (csoundPerformKsmps(csound) == CSOUND_SUCCESS) {
-    }
-
-    std::string messages;
-    while (csoundGetMessageCnt(csound) > 0) {
-        const char *message = csoundGetFirstMessage(csound);
-        if (message != nullptr) {
-            messages += message;
-        }
-        csoundPopFirstMessage(csound);
-    }
-    csoundDestroyMessageBuffer(csound);
-    EXPECT_NE(std::string::npos, messages.find("VALUE=37.000000"))
-        << messages;
+    ASSERT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, instrument));
 }
 
 TEST_F (OrcCompileTests, testReuse)

--- a/tests/commandline/structs/test_struct_array_k_index_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_k_index_member_access.csd
@@ -14,6 +14,7 @@ nchnls = 2
 ; Guards perf-time struct-array member reads: array[kIndex].member must lower
 ; to the k-rate ##array_get_struct path instead of failing opcode resolution.
 struct MyType val1:i, val2:i
+struct Selection idx:k
 
 opcode PickAt(items:MyType[], index:k):MyType
   xout items[index]
@@ -28,6 +29,11 @@ instr 1
   copyIndex:k init 1
   copy:MyType init array[copyIndex]
   assertEquals(copy.val1, 2)
+
+  ; A k-rate struct member has an init callback and can index an init read.
+  selection:Selection init 1
+  memberCopy:MyType init array[selection.idx]
+  assertEquals(memberCopy.val1, 2)
 
   ; An i-indexed k-array read is available during init and remains valid.
   indices:k[] fillarray 1

--- a/tests/commandline/structs/test_struct_array_k_index_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_k_index_member_access.csd
@@ -20,6 +20,10 @@ opcode PickAt(items:MyType[], index:k):MyType
   xout items[index]
 endop
 
+opcode CheckAtInit(items:MyType[], index:k):void
+  printfi "INIT_MEMBER=%f\n", 1, items[index].val1
+endop
+
 instr 1
   array:MyType[] init 2
   array[0].val1 = 1
@@ -35,6 +39,10 @@ instr 1
   memberCopy:MyType init array[selection.idx]
   assertEquals(memberCopy.val1, 2)
 
+  ; Other init-only consumers must receive the populated temporary too.
+  initConsumerIndex:k init 1
+  CheckAtInit(array, initConsumerIndex)
+
   ; An i-indexed k-array read is available during init and remains valid.
   indices:k[] fillarray 1
   indexedCopy:MyType init array[indices[0]]
@@ -45,10 +53,20 @@ instr 1
   perfIndex = 0
   perfValue:k = array[perfIndex].val1
 
+  ; An opcode with init setup and a perf callback must wait for perf to read.
+  printIndex:k init -1
+  printIndex = 0
+  printks "PERF_MEMBER=%f\n", 0.1, array[printIndex].val1
+
   ; Init-only type inspection must not force the getter to read at init.
   typeIndex:k init -1
   typeIndex = 0
   printtype array[typeIndex]
+
+  ; Nested type inspection must not force its operand to run at init.
+  nestedTypeIndex:k init -1
+  nestedTypeIndex = 0
+  prints "NESTED_TYPE=%s\n", typeof(array[nestedTypeIndex + 0].val1)
 
   ; The same rule applies to an aggregate read lowered inside xout.
   udoIndex:k init -1

--- a/tests/commandline/structs/test_struct_array_k_index_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_k_index_member_access.csd
@@ -20,32 +20,30 @@ opcode PickAt(items:MyType[], index:k):MyType
   xout items[index]
 endop
 
-opcode CheckAtInit(items:MyType[], index:k):void
-  printfi "INIT_MEMBER=%f\n", 1, items[index].val1
-endop
-
 instr 1
   array:MyType[] init 2
   array[0].val1 = 1
   array[1].val1 = 2
 
-  ; An explicit aggregate init must read its k-indexed source at init.
-  copyIndex:k init 1
+  ; Literal and i-rate indices select init-capable struct-array reads.
+  literalCopy:MyType init array[0]
+  assertEquals(literalCopy.val1, 1)
+
+  copyIndex:i init 1
   copy:MyType init array[copyIndex]
   assertEquals(copy.val1, 2)
 
-  ; A k-rate struct member has an init callback and can index an init read.
+  ; K-rate indices require an explicit conversion for an init-time read.
+  convertedIndex:k init 1
+  convertedCopy:MyType init array[i(convertedIndex)]
+  assertEquals(convertedCopy.val1, 2)
+
   selection:Selection init 1
-  memberCopy:MyType init array[selection.idx]
+  memberCopy:MyType init array[i(selection.idx)]
   assertEquals(memberCopy.val1, 2)
 
-  ; Other init-only consumers must receive the populated temporary too.
-  initConsumerIndex:k init 1
-  CheckAtInit(array, initConsumerIndex)
-
-  ; An i-indexed k-array read is available during init and remains valid.
   indices:k[] fillarray 1
-  indexedCopy:MyType init array[indices[0]]
+  indexedCopy:MyType init array[i(indices, 0)]
   assertEquals(indexedCopy.val1, 2)
 
   ; A performance read must not evaluate an invalid k-index during init.

--- a/tests/commandline/structs/test_struct_array_k_index_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_k_index_member_access.csd
@@ -15,6 +15,10 @@ nchnls = 2
 ; to the k-rate ##array_get_struct path instead of failing opcode resolution.
 struct MyType val1:i, val2:i
 
+opcode PickAt(items:MyType[], index:k):MyType
+  xout items[index]
+endop
+
 instr 1
   array:MyType[] init 2
   array[0].val1 = 1
@@ -25,6 +29,26 @@ instr 1
   copy:MyType init array[copyIndex]
   assertEquals(copy.val1, 2)
 
+  ; An i-indexed k-array read is available during init and remains valid.
+  indices:k[] fillarray 1
+  indexedCopy:MyType init array[indices[0]]
+  assertEquals(indexedCopy.val1, 2)
+
+  ; A performance read must not evaluate an invalid k-index during init.
+  perfIndex:k init -1
+  perfIndex = 0
+  perfValue:k = array[perfIndex].val1
+
+  ; Init-only type inspection must not force the getter to read at init.
+  typeIndex:k init -1
+  typeIndex = 0
+  printtype array[typeIndex]
+
+  ; The same rule applies to an aggregate read lowered inside xout.
+  udoIndex:k init -1
+  udoIndex = 1
+  udoValue:MyType = PickAt(array, udoIndex)
+
   ; Switch the index at k-rate and read the selected member each control pass.
   kindex = int(timeinstk() / 5)
   kval = array[kindex].val1
@@ -33,6 +57,10 @@ instr 1
   ktrigger changed kval
 
   ; Assert the observed value matches the active array element.
+  if (timeinstk() == 1) then
+    event "i", 2, 0, 0.001, perfValue, 1
+    event "i", 2, 0, 0.001, udoValue.val1, 2
+  endif
   if (ktrigger == 1) then
     kchanges += 1
     event "i", 2, 0, 0.001, kval, kindex + 1

--- a/tests/commandline/structs/test_struct_array_member_with_scalar.csd
+++ b/tests/commandline/structs/test_struct_array_member_with_scalar.csd
@@ -32,7 +32,7 @@ instr 1
   assertEquals(copied[1].value, 20)
 
   ; Read a whole struct from an array stored in a struct member.
-  copyIndex:k init 1
+  copyIndex:i init 1
   selected:Box init holder.items[copyIndex]
   assertEquals(selected.value, 20)
 

--- a/tests/commandline/structs/test_struct_array_member_with_scalar.csd
+++ b/tests/commandline/structs/test_struct_array_member_with_scalar.csd
@@ -31,7 +31,24 @@ instr 1
   assertEquals(copied[0].value, 10)
   assertEquals(copied[1].value, 20)
 
+  ; Read a whole struct from an array stored in a struct member.
+  copyIndex:k init 1
+  selected:Box init holder.items[copyIndex]
+  assertEquals(selected.value, 20)
+
+  ; Keep the matching performance read out of the init pass.
+  perfIndex:k init -1
+  perfIndex = 0
+  perfValue:k = holder.items[perfIndex].value
+  if (timeinstk() == 1) then
+    event "i", 2, 0, 0.001, perfValue, 10
+  endif
+
   prints "Struct-array member with scalar test passed\n"
+endin
+
+instr 2
+  assertEquals(p4, p5)
 endin
 
 </CsInstruments>

--- a/tests/commandline/structs/test_struct_array_nested_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_nested_member_access.csd
@@ -31,7 +31,7 @@ instr 1
   assertEquals(i1, 9)
 
   ; The array getter must run at init before the nested aggregate copy.
-  copyIndex:k init 1
+  copyIndex:i init 1
   copy:Inner init array[copyIndex].inner
   assertEquals(copy.val, 9)
 

--- a/tests/commandline/structs/test_struct_array_nested_member_access.csd
+++ b/tests/commandline/structs/test_struct_array_nested_member_access.csd
@@ -35,7 +35,19 @@ instr 1
   copy:Inner init array[copyIndex].inner
   assertEquals(copy.val, 9)
 
+  ; Nested performance reads must also leave the index untouched at init.
+  perfIndex:k init -1
+  perfIndex = 1
+  perfValue:k = array[perfIndex].inner.val
+  if (timeinstk() == 1) then
+    event "i", 2, 0, 0.001, perfValue, 9
+  endif
+
   prints "Struct array nested member access test passed!\n"
+endin
+
+instr 2
+  assertEquals(p4, p5)
 endin
 
 </CsInstruments>

--- a/tests/commandline/test_k_i_array_args.csd
+++ b/tests/commandline/test_k_i_array_args.csd
@@ -4,6 +4,13 @@
 </CsOptions>
 <CsInstruments>
 
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+#include "libassert.orc"
+
 opcode cycle, i, ik[]
   indx, kvals[] xin
   ival = i(kvals, indx % lenarray(kvals))
@@ -11,7 +18,27 @@ opcode cycle, i, ik[]
 endop
 
 instr 1
-ival = cycle(p4, [0,4,2,3,1])
+  ival = cycle(p4, [0,4,2,3,1])
+
+  values:k[] fillarray 10, 20
+  index:i init 1
+
+  ; The two-argument i() form explicitly samples a k-array during init.
+  converted:i = i(values, index)
+  assertEquals(converted, 20)
+
+  ; An i-rate index does not change a k-array read to i-rate. Change the
+  ; element during perf so this read must differ from the init sample above.
+  values[index] = 30
+  direct:k = values[index]
+
+  if (timeinstk() == 1) then
+    event "i", 2, 0, 0.001, direct, 30
+  endif
+endin
+
+instr 2
+  assertEquals(p4, p5)
 endin
 
 </CsInstruments>


### PR DESCRIPTION
## Backstory

This is a follow-up to the correctness review on #2629.

That PR added an exact struct-copy constructor, which exposed an ordering bug in explicit aggregate init. A k-indexed struct-array read lowered to the shared `.[]z` getter, but that getter only had a performance callback. The struct constructor then copied its temporary during init before the getter had filled it:

```csound
index:k init 0
copy:Box init boxes[index]
printf_i "COPY_INIT=%f\n", 1, copy.value
```

Before the first fix, this printed the default value:

```text
COPY_INIT=0.000000
```

The parent branch fixed that case and now prints `COPY_INIT=37.000000`. It did so by adding an init callback to the shared `.[]z` entry. A second review found that this also made every ordinary performance-rate struct-array read run during init. Code could then fail on an index that was intentionally invalid until the first control pass.

## Reproducer for the follow-up regression

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
ksmps = 32

struct Box value:i

instr 1
  box:Box init 37
  boxes:Box[] fillarray box

  index:k init -1
  index = 0
  value:k = boxes[index].value
  printf "VALUE=%f\n", 1, value
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

### Before: current parent branch

The getter runs during init, sees `-1`, and deletes the note before the first performance pass:

```text
INIT ERROR in instr 1 (opcode ##array_get_struct) line 14:
struct_array_get: invalid index for dimension 1
INIT ERROR in instr 1: note deleted (1 init errors)
1 errors in performance
```

### After

The ordinary read waits for the performance pass, after `index = 0` has run:

```text
VALUE=37.000000
end of Performance
```

The original explicit-init case also stays fixed and still prints `COPY_INIT=37.000000`.

## What changed

- Keep the shared k-index `.[]z` struct-array getter performance-only.
- Add a separate internal getter for explicit aggregate init.
- Track performance, general init, and explicit-init expression contexts while lowering array and nested member reads.
- Select the init-only getter only when an explicit aggregate copy needs its value during init.
- Reject computed k-rate index expressions that cannot supply an init-time value, instead of copying an unfilled temporary.
- Extend the existing struct-array tests for direct, nested, member-array, type-only, and UDO paths.

## Why this split matters

Init and performance callbacks define when an opcode may read its inputs. Sharing one entry across both cases makes an otherwise valid performance expression inspect provisional init values. It can abort a note, read the wrong array item, or do work that the orchestra only requested at control rate.

The split keeps each callback in its intended phase. The compiler picks the internal getter while it lowers the expression, so the performance path gains no runtime branch. Ordinary performance reads do no extra init work. Explicit aggregate init performs one required read during init and adds no performance callback. Both internal entries reuse the existing getter code.

## Checks

- `ninja -C build`
- Native unit suite: 172/172 passed
- `test_struct_array_k_index_member_access.csd`
- `test_struct_array_member_with_scalar.csd`
- `test_struct_array_nested_member_access.csd`
- Exact parent/child runs of both the explicit-init and performance-only reproducers
- `git diff --check`
