### PR TITLE
fix: keep audio channel-array I/O inside its buffers under local ksmps

### DIFF
--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1062,7 +1062,8 @@ static int32_t chnget_opcode_perf_a(CSOUND* csound, CHNGET* p)
   if (CS_KSMPS ==(uint32_t) csound->ksmps){
     csoundSpinLock(p->lock);
     if (UNLIKELY(offset)) memset(p->arg, '\0', sizeof(MYFLT)*offset);
-    memcpy(&p->arg[offset], p->fp, sizeof(MYFLT)*(CS_KSMPS-offset-early));
+    memcpy(&p->arg[offset], &p->fp[offset],
+           sizeof(MYFLT)*(CS_KSMPS-offset-early));
     if (UNLIKELY(early))
       memset(&p->arg[CS_KSMPS-early], '\0', sizeof(MYFLT)*early);
     csoundSpinUnLock(p->lock);
@@ -1881,7 +1882,7 @@ int32_t chnget_array_opcode_perf_a(CSOUND *csound, CHNGETARRAY *p)
       if (UNLIKELY(offset))
         memset(outPtr, '\0', sizeof(MYFLT) * offset);
       memcpy(&outPtr[offset],
-             p->channelPtrs[index],
+             &p->channelPtrs[index][offset],
              sizeof(MYFLT) * (CS_KSMPS - offset - early));
       if (UNLIKELY(early))
         memset(&outPtr[CS_KSMPS - early],

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1061,7 +1061,7 @@ static int32_t chnget_opcode_perf_a(CSOUND* csound, CHNGET* p)
 
   if (CS_KSMPS ==(uint32_t) csound->ksmps){
     csoundSpinLock(p->lock);
-    if (UNLIKELY(offset)) memset(p->arg, '\0', offset);
+    if (UNLIKELY(offset)) memset(p->arg, '\0', sizeof(MYFLT)*offset);
     memcpy(&p->arg[offset], p->fp, sizeof(MYFLT)*(CS_KSMPS-offset-early));
     if (UNLIKELY(early))
       memset(&p->arg[CS_KSMPS-early], '\0', sizeof(MYFLT)*early);
@@ -1069,7 +1069,7 @@ static int32_t chnget_opcode_perf_a(CSOUND* csound, CHNGET* p)
   }
   else {
     csoundSpinLock(p->lock);
-    if (UNLIKELY(offset)) memset(p->arg, '\0', offset);
+    if (UNLIKELY(offset)) memset(p->arg, '\0', sizeof(MYFLT)*offset);
     memcpy(&p->arg[offset], &(p->fp[offset+p->pos]),
            sizeof(MYFLT)*(CS_KSMPS-offset-early));
     if (UNLIKELY(early))
@@ -1315,7 +1315,7 @@ static int32_t chnset_opcode_perf_a(CSOUND *csound, CHNGET *p)
     memcpy(&p->fp[offset], &p->arg[offset],
            sizeof(MYFLT)*(CS_KSMPS-offset-early));
     if (UNLIKELY(early))
-      memset(&p->fp[early], '\0', sizeof(MYFLT)*(CS_KSMPS-early));
+      memset(&p->fp[CS_KSMPS-early], '\0', sizeof(MYFLT)*early);
     csoundSpinUnLock(p->lock);
   } else {
     /* Need lock for the channel */
@@ -1324,7 +1324,7 @@ static int32_t chnset_opcode_perf_a(CSOUND *csound, CHNGET *p)
     memcpy(&p->fp[offset+p->pos], &p->arg[offset],
            sizeof(MYFLT)*(CS_KSMPS-offset-early));
     if (UNLIKELY(early))
-      memset(&p->fp[early], '\0', sizeof(MYFLT)*(CS_KSMPS-early));
+      memset(&p->fp[p->pos+CS_KSMPS-early], '\0', sizeof(MYFLT)*early);
     p->pos += CS_KSMPS;
     p->pos %= (csound->ksmps-offset);
     csoundSpinUnLock(p->lock);
@@ -1825,6 +1825,7 @@ int32_t chnget_array_opcode_init(CSOUND* csound, CHNGETARRAY* p)
   else
     p->h.perf = (SUBR) chnget_array_opcode_perf_S;
 
+  p->pos = 0;
   return OK;
 }
 
@@ -1871,35 +1872,38 @@ int32_t chnget_array_opcode_perf_a(CSOUND *csound, CHNGETARRAY *p)
   uint32_t early  = p->h.insdshead->ksmps_no_end;
 
   int32_t index = 0;
-  int32_t blockIndex = 0;
-  MYFLT* outPtr;
   for (index = 0; index<p->arraySize; index++) {
-    blockIndex = csound->ksmps*index;
+    size_t blockIndex = (size_t) CS_KSMPS * (size_t) index;
+    MYFLT *outPtr = &p->arrayDat->data[blockIndex];
 
     if (CS_KSMPS == (uint32_t) csound->ksmps) {
       csoundSpinLock(p->lock);
       if (UNLIKELY(offset))
-        memset(&p->arrayDat->data[blockIndex], '\0', offset);
-      memcpy(&p->arrayDat->data[blockIndex+offset],
+        memset(outPtr, '\0', sizeof(MYFLT) * offset);
+      memcpy(&outPtr[offset],
              p->channelPtrs[index],
              sizeof(MYFLT) * (CS_KSMPS - offset - early));
       if (UNLIKELY(early))
-        memset(&p->arrayDat->data[blockIndex+CS_KSMPS - early],
+        memset(&outPtr[CS_KSMPS - early],
                '\0', sizeof(MYFLT) * early);
       csoundSpinUnLock(p->lock);
     } else {
       csoundSpinLock(p->lock);
-      if (UNLIKELY(offset)) memset(&outPtr, '\0', offset);
-      memcpy(&p->arrayDat->data[blockIndex+offset],
+      if (UNLIKELY(offset))
+        memset(outPtr, '\0', sizeof(MYFLT) * offset);
+      memcpy(&outPtr[offset],
              &(p->channelPtrs[index][offset + p->pos]),
              sizeof(MYFLT) * (CS_KSMPS - offset - early));
       if (UNLIKELY(early))
-        memset(&p->arrayDat->data[blockIndex+CS_KSMPS - early],
+        memset(&outPtr[CS_KSMPS - early],
                '\0', sizeof(MYFLT) * early);
-      p->pos += CS_KSMPS;
-      p->pos %= (csound->ksmps - offset);
       csoundSpinUnLock(p->lock);
     }
+  }
+
+  if (CS_KSMPS != (uint32_t) csound->ksmps) {
+    p->pos += CS_KSMPS;
+    p->pos %= (csound->ksmps - offset);
   }
 
   return OK;
@@ -2039,6 +2043,7 @@ int32_t chnset_array_opcode_init(CSOUND* csound, CHNGETARRAY* p)
   else
     p->h.perf = (SUBR) chnset_array_opcode_perf_S;
 
+  p->pos = 0;
   return OK;
 }
 
@@ -2099,20 +2104,24 @@ int32_t chnset_array_opcode_perf_a(CSOUND *csound, CHNGETARRAY *p)
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   ARRAYDAT* valueArr = (ARRAYDAT*) p->arrayDat;
   int32_t index = 0;
-  int32_t blockIndex = 0;
 
   for (index = 0; index<p->arraySize; index++) {
+    /* the source array's members are CS_KSMPS samples long, so stride
+       by the instrument's ksmps in both branches; the old code left
+       blockIndex stale in the local-ksmps branch */
+    size_t blockIndex = (size_t) CS_KSMPS * (size_t) index;
+    MYFLT *inPtr = &valueArr->data[blockIndex];
+
     if(CS_KSMPS == (uint32_t) csound->ksmps){
-      blockIndex = csound->ksmps*index;
       /* Need lock for the channel */
       csoundSpinLock(p->lock);
       if (UNLIKELY(offset)) memset(p->channelPtrs[index],
                                    '\0', sizeof(MYFLT)*offset);
-      memcpy(&p->channelPtrs[index][offset], &valueArr->data[blockIndex+offset],
+      memcpy(&p->channelPtrs[index][offset], &inPtr[offset],
              sizeof(MYFLT)*(CS_KSMPS-offset-early));
       if (UNLIKELY(early))
-        memset(&p->channelPtrs[index][early],
-               '\0', sizeof(MYFLT)*(CS_KSMPS-early));
+        memset(&p->channelPtrs[index][CS_KSMPS-early],
+               '\0', sizeof(MYFLT)*early);
       csoundSpinUnLock(p->lock);
     } else {
       /* Need lock for the channel */
@@ -2120,15 +2129,20 @@ int32_t chnset_array_opcode_perf_a(CSOUND *csound, CHNGETARRAY *p)
       if (UNLIKELY(offset)) memset(p->channelPtrs[index],
                                    '\0', sizeof(MYFLT)*offset);
       memcpy(&p->channelPtrs[index][offset+p->pos],
-             &valueArr->data[blockIndex+offset],
+             &inPtr[offset],
              sizeof(MYFLT)*(CS_KSMPS-offset-early));
       if (UNLIKELY(early))
-        memset(&p->channelPtrs[index][early],
-               '\0', sizeof(MYFLT)*(CS_KSMPS-early));
-      p->pos += CS_KSMPS;
-      p->pos %= (csound->ksmps-offset);
+        memset(&p->channelPtrs[index][p->pos+CS_KSMPS-early],
+               '\0', sizeof(MYFLT)*early);
       csoundSpinUnLock(p->lock);
     }
+  }
+
+  /* the position walks the channel's global-ksmps block once per
+     cycle, not once per array member */
+  if (CS_KSMPS != (uint32_t) csound->ksmps) {
+    p->pos += CS_KSMPS;
+    p->pos %= (csound->ksmps-offset);
   }
 
   return OK;

--- a/tests/commandline/arrays/test_chngeta_local_ksmps.csd
+++ b/tests/commandline/arrays/test_chngeta_local_ksmps.csd
@@ -1,0 +1,80 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 32
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  SNames[] fillarray "left", "right"
+  aBase phasor 1
+  aValues[] init 2
+  aValues[0] = aBase
+  aValues[1] = aBase + 100
+  chnseta aValues, SNames
+endin
+
+instr 2
+  setksmps 4
+  SNames[] fillarray "left", "right"
+  aValues[] chngeta SNames
+  kDifference = k(aValues[1]) - k(aValues[0])
+  if kDifference != 100 then
+    printks "aligned read mismatch: %.6f\n", 0, kDifference
+    exitnowk(-1)
+  endif
+endin
+
+instr 3
+  setksmps 4
+  SNames[] fillarray "left", "right"
+  aValues[] chngeta SNames
+  kFirst init 1
+  kOffset offsetsmps
+  if kFirst == 1 then
+    if kOffset == 0 || k(aValues[1]) - k(aValues[0]) != 100 then
+      printks "offset read mismatch: offset=%d, difference=%.6f\n", 0, \
+              kOffset, k(aValues[1]) - k(aValues[0])
+      exitnowk(-1)
+    endif
+    kFirst = 0
+  elseif k(aValues[1]) - k(aValues[0]) != 100 then
+    printks "offset read channels are out of step: %.6f\n", 0, \
+            k(aValues[1]) - k(aValues[0])
+    exitnowk(-1)
+  endif
+endin
+
+instr 4  ; writer with a local ksmps
+  setksmps 4
+  SNames[] fillarray "wleft", "wright"
+  aBase phasor 1
+  aValues[] init 2
+  aValues[0] = aBase
+  aValues[1] = aBase + 100
+  chnseta aValues, SNames
+endin
+
+instr 5  ; reader at the global ksmps
+  SNames[] fillarray "wleft", "wright"
+  aValues[] chngeta SNames
+  kStarted init 0
+  if kStarted == 1 && k(aValues[1]) - k(aValues[0]) != 100 then
+    printks "local-ksmps write mismatch: %.6f\n", 0, \
+            k(aValues[1]) - k(aValues[0])
+    exitnowk(-1)
+  endif
+  kStarted = 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.5
+i 2 0 0.5
+i 3 0.03125 0.25
+i 4 0 0.5
+i 5 0 0.5
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/arrays/test_chngeta_local_ksmps.csd
+++ b/tests/commandline/arrays/test_chngeta_local_ksmps.csd
@@ -69,6 +69,23 @@ instr 5  ; reader at the global ksmps
   endif
   kStarted = 1
 endin
+
+instr 6  ; sample-accurate readers at the global ksmps
+  SNames[] fillarray "left", "right"
+  aValues[] chngeta SNames
+  aValue chnget "left"
+  kFirst init 1
+  if kFirst == 1 then
+    kOffset offsetsmps
+    kExpected = kOffset / sr
+    if kOffset == 0 || k(aValues[0]) != kExpected || k(aValue) != kExpected then
+      printks "global-ksmps offset read mismatch: offset=%d, array=%.6f, scalar=%.6f, expected=%.6f\n", 0, \
+              kOffset, k(aValues[0]), k(aValue), kExpected
+      exitnowk(-1)
+    endif
+    kFirst = 0
+  endif
+endin
 </CsInstruments>
 <CsScore>
 i 1 0 0.5
@@ -76,5 +93,6 @@ i 2 0 0.5
 i 3 0.03125 0.25
 i 4 0 0.5
 i 5 0 0.5
+i 6 0.03125 0.25
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -844,6 +844,10 @@ def runTest():
             "reject byte-wise clearing of managed array channels",
             1,
         ],
+        [
+            "arrays/test_chngeta_local_ksmps.csd",
+            "read audio channel arrays with a local ksmps",
+        ],
         ["complex_array_test.csd", "testing complex array ops"],
         ["test_array_channels.csd", "testing bus channels holding arrays"],
         ["fft_array_test.csd", "testing complex fft array ops"],


### PR DESCRIPTION
`chnget_array_opcode_perf_a()` strode its output array by the global ksmps while the array's members, the copy length, and the destination offset all used the instrument's local ksmps, so any read from an instrument with a smaller ksmps wrote past the array. Its sample-accurate offset clear zeroed the address of a dead local pointer instead of the array, and the shared read position advanced once per array member instead of once per cycle, so the members of a multi-channel array were read out of step with each other. The stride now uses the instrument's ksmps to match the allocation, the offset clear writes to the array, and the position advances once per cycle after all members are copied.

The writer, `chnset_array_opcode_perf_a()`, had the mirror-image defects plus one of its own: in the local-ksmps branch `blockIndex` was never assigned, so every channel was written from the array's first member. It now strides the source by the instrument's ksmps, advances its position once per cycle, and its end-of-note clear zeroes the last `early` samples instead of everything from index `early` onward ‚Äî the same inverted clear sat in the scalar `chnset`, fixed alike. The scalar `chnget` cleared its offset prefix in bytes rather than samples; it now clears whole samples.

The regression test writes and reads two-channel audio arrays across every ksmps pairing: a global-ksmps writer read from a local-ksmps instrument, with and without a sample-accurate offset, and a local-ksmps writer read at the global ksmps. Each case checks the two channels stay exactly 100 apart, so a stride, position, or clear defect shows up as a value mismatch when it does not crash outright.

## Before

```sh
csound tests/soak/channelArrayOpcodes.csd
```

```text
==ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8 at 0x... thread T0
    #1 chnget_array_opcode_perf_a bus.c:1893
    #2 kperf csound_perf.c:365
SUMMARY: AddressSanitizer: heap-buffer-overflow bus.c:1893 in chnget_array_opcode_perf_a
```

The new regression test dies with the same report.

## After

Both the soak test and the regression test run clean under AddressSanitizer, and every channel pairing keeps its expected values.

Closes #2689