### PR TITLE
Fix sample-accurate tail clearing for scalar UDO audio outputs

### DIFF
--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -2199,7 +2199,7 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
 
         /* clear the end portion of outputs for sample accurate end */
         if (early) {
-          memset((char*)out + g_ksmps, '\0', sizeof(MYFLT) * early);
+          memset((MYFLT*)out + g_ksmps, '\0', sizeof(MYFLT) * early);
         }
       } else if (current->varType == &CS_VAR_TYPE_ARRAY &&
                  current->subType == &CS_VAR_TYPE_A) {

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -796,6 +796,51 @@ schedule(1,6/sr,0.5)
 
 }
 
+TEST_F (OrcCompileTests, testSampleAccurateLocalKsmpsUdoOutputTail)
+{
+  const char* instrument = R"(
+sr = 64
+ksmps = 64
+nchnls = 2
+0dbfs = 1
+
+opcode passa, a, a
+  aIn xin
+  setksmps 32
+  xout aIn
+endop
+
+instr 1
+  aConst = 1
+  aOut passa aConst
+  outch p4, aOut
+endin
+
+schedule(1, 0, 24 / sr, 1)
+schedule(1, 0, 40 / sr, 2)
+)";
+
+  ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+  ASSERT_EQ(csoundSetOption(csound, "--sample-accurate"), CSOUND_SUCCESS);
+  ASSERT_EQ(csoundCompileOrc(csound, instrument), CSOUND_SUCCESS);
+  ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+  ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+  const MYFLT *spout = csoundGetSpout(csound);
+  ASSERT_NE(spout, nullptr);
+  constexpr int32_t blockSize = 64;
+  constexpr int32_t channelCount = 2;
+  constexpr int32_t endSamples[] = {24, 40};
+  for (int32_t sample = 0; sample < blockSize; ++sample) {
+    for (int32_t channel = 0; channel < channelCount; ++channel) {
+      const MYFLT expected =
+        sample < endSamples[channel] ? FL(1.0) : FL(0.0);
+      EXPECT_EQ(expected, spout[sample * channelCount + channel])
+        << "sample " << sample << ", channel " << channel + 1;
+    }
+  }
+}
+
 TEST_F (OrcCompileTests, testCompileCSD)
 {
   const char* instrument = R"(


### PR DESCRIPTION
## Summary

Fix the scalar audio-output tail clear for UDOs that use a local `ksmps`. At a sample-accurate note end, the code now advances the output pointer in `MYFLT` samples before clearing the inactive tail. This matches the audio-array path and leaves active samples unchanged.

A native regression test covers note ends at samples 24 and 40 in a 64-sample block.

Closes #2681

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0 --sample-accurate
</CsOptions>
<CsInstruments>
sr = 64
ksmps = 64
nchnls = 1
0dbfs = 1

opcode passa, a, a
  aIn xin
  setksmps 32
  xout aIn
endop

instr 1
  aConst = 1
  aOut passa aConst
  kn = 0
  while kn < ksmps do
    printf "s[%d]=%f\n", kn+1, kn, aOut[kn]
    kn += 1
  od
  out aOut
endin
</CsInstruments>
<CsScore>
; 40 samples at sr = 64
i 1 0 0.625
</CsScore>
</CsoundSynthesizer>
```

The note ends after sample 39, so samples 40 through 63 should be zero.

## Before

With double samples, the code adds `g_ksmps` after casting the output to `char *`. For `g_ksmps = 40`, the clear begins at byte 40, which is sample 5.

```text
s[0..4]   = 1.000000
s[5..28]  = 0.000000
s[29..39] = 1.000000
s[40..63] = 0.000000
```

## After

The pointer remains a `MYFLT *`, so `g_ksmps` counts samples and the clear begins at sample 40.

```text
s[0..39]  = 1.000000
s[40..63] = 0.000000
```