### PR TITLE
fix: preserve strstrip buffers on reallocation

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -2657,13 +2657,29 @@ lastcycle(CSOUND *csound, LASTCYCLE *p) {
  *
  */
 
-// make sure that the out string has enough allocated space
-// This can be run only at init time
-static int32_t _string_ensure(CSOUND *csound, STRINGDAT *s, int32_t size) {
-    if (s->size >= (size_t)size)
+// Make sure that the output string has enough allocated space.
+// This can run only at init time.
+static int32_t string_ensure(CSOUND *csound, STRINGDAT *s, size_t size) {
+    if (s->size >= size)
         return OK;
-    csound->ReAlloc(csound, s->data, size);
+
+    char *data = csound->ReAlloc(csound, s->data, size);
+    if (UNLIKELY(data == NULL))
+        return INITERR(Str("memory allocation failure"));
+
+    s->data = data;
     s->size = size;
+    return OK;
+}
+
+static int32_t string_copy(CSOUND *csound, STRINGDAT *out,
+                           const char *src, size_t size) {
+    int32_t result = string_ensure(csound, out, size + 1);
+    if (UNLIKELY(result != OK))
+        return result;
+
+    memmove(out->data, src, size);
+    out->data[size] = '\0';
     return OK;
 }
 
@@ -2676,46 +2692,19 @@ typedef struct {
 
 static int32_t
 stripl(CSOUND *csound, STR1_1 *p) {
-    char *str = p->in->data;
-    size_t idx0;
-    for(idx0=0; idx0 < p->in->size; idx0++) {
-        if(!isspace(str[idx0]))
-            break;
-    }
-    // now idx points to start of content
-    if(str[idx0] == 0) {
-        // empty string
-        _string_ensure(csound, p->out, 1);
-        p->out->data[0] = 0;
-        return OK;
-    }
-    str += idx0;
-    size_t insize = strlen(str);
-    _string_ensure(csound, p->out, (int32_t) insize);
-    memcpy(p->out->data, str, insize);
-    return OK;
+    const char *str = p->in->data;
+    while (isspace((unsigned char)*str))
+        str++;
+    return string_copy(csound, p->out, str, strlen(str));
 }
 
 static int32_t
 stripr(CSOUND *csound, STR1_1 *p) {
-    // Trim trailing space
-    char *str = p->in->data;
-    int32_t size = (int32_t) strlen(str) - 1;
-    const char *end = str + size;
-    while(size && isspace(*end)) {
-        end--;
+    const char *str = p->in->data;
+    size_t size = strlen(str);
+    while (size > 0 && isspace((unsigned char)str[size - 1]))
         size--;
-    }
-    size += 1;
-    if(size > 0) {
-        _string_ensure(csound, p->out, size);
-        memcpy(p->out->data, str, size);
-    } else {
-        _string_ensure(csound, p->out, 1);
-        p->out->data[0] = 0;
-    }
-     return OK;
-
+    return string_copy(csound, p->out, str, size);
 }
 
 static int32_t
@@ -2730,44 +2719,33 @@ stripside(CSOUND *csound, STR1_1 *p) {
     return INITERRF("which should be one of 'l' or 'r', got %s", p->which->data);
 }
 
-// returns length
-int32_t _str_find_edges(const char *str, int32_t *startidx) {
-    // left
-    int32_t idx0 = 0;
+// Return the trimmed length and set the first non-space byte offset.
+static size_t str_find_edges(const char *str, size_t *startidx) {
+    size_t idx0 = 0;
     while(isspace((unsigned char)*str)) {
         str++;
         idx0++;
     }
 
     if(*str == 0) {
-        // Only whitespace
+        *startidx = idx0;
         return 0;
     }
 
-    // right
-    int32_t size = (int32_t) strlen(str) - 1;
-    const char *end = str + size;
-    while(size && isspace(*end)) {
-        end--;
+    size_t size = strlen(str);
+    while(size > 0 && isspace((unsigned char)str[size - 1])) {
         size--;
     }
     *startidx = idx0;
-    return size+1;
+    return size;
 }
 
 
 static int32_t
 strstrip(CSOUND *csound, STR1_1 *p) {
-    int32_t startidx;
-    int32_t size = _str_find_edges(p->in->data, &startidx);
-    if(size > 0) {
-        _string_ensure(csound, p->out, size);
-        memcpy(p->out->data, p->in->data + startidx, size);
-    } else {
-        _string_ensure(csound, p->out, 1);
-        p->out->data[0] = 0;
-    }
-    return OK;
+    size_t startidx;
+    size_t size = str_find_edges(p->in->data, &startidx);
+    return string_copy(csound, p->out, p->in->data + startidx, size);
 }
 
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -553,6 +553,10 @@ def runTest():
         ["test_instr0_labels.csd", "test labels in instr0 space"],
         ["test_string.csd", "test string assignment and printing"],
         [
+            "test_strstrip_reallocation.csd",
+            "test strstrip reallocation and termination",
+        ],
+        [
             "test_string_preprocessor_whitespace.csd",
             "preserve function-like whitespace inside strings",
         ],

--- a/tests/commandline/test_strstrip_reallocation.csd
+++ b/tests/commandline/test_strstrip_reallocation.csd
@@ -1,0 +1,51 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+
+instr 1
+  Scontent = "hello world with lots of leading and trailing spaces to force a realloc"
+  Sin sprintf "        %s        ", Scontent
+
+  Sboth strstrip Sin
+  Sleft strstrip Sin, "l"
+  Sright strstrip Sin, "r"
+
+  SleftExpected strcat Scontent, "        "
+  SrightExpected strcat "        ", Scontent
+
+  if (strcmp(Sboth, Scontent) != 0) then
+    prints "strstrip failed: expected '[%s]', got '[%s]'\n", Scontent, Sboth
+    exitnow(1)
+  endif
+  if (strcmp(Sleft, SleftExpected) != 0) then
+    prints "strstrip left failed: expected '[%s]', got '[%s]'\n", \
+      SleftExpected, Sleft
+    exitnow(1)
+  endif
+  if (strcmp(Sright, SrightExpected) != 0) then
+    prints "strstrip right failed: expected '[%s]', got '[%s]'\n", \
+      SrightExpected, Sright
+    exitnow(1)
+  endif
+
+  SemptyBoth strstrip "        "
+  SemptyLeft strstrip "        ", "l"
+  SemptyRight strstrip "        ", "r"
+  if (
+    strcmp(SemptyBoth, "") != 0 ||
+    strcmp(SemptyLeft, "") != 0 ||
+    strcmp(SemptyRight, "") != 0
+  ) then
+    prints "strstrip whitespace-only input did not return empty strings\n"
+    exitnow(1)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_strstrip_reallocation.csd
+++ b/tests/commandline/test_strstrip_reallocation.csd
@@ -5,7 +5,10 @@
 <CsInstruments>
 
 instr 1
-  Scontent = "hello world with lots of leading and trailing spaces to force a realloc"
+  Sunit = "hello world with lots of leading and trailing spaces to force a realloc"
+  Scontent2 strcat Sunit, Sunit
+  Scontent4 strcat Scontent2, Scontent2
+  Scontent strcat Scontent4, Scontent4
   Sin sprintf "        %s        ", Scontent
 
   Sboth strstrip Sin


### PR DESCRIPTION
Closes #2686.

## What changed

`strstrip` now keeps the pointer returned by `ReAlloc`, reports allocation
failure, reserves space for the null byte, and terminates every result.

The left, right, and two-sided forms now use one copy helper. The helper also
handles overlapping buffers, empty strings, and whitespace-only strings.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  Sin = "        hello world with lots of leading and trailing spaces to force a realloc        "
  Sout strstrip Sin
  prints "[%s]\n", Sout
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
e
</CsScore>
</CsoundSynthesizer>
```

## Before

The resize could move the buffer while `strstrip` kept the freed address. The
copy also omitted the final null byte.

```text
[hello world with lots of leading and trailing spaces to force a realloc<garbage bytes>]
csound command: Segmentation fault
```

## After

```text
[hello world with lots of leading and trailing spaces to force a realloc]
```
