### PR TITLE
Fix signal-flow graph lifetime crashes

### DIFF
--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -339,8 +339,8 @@ struct Outleta : public OpcodeNoteoffBase<Outleta> {
         std::find(aoutlets.begin(), aoutlets.end(), this);
     if (thisoutlet != aoutlets.end()) {
       aoutlets.erase(thisoutlet);
-      warn(csound, Str("Removed instance 0x%x of %d instances of outleta %s\n"),
-           this, aoutlets.size(), sourceOutletId);
+      warn(csound, Str("Removed instance %p of %zu instances of outleta %s\n"),
+           (void *)this, aoutlets.size(), sourceOutletId);
     }
     return OK;
   }
@@ -485,8 +485,8 @@ struct Outletk : public OpcodeNoteoffBase<Outletk> {
         std::find(koutlets.begin(), koutlets.end(), this);
     if (thisoutlet != koutlets.end()) {
       koutlets.erase(thisoutlet);
-      warn(csound, Str("Removed 0x%x of %d instances of outletk %s\n"), this,
-           koutlets.size(), sourceOutletId);
+      warn(csound, Str("Removed %p of %zu instances of outletk %s\n"),
+           (void *)this, koutlets.size(), sourceOutletId);
     }
     return OK;
   }
@@ -618,8 +618,8 @@ struct Outletf : public OpcodeNoteoffBase<Outletf> {
         std::find(foutlets.begin(), foutlets.end(), this);
     if (thisoutlet != foutlets.end()) {
       foutlets.erase(thisoutlet);
-      warn(csound, Str("Removed 0x%x of %d instances of outletf %s\n"), this,
-           foutlets.size(), sourceOutletId);
+      warn(csound, Str("Removed %p of %zu instances of outletf %s\n"),
+           (void *)this, foutlets.size(), sourceOutletId);
     }
     return OK;
   }
@@ -824,8 +824,8 @@ struct Outletv : public OpcodeNoteoffBase<Outletv> {
         std::find(voutlets.begin(), voutlets.end(), this);
     if (thisoutlet != voutlets.end()) {
       voutlets.erase(thisoutlet);
-      warn(csound, Str("Removed 0x%x of %d instances of outletv %s\n"), this,
-           voutlets.size(), sourceOutletId);
+      warn(csound, Str("Removed %p of %zu instances of outletv %s\n"),
+           (void *)this, voutlets.size(), sourceOutletId);
     }
     return OK;
   }
@@ -994,8 +994,8 @@ struct Outletkid : public OpcodeNoteoffBase<Outletkid> {
         std::find(koutlets.begin(), koutlets.end(), this);
     if (thisoutlet != koutlets.end()) {
       koutlets.erase(thisoutlet);
-      warn(csound, Str("Removed 0x%x of %d instances of outletkid %s\n"), this,
-           koutlets.size(), sourceOutletId);
+      warn(csound, Str("Removed %p of %zu instances of outletkid %s\n"),
+           (void *)this, koutlets.size(), sourceOutletId);
     }
     return OK;
   }
@@ -1376,7 +1376,7 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
     }
     if (UNLIKELY(named == 0)) {
       return csound->InitError(csound, Str("Named gen \"%s\" not defined"),
-                               (char *)p->p4);
+                               ((STRINGDAT *)p->p4)->data);
     } else {
       ftevt->p[4] = named->genum;
     }

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -181,7 +181,29 @@ unsigned long djb2_hash(unsigned char *str) {
  */
 struct EventBlock {
   EVTBLK evtblk;
+  std::vector<MYFLT> pfields;
   unsigned long strarg_djb2_hash;
+
+  explicit EventBlock(size_t pfieldCount)
+      : evtblk{}, pfields(pfieldCount, FL(0.0)), strarg_djb2_hash(0) {
+    evtblk.p = pfields.data();
+  }
+
+  EventBlock(const EventBlock &other)
+      : evtblk(other.evtblk), pfields(other.pfields),
+        strarg_djb2_hash(other.strarg_djb2_hash) {
+    evtblk.p = pfields.data();
+  }
+
+  EventBlock &operator=(const EventBlock &other) {
+    if (this != &other) {
+      evtblk = other.evtblk;
+      pfields = other.pfields;
+      strarg_djb2_hash = other.strarg_djb2_hash;
+      evtblk.p = pfields.data();
+    }
+    return *this;
+  }
 };
 
 
@@ -315,9 +337,11 @@ struct Outleta : public OpcodeNoteoffBase<Outleta> {
         sfg_globals->aoutletsForSourceOutletIds[sourceOutletId];
     std::vector<Outleta *>::iterator thisoutlet =
         std::find(aoutlets.begin(), aoutlets.end(), this);
-    aoutlets.erase(thisoutlet);
-    warn(csound, Str("Removed instance 0x%x of %d instances of outleta %s\n"),
-         this, aoutlets.size(), sourceOutletId);
+    if (thisoutlet != aoutlets.end()) {
+      aoutlets.erase(thisoutlet);
+      warn(csound, Str("Removed instance 0x%x of %d instances of outleta %s\n"),
+           this, aoutlets.size(), sourceOutletId);
+    }
     return OK;
   }
 };
