### PR TITLE
Fix voice SingWave header initialization

### DIFF
--- a/Opcodes/singwave.c
+++ b/Opcodes/singwave.c
@@ -330,11 +330,11 @@ int32_t voicformset(CSOUND *csound, VOICF *p)
     MYFLT amp = (*p->amp)*AMP_RSCALE; /* Normalise */
     int32_t i;
 
+    p->voiced.h = p->h;
     if (UNLIKELY(make_SingWave(csound, &p->voiced, p->ifn, p->ivfn)!=OK))
       return NOTOK;
     Envelope_setRate(csound, &(p->voiced.envelope), FL(0.001));
     Envelope_setTarget(&(p->voiced.envelope), FL(0.0));
-    p->voiced.h = p->h;
     make_Noise(p->noise);
 
     for (i=0; i<4; i++) {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -547,6 +547,7 @@ def runTest():
         ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
         ["test_oversample.csd", "test oversampling in new-style UDO"],
         ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
+        ["test_voice_init.csd", "voice initializes its SingWave helper"],
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],

--- a/tests/commandline/test_voice_init.csd
+++ b/tests/commandline/test_voice_init.csd
@@ -1,0 +1,21 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  aout voice 0.8, 200, 1, 0.488, 0, 1, 1, 2
+  out aout
+endin
+</CsInstruments>
+<CsScore>
+f 1 0 256 10 1
+f 2 0 256 10 1
+i 1 0 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
## Summary

`voice` called `make_SingWave` before it copied the parent opcode header into the embedded `SingWave`. This left `h.insdshead` null when `Modulatr_setVibFreq` read `CS_ONEDSR`.

Move the header copy before `make_SingWave` and add this case to the command-line regression run.

## Reproducer

```csound
<CsoundSynthesizer>
<CsOptions>
-n -m0
</CsOptions>
<CsInstruments>
sr = 44100
ksmps = 32
nchnls = 1
0dbfs = 1

instr 1
  aout voice 0.8, 200, 1, 0.488, 0, 1, 1, 2
  out aout
endin
</CsInstruments>
<CsScore>
f 1 0 256 10 1
f 2 0 256 10 1
i 1 0 0.01
</CsScore>
</CsoundSynthesizer>
```

## Before change

The CSD crashes during instrument setup. A sanitizer build reports a null `INSDS` access in `singwave.c` when `make_SingWave` sets the vibrato rate.

## After change

The same CSD reaches the end of the performance and exits with status 0.

Closes #2693