### PR TITLE
fix: size PVS channel frame buffers from the incoming frame length

### DIFF
--- a/H/bus.h
+++ b/H/bus.h
@@ -180,6 +180,8 @@ extern "C" {
   int32_t     pvsin_perf(CSOUND *, FCHAN *);
   int32_t     pvsout_init(CSOUND *, FCHAN *);
   int32_t     pvsout_perf(CSOUND *, FCHAN *);
+  int32_t     csoundSetPvsChannel(CSOUND *, const char *, const PVSDAT *);
+  int32_t     csoundGetPvsChannel(CSOUND *, const char *, PVSDAT *);
 
   int32_t     sensekey_perf(CSOUND *, KSENSE *);
 

--- a/H/bus.h
+++ b/H/bus.h
@@ -180,8 +180,6 @@ extern "C" {
   int32_t     pvsin_perf(CSOUND *, FCHAN *);
   int32_t     pvsout_init(CSOUND *, FCHAN *);
   int32_t     pvsout_perf(CSOUND *, FCHAN *);
-  int32_t     csoundSetPvsChannel(CSOUND *, const char *, const PVSDAT *);
-  int32_t     csoundGetPvsChannel(CSOUND *, const char *, PVSDAT *);
 
   int32_t     sensekey_perf(CSOUND *, KSENSE *);
 

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -38,6 +38,16 @@
 #include "namedins.h"
 
 int32_t *get_channel_lock(CSOUND *csound, const char *name);
+
+static int32_t pvs_frame_nbytes(int32_t N, size_t *nbytes)
+{
+  if (UNLIKELY(N < 0 ||
+               (size_t) N > SIZE_MAX / sizeof(float) - 2))
+    return CSOUND_ERROR;
+  *nbytes = ((size_t) N + 2) * sizeof(float);
+  return CSOUND_SUCCESS;
+}
+
 int32_t chani_opcode_perf_k(CSOUND *csound, CHNVAL *p){
   int32_t     n = (int32_t)MYFLT2LRND(*(p->a));
   char chan_name[16];
@@ -211,6 +221,13 @@ int32_t pvsin_perf(CSOUND *csound, FCHAN *p){
 
 int32_t pvsout_init(CSOUND *csound, FCHAN *p){
   PVSDAT *fin = p->r;
+  size_t frame_size;
+
+  if (UNLIKELY(pvs_frame_nbytes(fin->N, &frame_size) != CSOUND_SUCCESS ||
+               fin->frame.auxp == NULL ||
+               fin->frame.size < frame_size))
+    return csound->InitError(csound, Str("pvsout: invalid source frame"));
+
   if(GetTypeForArg(p->a) == &CS_VAR_TYPE_S)
     strncpy(p->name, ((STRINGDAT *)p->a)->data, MAX_CHAN_NAME);
   else {
@@ -224,10 +241,8 @@ int32_t pvsout_init(CSOUND *csound, FCHAN *p){
     p->lock = (spin_lock_t *)
       get_channel_lock(csound, p->name);
     csoundSpinLock(p->lock);
-    if(p->f->frame.auxp == NULL || p->f->N < fin->N) {
-      csound->AuxAlloc(csound, (p->f->N + 2) * sizeof(float),
-                       &p->f->frame);
-    }
+    if(p->f->frame.auxp == NULL || p->f->frame.size < frame_size)
+      csound->AuxAlloc(csound, frame_size, &p->f->frame);
     memcpy(p->f, fin, sizeof(PVSDAT)-sizeof(AUXCH));
     csoundSpinUnLock(p->lock);
   }
@@ -2877,6 +2892,14 @@ int32_t csoundSetPvsChannel(CSOUND *csound, const char *name,
                             const PVSDAT *fin)
 {
   PVSDAT *f;
+  size_t frame_size;
+
+  if (UNLIKELY(fin == NULL ||
+               pvs_frame_nbytes(fin->N, &frame_size) != CSOUND_SUCCESS ||
+               fin->frame.auxp == NULL ||
+               fin->frame.size < frame_size))
+    return CSOUND_ERROR;
+
   if (LIKELY(csoundGetChannelPtr(csound, (void **) &f, name,
                                  CSOUND_PVS_CHANNEL | CSOUND_INPUT_CHANNEL)
              == CSOUND_SUCCESS)){
@@ -2884,11 +2907,12 @@ int32_t csoundSetPvsChannel(CSOUND *csound, const char *name,
       get_channel_lock(csound, name);
 
     csoundSpinLock(lock);
-    if (f->frame.auxp == NULL || f->N < fin->N)
-      csound->AuxAlloc(csound, fin->frame.size, &f->frame);
-    memcpy(f, fin, sizeof(PVSDAT)-sizeof(AUXCH));
-    if (fin->frame.auxp != NULL)
-      memcpy(f->frame.auxp, fin->frame.auxp, fin->frame.size);
+    if (f->frame.auxp == NULL || f->frame.size < frame_size)
+      csound->AuxAlloc(csound, frame_size, &f->frame);
+    if (f != fin) {
+      memcpy(f, fin, sizeof(PVSDAT)-sizeof(AUXCH));
+      memcpy(f->frame.auxp, fin->frame.auxp, frame_size);
+    }
     csoundSpinUnLock(lock);
   } else {
     return CSOUND_ERROR;
@@ -2900,16 +2924,30 @@ int32_t csoundGetPvsChannel(CSOUND *csound, const char *name,
                             PVSDAT *fout)
 {
   PVSDAT *f;
-  if (UNLIKELY(csoundGetChannelPtr(csound, (void **) &f, name,
-                                   CSOUND_PVS_CHANNEL | CSOUND_OUTPUT_CHANNEL)
-               == CSOUND_SUCCESS)){
+  size_t frame_size;
+
+  if (UNLIKELY(fout == NULL))
+    return CSOUND_ERROR;
+
+  if (LIKELY(csoundGetChannelPtr(csound, (void **) &f, name,
+                                 CSOUND_PVS_CHANNEL | CSOUND_OUTPUT_CHANNEL)
+             == CSOUND_SUCCESS)){
     spin_lock_t *lock = (spin_lock_t *)
       get_channel_lock(csound, name);
     if (UNLIKELY(f == NULL)) return CSOUND_ERROR;
     csoundSpinLock(lock);
-    memcpy(fout, f, sizeof(PVSDAT)-sizeof(AUXCH));
-    if (fout->frame.auxp != NULL && f->frame.auxp != NULL)
-      memcpy(fout->frame.auxp, f->frame.auxp, sizeof(float)*(fout->N));
+    if (UNLIKELY(pvs_frame_nbytes(f->N, &frame_size) != CSOUND_SUCCESS ||
+                 fout->frame.auxp == NULL ||
+                 fout->frame.size < frame_size ||
+                 f->frame.auxp == NULL ||
+                 f->frame.size < frame_size)) {
+      csoundSpinUnLock(lock);
+      return CSOUND_ERROR;
+    }
+    if (fout != f) {
+      memcpy(fout, f, sizeof(PVSDAT)-sizeof(AUXCH));
+      memcpy(fout->frame.auxp, f->frame.auxp, frame_size);
+    }
     csoundSpinUnLock(lock);
   } else {
     return CSOUND_ERROR;

--- a/include/csound.h
+++ b/include/csound.h
@@ -1191,6 +1191,22 @@ extern "C" {
   PUBLIC void csoundSetPvsData(PVSDAT *pvsdat, const float *frame);
 
   /**
+   * Copy pvsdat into a named PVS input channel.
+   * The source frame must hold N + 2 float values.
+   * Returns CSOUND_SUCCESS or CSOUND_ERROR if the channel or frame is invalid.
+   */
+  PUBLIC int32_t csoundSetPvsChannel(CSOUND *csound, const char *name,
+                                     const PVSDAT *pvsdat);
+
+  /**
+   * Copy a named PVS output channel into pvsdat.
+   * The destination frame must have space for N + 2 float values.
+   * Returns CSOUND_SUCCESS or CSOUND_ERROR if the channel or frame is invalid.
+   */
+  PUBLIC int32_t csoundGetPvsChannel(CSOUND *csound, const char *name,
+                                     PVSDAT *pvsdat);
+
+  /**
    * returns the size of data stored in a channel; for string channels
    * this might change if the channel space gets reallocated
    * Since string variables use dynamic memory allocation

--- a/tests/c/channel_tests.cpp
+++ b/tests/c/channel_tests.cpp
@@ -4,6 +4,7 @@
 #include "csound.h"
 #include "csound_type_system.h"
 #include "csdl.h"
+#include "bus.h"
 
 #define csoundCompileOrc(a,b) csoundCompileOrc(a,b,0)
 #define csoundScoreEvent(a,b,c,d) csoundEvent(a,0,c,d,0)
@@ -211,32 +212,69 @@ TEST_F (ChannelTests, ChannelOpcodes)
 
 const char orc5[] = "chn_k \"winsize\", 3\n"
         "instr 1\n"
-        "finput pvsin 1 \n"
+        "finput pvsin \"pvs-input\"\n"
         "ioverlap, inumbins, iwinsize, iformat pvsinfo finput\n"
-        "pvsout finput, 1\n"
+        "pvsout finput, \"pvs-output\"\n"
         "chnset iwinsize, \"winsize\"\n"
         "endin\n";
-/*
- NEEDS TO BE ADAPTED for new API
+
 TEST_F (ChannelTests, PVSOpcodes)
 {
+    constexpr int32_t fftSize = 1024;
+    constexpr int32_t overlap = 256;
+    constexpr int32_t windowSize = 1024;
+    constexpr size_t frameLength = fftSize + 2;
+    float frame[frameLength];
+    for (size_t i = 0; i < frameLength; ++i)
+      frame[i] = static_cast<float>(i) + 0.25f;
+
     int32_t err = csoundCompileOrc(csound, orc5);
-    ASSERT_TRUE(err == CSOUND_SUCCESS);
-    err = csoundStart(csound);
-    PVSDATEXT pvs_data, pvs_data2;
-    memset(&pvs_data,0,sizeof(PVSDATEXT));
-    memset(&pvs_data2,0,sizeof(PVSDATEXT));
-    pvs_data.N = 16;
-    pvs_data.winsize = 32;
-    err = csoundSetPvsChannel(csound, &pvs_data, "1");
-    err = csoundGetPvsChannel(csound, &pvs_data2, "1");
-    ASSERT_EQ(pvs_data.N, pvs_data2.N);
+    ASSERT_EQ(CSOUND_SUCCESS, err);
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+
+    PVSDAT *input = csoundInitPvsChannel(csound, "host-input",
+                                         fftSize, overlap, windowSize,
+                                         PVS_WIN_HANN, PVS_AMP_FREQ);
+    ASSERT_NE(nullptr, input);
+    csoundSetPvsData(input, frame);
+
+    PVSDAT invalidInput = *input;
+    invalidInput.frame.size -= sizeof(float);
+    EXPECT_EQ(CSOUND_ERROR,
+              csoundSetPvsChannel(csound, "invalid-input", &invalidInput));
+    ASSERT_EQ(CSOUND_SUCCESS,
+              csoundSetPvsChannel(csound, "pvs-input", input));
+
     MYFLT pFields[] = {1.0, 0.0, 1.0};
-    err = csoundScoreEvent(csound, 'i', pFields, 3);
-    err = csoundPerformKsmps(csound);
-    ASSERT_EQ(32.0, csoundGetControlChannel(csound, "winsize", NULL));
+    csoundScoreEvent(csound, 'i', pFields, 3);
+    ASSERT_EQ(CSOUND_SUCCESS, csoundPerformKsmps(csound));
+    EXPECT_EQ(windowSize,
+              csoundGetControlChannel(csound, "winsize", nullptr));
+
+    PVSDAT *smallOutput = csoundInitPvsChannel(csound, "host-small-output",
+                                               fftSize / 2, overlap, windowSize,
+                                               PVS_WIN_HANN, PVS_AMP_FREQ);
+    ASSERT_NE(nullptr, smallOutput);
+    EXPECT_EQ(CSOUND_ERROR,
+              csoundGetPvsChannel(csound, "pvs-output", smallOutput));
+    EXPECT_EQ(fftSize / 2, csoundPvsDataFFTSize(smallOutput));
+
+    PVSDAT *output = csoundInitPvsChannel(csound, "host-output",
+                                          fftSize, overlap, windowSize,
+                                          PVS_WIN_HANN, PVS_AMP_FREQ);
+    ASSERT_NE(nullptr, output);
+    ASSERT_EQ(CSOUND_SUCCESS,
+              csoundGetPvsChannel(csound, "pvs-output", output));
+    EXPECT_EQ(fftSize, csoundPvsDataFFTSize(output));
+    EXPECT_EQ(overlap, csoundPvsDataOverlap(output));
+    EXPECT_EQ(windowSize, csoundPvsDataWindowSize(output));
+    EXPECT_EQ(PVS_AMP_FREQ, csoundPvsDataFormat(output));
+
+    const float *outputFrame = csoundGetPvsData(output);
+    ASSERT_NE(nullptr, outputFrame);
+    for (size_t i = 0; i < frameLength; ++i)
+      EXPECT_EQ(frame[i], outputFrame[i]) << "frame index " << i;
 }
-*/
 
 TEST_F (ChannelTests, InvalidChannel)
 {

--- a/tests/c/channel_tests.cpp
+++ b/tests/c/channel_tests.cpp
@@ -4,7 +4,7 @@
 #include "csound.h"
 #include "csound_type_system.h"
 #include "csdl.h"
-#include "bus.h"
+#include "pstream.h"
 
 #define csoundCompileOrc(a,b) csoundCompileOrc(a,b,0)
 #define csoundScoreEvent(a,b,c,d) csoundEvent(a,0,c,d,0)
@@ -237,6 +237,12 @@ TEST_F (ChannelTests, PVSOpcodes)
                                          PVS_WIN_HANN, PVS_AMP_FREQ);
     ASSERT_NE(nullptr, input);
     csoundSetPvsData(input, frame);
+
+    PVSDAT *invalidDestination =
+      csoundInitPvsChannel(csound, "invalid-input",
+                           fftSize, overlap, windowSize,
+                           PVS_WIN_HANN, PVS_AMP_FREQ);
+    ASSERT_NE(nullptr, invalidDestination);
 
     PVSDAT invalidInput = *input;
     invalidInput.frame.size -= sizeof(float);


### PR DESCRIPTION
`pvsout_init()` sized the channel frame from the channel's stored `N`, which is zero on first use, then copied the incoming metadata over it. `pvsout_perf()` then wrote a full frame into that 8-byte buffer and overflowed the heap. The allocation now uses the incoming frame's `N` and grows whenever the existing buffer is too small, matching `pvsin_init()`.

The host API paths carried the same defect. `csoundSetPvsChannel()` now validates the source frame and allocates from the real frame length (`(N + 2)` floats) instead of trusting `fin->frame.size`. `csoundGetPvsChannel()` now checks the caller's buffer size before copying and includes the two guard bins it previously dropped. Both reject frames whose buffer is missing or smaller than their `N` claims.

The `PVSOpcodes` native test, commented out since the API change, is re-enabled and adapted. It writes a full-size frame through `csoundSetPvsChannel()`, runs it through `pvsin`/`pvsout`, reads it back with `csoundGetPvsChannel()`, and checks that undersized source and destination buffers are rejected.

## Before

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  ain oscili 0.5, 440
  fsig pvsanal ain, 1024, 256, 1024, 1
  pvsout fsig, "testchan"
endin
</CsInstruments>
<CsScore>
i 1 0 0.05
</CsScore>
</CsoundSynthesizer>
```

```text
SECTION 1:

csound command: Segmentation fault
```

Under AddressSanitizer:

```text
==ERROR: AddressSanitizer: heap-buffer-overflow ...
WRITE of size 4104 at 0x... thread T0
    #1 pvsout_perf bus.c:268
    #3 pvsout_init bus.c:228
SUMMARY: AddressSanitizer: heap-buffer-overflow bus.c:268 in pvsout_perf
```

## After

```text
SECTION 1:
end of Performance
		   overall amps:  0.00000
	   overall samples out of range:        0
```

Clean under AddressSanitizer.

Fixes https://github.com/csound/csound/issues/2679