@@ -459,9 +483,11 @@ struct Outletk : public OpcodeNoteoffBase<Outletk> {
         sfg_globals->koutletsForSourceOutletIds[sourceOutletId];
     std::vector<Outletk *>::iterator thisoutlet =
         std::find(koutlets.begin(), koutlets.end(), this);
-    koutlets.erase(thisoutlet);
-    warn(csound, Str("Removed 0x%x of %d instances of outletk %s\n"), this,
-         koutlets.size(), sourceOutletId);
+    if (thisoutlet != koutlets.end()) {
+      koutlets.erase(thisoutlet);
+      warn(csound, Str("Removed 0x%x of %d instances of outletk %s\n"), this,
+           koutlets.size(), sourceOutletId);
+    }
     return OK;
   }
 };
@@ -585,13 +611,16 @@ struct Outletf : public OpcodeNoteoffBase<Outletf> {
     return OK;
   }
   int32_t noteoff(CSOUND *csound) {
+    LockGuard guard(csound, sfg_globals->signal_flow_ports_lock);
     std::vector<Outletf *> &foutlets =
         sfg_globals->foutletsForSourceOutletIds[sourceOutletId];
     std::vector<Outletf *>::iterator thisoutlet =
         std::find(foutlets.begin(), foutlets.end(), this);
-    foutlets.erase(thisoutlet);
-    warn(csound, Str("Removed 0x%x of %d instances of outletf %s\n"), this,
-         foutlets.size(), sourceOutletId);
+    if (thisoutlet != foutlets.end()) {
+      foutlets.erase(thisoutlet);
+      warn(csound, Str("Removed 0x%x of %d instances of outletf %s\n"), this,
+           foutlets.size(), sourceOutletId);
+    }
     return OK;
   }
 };
@@ -793,9 +822,11 @@ struct Outletv : public OpcodeNoteoffBase<Outletv> {
         sfg_globals->voutletsForSourceOutletIds[sourceOutletId];
     std::vector<Outletv *>::iterator thisoutlet =
         std::find(voutlets.begin(), voutlets.end(), this);
-    voutlets.erase(thisoutlet);
-    warn(csound, Str("Removed 0x%x of %d instances of outletv %s\n"), this,
-         voutlets.size(), sourceOutletId);
+    if (thisoutlet != voutlets.end()) {
+      voutlets.erase(thisoutlet);
+      warn(csound, Str("Removed 0x%x of %d instances of outletv %s\n"), this,
+           voutlets.size(), sourceOutletId);
+    }
     return OK;
   }
 };
@@ -961,9 +992,11 @@ struct Outletkid : public OpcodeNoteoffBase<Outletkid> {
         sfg_globals->kidoutletsForSourceOutletIds[sourceOutletId];
     std::vector<Outletkid *>::iterator thisoutlet =
         std::find(koutlets.begin(), koutlets.end(), this);
-    koutlets.erase(thisoutlet);
-    warn(csound, Str("Removed 0x%x of %d instances of outletkid %s\n"), this,
-         koutlets.size(), sourceOutletId);
+    if (thisoutlet != koutlets.end()) {
+      koutlets.erase(thisoutlet);
+      warn(csound, Str("Removed 0x%x of %d instances of outletkid %s\n"), this,
+           koutlets.size(), sourceOutletId);
+    }
     return OK;
   }
 };
