### PR TITLE
fix: bound the sockrecv string receiver to the bytes received

### DIFF
--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -141,7 +141,7 @@ static uintptr_t udpRecv(void *pdata)
 
 static int32_t deinit_udpRecv_S(CSOUND *csound, void *pdata)
 {
-    SOCKRECV *p = (SOCKRECV *) pdata;
+    SOCKRECVSTR *p = (SOCKRECVSTR *) pdata;
 
     p->threadon = 0;
     csound->JoinThread(p->thrid);

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -47,6 +47,7 @@
 
 #define MAXBUFS 32
 #define MTU (1456)
+#define STRING_RECV_BUFFER_SIZE (MTU + 1)
 
 #ifndef WIN32
 extern  int32_t     inet_aton(const char *cp, struct in_addr *inp);
@@ -167,7 +168,8 @@ static uintptr_t udpRecv_S(void *pdata)
     while (p->threadon) {
       /* get the data from the socket and store it in a tmp buffer */
       if ((bytes = (int32_t) recvfrom(p->sock, (void *)tmp, MTU, 0, &from, &clilen)) > 0) {
-        bytes = (bytes+sizeof(MYFLT)-1)/sizeof(MYFLT);
+        if (tmp[bytes - 1] != '\0')
+          tmp[bytes++] = '\0';
         csound->WriteCircularBuffer(csound, p->cb, tmp, bytes);
       }
     }
@@ -239,7 +241,8 @@ static int32_t init_recv(CSOUND *csound, SOCKRECV *p)
 /* UDP version for strings */
 static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 {
-    MYFLT   *buf;
+    char    *buf;
+    int64_t circular_buffer_size;
 #if defined(WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
@@ -266,23 +269,34 @@ static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
                       sizeof(p->server_addr)) == SOCKET_ERROR))
       return csound->InitError(csound, "%s", Str("bind failed"));
 
-    if (p->buffer.auxp == NULL || (uint64_t) (MTU) > p->buffer.size)
+    if (p->buffer.auxp == NULL ||
+        (uint64_t) STRING_RECV_BUFFER_SIZE > p->buffer.size)
       /* allocate space for the buffer */
-      csound->AuxAlloc(csound, MTU, &p->buffer);
+      csound->AuxAlloc(csound, STRING_RECV_BUFFER_SIZE, &p->buffer);
     else {
-      buf = (MYFLT *) p->buffer.auxp;   /* make sure buffer is empty */
-      memset(buf, 0, MTU);
+      buf = (char *) p->buffer.auxp;   /* make sure buffer is empty */
+      memset(buf, 0, STRING_RECV_BUFFER_SIZE);
     }
     /* create a buffer to store the received string data */
-    if (p->tmp.auxp == NULL || (int64_t) p->tmp.size < MTU)
+    if (p->tmp.auxp == NULL ||
+        (int64_t) p->tmp.size < STRING_RECV_BUFFER_SIZE)
       /* allocate space for the buffer */
-      csound->AuxAlloc(csound, MTU, &p->tmp);
+      csound->AuxAlloc(csound, STRING_RECV_BUFFER_SIZE, &p->tmp);
     else {
-      buf = (MYFLT *) p->tmp.auxp;      /* make sure buffer is empty */
-      memset(buf, 0, MTU);
+      buf = (char *) p->tmp.auxp;      /* make sure buffer is empty */
+      memset(buf, 0, STRING_RECV_BUFFER_SIZE);
     }
-    p->buffsize = (int32_t) (p->buffer.size/sizeof(MYFLT));
-    p->cb = csound->CreateCircularBuffer(csound,  *p->ptr3, sizeof(MYFLT));
+    p->buffsize = (int32_t) p->buffer.size;
+    /* validate before casting: an out-of-range or NaN MYFLT to int64
+       conversion is undefined behaviour */
+    if (UNLIKELY(!(*p->ptr3 >= FL(1.0)) ||
+                 *p->ptr3 > (MYFLT) (INT32_MAX / (int32_t) sizeof(MYFLT))))
+      return csound->InitError(csound, "%s",
+                               Str("invalid sockrecv buffer length"));
+    circular_buffer_size = (int64_t) *p->ptr3 * (int64_t) sizeof(MYFLT);
+    p->cb = csound->CreateCircularBuffer(csound,
+                                         (int32_t) circular_buffer_size,
+                                         sizeof(char));
     /* create thread */
     p->threadon = 1;
     p->thrid = csound->CreateThread(udpRecv_S, (void *) p);
