### PR TITLE
Fix GEN41/GEN42 table bounds and discrete random setup

### DIFF
--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -1995,61 +1995,76 @@ static int32_t gen40(FGDATA *ff, FUNC *ftp)               /*gab d5*/
 static int32_t gen41(FGDATA *ff, FUNC *ftp)   /*gab d5*/
 {
     MYFLT   *fp = ftp->ftable, *pp = &ff->e.p[5];
-    int32_t     i, j, k, width;
-    MYFLT    tot_prob = FL(0.0);
-    int32_t     nargs = ff->e.pcnt - 4;
+    int32_t i, j, limit;
+    MYFLT   cumulative = FL(0.0), tot_prob = FL(0.0);
+    int32_t nargs = ff->e.pcnt - 4;
 
-    //printf("*** nargs = %d, len = %d, number = %d\n", nargs, ftp->flen, ftp->fno);
-    for (j=0; j < nargs; j+=2) {
-      if (UNLIKELY(pp[j+1]<0))
-        return csoundFtError(ff, Str("Gen41: negative probability not allowed"));
-      tot_prob += pp[j+1];
+    if (UNLIKELY(nargs < 2 || (nargs & 1)))
+      return csoundFtError(ff,
+                           Str("Gen41: Must have even number of arguments"));
+    for (j = 0; j < nargs; j += 2) {
+      if (UNLIKELY(pp[j + 1] < FL(0.0)))
+        return csoundFtError(ff,
+                             Str("Gen41: negative probability not allowed"));
+      tot_prob += pp[j + 1];
     }
-    //printf("total prob = %g\n", tot_prob);
-    if (nargs&1)
-      return csoundFtError(ff, Str("Gen41: Must have even numer of arguments"));
-    for (i=0, j=0; j< nargs; j+=2) {
-      width = (int32_t) ((pp[j+1]/tot_prob) * ff->flen +.5);
-      for ( k=0; k < width; k++,i++) {
-        if (i<ff->flen) {
-          //printf("*** i=%d, j=%d, pp]j] = %f\n", i, j, pp[j]);
-          fp[i] = pp[j];
-        } //else printf("%d out of range\n", i);
-      }
+    if (UNLIKELY(tot_prob <= FL(0.0)))
+      return csoundFtError(ff,
+                           Str("Gen41: probability total must be positive"));
+
+    for (i = 0, j = 0; j < nargs; j += 2) {
+      cumulative += pp[j + 1];
+      limit = (j + 2 == nargs
+                 ? ff->flen
+                 : (int32_t) ((cumulative / tot_prob) * ff->flen + FL(0.5)));
+      if (limit > ff->flen)
+        limit = ff->flen;
+      while (i < limit)
+        fp[i++] = pp[j];
     }
-    //printf("GEN41: i=%d le=%d\n", i, ff->flen);
-    if (UNLIKELY(i<=ff->flen))
-      fp[i] = pp[j-1]; /* conditional is attempt to stop error */
+    fp[ff->flen] = fp[ff->flen - 1];
 
     return OK;
 }
 
 static int32_t gen42(FGDATA *ff, FUNC *ftp) /*gab d5*/
 {
-    MYFLT   *fp = ftp->ftable, inc;
-    int32_t     j, k, width;
-    MYFLT    tot_prob = FL(0.0);
-    int32_t     nargs = ff->e.pcnt - 4;
-    MYFLT   *valp = &ff->e.p[5];
+    MYFLT   *fp = ftp->ftable, *pp = &ff->e.p[5];
+    MYFLT   cumulative = FL(0.0), tot_prob = FL(0.0);
+    int32_t i, j, k, limit, width;
+    int32_t nargs = ff->e.pcnt - 4;
 
-    for (j=0; j < nargs; j+=3) {
-      valp++;
-      valp++;
-      tot_prob += *valp++;
+    if (UNLIKELY(nargs < 3 || nargs % 3 != 0))
+      return csoundFtError(ff,
+                           Str("Gen42: Must have a multiple of three arguments"));
+    for (j = 0; j < nargs; j += 3) {
+      if (UNLIKELY(pp[j + 2] < FL(0.0)))
+        return csoundFtError(ff,
+                             Str("Gen42: negative probability not allowed"));
+      tot_prob += pp[j + 2];
     }
-    valp = &ff->e.p[5];
-    for (j=0; j< nargs; j+=3) {
-      MYFLT p1, p2, p3;
-      p1 = *valp++;
-      p2 = *valp++;
-      p3 = *valp++;
-      width = (int32_t) ((p3/tot_prob) * ff->flen +FL(0.5));
-      inc = (p2-p1) / (MYFLT) (width-1);
-      for ( k=0; k < width; k++) {
-        *fp++ = p1+(inc*k);
+    if (UNLIKELY(tot_prob <= FL(0.0)))
+      return csoundFtError(ff,
+                           Str("Gen42: probability total must be positive"));
+
+    for (i = 0, j = 0; j < nargs; j += 3) {
+      cumulative += pp[j + 2];
+      limit = (j + 3 == nargs
+                 ? ff->flen
+                 : (int32_t) ((cumulative / tot_prob) * ff->flen + FL(0.5)));
+      if (limit > ff->flen)
+        limit = ff->flen;
+      width = limit - i;
+      if (width == 1) {
+        fp[i++] = pp[j];
+      }
+      else if (width > 1) {
+        MYFLT inc = (pp[j + 1] - pp[j]) / (MYFLT) (width - 1);
+        for (k = 0; k < width; k++, i++)
+          fp[i] = pp[j] + inc * k;
       }
     }
-    *fp = *(fp-1);
+    fp[ff->flen] = fp[ff->flen - 1];
 
     return OK;
 }

--- a/Engine/fgens.c
+++ b/Engine/fgens.c
@@ -2003,10 +2003,16 @@ static int32_t gen41(FGDATA *ff, FUNC *ftp)   /*gab d5*/
       return csoundFtError(ff,
                            Str("Gen41: Must have even number of arguments"));
     for (j = 0; j < nargs; j += 2) {
+      if (UNLIKELY(!isfinite(pp[j + 1])))
+        return csoundFtError(ff,
+                             Str("Gen41: probability must be finite"));
       if (UNLIKELY(pp[j + 1] < FL(0.0)))
         return csoundFtError(ff,
                              Str("Gen41: negative probability not allowed"));
       tot_prob += pp[j + 1];
+      if (UNLIKELY(!isfinite(tot_prob)))
+        return csoundFtError(ff,
+                             Str("Gen41: probability total must be finite"));
     }
     if (UNLIKELY(tot_prob <= FL(0.0)))
       return csoundFtError(ff,
@@ -2038,10 +2044,16 @@ static int32_t gen42(FGDATA *ff, FUNC *ftp) /*gab d5*/
       return csoundFtError(ff,
                            Str("Gen42: Must have a multiple of three arguments"));
     for (j = 0; j < nargs; j += 3) {
+      if (UNLIKELY(!isfinite(pp[j + 2])))
+        return csoundFtError(ff,
+                             Str("Gen42: probability must be finite"));
       if (UNLIKELY(pp[j + 2] < FL(0.0)))
         return csoundFtError(ff,
                              Str("Gen42: negative probability not allowed"));
       tot_prob += pp[j + 2];
+      if (UNLIKELY(!isfinite(tot_prob)))
+        return csoundFtError(ff,
+                             Str("Gen42: probability total must be finite"));
     }
     if (UNLIKELY(tot_prob <= FL(0.0)))
       return csoundFtError(ff,

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -1210,6 +1210,13 @@ static int32_t Cuserrnd_set(CSOUND *csound, CURAND *p)
     return OK;
 }
 
+static int32_t Duserrnd_set(CSOUND *csound, DURAND *p)
+{
+    IGN(csound);
+    p->pfn = 0;
+    return OK;
+}
+
 static int32_t aContinuousUserRand(CSOUND *csound, CURAND *p)
 { /* gab d5*/
     MYFLT min = *p->min, rge = *p->max;
@@ -1567,14 +1574,15 @@ static OENTRY localops[] = {
 { "randomh.k",  S(RANDOMH), 0, "k", "kkkoo",
                                  (SUBR)randomh_set,(SUBR)krandomh,NULL},
 { "urd.i",  S(DURAND),  0, "i", "i", (SUBR)iDiscreteUserRand, NULL, NULL    },
-{ "urd.k",  S(DURAND),  0, "k", "k", (SUBR)Cuserrnd_set,(SUBR)kDiscreteUserRand },
+{ "urd.k",  S(DURAND),  0, "k", "k",
+                              (SUBR)Duserrnd_set, (SUBR)kDiscreteUserRand },
 { "urd.a",  S(DURAND),  0, "a", "k",
-                              (SUBR)Cuserrnd_set, (SUBR)aDiscreteUserRand },
+                              (SUBR)Duserrnd_set, (SUBR)aDiscreteUserRand },
 { "duserrnd.i", S(DURAND),0, "i", "i",  (SUBR)iDiscreteUserRand, NULL, NULL },
 { "duserrnd.k", S(DURAND),0, "k", "k",
-                                (SUBR)Cuserrnd_set,(SUBR)kDiscreteUserRand,NULL },
+                            (SUBR)Duserrnd_set,(SUBR)kDiscreteUserRand,NULL },
 { "duserrnd.a", S(DURAND),0, "a", "k",
-                                (SUBR)Cuserrnd_set,(SUBR)aDiscreteUserRand },
+                                (SUBR)Duserrnd_set,(SUBR)aDiscreteUserRand },
 { "trigger",  S(TRIG),  0, "k", "kkk",  (SUBR)trig_set, (SUBR)trig,   NULL  },
 { "sum",      S(SUM),   0, "a", "y",    (SUBR)sum_init, (SUBR)sum_               },
 { "product",  S(SUM),   0, "a", "y",    NULL, (SUBR)product           },

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -1125,7 +1125,7 @@ static int32_t jittersa(CSOUND *csound, JITTERS *p)
 
 static int32_t kDiscreteUserRand(CSOUND *csound, DURAND *p)
 { /* gab d5*/
-    if (p->pfn != (int32)*p->tableNum) {
+    if (p->ftp == NULL || p->pfn != (int32)*p->tableNum) {
       if (UNLIKELY( (p->ftp = csound->FTFind(csound, p->tableNum) ) == NULL))
         goto err1;
       p->pfn = (int32)*p->tableNum;
@@ -1140,6 +1140,7 @@ static int32_t kDiscreteUserRand(CSOUND *csound, DURAND *p)
 
 static int32_t iDiscreteUserRand(CSOUND *csound, DURAND *p)
 {
+    p->ftp = NULL;
     p->pfn = 0L;
     kDiscreteUserRand(csound,p);
     return OK;
@@ -1152,7 +1153,7 @@ static int32_t aDiscreteUserRand(CSOUND *csound, DURAND *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS, flen;
 
-    if (p->pfn != (int32)*p->tableNum) {
+    if (p->ftp == NULL || p->pfn != (int32)*p->tableNum) {
       if (UNLIKELY( (p->ftp = csound->FTFind(csound, p->tableNum) ) == NULL))
         goto err1;
       p->pfn = (int32)*p->tableNum;
@@ -1213,6 +1214,7 @@ static int32_t Cuserrnd_set(CSOUND *csound, CURAND *p)
 static int32_t Duserrnd_set(CSOUND *csound, DURAND *p)
 {
     IGN(csound);
+    p->ftp = NULL;
     p->pfn = 0;
     return OK;
 }

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -1166,7 +1166,7 @@ static int32_t aDiscreteUserRand(CSOUND *csound, DURAND *p)
       memset(&out[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps; n++) {
-      out[n] = table[(int32)(randGab(csound)) * flen];
+      out[n] = table[(int32)(randGab(csound) * flen)];
     }
     return OK;
  err1:

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -539,6 +539,16 @@ def runTest():
             "test_gen41_gen42_bounds.csd",
             "test bounded GEN41 and GEN42 probability rounding",
         ],
+        [
+            "test_gen41_nonfinite_total.csd",
+            "expected failure: GEN41 probability total overflows",
+            1,
+        ],
+        [
+            "test_gen42_nonfinite_total.csd",
+            "expected failure: GEN42 probability total overflows",
+            1,
+        ],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -535,6 +535,10 @@ def runTest():
         ["test_gen44_matrix_malformed.csd", "reject a malformed GEN44 matrix size", 1],
         ["test_gen44_matrix_missing_close.csd", "reject a GEN44 header without >", 1],
         ["test_gen49_defer.csd", "test GEN49 deferred length"],
+        [
+            "test_gen41_gen42_bounds.csd",
+            "test bounded GEN41 and GEN42 probability rounding",
+        ],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],

--- a/tests/commandline/test_gen41_gen42_bounds.csd
+++ b/tests/commandline/test_gen41_gen42_bounds.csd
@@ -16,6 +16,7 @@ gi42RoundAbove ftgen 3, 0, -8, -42, \
 gi42RoundBelow ftgen 4, 0, -8, -42, \
   10, 10, 1, 20, 21, 1, 30, 30, 1, \
   40, 40, 1, 50, 51, 1, 60, 60, 1
+giAudioChoices ftgen 5, 0, -4, -2, 10, 20, 30, 40
 
 opcode AssertTableValue(ndx:i, fn:i, expected:i):void
   value:i = table:i(ndx, fn)
@@ -72,6 +73,18 @@ instr 1
 
   kDiscrete duserrnd gi41RoundAbove
   kRange urd gi42RoundAbove
+  aDiscrete duserrnd giAudioChoices
+  aRange urd giAudioChoices
+  kDiscreteMax maxk aDiscrete, 1, 2
+  kRangeMax maxk aRange, 1, 2
+  if kDiscreteMax <= 10 then
+    printf "audio-rate duserrnd stayed on table element zero\n", 1
+    exitnowk(-1)
+  endif
+  if kRangeMax <= 10 then
+    printf "audio-rate urd stayed on table element zero\n", 1
+    exitnowk(-1)
+  endif
   printks "random values: %f %f\n", 1, kDiscrete, kRange
 endin
 </CsInstruments>

--- a/tests/commandline/test_gen41_gen42_bounds.csd
+++ b/tests/commandline/test_gen41_gen42_bounds.csd
@@ -20,7 +20,7 @@ gi42RoundBelow ftgen 4, 0, -8, -42, \
 opcode AssertTableValue(ndx:i, fn:i, expected:i):void
   value:i = table:i(ndx, fn)
   if value != expected then
-    prints("table %d index %d: expected %f, got %f\n", \
+    prints("table %d index %d: expected %d, got %f\n", \
            fn, ndx, expected, value)
     exitnow(-1)
   endif
@@ -62,6 +62,13 @@ instr 1
   AssertTableValue(5, gi42RoundBelow, 50)
   AssertTableValue(6, gi42RoundBelow, 51)
   AssertTableValue(7, gi42RoundBelow, 60)
+
+  iBuiltinZero duserrnd 0
+  iBuiltinNegative duserrnd -1
+  kBuiltinZeroTable init 0
+  kBuiltinNegativeTable init -1
+  kBuiltinZero duserrnd kBuiltinZeroTable
+  aBuiltinNegative duserrnd kBuiltinNegativeTable
 
   kDiscrete duserrnd gi41RoundAbove
   kRange urd gi42RoundAbove

--- a/tests/commandline/test_gen41_gen42_bounds.csd
+++ b/tests/commandline/test_gen41_gen42_bounds.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+gi41RoundAbove ftgen 1, 0, -8, -41, 10, 1, 20, 1, 30, 1
+gi41RoundBelow ftgen 2, 0, -8, -41, \
+  10, 1, 20, 1, 30, 1, 40, 1, 50, 1, 60, 1
+gi42RoundAbove ftgen 3, 0, -8, -42, \
+  10, 12, 1, 20, 21, 1, 30, 32, 1
+gi42RoundBelow ftgen 4, 0, -8, -42, \
+  10, 10, 1, 20, 21, 1, 30, 30, 1, \
+  40, 40, 1, 50, 51, 1, 60, 60, 1
+
+opcode AssertTableValue(ndx:i, fn:i, expected:i):void
+  value:i = table:i(ndx, fn)
+  if value != expected then
+    prints("table %d index %d: expected %f, got %f\n", \
+           fn, ndx, expected, value)
+    exitnow(-1)
+  endif
+endop
+
+instr 1
+  AssertTableValue(0, gi41RoundAbove, 10)
+  AssertTableValue(1, gi41RoundAbove, 10)
+  AssertTableValue(2, gi41RoundAbove, 10)
+  AssertTableValue(3, gi41RoundAbove, 20)
+  AssertTableValue(4, gi41RoundAbove, 20)
+  AssertTableValue(5, gi41RoundAbove, 30)
+  AssertTableValue(6, gi41RoundAbove, 30)
+  AssertTableValue(7, gi41RoundAbove, 30)
+
+  AssertTableValue(0, gi41RoundBelow, 10)
+  AssertTableValue(1, gi41RoundBelow, 20)
+  AssertTableValue(2, gi41RoundBelow, 20)
+  AssertTableValue(3, gi41RoundBelow, 30)
+  AssertTableValue(4, gi41RoundBelow, 40)
+  AssertTableValue(5, gi41RoundBelow, 50)
+  AssertTableValue(6, gi41RoundBelow, 50)
+  AssertTableValue(7, gi41RoundBelow, 60)
+
+  AssertTableValue(0, gi42RoundAbove, 10)
+  AssertTableValue(1, gi42RoundAbove, 11)
+  AssertTableValue(2, gi42RoundAbove, 12)
+  AssertTableValue(3, gi42RoundAbove, 20)
+  AssertTableValue(4, gi42RoundAbove, 21)
+  AssertTableValue(5, gi42RoundAbove, 30)
+  AssertTableValue(6, gi42RoundAbove, 31)
+  AssertTableValue(7, gi42RoundAbove, 32)
+
+  AssertTableValue(0, gi42RoundBelow, 10)
+  AssertTableValue(1, gi42RoundBelow, 20)
+  AssertTableValue(2, gi42RoundBelow, 21)
+  AssertTableValue(3, gi42RoundBelow, 30)
+  AssertTableValue(4, gi42RoundBelow, 40)
+  AssertTableValue(5, gi42RoundBelow, 50)
+  AssertTableValue(6, gi42RoundBelow, 51)
+  AssertTableValue(7, gi42RoundBelow, 60)
+
+  kDiscrete duserrnd gi41RoundAbove
+  kRange urd gi42RoundAbove
+  printks "random values: %f %f\n", 1, kDiscrete, kRange
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+i 1 0.02 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_gen41_nonfinite_total.csd
+++ b/tests/commandline/test_gen41_nonfinite_total.csd
@@ -1,0 +1,17 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giInvalid ftgen 1, 0, -8, -41, \
+  10, 1e308, 20, 1e308, 30, 1e308
+</CsInstruments>
+<CsScore>
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_gen42_nonfinite_total.csd
+++ b/tests/commandline/test_gen42_nonfinite_total.csd
@@ -1,0 +1,17 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giInvalid ftgen 1, 0, -8, -42, \
+  10, 12, 1e308, 20, 22, 1e308, 30, 32, 1e308
+</CsInstruments>
+<CsScore>
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
## Summary

- fill GEN41 and GEN42 tables from rounded cumulative probability limits
- reject malformed probability data before writing a table
- give `urd` and `duserrnd` a setup function for their actual opcode data type
- add cases where separate probability widths would round both above and below the table length

Closes #2690.

## Root cause

GEN42 rounded each probability run on its own and wrote every rounded run. The
run widths could add up to more than the table length, so GEN42 wrote past the
guard point. GEN41 bounded each run but could leave cells unset when the widths
added up to less than the table length.

`urd` and `duserrnd` also used `Cuserrnd_set`, which takes a larger `CURAND`
object. The opcodes allocate a `DURAND` object, so the setup function wrote
`pfn` at the wrong offset and damaged the following init data.

The new fill code rounds cumulative limits, makes the last limit equal to the
table length, and writes the guard point once.

## Before and after

This CSD covers an eight-cell GEN42 table whose three equal runs used to round
to nine cells. It also initializes both discrete random opcodes.

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 44100
ksmps = 32
nchnls = 1
0dbfs = 1

giDiscrete ftgen 1, 0, -8, -41, 10, 1, 20, 1, 30, 1
giRanges ftgen 2, 0, -8, -42, \
  10, 12, 1, 20, 22, 1, 30, 32, 1

instr 1
  kDiscrete duserrnd giDiscrete
  kRange urd giRanges
  printks "values: %f %f\n", 1, kDiscrete, kRange
endin
</CsInstruments>
<CsScore>
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

Before this change, the AddressSanitizer build stops in GEN42:

```text
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8
    #0 gen42
    #1 csoundFTCreate
    #2 ftgen_
SUMMARY: AddressSanitizer: heap-buffer-overflow in gen42
ABORTING
```

After this change, the same AddressSanitizer build completes:

```text
SECTION 1:
values: 30.000000 12.000000
end of Performance
overall samples out of range: 0
```