@@ -1303,14 +1336,27 @@ static void warn(CSOUND *csound, const char *format, ...) {
  */
 static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
                       bool hasStringParameter) {
-  SignalFlowGraphState *sfg_globals;
+  if (UNLIKELY(p == nullptr || p->ifno == nullptr || p->p1 == nullptr ||
+               p->p2 == nullptr || p->p3 == nullptr || p->p4 == nullptr ||
+               p->p5 == nullptr)) {
+    return csound->InitError(csound, "%s", Str("ftgenonce: invalid arguments"));
+  }
+  SignalFlowGraphState *sfg_globals = nullptr;
   QueryGlobalPointer(csound, "sfg_globals", sfg_globals);
+  if (UNLIKELY(sfg_globals == nullptr ||
+               sfg_globals->signal_flow_ftables_lock == nullptr)) {
+    return csound->InitError(csound, "%s",
+                             Str("ftgenonce: not initialized"));
+  }
   LockGuard guard(csound, sfg_globals->signal_flow_ftables_lock);
   int32_t result = OK;
-  EventBlock eventBlock;
+  int32_t inputArgCount = GetInputArgCnt((OPDS *)p);
+  if (UNLIKELY(inputArgCount < 5)) {
+    return csound->InitError(csound, "%s", Str("ftgenonce: invalid arguments"));
+  }
+  EventBlock eventBlock((size_t)inputArgCount + 1);
   EVTBLK *ftevt = &eventBlock.evtblk;
   *p->ifno = FL(0.0);
-  std::memset(ftevt, 0, sizeof(EVTBLK));
   // ifno ftgenonce ipfno, ip2dummy, ip4size, ip5gen, ip6arga, ip7argb,...
   ftevt->opcod = 'f';
   ftevt->strarg = 0;
@@ -1329,9 +1375,6 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
       named = named->next; /*  and round again   */
     }
     if (UNLIKELY(named == 0)) {
-      if (sfg_globals->signal_flow_ftables_lock != 0) {
-        csound->UnlockMutex(sfg_globals->signal_flow_ftables_lock);
-      }
       return csound->InitError(csound, Str("Named gen \"%s\" not defined"),
                                (char *)p->p4);
     } else {
@@ -1354,21 +1397,22 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
       ftevt->strarg = ((STRINGDAT *)p->p5)->data;
       break;
     default:
-      if (sfg_globals->signal_flow_ftables_lock != 0) {
-        csound->UnlockMutex(sfg_globals->signal_flow_ftables_lock);
-      }
       return csound->InitError(csound, "%s", Str("ftgen string arg not allowed"));
     }
   } else {
     ftevt->p[5] = *p->p5;
   }
   // Copy the remaining parameters.
-  ftevt->pcnt = (int16)GetInputArgCnt((OPDS *)p);
+  ftevt->pcnt = inputArgCount;
   int32_t n = ftevt->pcnt - 5;
   if (n > 0) {
     MYFLT **argp = p->argums;
     MYFLT *fp = &ftevt->p[0] + 6;
     do {
+      if (UNLIKELY(*argp == nullptr)) {
+        return csound->InitError(csound, "%s",
+                                 Str("ftgenonce: invalid arguments"));
+      }
       *fp++ = **argp++;
     } while (--n);
   }
@@ -1434,19 +1478,20 @@ static OENTRY oentries[] = {
     {(char *)"inleta", sizeof(Inleta), _CR,  (char *)"a", (char *)"S",
      (SUBR)&Inleta::init_, (SUBR)&Inleta::audio_},
     {(char *)"outletk", sizeof(Outletk), _CW,  (char *)"", (char *)"Sk",
-     (SUBR)&Outletk::init_, (SUBR)&Outletk::kontrol_, (SUBR)&Outleta::deinit_},
+     (SUBR)&Outletk::init_, (SUBR)&Outletk::kontrol_, (SUBR)&Outletk::deinit_},
     {(char *)"inletk", sizeof(Inletk), _CR,  (char *)"k", (char *)"S",
      (SUBR)&Inletk::init_, (SUBR)&Inletk::kontrol_, 0},
     {(char *)"outletkid", sizeof(Outletkid), _CW,  (char *)"", (char *)"SSk",
-     (SUBR)&Outletk::init_, (SUBR)&Outletk::kontrol_, (SUBR)&Outleta::deinit_},
+     (SUBR)&Outletkid::init_, (SUBR)&Outletkid::kontrol_,
+     (SUBR)&Outletkid::deinit_},
     {(char *)"inletkid", sizeof(Inletkid), _CR,  (char *)"k", (char *)"SS",
-     (SUBR)&Inletk::init_, (SUBR)&Inletk::kontrol_, 0},
+     (SUBR)&Inletkid::init_, (SUBR)&Inletkid::kontrol_, 0},
     {(char *)"outletf", sizeof(Outletf), _CW,  (char *)"", (char *)"Sf",
-     (SUBR)&Outletf::init_, (SUBR)&Outletf::audio_, (SUBR)&Outleta::deinit_},
+     (SUBR)&Outletf::init_, (SUBR)&Outletf::audio_, (SUBR)&Outletf::deinit_},
     {(char *)"inletf", sizeof(Inletf), _CR,  (char *)"f", (char *)"S",
      (SUBR)&Inletf::init_, (SUBR)&Inletf::audio_},
     {(char *)"outletv", sizeof(Outletv), _CW,  (char *)"", (char *)"Sa[]",
-     (SUBR)&Outletv::init_, (SUBR)&Outletv::audio_, (SUBR)&Outleta::deinit_},
+     (SUBR)&Outletv::init_, (SUBR)&Outletv::audio_, (SUBR)&Outletv::deinit_},
     {(char *)"inletv", sizeof(Inletv), _CR,  (char *)"a[]", (char *)"S",
      (SUBR)&Inletv::init_, (SUBR)&Inletv::audio_},
     {(char *)"connect", sizeof(Connect), 0,  (char *)"", (char *)"iSiSp",

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -524,7 +524,6 @@ def runTest():
         ["test_parse_error_udo_missing_inargs.csd", "expected failure: udo missing inargs", 1],
         ["test_parse_error_udo_missing_commas.csd", "expected failure: udo missing commas", 1],
         ["test_parse_error_udo_missing_arglist.csd", "expected failure: udo missing arg list", 1],
-        ["test_signalflowgraph_lifetime.csd", "test signal-flow graph cleanup and ftgenonce"],
         ["test_gen49_defer.csd", "test GEN49 deferred length"],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
@@ -801,6 +800,14 @@ def runTest():
             '-- concert.orc "first violin" --logfile=ignored ""',
         ],
     ]
