### PR TITLE
fix: count multidimensional audio array members once in UDO copies

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -110,7 +110,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DBUILD_TESTS=1
           -DBUILD_STATIC_LIBRARY=1
-          -DUSE_MP3=0
+          -DUSE_MP3=1
           -DUSE_CURL=0
 
       - name: Build sanitizer Csound

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -79,8 +79,11 @@ jobs:
           make csdtests
 
   linux_sanitizer:
-    name: Linux/Ubuntu sanitizer regression
+    name: Linux/Ubuntu full tests (ASan + UBSan)
     runs-on: ubuntu-latest
+    env:
+      ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
     steps:
       - name: Checkout source code
         uses: actions/checkout@v5
@@ -90,8 +93,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build bison flex \
-            gettext libasound2-dev libsndfile1-dev libsamplerate0-dev
+          sudo apt-get install -y \
+            build-essential cmake ninja-build python3 libgtest-dev \
+            libsndfile1-dev libasound2-dev libjack-dev portaudio19-dev \
+            libportmidi-dev libpulse-dev swig liblua5.1-0-dev default-jdk \
+            liblo-dev ladspa-sdk dssi-dev libsamplerate0-dev \
+            libpipewire-0.3-dev bison flex gettext
 
       - name: Configure sanitizer build
         env:
@@ -101,24 +108,28 @@ jobs:
         run: >
           cmake -S . -B build-sanitize -G Ninja
           -DCMAKE_BUILD_TYPE=Debug
-          -DBUILD_CSBEATS=0
-          -DBUILD_PERFTHREAD_CLASS=0
-          -DBUILD_PLUGINS=0
-          -DBUILD_STATIC_LIBRARY=0
-          -DBUILD_TESTS=0
-          -DBUILD_UTILITIES=0
-          -DUSE_CURL=0
+          -DBUILD_TESTS=1
+          -DBUILD_STATIC_LIBRARY=1
           -DUSE_MP3=0
+          -DUSE_CURL=0
 
       - name: Build sanitizer Csound
-        run: cmake --build build-sanitize --target csound-bin -j"$(nproc)"
+        run: cmake --build build-sanitize --parallel "$(nproc)"
 
-      - name: Run multidimensional UDO regression
-        env:
-          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
-          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
-          OPCODE7DIR64: ${{ github.workspace }}/build-sanitize
-        run: ./build-sanitize/csound tests/commandline/test_arrays_in_udo.csd
+      - name: Run unit tests
+        run: >
+          ctest --test-dir build-sanitize
+          --parallel "$(nproc)"
+          --output-on-failure
+          --no-tests=error
+
+      - name: Run CSD tests
+        run: |
+          cmake --build build-sanitize --target csdtests
+          if grep -E 'AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:' \
+            build-sanitize/tests/commandline/results.txt; then
+            exit 1
+          fi
 
   linux_build_vcpkg:
     name: Linux/Ubuntu build (vcpkg)

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -78,6 +78,48 @@ jobs:
           cd build
           make csdtests
 
+  linux_sanitizer:
+    name: Linux/Ubuntu sanitizer regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build bison flex \
+            gettext libasound2-dev libsndfile1-dev libsamplerate0-dev
+
+      - name: Configure sanitizer build
+        env:
+          CFLAGS: -fsanitize=address,undefined -fno-omit-frame-pointer
+          CXXFLAGS: -fsanitize=address,undefined -fno-omit-frame-pointer
+          LDFLAGS: -fsanitize=address,undefined
+        run: >
+          cmake -S . -B build-sanitize -G Ninja
+          -DCMAKE_BUILD_TYPE=Debug
+          -DBUILD_CSBEATS=0
+          -DBUILD_PERFTHREAD_CLASS=0
+          -DBUILD_PLUGINS=0
+          -DBUILD_STATIC_LIBRARY=0
+          -DBUILD_TESTS=0
+          -DBUILD_UTILITIES=0
+          -DUSE_CURL=0
+          -DUSE_MP3=0
+
+      - name: Build sanitizer Csound
+        run: cmake --build build-sanitize --target csound-bin -j"$(nproc)"
+
+      - name: Run multidimensional UDO regression
+        env:
+          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+          OPCODE7DIR64: ${{ github.workspace }}/build-sanitize
+        run: ./build-sanitize/csound tests/commandline/test_arrays_in_udo.csd
+
   linux_build_vcpkg:
     name: Linux/Ubuntu build (vcpkg)
     runs-on: ubuntu-latest

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2725,7 +2725,7 @@ static ARG *create_arg(CSOUND *csound, INSTRTXT *ip, char *s,
             setup_arg_for_var_name(csound, arg, csound->engineState.varPool, s) != NULL) {
     arg->type = ARG_GLOBAL;
     if(is_audio_var(csound, arg->argPtr, arg->structPath))
-          ip->glbvarcnt++;  
+          ip->glbvarcnt++;
   }
   /* otherwise we have a local arg */
   else {

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1486,7 +1486,7 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   if(tp->glbvarcnt > 0 &&
      CS_ESR != csound->esr)
     return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
-  
+
 
   inm->recurse_depth++;
   if (csound->oparms->recursion_depth > 0 &&
@@ -1498,7 +1498,7 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
                              Str("error: UDO %s max recursion depth %d reached"),
                              inm->name, csound->oparms->recursion_depth);
   }
