### PR TITLE
fix: preserve C-locale parsing in csoundSscanf

### DIFF
--- a/Top/getstring.c
+++ b/Top/getstring.c
@@ -269,7 +269,6 @@ double csoundStrtod(char* nptr, char** endptr) {
     int32_t retVal;
     va_start(args, format);
     retVal = vsscanf_l(str,csound_c_locale,format,args);
-    retVal = vsscanf(str,format,args);
     va_end(args);
     return retVal;
 }

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -4,6 +4,7 @@
 #include "fftlib.h"
 #include <algorithm>
 #include <atomic>
+#include <clocale>
 #include <cmath>
 #include <cstring>
 #include <stdio.h>
@@ -53,6 +54,41 @@ std::string drainMessageBuffer(CSOUND *csound)
         csoundPopFirstMessage(csound);
     }
     return messages;
+}
+
+class NumericLocaleGuard {
+public:
+    NumericLocaleGuard()
+    {
+        const char *locale = std::setlocale(LC_NUMERIC, nullptr);
+        if (locale != nullptr)
+            savedLocale = locale;
+    }
+
+    ~NumericLocaleGuard()
+    {
+        if (!savedLocale.empty())
+            std::setlocale(LC_NUMERIC, savedLocale.c_str());
+    }
+
+private:
+    std::string savedLocale;
+};
+
+bool setCommaDecimalLocale()
+{
+    static const char *const candidates[] = {
+      "de_DE.UTF-8", "de_DE.utf8", "de_DE",
+      "fr_FR.UTF-8", "fr_FR.utf8", "fr_FR",
+      "German_Germany.1252", "German_Germany.65001"
+    };
+
+    for (const char *candidate : candidates) {
+        if (std::setlocale(LC_NUMERIC, candidate) != nullptr &&
+            std::strcmp(std::localeconv()->decimal_point, ",") == 0)
+            return true;
+    }
+    return false;
 }
 
 }
@@ -122,6 +158,19 @@ TEST_F (EngineTests, testComplexFftMatchesDirectDft)
               << "round trip size " << size << ", component " << i;
         }
     }
+}
+
+TEST_F (EngineTests, testSscanfUsesCLocale)
+{
+    NumericLocaleGuard localeGuard;
+    if (!setCommaDecimalLocale())
+        GTEST_SKIP() << "No comma-decimal locale is installed";
+
+    char input[] = "3.5";
+    double value = 0.0;
+
+    EXPECT_EQ(csound->Sscanf(input, "%lf", &value), 1);
+    EXPECT_DOUBLE_EQ(value, 3.5);
 }
 
 TEST_F (EngineTests, testComplexFftReportsUnsupportedSizes)


### PR DESCRIPTION
Closes #2685.

`csoundSscanf()` scanned the same input twice: first with `vsscanf_l()` and then with `vsscanf()` using the same `va_list`. The second call reused an exhausted argument list and could replace the C-locale result with one parsed under the current locale.

Remove the second scan so the argument list is consumed once, and add coverage for dot-decimal input under a comma-decimal locale.

## Before / after

With `value.txt` containing:

```text
3.5
```

and this CSD:

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d
</CsOptions>
<CsInstruments>
ksmps = 32

instr 1
  kValue readk "value.txt", 7, 1
  printf "value = %.1f\n", 1, kValue
  turnoff
endin
</CsInstruments>
<CsScore>
i 1 0 1
</CsScore>
</CsoundSynthesizer>
```

Run it from a host that sets `LC_NUMERIC` to `de_DE.UTF-8` after `csoundCreate()`. Text format `7` in `readk` reaches `CS_SSCANF`.

Before:

```text
value = 3,0
```

After:

```text
value = 3,5
```