+
+    if not csoundExecutable.lower().endswith((".wasm", ".cwasm")):
+        tests.append(
+            [
+                "test_signalflowgraph_lifetime.csd",
+                "test signal-flow graph cleanup and ftgenonce",
+            ]
+        )
 
     arrayTests = [
         ["arrays/arrays_i_local.csd", "local i[]"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -524,6 +524,7 @@ def runTest():
         ["test_parse_error_udo_missing_inargs.csd", "expected failure: udo missing inargs", 1],
         ["test_parse_error_udo_missing_commas.csd", "expected failure: udo missing commas", 1],
         ["test_parse_error_udo_missing_arglist.csd", "expected failure: udo missing arg list", 1],
+        ["test_signalflowgraph_lifetime.csd", "test signal-flow graph cleanup and ftgenonce"],
         ["test_gen49_defer.csd", "test GEN49 deferred length"],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],

--- a/tests/commandline/test_signalflowgraph_lifetime.csd
+++ b/tests/commandline/test_signalflowgraph_lifetime.csd
@@ -1,0 +1,30 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+connect "Source", "value", "Sink", "value"
+
+instr Source
+  iTable ftgenonce 0, 0, 16, 10, 1
+  kValue table 0, iTable
+  outletk "value", kValue
+endin
+
+instr Sink
+  kValue inletk "value"
+endin
+</CsInstruments>
+<CsScore>
+i "Sink" 0 0.15
+i "Source" 0 0.03
+i "Source" 0.05 0.03
+i "Source" 0.10 0.03
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Closes #2691

## What changed

`EventBlock` now owns its p-field data, so `ftgenonce` keeps a valid `EVTBLK::p` pointer when it creates and stores a map key. It also checks required pointers before use.

Outlet cleanup now erases an instance only when `find` returns a valid item. Each outlet and instance-ID opcode also uses its own init, run, and cleanup hooks. `outletf` cleanup now takes the shared port lock.

## Before

This CSD crashes on `develop` when the first `Source` instance calls `ftgenonce`:

```csound
<CsoundSynthesizer>
<CsOptions>
-n -d -m0
</CsOptions>
<CsInstruments>
sr = 48000
ksmps = 32
nchnls = 1
0dbfs = 1

connect "Source", "value", "Sink", "value"

instr Source
  iTable ftgenonce 0, 0, 16, 10, 1
  kValue table 0, iTable
  outletk "value", kValue
endin

instr Sink
  kValue inletk "value"
endin
</CsInstruments>
<CsScore>
i "Sink" 0 0.15
i "Source" 0 0.03
i "Source" 0.05 0.03
i "Source" 0.10 0.03
e
</CsScore>
</CsoundSynthesizer>
```

Result before the change:

```text
AddressSanitizer: SEGV on unknown address 0x000000000000
The signal is caused by a WRITE memory access.
csound command: Segmentation fault
```

The null write happens after the code clears `EVTBLK`, including its new dynamic `p` pointer. The old outlet hooks can also call `erase(end())` during instance cleanup.

## After

The same CSD creates and frees all three `Source` instances and exits with status 0:

```text
SECTION 1:
end of Performance
           overall amps:  0.00000
   overall samples out of range:        0
```