-  
+
   if (!p->ip) {
     /* search for already allocated, but not active instance */
     /* if none was found, allocate a new instance */
@@ -2486,7 +2486,7 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
      *p->i_ksmps > 0 /* no-op */ &&
      csound->ksmps != *p->i_ksmps /* no-op */)
     return csoundInitError(csound, "local ksmps not permitted with global audio vars\n");
-  
+
   uint32_t  l_ksmps, n;
   OPCOD_IOBUFS *udo = (OPCOD_IOBUFS *) p->h.insdshead->opcod_iobufs;
   MYFLT parent_sr = udo ? udo->parent_ip->esr : csound->esr;
@@ -2620,7 +2620,7 @@ int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
   if(p->h.insdshead->instr->glbvarcnt > 0  &&
      *p->os > 1 /* no op */)
     return csoundInitError(csound, "local sr not permitted with global audio vars\n");
-  
+
   int32_t os, lksmps;
   MYFLT l_sr, onedos;
   OPCOD_IOBUFS *udo = (OPCOD_IOBUFS *) p->h.insdshead->opcod_iobufs;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -2041,16 +2041,15 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
                    current->subType == &CS_VAR_TYPE_A) {
           ARRAYDAT* src = (ARRAYDAT*)external_ptrs[i + inm->outchns];
           ARRAYDAT* target = (ARRAYDAT*)internal_ptrs[i + inm->outchns];
-          int32_t count = src->sizes[0];
-          int32_t j;
-          if (src->dimensions > 1) {
-            for (j = 0; j < src->dimensions; j++) {
-              count *= src ->sizes[j];
-            }
+          size_t count, j;
+          if (UNLIKELY(csound_array_member_count(src, &count) != OK)) {
+            return csound->PerfError(
+              csound, &p->h, "%s", Str("invalid audio array size in UDO input"));
           }
 
           for (j = 0; j < count; j++) {
-            int32_t memberOffset = j * (src->arrayMemberSize / sizeof(MYFLT));
+            size_t memberOffset =
+              j * ((size_t)src->arrayMemberSize / sizeof(MYFLT));
             MYFLT* in = src->data + memberOffset;
             MYFLT* out = target->data + memberOffset;
             *out = *(in + ofs);
@@ -2081,16 +2080,15 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
                    current->subType == &CS_VAR_TYPE_A) {
           ARRAYDAT* src = (ARRAYDAT*)internal_ptrs[i];
           ARRAYDAT* target = (ARRAYDAT*)external_ptrs[i];
-          int32_t count = src->sizes[0];
-          int32_t j;
-          if (src->dimensions > 1) {
-            for (j = 0; j < src->dimensions; j++) {
-              count *= src->sizes[j];
-            }
+          size_t count, j;
+          if (UNLIKELY(csound_array_member_count(src, &count) != OK)) {
+            return csound->PerfError(
+              csound, &p->h, "%s", Str("invalid audio array size in UDO output"));
           }
 
           for (j = 0; j < count; j++) {
-            int32_t memberOffset = j * (src->arrayMemberSize / sizeof(MYFLT));
+            size_t memberOffset =
+              j * ((size_t)src->arrayMemberSize / sizeof(MYFLT));
             MYFLT* in = src->data + memberOffset;
             MYFLT* out = target->data + memberOffset;
             *(out + ofs) = *in;
@@ -2150,16 +2148,15 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
                    current->subType == &CS_VAR_TYPE_A) {
           ARRAYDAT* src = (ARRAYDAT*)external_ptrs[i + inm->outchns];
           ARRAYDAT* target = (ARRAYDAT*)internal_ptrs[i + inm->outchns];
-          int32_t count = src->sizes[0];
-          int32_t j;
-          if (src->dimensions > 1) {
-            for (j = 0; j < src->dimensions; j++) {
-              count *= src->sizes[j];
-            }
+          size_t count, j;
+          if (UNLIKELY(csound_array_member_count(src, &count) != OK)) {
+            return csound->PerfError(
+              csound, &p->h, "%s", Str("invalid audio array size in UDO input"));
           }
 
           for (j = 0; j < count; j++) {
-            int memberOffset = j * (src->arrayMemberSize / sizeof(MYFLT));
+            size_t memberOffset =
+              j * ((size_t)src->arrayMemberSize / sizeof(MYFLT));
             MYFLT* in = src->data + memberOffset;
             MYFLT* out = target->data + memberOffset;
             memcpy(out, in + ofs, asigSize);
@@ -2194,15 +2191,14 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
                    current->subType == &CS_VAR_TYPE_A) {
           ARRAYDAT* src = (ARRAYDAT*)internal_ptrs[i];
           ARRAYDAT* target = (ARRAYDAT*)external_ptrs[i];
-          int32_t count = src->sizes[0];
-          int32_t j;
-          if (src->dimensions > 1) {
-            for (j = 0; j < src->dimensions; j++) {
-              count *= src->sizes[j];
-            }
+          size_t count, j;
+          if (UNLIKELY(csound_array_member_count(src, &count) != OK)) {
+            return csound->PerfError(
+              csound, &p->h, "%s", Str("invalid audio array size in UDO output"));
           }
           for (j = 0; j < count; j++) {
-            int memberOffset = j * (src->arrayMemberSize / sizeof(MYFLT));
+            size_t memberOffset =
+              j * ((size_t)src->arrayMemberSize / sizeof(MYFLT));
             MYFLT* in = src->data + memberOffset;
             MYFLT* out = target->data + memberOffset;
             memcpy(out + ofs, in, asigSize);
@@ -2244,17 +2240,16 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
                  current->subType == &CS_VAR_TYPE_A) {
         if (offset || early) {
           ARRAYDAT* outDat = (ARRAYDAT*)out;
-          int32_t count = outDat->sizes[0];
-          int32_t j;
-          if (outDat->dimensions > 1) {
-            for (j = 0; j < outDat->dimensions; j++) {
-              count *= outDat->sizes[j];
-            }
+          size_t count, j;
+          if (UNLIKELY(csound_array_member_count(outDat, &count) != OK)) {
+            return csound->PerfError(
+              csound, &p->h, "%s", Str("invalid audio array size in UDO output"));
           }
 
           if (offset) {
             for (j = 0; j < count; j++) {
-              int memberOffset = j * (outDat->arrayMemberSize / sizeof(MYFLT));
+              size_t memberOffset =
+                j * ((size_t)outDat->arrayMemberSize / sizeof(MYFLT));
               MYFLT* outMem = outDat->data + memberOffset;
               memset(outMem, '\0', sizeof(MYFLT) * offset);
             }
@@ -2262,7 +2257,8 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
 
           if (early) {
             for (j = 0; j < count; j++) {
-              int32_t memberOffset = j * (outDat->arrayMemberSize / sizeof(MYFLT));
+              size_t memberOffset =
+                j * ((size_t)outDat->arrayMemberSize / sizeof(MYFLT));
               MYFLT* outMem = outDat->data + memberOffset;
               memset(outMem + g_ksmps, '\0', sizeof(MYFLT) * early);
             }

--- a/InOut/libmpadec/mpadec.c
+++ b/InOut/libmpadec/mpadec.c
@@ -224,7 +224,7 @@ static uint32_t sync_buffer(mpadec_t mpadec)
     if (mpa->state == MPADEC_STATE_START) {
       buf += 128; i -= 128;
       while (i >= 4) {
-        register uint32_t tmp = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+        register uint32_t tmp = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
         if (((tmp & 0xFFE00000) == 0xFFE00000) &&
             (tmp & (3<<17))                    &&
             ((tmp & (3<<10)) != (3<<10))) {
@@ -236,7 +236,7 @@ static uint32_t sync_buffer(mpadec_t mpadec)
               }
               else {
                 register uint32_t tmp2 =
-                  (buf[mpa->frame.frame_size]<<24)     |
+                  ((uint32_t)buf[mpa->frame.frame_size]<<24) |
                   (buf[mpa->frame.frame_size + 1]<<16) |
                   (buf[mpa->frame.frame_size + 2]<<8)  |
                   buf[mpa->frame.frame_size + 3];
@@ -263,7 +263,7 @@ static uint32_t sync_buffer(mpadec_t mpadec)
       }
     } else {
       while (i >= 4) {
-        register uint32_t tmp = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+        register uint32_t tmp = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
         if (((tmp & 0xFFE00000) == 0xFFE00000) &&
             (tmp & (3<<17))                    &&
             ((tmp & (3<<10)) != (3<<10))) {

--- a/InOut/libmpadec/mpadec.c
+++ b/InOut/libmpadec/mpadec.c
@@ -90,7 +90,7 @@ static uint32_t detect_frame_size(mpadec_t mpadec)
     buf += mpa->frame.frame_size;
     i -= mpa->frame.frame_size;
     while (i >= 4) {
-      register uint32_t tmp = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+      register uint32_t tmp = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
       if (((tmp & 0xFFE00000) == 0xFFE00000) &&
           (tmp & (3 << 17)) &&
           ((tmp & (3 << 10)) != (3 << 10))) {
@@ -102,7 +102,7 @@ static uint32_t detect_frame_size(mpadec_t mpadec)
             uint32_t fs = mpa->bytes_left - i - mpa->frame.padding + ((tmp>>9) & 1);
             if (i >= (fs + 4)) {
               buf += fs;
-              tmp = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+              tmp = ((uint32_t)buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
               buf -= fs;
               if (((tmp & 0xFFE00000) == 0xFFE00000) &&
                   (tmp & (3 << 17))                  &&
@@ -333,14 +333,14 @@ static int32_t first_frame(mpadec_t mpadec)
         mpa->next_byte += framesize;
         mpa->bytes_left -= framesize;
         buf += 4;
-        mpa->tag_info.flags = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+        mpa->tag_info.flags = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
         buf += 4;
         if (mpa->tag_info.flags & 1) {
-          mpa->tag_info.frames = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+          mpa->tag_info.frames = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
           buf += 4;
         };
         if (mpa->tag_info.flags & 2) {
-          mpa->tag_info.bytes = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+          mpa->tag_info.bytes = ((uint32_t)buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
           buf += 4;
         };
         if (mpa->tag_info.flags & 4) {

--- a/Opcodes/OSC.c
+++ b/Opcodes/OSC.c
@@ -563,21 +563,27 @@ static int32_t OSC_handler(const char *path, const char *types,
           }
           /* copy argument list */
           for (i = 0; o->saved_types[i] != '\0'; i++) {
+            lo_arg value;
             switch (types[i]) {
             default:              /* Should not happen */
             case 'i':
-              m->args[i].number = (MYFLT) argv[i]->i; break;
+              memcpy(&value.i, (const void *) argv[i], sizeof(value.i));
+              m->args[i].number = (MYFLT) value.i; break;
             case 'h':
-              m->args[i].number = (MYFLT) argv[i]->i64; break;
+              memcpy(&value.i64, (const void *) argv[i], sizeof(value.i64));
+              m->args[i].number = (MYFLT) value.i64; break;
             case 'c':
-               m->args[i].number= (MYFLT) argv[i]->c; break;
+              memcpy(&value.c, (const void *) argv[i], sizeof(value.c));
+              m->args[i].number = (MYFLT) value.c; break;
             case 'f':
-               m->args[i].number = (MYFLT) argv[i]->f; break;
+              memcpy(&value.f, (const void *) argv[i], sizeof(value.f));
+              m->args[i].number = (MYFLT) value.f; break;
             case 'd':
-               m->args[i].number= (MYFLT) argv[i]->d; break;
+              memcpy(&value.d, (const void *) argv[i], sizeof(value.d));
+              m->args[i].number = (MYFLT) value.d; break;
             case 's':
               { // ***NO CHECK THAT m->args[i] IS A STRING
-                char  *src = (char*) &(argv[i]->s), *dst = m->args[i].string.data;
+                char *src = (char *) argv[i], *dst = m->args[i].string.data;
                 if (m->args[i].string.size <= strlen(src)) {
                   if (dst != NULL) csound->Free(csound, dst);
                   dst = csound->Strdup(csound, src);
@@ -1209,18 +1215,24 @@ static int32_t OSC_ahandler(const char *path, const char *types,
           }
           /* copy argument list */
           for (i = 0; o->saved_types[i] != '\0'; i++) {
+            lo_arg value;
             switch (types[i]) {
             default:              /* Should not happen */
             case 'i':
-              m->args[i].number = (MYFLT) argv[i]->i; break;
+              memcpy(&value.i, (const void *) argv[i], sizeof(value.i));
+              m->args[i].number = (MYFLT) value.i; break;
             case 'h':
-              m->args[i].number = (MYFLT) argv[i]->i64; break;
+              memcpy(&value.i64, (const void *) argv[i], sizeof(value.i64));
+              m->args[i].number = (MYFLT) value.i64; break;
             case 'c':
-              m->args[i].number= (MYFLT) argv[i]->c; break;
+              memcpy(&value.c, (const void *) argv[i], sizeof(value.c));
+              m->args[i].number = (MYFLT) value.c; break;
             case 'f':
-              m->args[i].number = (MYFLT) argv[i]->f; break;
+              memcpy(&value.f, (const void *) argv[i], sizeof(value.f));
+              m->args[i].number = (MYFLT) value.f; break;
             case 'd':
-              m->args[i].number= (MYFLT) argv[i]->d; break;
+              memcpy(&value.d, (const void *) argv[i], sizeof(value.d));
+              m->args[i].number = (MYFLT) value.d; break;
             }
           }
           retval = 0;

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -930,7 +930,7 @@ static int32_t grain3set(CSOUND *csound, GRAIN3 *p)
     csound->AuxAlloc(csound, n, &(p->auxdata));
   p->phase = (uint32 *) p->auxdata.auxp;
   p->phasef = (double *) p->auxdata.auxp;
-  p->osc = (GRAIN2_OSC *) ((uint32 *) p->phase + CS_KSMPS + 1);
+  p->osc = (GRAIN2_OSC *) (p->phasef + CS_KSMPS + 1);
   p->osc_start = p->osc;
   p->osc_end = p->osc;
   p->osc_max = p->osc + (p->ovrlap - 1);

--- a/tests/commandline/test_arrays_in_udo.csd
+++ b/tests/commandline/test_arrays_in_udo.csd
@@ -1,6 +1,6 @@
 <CsoundSynthesizer>
 <CsOptions>
--n -d -m0
+-n -d -m0 --sample-accurate
 </CsOptions>
 <CsInstruments>
 sr=64
@@ -71,8 +71,8 @@ instr 2
            + abs(aOut32[1][0] - aIn[1][0]) \
            + abs(aOut32[1][1] - aIn[1][1]) \
            + abs(aOut32[1][2] - aIn[1][2])
-  kError1 downsamp aError1
-  kError32 downsamp aError32
+  kError1 max_k aError1, 1, 1
+  kError32 max_k aError32, 1, 1
   if kError1 > 0.0000001 || kError32 > 0.0000001 then
     printks "multidimensional audio array UDO copy failed: %f, %f\n", \
             0, kError1, kError32
@@ -83,7 +83,7 @@ endin
 </CsInstruments>
 <CsScore>
 i 1 0 0.5
-i 2 0 0.5
+i 2 0 1
+i 2 1.25 0.5
 </CsScore>
 </CsoundSynthesizer>
-

--- a/tests/commandline/test_arrays_in_udo.csd
+++ b/tests/commandline/test_arrays_in_udo.csd
@@ -1,7 +1,10 @@
 <CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
 <CsInstruments>
-sr=44100
-ksmps=1
+sr=64
+ksmps=64
 nchnls=1
 0dbfs=1
 
@@ -28,14 +31,59 @@ instr 1
 
 aout OscBank 440, .5, 8
 
-outs aout, aout
+out aout
 
+endin
+
+opcode PassAudioArray1, a[], a[]
+  aIn[][] xin
+  setksmps 1
+  xout aIn
+endop
+
+opcode PassAudioArray32, a[], a[]
+  aIn[][] xin
+  setksmps 32
+  xout aIn
+endop
+
+instr 2
+  aIn[][] init 2, 3
+  aIn[0][0] = 0.1
+  aIn[0][1] = 0.2
+  aIn[0][2] = 0.3
+  aIn[1][0] = 0.4
+  aIn[1][1] = 0.5
+  aIn[1][2] = 0.6
+
+  aOut1[][] PassAudioArray1 aIn
+  aOut32[][] PassAudioArray32 aIn
+
+  aError1 = abs(aOut1[0][0] - aIn[0][0]) \
+          + abs(aOut1[0][1] - aIn[0][1]) \
+          + abs(aOut1[0][2] - aIn[0][2]) \
+          + abs(aOut1[1][0] - aIn[1][0]) \
+          + abs(aOut1[1][1] - aIn[1][1]) \
+          + abs(aOut1[1][2] - aIn[1][2])
+  aError32 = abs(aOut32[0][0] - aIn[0][0]) \
+           + abs(aOut32[0][1] - aIn[0][1]) \
+           + abs(aOut32[0][2] - aIn[0][2]) \
+           + abs(aOut32[1][0] - aIn[1][0]) \
+           + abs(aOut32[1][1] - aIn[1][1]) \
+           + abs(aOut32[1][2] - aIn[1][2])
+  kError1 downsamp aError1
+  kError32 downsamp aError32
+  if kError1 > 0.0000001 || kError32 > 0.0000001 then
+    printks "multidimensional audio array UDO copy failed: %f, %f\n", \
+            0, kError1, kError32
+    exitnowk(1)
+  endif
 endin
 
 </CsInstruments>
 <CsScore>
-i1 0 .5
+i 1 0 0.5
+i 2 0 0.5
 </CsScore>
 </CsoundSynthesizer>
-
 

--- a/tests/commandline/test_local_ksmps_global_fail.csd
+++ b/tests/commandline/test_local_ksmps_global_fail.csd
@@ -36,7 +36,7 @@ opcode Test4,0,0
 endop
 
 opcode Test00,0,0
- setksmps 10 
+ setksmps 10
  gaatest[0] = 1 //ok
  prints "OK!"
 endop


### PR DESCRIPTION
The five copy and clear blocks in `useropcd_local_ksmps()` seeded the member count with `sizes[0]` and then multiplied by every dimension starting from `sizes[0]` again, squaring the first dimension. A `2 x 3` audio array reported 12 members instead of 6, so the copy loops read and wrote six members past the array buffer on every k-cycle.

All five blocks now get the member count from `csound_array_member_count()`, which counts each dimension once, checks for negative or overflowing sizes, and returns the count as `size_t`. The member offsets are computed in `size_t` as well, so large arrays or a large ksmps no longer overflow a signed 32-bit product. A helper failure aborts the UDO with a perf error instead of copying with a bogus count.

`test_arrays_in_udo.csd` gains an instrument that passes a `2 x 3` audio array through two UDOs with local ksmps 1 and 32, compares every member of the output against the input, and exits nonzero on mismatch. On the unfixed code the test aborts under AddressSanitizer.

## Before

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 64
ksmps = 64
nchnls = 1
0dbfs = 1

opcode passaa, a[], a[]
  aIn[][] xin
  setksmps 32
  xout aIn
endop

instr 1
  aIn[][] init 2, 3
  aOut[][] passaa aIn
  out aOut[0][0]
endin
</CsInstruments>
<CsScore>
i 1 0 1
</CsScore>
</CsoundSynthesizer>
```

```text
==ERROR: AddressSanitizer: heap-buffer-overflow ...
READ of size 256 at 0x... thread T0
    #1 useropcd_local_ksmps udo.c:2126
SUMMARY: AddressSanitizer: heap-buffer-overflow udo.c:2126 in useropcd_local_ksmps
```

## After

```text
SECTION 1:
end of Performance
		   overall amps:  0.00000
	   overall samples out of range:        0
```

Clean under AddressSanitizer.

## Extra sanitizer fixes

The full UBSan run found three older bugs outside the UDO array copy path:

- liblo can pack OSC arguments on 4-byte boundaries, while `lo_arg` may need an 8-byte boundary. The OSC handlers now copy each value to aligned local storage before reading it.
- The MP3 decoder shifted a signed byte into the top of a 32-bit header. It now casts the byte to `uint32_t` first.
- `grain3` placed its oscillator state halfway through a `double` phase buffer. It now starts after the buffer, which removes the overlap and keeps the state aligned.

Closes #2680