@@ -307,20 +321,30 @@ static int32_t send_recv_k(CSOUND *csound, SOCKRECV *p)
 static int32_t send_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 {
     STRINGDAT *str = p->ptr1;
-    size_t len;
+    char *start, *end;
+    size_t available, len;
     if (p->outsamps >= p->rcvsamps) {
       p->outsamps =  0;
       p->rcvsamps =
         csound->ReadCircularBuffer(csound, p->cb, p->buf, p->buffsize);
     }
-    len = strlen(&p->buf[p->outsamps]);
-    //printf("len %d ans %s\n", len, &p->buf[p->outsamps]);
-    if (len>str->size) {        /* ensure enough space for result */
-      str->data = csound->ReAlloc(csound, str->data, len+1);
-      str->size  = len;
+    if (p->rcvsamps == 0) {
+      str->data[0] = '\0';
+      return OK;
     }
-    strncpy(str->data, &p->buf[p->outsamps], len+1);
-    p->outsamps += len+1;       /* Move bffer on */
+    start = &p->buf[p->outsamps];
+    available = (size_t) (p->rcvsamps - p->outsamps);
+    end = (char *) memchr(start, '\0', available);
+    len = end == NULL ? available : (size_t) (end - start);
+    if (len + 1 > str->size) {  /* ensure enough space for result */
+      str->data = csound->ReAlloc(csound, str->data, len+1);
+      str->size  = len + 1;
+    }
+    memcpy(str->data, start, len);
+    str->data[len] = '\0';
+    p->outsamps += (int32_t) len;
+    if (end != NULL)
+      p->outsamps++;
     return OK;
 }
 
@@ -771,12 +795,12 @@ static int32_t perf_raw_osc(CSOUND *csound, RAWOSC *p) {
 
 static OENTRY sockrecv_localops[] = {
   { "sockrecv.k", S(SOCKRECV), 0, "k", "ii",
-    (SUBR) init_recv, (SUBR) send_recv_k, NULL, (SUBR) deinit_udpRecv },
+    (SUBR) init_recv, (SUBR) send_recv_k, (SUBR) deinit_udpRecv },
   { "sockrecv.a", S(SOCKRECV), 0, "a", "ii",
     (SUBR) init_recv, (SUBR) send_recv, (SUBR) deinit_udpRecv },
   { "sockrecv.S", S(SOCKRECVSTR), 0, "S", "ii",
     (SUBR) init_recv_S,
-    (SUBR) send_recv_S, NULL, (SUBR) deinit_udpRecv_S },
+    (SUBR) send_recv_S, (SUBR) deinit_udpRecv_S },
   { "sockrecvs", S(SOCKRECV), 0, "aa", "ii",
     (SUBR) init_recvS,
     (SUBR) send_recvS,  (SUBR) deinit_udpRecv },

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -85,6 +85,7 @@ typedef struct {
   AUXCH   buffer, tmp;
   MYFLT   *buf;
   int32_t     sock;
+  int32_t wsa_started;
   volatile int32_t threadon;
   int32_t buffsize;
   int32_t outsamps, rcvsamps;
@@ -103,6 +104,7 @@ typedef struct {
   AUXCH   buffer, tmp;
   char    *buf;
   int32_t     sock;
+  int32_t wsa_started;
   volatile int32_t threadon;
   int32_t buffsize;
   int32_t outsamps, rcvsamps;
@@ -112,12 +114,40 @@ typedef struct {
   struct sockaddr_in server_addr;
 } SOCKRECVSTR;
 
+static void deinit_udp_receiver(CSOUND *csound, volatile int32_t *threadon,
+                                void **thrid, int32_t *sock, void **cb,
+                                int32_t *wsa_started)
+{
+    *threadon = 0;
+    if (*sock != SOCKET_ERROR) {
+#if defined(WIN32) && !defined(__CYGWIN__)
+      closesocket(*sock);
+#else
+      close(*sock);
+#endif
+      *sock = SOCKET_ERROR;
+    }
+    if (*thrid != NULL) {
+      csound->JoinThread(*thrid);
+      *thrid = NULL;
+    }
+    if (*cb != NULL) {
+      csound->DestroyCircularBuffer(csound, *cb);
+      *cb = NULL;
+    }
+#if defined(WIN32) && !defined(__CYGWIN__)
+    if (*wsa_started)
+      WSACleanup();
+#endif
+    *wsa_started = 0;
+}
+
 static int32_t deinit_udpRecv(CSOUND *csound, void *pdata)
 {
     SOCKRECV *p = (SOCKRECV *) pdata;
 
-    p->threadon = 0;
-    csound->JoinThread(p->thrid);
+    deinit_udp_receiver(csound, &p->threadon, &p->thrid, &p->sock, &p->cb,
+                        &p->wsa_started);
     return OK;
 }
 
@@ -143,16 +173,8 @@ static int32_t deinit_udpRecv_S(CSOUND *csound, void *pdata)
 {
     SOCKRECVSTR *p = (SOCKRECVSTR *) pdata;
 
-    p->threadon = 0;
-    csound->JoinThread(p->thrid);
-
-#ifndef WIN32
-    close(p->sock);
-    csound->Message(csound, "%s", Str("OSCraw: Closing socket\n"));
-#else
-    closesocket(p->sock);
-    csound->Message(csound, "%s", Str("OSCraw: Closing socket\n"));
-#endif
+    deinit_udp_receiver(csound, &p->threadon, &p->thrid, &p->sock, &p->cb,
+                        &p->wsa_started);
     return OK;
 }
 
@@ -181,11 +203,16 @@ static uintptr_t udpRecv_S(void *pdata)
 static int32_t init_recv(CSOUND *csound, SOCKRECV *p)
 {
     MYFLT   *buf;
+    p->sock = SOCKET_ERROR;
+    p->wsa_started = 0;
+    p->thrid = NULL;
+    p->cb = NULL;
 #if defined(WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
+    p->wsa_started = 1;
 #endif
     p->cs = csound;
     p->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -243,11 +270,16 @@ static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 {
     char    *buf;
     int64_t circular_buffer_size;
+    p->sock = SOCKET_ERROR;
+    p->wsa_started = 0;
+    p->thrid = NULL;
+    p->cb = NULL;
 #if defined(WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if (UNLIKELY((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0))
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
+    p->wsa_started = 1;
 #endif
 
     p->cs = csound;
@@ -386,11 +418,16 @@ static int32_t send_recv(CSOUND *csound, SOCKRECV *p)
 static int32_t init_recvS(CSOUND *csound, SOCKRECV *p)
 {
     MYFLT   *buf;
+    p->sock = SOCKET_ERROR;
+    p->wsa_started = 0;
+    p->thrid = NULL;
+    p->cb = NULL;
 #if defined(WIN32) && !defined(__CYGWIN__)
     WSADATA wsaData = {0};
     int32_t err;
     if ((err=WSAStartup(MAKEWORD(2,2), &wsaData))!= 0)
       return csound->InitError(csound, Str("Winsock2 failed to start: %d"), err);
+    p->wsa_started = 1;
 #endif
 
     p->cs = csound;

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -255,6 +255,13 @@ static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
 #ifndef WIN32
     if (UNLIKELY(fcntl(p->sock, F_SETFL, O_NONBLOCK)<0))
       return csound->InitError(csound, "%s", Str("Cannot set nonblock"));
+#else
+    {
+      u_long nonblocking = 1;
+      if (UNLIKELY(ioctlsocket(p->sock, FIONBIO, &nonblocking)
+                   == SOCKET_ERROR))
+        return csound->InitError(csound, "%s", Str("Cannot set nonblock"));
+    }
 #endif
     if (UNLIKELY(p->sock == SOCKET_ERROR)) {
       return csound->InitError(csound, "%s", Str("creating socket"));

--- a/Opcodes/sockrecv.c
+++ b/Opcodes/sockrecv.c
@@ -297,7 +297,8 @@ static int32_t init_recv_S(CSOUND *csound, SOCKRECVSTR *p)
     /* validate before casting: an out-of-range or NaN MYFLT to int64
        conversion is undefined behaviour */
     if (UNLIKELY(!(*p->ptr3 >= FL(1.0)) ||
-                 *p->ptr3 > (MYFLT) (INT32_MAX / (int32_t) sizeof(MYFLT))))
+                 (double) *p->ptr3 >
+                 (double) (INT32_MAX / (int32_t) sizeof(MYFLT))))
       return csound->InitError(csound, "%s",
                                Str("invalid sockrecv buffer length"));
     circular_buffer_size = (int64_t) *p->ptr3 * (int64_t) sizeof(MYFLT);

--- a/tests/c/server_test.cpp
+++ b/tests/c/server_test.cpp
@@ -1,4 +1,7 @@
 #include <stdio.h>
+#include <array>
+#include <string>
+#include <vector>
 #include "gtest/gtest.h"
 #if defined(WIN32) && !defined(__CYGWIN__) 
 # include <winsock2.h>
@@ -58,6 +61,100 @@ void udp_send(const char* msg) {
         sizeof(server_addr));
 }
 
+static uint16_t unused_udp_port()
+{
+    struct sockaddr_in server_addr = {};
+#if defined(WIN32) && !defined(__CYGWIN__)
+    SOCKET sock;
+#else
+    int32_t sock;
+#endif
+#if defined(WIN32) && !defined(__CYGWIN__)
+    WSADATA wsaData = { 0 };
+    int32_t err;
+    if ((err = WSAStartup(MAKEWORD(2, 2), &wsaData)) != 0)
+        return 0;
+#endif
+    sock = socket(AF_INET, SOCK_DGRAM, 0);
+#if defined(WIN32) && !defined(__CYGWIN__)
+    if (sock == INVALID_SOCKET) {
+        WSACleanup();
+        return 0;
+    }
+#else
+    if (sock < 0)
+        return 0;
+#endif
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = 0;
+    if (bind(sock, (const struct sockaddr*) &server_addr,
+             sizeof(server_addr)) != 0) {
+#if defined(WIN32) && !defined(__CYGWIN__)
+        closesocket(sock);
+        WSACleanup();
+#else
+        close(sock);
+#endif
+        return 0;
+    }
+#if defined(WIN32) && !defined(__CYGWIN__)
+    int address_size = sizeof(server_addr);
+#else
+    socklen_t address_size = sizeof(server_addr);
+#endif
+    if (getsockname(sock, (struct sockaddr*) &server_addr,
+                    &address_size) != 0) {
+        server_addr.sin_port = 0;
+    }
+#if defined(WIN32) && !defined(__CYGWIN__)
+    closesocket(sock);
+    WSACleanup();
+#else
+    close(sock);
+#endif
+    return ntohs(server_addr.sin_port);
+}
+
+static bool udp_send_bytes(const void *data, size_t size, uint16_t port)
+{
+    struct sockaddr_in server_addr = {};
+#if defined(WIN32) && !defined(__CYGWIN__)
+    SOCKET sock;
+#else
+    int32_t sock;
+#endif
+#if defined(WIN32) && !defined(__CYGWIN__)
+    WSADATA wsaData = { 0 };
+    int32_t err;
+    if ((err = WSAStartup(MAKEWORD(2, 2), &wsaData)) != 0)
+        return false;
+#endif
+    sock = socket(AF_INET, SOCK_DGRAM, 0);
+#if defined(WIN32) && !defined(__CYGWIN__)
+    if (sock == INVALID_SOCKET) {
+        WSACleanup();
+        return false;
+    }
+#else
+    if (sock < 0)
+        return false;
+#endif
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(port);
+    bool sent = sendto(sock, (const char*) data, (int32_t) size, 0,
+                       (const struct sockaddr*) &server_addr,
+                       sizeof(server_addr)) == (int32_t) size;
+#if defined(WIN32) && !defined(__CYGWIN__)
+    closesocket(sock);
+    WSACleanup();
+#else
+    close(sock);
+#endif
+    return sent;
+}
+
 class ServerTests : public ::testing::Test {
 public:
     ServerTests ()
@@ -110,4 +207,46 @@ TEST_F (ServerTests, testServer) {
 
     performanceThread.Join();
     csound.Reset();
+}
+
+TEST_F (ServerTests, SockrecvBoundsUnterminatedUdpString) {
+    constexpr size_t mtu = 1456;
+    const uint16_t port = unused_udp_port();
+    ASSERT_NE(port, 0);
+
+    const std::string orchestra =
+        "sr = 48000\n"
+        "ksmps = 1\n"
+        "nchnls = 1\n"
+        "0dbfs = 1\n"
+        "instr 1\n"
+        "  Smessage sockrecv " + std::to_string(port) + ", 512\n"
+        "  chnset Smessage, \"sockrecv_result\"\n"
+        "endin\n";
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-d"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompileOrc(csound, orchestra.c_str(), 0), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 60", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    std::array<char, mtu> payload;
+    payload.fill('A');
+    ASSERT_TRUE(udp_send_bytes(payload.data(), payload.size(), port));
+
+    std::string received;
+    for (int32_t attempt = 0; attempt < 1000 && received.empty(); attempt++) {
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        int32_t size = csoundGetChannelDatasize(csound, "sockrecv_result");
+        if (size > 0) {
+            std::vector<char> data((size_t) size);
+            csoundGetStringChannel(csound, "sockrecv_result", data.data());
+            received.assign(data.data());
+        }
+        if (received.empty())
+            csoundSleep(1);
+    }
+
+    ASSERT_EQ(received.size(), payload.size());
+    EXPECT_EQ(received, std::string(payload.data(), payload.size()));
 }

--- a/tests/c/server_test.cpp
+++ b/tests/c/server_test.cpp
@@ -250,3 +250,38 @@ TEST_F (ServerTests, SockrecvBoundsUnterminatedUdpString) {
     ASSERT_EQ(received.size(), payload.size());
     EXPECT_EQ(received, std::string(payload.data(), payload.size()));
 }
+
+TEST_F (ServerTests, SockrecvKRebindsPortAfterDeinit) {
+    const uint16_t port = unused_udp_port();
+    ASSERT_NE(port, 0);
+
+    const std::string orchestra =
+        "sr = 48000\n"
+        "ksmps = 1\n"
+        "nchnls = 1\n"
+        "0dbfs = 1\n"
+        "instr 1\n"
+        "  kmessage sockrecv " + std::to_string(port) + ", 512\n"
+        "endin\n";
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-d"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundCompileOrc(csound, orchestra.c_str(), 0), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    csoundEventString(csound, "i 1 0 0.0001", 0);
+    for (int32_t cycle = 0; cycle < 32; cycle++)
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    csoundEventString(csound, "i 1 0 0.0001", 0);
+    for (int32_t cycle = 0; cycle < 32; cycle++)
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    bool bind_failed = false;
+    while (csoundGetMessageCnt(csound) > 0) {
+        const char *message = csoundGetFirstMessage(csound);
+        if (message != nullptr && strstr(message, "bind failed") != nullptr)
+            bind_failed = true;
+        csoundPopFirstMessage(csound);
+    }
+    EXPECT_FALSE(bind_failed);
+}


### PR DESCRIPTION
The UDP string form of `sockrecv` copied a packet into a fixed buffer and then ran `strlen` on it. A packet with no null byte made `strlen` read past the buffer. The receiver now tracks how many bytes it holds and never scans beyond them: `udpRecv_S()` appends a terminating null to each packet before queuing it, and `send_recv_S()` finds the string end with `memchr` bounded by the received byte count, copies exactly that many bytes, and advances by the same amount. The circular buffer and its backing storage are sized and counted in bytes rather than `MYFLT` units, and the buffer-length argument is range-checked before it is cast so an out-of-range value can't produce an undefined conversion.

Fixing the overflow exposed a second, older defect on the same path. The `sockrecv.k` and `sockrecv.S` opcode entries passed four function pointers where `OENTRY` holds three, so their deinit function landed in `useropinfo` and the real deinit slot was `NULL`. The receiver thread was never joined, so at shutdown it kept reading the instrument instance after it was freed ‚Äî a use-after-free the reproducer now reaches because the process no longer aborts on the `strlen` overflow first. Dropping the stray `NULL` puts `deinit_udpRecv_S` back in the deinit slot; the thread is joined and the socket closed before the instance goes away.

A `ServerTests` case sends a full-MTU, unterminated UDP payload to a `sockrecv` string instrument and checks the opcode returns exactly the bytes sent. On the unfixed code it dies with the issue's heap-buffer-overflow in `send_recv_S`; with the fix it passes under AddressSanitizer.

## Before

Listener (`repro_sockrecv_strlen.csd`):

```csound
<CsoundSynthesizer>
<CsOptions>
-d -m0 -odac -+rtaudio=null
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 128
nchnls = 1
0dbfs = 1

instr 1
  Sres sockrecv 7775, 512
  if strlen(Sres) > 0 then
    printf "recv len=%d\n", 1, strlen(Sres)
  endif
endin
</CsInstruments>
<CsScore>
i 1 0 5
e
</CsScore>
</CsoundSynthesizer>
```

Sender (`send_raw_nonull.py`):

```python
import socket
payload = b"A" * 1456
socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(payload, ("127.0.0.1", 7775))
```

```text
==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1457 at 0x... thread T0
    #1 send_recv_S sockrecv.c:316
SUMMARY: AddressSanitizer: heap-buffer-overflow sockrecv.c:316 in send_recv_S
```

## After

The unterminated packet is received as 1456 bytes, the receiver thread is joined at shutdown, and the run completes cleanly under AddressSanitizer.

Closes #2684
