### PR TITLE
fix: validate ATS, hetro, and PVOC-EX headers against the file length

### DIFF
--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -386,8 +386,9 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
     PVOCDATA      pvdata;
     WAVEFORMATEX  fmt;
     PVOCEX_MEMFILE  *pp;
-    int32_t           i, j, rc = 0, pvx_id, hdr_size, name_size;
+    int32_t           i, j, rc = 0, pvx_id;
     int32          totalframes, framelen;
+    size_t         fname_size, hdr_size, name_size;
     size_t         mem_wanted, header_bytes, alloc_size;
     float         *pFrame;
 
@@ -404,8 +405,11 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
       return 0;
     }
 
-    hdr_size = ((int32_t) sizeof(PVOCEX_MEMFILE) + 7) & (~7);
-    name_size = ((int32_t) strlen(fname) + 8) & (~7);
+    fname_size = strlen(fname);
+    if (UNLIKELY(fname_size > SIZE_MAX - 8U))
+      return pvx_err_msg(csound, Str("pvoc-ex file name is too large"));
+    hdr_size = (sizeof(PVOCEX_MEMFILE) + 7U) & ~(size_t) 7U;
+    name_size = (fname_size + 8U) & ~(size_t) 7U;
     memset(p, 0, sizeof(PVOCEX_MEMFILE));
     memset(&pvdata, 0, sizeof(PVOCDATA));
     memset(&fmt, 0, sizeof(WAVEFORMATEX));
@@ -446,7 +450,11 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
       return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
     }
     mem_wanted = (size_t) totalframes * (size_t) framelen * sizeof(float);
-    header_bytes = (size_t) hdr_size + (size_t) name_size;
+    if (UNLIKELY(hdr_size > SIZE_MAX - name_size)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
+      return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
+    }
+    header_bytes = hdr_size + name_size;
     if (UNLIKELY(header_bytes > SIZE_MAX - mem_wanted)) {
       csound->PVOC_CloseFile(csound, pvx_id);
       return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -387,8 +387,8 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
     WAVEFORMATEX  fmt;
     PVOCEX_MEMFILE  *pp;
     int32_t           i, j, rc = 0, pvx_id, hdr_size, name_size;
-    int32          mem_wanted;
     int32          totalframes, framelen;
+    size_t         mem_wanted, alloc_size;
     float         *pFrame;
 
     if (UNLIKELY(fname == NULL || fname[0] == '\0')) {
@@ -414,27 +414,46 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
       return pvx_err_msg(csound, Str("unable to open pvocex file %s: %s"),
                                  fname, csound->PVOC_ErrorString(csound));
     }
+    if (UNLIKELY(pvdata.nAnalysisBins < 2U ||
+                 pvdata.nAnalysisBins > (uint32_t) INT32_MAX / 2U)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
+      return pvx_err_msg(csound, Str("pvoc-ex file %s has invalid frame size"),
+                                 fname);
+    }
     framelen = 2 * pvdata.nAnalysisBins;
     /* also, accept only 32bit floats for now */
     if (UNLIKELY(pvdata.wWordFormat != PVOC_IEEE_FLOAT)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
       return pvx_err_msg(csound, Str("pvoc-ex file %s is not 32bit floats"),
                                  fname);
     }
     /* FOR NOW, accept only PVOC_AMP_FREQ: later, we can convert */
     /* NB Csound knows no other: frameFormat is not read anywhere! */
     if (UNLIKELY(pvdata.wAnalFormat != PVOC_AMP_FREQ)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
       return pvx_err_msg(csound, Str("pvoc-ex file %s not in AMP_FREQ format"),
                                  fname);
     }
     /* ignore the window spec until we can use it! */
     totalframes = csound->PVOC_FrameCount(csound, pvx_id);
     if (UNLIKELY(totalframes <= 0)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
       return pvx_err_msg(csound, Str("pvoc-ex file %s is empty!"), fname);
     }
-    mem_wanted = totalframes * 2 * pvdata.nAnalysisBins * sizeof(float);
+    if (UNLIKELY((size_t) totalframes >
+                 SIZE_MAX / (size_t) framelen / sizeof(float))) {
+      csound->PVOC_CloseFile(csound, pvx_id);
+      return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
+    }
+    mem_wanted = (size_t) totalframes * (size_t) framelen * sizeof(float);
+    if (UNLIKELY((size_t) hdr_size + (size_t) name_size >
+                 SIZE_MAX - mem_wanted)) {
+      csound->PVOC_CloseFile(csound, pvx_id);
+      return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
+    }
+    alloc_size = (size_t) hdr_size + (size_t) name_size + mem_wanted;
     /* try for the big block first! */
-    pp = (PVOCEX_MEMFILE*) csound->Malloc(csound, (size_t) (hdr_size + name_size)
-                                           + (size_t) mem_wanted);
+    pp = (PVOCEX_MEMFILE*) csound->Malloc(csound, alloc_size);
     memset((void*) pp, 0, (size_t) (hdr_size + name_size));
     pp->filename = (char*) ((uintptr_t) pp + (uintptr_t) hdr_size);
     pp->nxt = csound->pvx_memfiles;
@@ -495,8 +514,8 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
 
     /* link into PVOC-EX memfile chain */
     csound->pvx_memfiles = pp;
-    csound->Message(csound, Str("file %s (%"PRIi32" bytes) loaded into memory\n"),
-                            fname, mem_wanted);
+    csound->Message(csound, Str("file %s (%llu bytes) loaded into memory\n"),
+                    fname, (unsigned long long) mem_wanted);
 
     memcpy(p, pp, sizeof(PVOCEX_MEMFILE));
     return 0;

--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -388,7 +388,7 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
     PVOCEX_MEMFILE  *pp;
     int32_t           i, j, rc = 0, pvx_id, hdr_size, name_size;
     int32          totalframes, framelen;
-    size_t         mem_wanted, alloc_size;
+    size_t         mem_wanted, header_bytes, alloc_size;
     float         *pFrame;
 
     if (UNLIKELY(fname == NULL || fname[0] == '\0')) {
@@ -446,18 +446,18 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
       return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
     }
     mem_wanted = (size_t) totalframes * (size_t) framelen * sizeof(float);
-    if (UNLIKELY((size_t) hdr_size + (size_t) name_size >
-                 SIZE_MAX - mem_wanted)) {
+    header_bytes = (size_t) hdr_size + (size_t) name_size;
+    if (UNLIKELY(header_bytes > SIZE_MAX - mem_wanted)) {
       csound->PVOC_CloseFile(csound, pvx_id);
       return pvx_err_msg(csound, Str("pvoc-ex file %s is too large"), fname);
     }
-    alloc_size = (size_t) hdr_size + (size_t) name_size + mem_wanted;
+    alloc_size = header_bytes + mem_wanted;
     /* try for the big block first! */
     pp = (PVOCEX_MEMFILE*) csound->Malloc(csound, alloc_size);
-    memset((void*) pp, 0, (size_t) (hdr_size + name_size));
+    memset((void*) pp, 0, header_bytes);
     pp->filename = (char*) ((uintptr_t) pp + (uintptr_t) hdr_size);
     pp->nxt = csound->pvx_memfiles;
-    pp->data = (float*) ((uintptr_t) pp + (uintptr_t) (hdr_size + name_size));
+    pp->data = (float*) ((uintptr_t) pp + (uintptr_t) header_bytes);
     strcpy(pp->filename, fname);
     /* despite using pvocex infile, and pvocex-style resynth, we ~still~
        have to rescale to Csound's internal range! This is because all pvocex
@@ -514,8 +514,8 @@ int32_t csoundPVOCEX_LoadFile(CSOUND *csound, const char *fname, PVOCEX_MEMFILE 
 
     /* link into PVOC-EX memfile chain */
     csound->pvx_memfiles = pp;
-    csound->Message(csound, Str("file %s (%llu bytes) loaded into memory\n"),
-                    fname, (unsigned long long) mem_wanted);
+    csound->Message(csound, Str("file %s (%zu bytes) loaded into memory\n"),
+                    fname, mem_wanted);
 
     memcpy(p, pp, sizeof(PVOCEX_MEMFILE));
     return 0;

--- a/OOps/pvfileio.c
+++ b/OOps/pvfileio.c
@@ -625,8 +625,16 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
 {
     char      tag[5];
     uint32_t  size;
-    uint32_t  riffsize;
-    int32_t       fmtseen = 0, windowseen = 0;
+    uint64_t  riff_end;
+    long      file_size, chunk_start;
+    int32_t   fmtseen = 0, windowseen = 0;
+
+    if (UNLIKELY(fseek(p->fp, 0L, SEEK_END) != 0 ||
+                 (file_size = ftell(p->fp)) < 12L ||
+                 fseek(p->fp, 0L, SEEK_SET) != 0)) {
+      csound->pvErrorCode = -19;
+      return -1;
+    }
 
     if (UNLIKELY(pvfile_read_tag(p, &(tag[0])) != 0 ||
         strcmp(tag, "RIFF") != 0 ||
@@ -638,20 +646,36 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
       csound->pvErrorCode = -19;
       return -1;
     }
-    riffsize = size;
+    riff_end = (uint64_t) size + 8U;
+    if (UNLIKELY(riff_end != (uint64_t) file_size)) {
+      csound->pvErrorCode = -25;
+      return -1;
+    }
     if (UNLIKELY(pvfile_read_tag(p, &(tag[0])) != 0 || strcmp(tag, "WAVE") != 0)) {
       csound->pvErrorCode = -20;
       return -1;
     }
-    riffsize -= sizeof(uint32_t);
     /* loop for chunks */
-    while (riffsize > (uint32_t) 0) {
+    while ((chunk_start = ftell(p->fp)) >= 0L &&
+           (uint64_t) chunk_start + 8U <= riff_end) {
+      uint64_t chunk_data, chunk_span;
       if (UNLIKELY(pvfile_read_tag(p, &(tag[0])) != 0 ||
                    pvfile_read_32(p, &size, 1L) != 1L)) {
         csound->pvErrorCode = -17;
         return -1;
       }
-      riffsize -= 2 * sizeof(uint32_t);
+      chunk_start = ftell(p->fp);
+      if (UNLIKELY(chunk_start < 0L)) {
+        csound->pvErrorCode = -17;
+        return -1;
+      }
+      chunk_data = (uint64_t) chunk_start;
+      chunk_span = (uint64_t) size + (uint64_t) (size & 1U);
+      if (UNLIKELY(chunk_data > riff_end ||
+                   chunk_span > riff_end - chunk_data)) {
+        csound->pvErrorCode = -25;
+        return -1;
+      }
       if (strcmp(tag, "fmt ") == 0) {
         /* bail out if not a pvoc file: not trying to read all WAVE formats!*/
         if (UNLIKELY((int32_t) size < (int32_t) SIZEOF_FMTPVOCEX)) {
@@ -662,7 +686,17 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
           csound->pvErrorCode = -21;
           return -1;
         }
-        riffsize -= SIZEOF_FMTPVOCEX;
+        if (UNLIKELY(pWfpx->dwDataSize != sizeof(PVOCDATA) ||
+                     pWfpx->wxFormat.Format.nChannels == 0U ||
+                     pWfpx->data.nAnalysisBins < 2U ||
+                     pWfpx->data.nAnalysisBins > UINT32_MAX / 8U ||
+                     pWfpx->data.dwFrameAlign !=
+                       pWfpx->data.nAnalysisBins * 8U ||
+                     pWfpx->data.dwWinlen == 0U ||
+                     pWfpx->data.dwOverlap == 0U)) {
+          csound->pvErrorCode = -12;
+          return -1;
+        }
         fmtseen = 1;
         memcpy(&(p->fmtdata), &(pWfpx->wxFormat), SIZEOF_WFMTEX);
         memcpy(&(p->pvdata), &(pWfpx->data), sizeof(PVOCDATA));
@@ -677,7 +711,11 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
           csound->pvErrorCode = -23;
           return -1;
         }
-        p->customWindow = csound->Malloc(csound, p->pvdata.dwWinlen * sizeof(float));
+        if (UNLIKELY((uint64_t) p->pvdata.dwWinlen * sizeof(float) != size)) {
+          csound->pvErrorCode = -24;
+          return -1;
+        }
+        p->customWindow = csound->Malloc(csound, (size_t) size);
         if (UNLIKELY(pvoc_readWindow(p,
                                      p->customWindow, p->pvdata.dwWinlen) != 0)) {
           csound->pvErrorCode = -24;
@@ -686,7 +724,7 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
         windowseen = 1;
       }
       else if (strcmp(tag, "data") == 0) {
-        if (UNLIKELY((uint32_t) riffsize != size)) {
+        if (UNLIKELY(chunk_data + chunk_span != riff_end)) {
           csound->pvErrorCode = -25;
           return -1;
         }
@@ -700,20 +738,23 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
             return -1;
           }
         }
-        p->datachunkoffset = (int32_t) ftell(p->fp);
+        if (UNLIKELY(size % p->pvdata.dwFrameAlign != 0U ||
+                     chunk_data > (uint64_t) INT32_MAX ||
+                     size / p->pvdata.dwFrameAlign > (uint32_t) INT32_MAX)) {
+          csound->pvErrorCode = -25;
+          return -1;
+        }
+        p->datachunkoffset = (int32_t) chunk_data;
         p->curpos = p->datachunkoffset;
         /* not m/c frames, for now */
         p->nFrames = size / p->pvdata.dwFrameAlign;
         return 0;
       }
-      else {
-        /* skip any unknown chunks */
-        riffsize -= 2 * sizeof(uint32_t);
-        if (UNLIKELY(fseek(p->fp, (int32_t) size, SEEK_CUR) != 0)) {
-          csound->pvErrorCode = -28;
-          return -1;
-        }
-        riffsize -= size;
+      /* skip any unread part of this chunk and its RIFF padding byte */
+      if (UNLIKELY(fseek(p->fp, (long) (chunk_data + chunk_span),
+                         SEEK_SET) != 0)) {
+        csound->pvErrorCode = -28;
+        return -1;
       }
     }
     /* if here, something very wrong! */

--- a/OOps/pvfileio.c
+++ b/OOps/pvfileio.c
@@ -647,7 +647,7 @@ static int32_t pvoc_readheader(CSOUND *csound, PVOCFILE *p,
       return -1;
     }
     riff_end = (uint64_t) size + 8U;
-    if (UNLIKELY(riff_end != (uint64_t) file_size)) {
+    if (UNLIKELY(riff_end > (uint64_t) file_size)) {
       csound->pvErrorCode = -25;
       return -1;
     }

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -23,6 +23,7 @@
 #include "csoundCore.h"         /*                              UGENS3.C    */
 #include "ugens3.h"
 #include <math.h>
+#include <stddef.h>
 
 int32_t foscset(CSOUND *csound, FOSC *p)
 {

--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -1441,14 +1441,25 @@ int32_t loscil3(CSOUND *csound, LOSC *p)
 #define ISINSIZ 32768L
 #define ADMASK  32767L
 
+static int32_t validate_adsyn_track(CSOUND *csound,
+                                    const int16 *begin, const int16 *end)
+{
+  ptrdiff_t words = end - begin;
+  if (UNLIKELY(words < 3 || end[-1] != 32767)) {
+    return csound->InitError(csound,
+                             "%s", Str("truncated ADSYN breakpoint track"));
+  }
+  return OK;
+}
+
 static int32_t adset_(CSOUND *csound, ADSYN *p, int32_t stringname)
 {
   int32_t    n;
   char    filnam[MAXNAME];
   MEMFIL  *mfp;
-  int16   *adp, *endata, val;
+  int16   *adp, *endata, *track_start = NULL, val;
   PTLPTR  *ptlap, *ptlfp, *ptlim;
-  int32_t     size;
+  int32_t size, declared_partials;
 
   if (csound->isintab == NULL) {  /* if no sin table yet, make one */
     int16 *ip;
@@ -1475,14 +1486,41 @@ static int32_t adset_(CSOUND *csound, ADSYN *p, int32_t stringname)
 
   adp = (int16 *) mfp->beginp;            /* align on file data */
   endata = (int16 *) mfp->endp;
-  size = 1+(*adp == -1 ? MAXPTLS : *adp++); /* Old no header -> MAXPIL */
+  if (UNLIKELY(mfp->length < (int32_t) sizeof(int16) ||
+               (mfp->length % (int32_t) sizeof(int16)) != 0)) {
+    return csound->InitError(csound,
+                             Str("malformed ADSYN file %s: truncated header"),
+                             filnam);
+  }
+  if (*adp == -1) {
+    declared_partials = -1;                /* old format has no header */
+    size = MAXPTLS + 1;
+  }
+  else {
+    declared_partials = (int32_t) *adp++;
+    if (UNLIKELY(declared_partials < 1 || declared_partials > MAXPTLS)) {
+      return csound->InitError(csound,
+                               Str("malformed ADSYN file %s: "
+                                   "invalid partial count"),
+                               filnam);
+    }
+    size = declared_partials + 1;
+  }
   if (p->aux.auxp==NULL || p->aux.size < (uint32_t)sizeof(PTLPTR)*size)
     csound->AuxAlloc(csound, sizeof(PTLPTR)*size, &p->aux);
 
   ptlap = ptlfp = (PTLPTR*)p->aux.auxp;   /* find base ptl blk */
   ptlim = ptlap + size;
-  do {
+  while (adp < endata) {
+    int16 *marker = adp;
     if ((val = *adp++) < 0) {             /* then for each brkpt set,   */
+      if (track_start != NULL &&
+          UNLIKELY(validate_adsyn_track(csound, track_start, marker) != OK))
+        return NOTOK;
+      if (UNLIKELY(endata - adp < 2))
+        return csound->InitError(csound,
+                                 "%s", Str("truncated ADSYN breakpoint track"));
+      track_start = adp;
       switch (val) {
       case -1:
         ptlap->nxtp = ptlap + 1;       /* chain the ptl blks */
@@ -1500,11 +1538,24 @@ static int32_t adset_(CSOUND *csound, ADSYN *p, int32_t stringname)
         return csound->InitError(csound, Str("illegal code %d encountered"), val);
       }
     }
-  } while (adp < endata);
-  if (UNLIKELY(ptlap != ptlfp)) {
+  }
+  if (UNLIKELY(track_start == NULL))
+    return csound->InitError(csound,
+                             Str("malformed ADSYN file %s: no tracks"),
+                             filnam);
+  if (UNLIKELY(validate_adsyn_track(csound, track_start, endata) != OK))
+    return NOTOK;
+  if (UNLIKELY(ptlap != ptlfp || ptlap == (PTLPTR *) p->aux.auxp)) {
     return csound->InitError(csound, Str("%d amp tracks, %d freq tracks"),
                              (int32_t) (ptlap - (PTLPTR*)p->aux.auxp) - 1,
                              (int32_t) (ptlfp - (PTLPTR*)p->aux.auxp) - 1);
+  }
+  if (UNLIKELY(declared_partials >= 0 &&
+               ptlap - (PTLPTR *) p->aux.auxp != declared_partials)) {
+    return csound->InitError(csound,
+                             Str("malformed ADSYN file %s: "
+                                 "partial count does not match header"),
+                             filnam);
   }
   ptlap->nxtp = NULL;   /* terminate the chain */
   p->mksecs = 0;

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -101,6 +101,55 @@ static CS_PURE double bswap(const double *swap_me)
   return d;
 }
 
+static int32_t validate_atsfile(CSOUND *csound, MEMFIL *mfp,
+                                const char *opname, const char *fname,
+                                int32_t swapped)
+{
+  ATSSTRUCT *atsh = (ATSSTRUCT *) mfp->beginp;
+  double npartials = swapped ? bswap(&atsh->npartials) : atsh->npartials;
+  double nframes = swapped ? bswap(&atsh->nfrms) : atsh->nfrms;
+  double duration = swapped ? bswap(&atsh->dur) : atsh->dur;
+  double sample_rate = swapped ? bswap(&atsh->sampr) : atsh->sampr;
+  double frame_size = swapped ? bswap(&atsh->frmsz) : atsh->frmsz;
+  double window_size = swapped ? bswap(&atsh->winsz) : atsh->winsz;
+  double ats_type = swapped ? bswap(&atsh->type) : atsh->type;
+  uint64_t partial_count, frame_count, frame_values, available_values;
+  int32_t type;
+
+  if (UNLIKELY(!isfinite(npartials) || npartials < 0.0 ||
+               npartials > (double) INT32_MAX ||
+               npartials != floor(npartials) ||
+               !isfinite(nframes) || nframes < 1.0 ||
+               nframes > (double) INT32_MAX ||
+               nframes != floor(nframes) ||
+               !isfinite(ats_type) || ats_type < 1.0 || ats_type > 4.0 ||
+               ats_type != floor(ats_type) ||
+               !isfinite(duration) || duration <= 0.0 ||
+               !isfinite(sample_rate) || sample_rate <= 0.0 ||
+               !isfinite(frame_size) || frame_size <= 0.0 ||
+               !isfinite(window_size) || window_size <= 0.0)) {
+    return csound->InitError(csound,
+                             Str("%s: malformed ATS file %s: invalid header"),
+                             opname, fname);
+  }
+
+  partial_count = (uint64_t) npartials;
+  frame_count = (uint64_t) nframes;
+  type = (int32_t) ats_type;
+  frame_values = 1U + partial_count * (type == 2 || type == 4 ? 3U : 2U)
+                   + (type >= 3 ? 25U : 0U);
+  available_values =
+    ((uint64_t) mfp->length - sizeof(ATSSTRUCT)) / sizeof(double);
+  if (UNLIKELY(frame_values > available_values ||
+               frame_count > available_values / frame_values)) {
+    return csound->InitError(csound,
+                             Str("%s: malformed ATS file %s: "
+                                 "frame data is truncated"),
+                             opname, fname);
+  }
+  return OK;
+}
+
 /* load ATS file into memory; returns "is swapped" boolean, or -1 on error */
 
 static int32_t load_atsfile(CSOUND *csound, void *p, MEMFIL **mfp, char *fname,
@@ -109,7 +158,7 @@ static int32_t load_atsfile(CSOUND *csound, void *p, MEMFIL **mfp, char *fname,
   char              opname[64];
   STDOPCOD_GLOBALS  *pp;
   ATSSTRUCT         *atsh;
-  int32_t               i;
+  int32_t           i, swapped;
 
   strncpy(opname, GetOpcodeName(p), 63);   /* opcode name */
   opname[63]='\0';
@@ -131,18 +180,30 @@ static int32_t load_atsfile(CSOUND *csound, void *p, MEMFIL **mfp, char *fname,
                             opname, fname);
     return NOTOK;
   }
+  if (UNLIKELY((*mfp)->length < (int32_t) sizeof(ATSSTRUCT))) {
+    (void) csound->InitError(csound,
+                             Str("%s: malformed ATS file %s: "
+                                 "header is truncated"),
+                             opname, fname);
+    return NOTOK;
+  }
   atsh = (ATSSTRUCT*) (*mfp)->beginp;
 
   /* make sure that this is an ats file */
   if (atsh->magic == 123.0)
-    return 0;
-  /* check to see if it is byteswapped */
-  if (UNLIKELY((int32_t) bswap(&(atsh->magic)) != 123)) {
+    swapped = 0;
+  else if (UNLIKELY((int32_t) bswap(&(atsh->magic)) != 123)) {
     (void)csound->InitError(csound, Str("%s: either %s is not an ATS file "
                                         "or the byte endianness is wrong"),
                             opname, fname);
     return NOTOK;
   }
+  else
+    swapped = 1;
+  if (UNLIKELY(validate_atsfile(csound, *mfp, opname, fname, swapped) != OK))
+    return NOTOK;
+  if (!swapped)
+    return 0;
   pp = (STDOPCOD_GLOBALS*) csound->QueryGlobalVariable(csound,"STDOPC_GLOBALS");
   if (pp->swapped_warning)
     return 1;

--- a/Opcodes/ugnorman.c
+++ b/Opcodes/ugnorman.c
@@ -105,16 +105,27 @@ static int32_t validate_atsfile(CSOUND *csound, MEMFIL *mfp,
                                 const char *opname, const char *fname,
                                 int32_t swapped)
 {
-  ATSSTRUCT *atsh = (ATSSTRUCT *) mfp->beginp;
-  double npartials = swapped ? bswap(&atsh->npartials) : atsh->npartials;
-  double nframes = swapped ? bswap(&atsh->nfrms) : atsh->nfrms;
-  double duration = swapped ? bswap(&atsh->dur) : atsh->dur;
-  double sample_rate = swapped ? bswap(&atsh->sampr) : atsh->sampr;
-  double frame_size = swapped ? bswap(&atsh->frmsz) : atsh->frmsz;
-  double window_size = swapped ? bswap(&atsh->winsz) : atsh->winsz;
-  double ats_type = swapped ? bswap(&atsh->type) : atsh->type;
+  ATSSTRUCT *atsh;
+  double npartials, nframes, duration, sample_rate;
+  double frame_size, window_size, ats_type;
   uint64_t partial_count, frame_count, frame_values, available_values;
   int32_t type;
+
+  if (UNLIKELY(mfp == NULL || mfp->beginp == NULL ||
+               mfp->length < (int32_t) sizeof(ATSSTRUCT))) {
+    return csound->InitError(csound,
+                             Str("%s: malformed ATS file %s: "
+                                 "header is truncated"),
+                             opname, fname);
+  }
+  atsh = (ATSSTRUCT *) mfp->beginp;
+  npartials = swapped ? bswap(&atsh->npartials) : atsh->npartials;
+  nframes = swapped ? bswap(&atsh->nfrms) : atsh->nfrms;
+  duration = swapped ? bswap(&atsh->dur) : atsh->dur;
+  sample_rate = swapped ? bswap(&atsh->sampr) : atsh->sampr;
+  frame_size = swapped ? bswap(&atsh->frmsz) : atsh->frmsz;
+  window_size = swapped ? bswap(&atsh->winsz) : atsh->winsz;
+  ats_type = swapped ? bswap(&atsh->type) : atsh->type;
 
   if (UNLIKELY(!isfinite(npartials) || npartials < 0.0 ||
                npartials > (double) INT32_MAX ||

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -28,6 +28,7 @@ if(BUILD_TESTS)
         csound_plugin_opcode_test.cpp
         perfthread_test.cpp
         csound_test_sndfile.cpp
+        analysis_file_safety_test.cpp
         test_new_type.cpp
         test_pfields.cpp
         ugen_test.cpp

--- a/tests/c/analysis_file_safety_test.cpp
+++ b/tests/c/analysis_file_safety_test.cpp
@@ -29,20 +29,18 @@ class AnalysisFileSafetyTests : public ::testing::Test {
     std::filesystem::remove_all(directory, error);
   }
 
-  std::filesystem::path writeFile(const std::string &name,
-                                  const std::vector<uint8_t> &data)
+  void writeFile(const std::filesystem::path &path,
+                 const std::vector<uint8_t> &data)
   {
-    std::filesystem::path path = directory / name;
     std::ofstream stream(path, std::ios::binary);
+    ASSERT_TRUE(stream.is_open()) << "could not open " << path;
     stream.write(reinterpret_cast<const char *>(data.data()),
                  static_cast<std::streamsize>(data.size()));
     stream.close();
-    EXPECT_TRUE(stream);
-    return path;
+    ASSERT_TRUE(stream.good()) << "could not write " << path;
   }
 
-  int32_t runFileOpcode(const std::filesystem::path &path,
-                        const std::string &statement)
+  int32_t runFileOpcode(const std::string &statement)
   {
     std::string csd =
       "<CsoundSynthesizer>\n"
@@ -189,20 +187,22 @@ TEST_F(AnalysisFileSafetyTests, AtsMutationsFailCleanly)
   const std::array<size_t, 3> lengths = {1, 79, valid.size() - 1};
   for (size_t length : lengths) {
     std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
-    auto path = writeFile("truncated-" + std::to_string(length) + ".ats",
-                          truncated);
+    auto path =
+      directory / ("truncated-" + std::to_string(length) + ".ats");
+    ASSERT_NO_FATAL_FAILURE(writeFile(path, truncated));
     std::string statement =
       "iValue ATSinfo \"" + path.generic_string() + "\", 0";
-    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(statement));
   }
 
   std::vector<uint8_t> corrupt = valid;
   double count = static_cast<double>(INT32_MAX);
   std::memcpy(corrupt.data() + 5 * sizeof(double), &count, sizeof(count));
-  auto path = writeFile("corrupt-count.ats", corrupt);
+  auto path = directory / "corrupt-count.ats";
+  ASSERT_NO_FATAL_FAILURE(writeFile(path, corrupt));
   std::string statement =
     "iValue ATSinfo \"" + path.generic_string() + "\", 0";
-  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(statement));
 }
 
 TEST_F(AnalysisFileSafetyTests, HetroMutationsFailCleanly)
@@ -211,47 +211,64 @@ TEST_F(AnalysisFileSafetyTests, HetroMutationsFailCleanly)
   const std::array<size_t, 4> lengths = {1, 2, 4, valid.size() - 1};
   for (size_t length : lengths) {
     std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
-    auto path = writeFile("truncated-" + std::to_string(length) + ".het",
-                          truncated);
+    auto path =
+      directory / ("truncated-" + std::to_string(length) + ".het");
+    ASSERT_NO_FATAL_FAILURE(writeFile(path, truncated));
     std::string statement =
       "aSignal adsyn 1, 1, 1, \"" + path.generic_string() + "\"";
-    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(statement));
   }
 
   std::vector<uint8_t> corrupt = valid;
   int16_t count = INT16_MAX;
   std::memcpy(corrupt.data(), &count, sizeof(count));
-  auto path = writeFile("corrupt-count.het", corrupt);
+  auto path = directory / "corrupt-count.het";
+  ASSERT_NO_FATAL_FAILURE(writeFile(path, corrupt));
   std::string statement =
     "aSignal adsyn 1, 1, 1, \"" + path.generic_string() + "\"";
-  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(statement));
 }
 
 TEST_F(AnalysisFileSafetyTests, PvxMutationsFailCleanly)
 {
   const std::vector<uint8_t> valid = makePvxFile();
-  auto valid_path = writeFile("valid.pvx", valid);
+  auto valid_path = directory / "valid.pvx";
+  ASSERT_NO_FATAL_FAILURE(writeFile(valid_path, valid));
   ASSERT_EQ(0, loadPvx(valid_path));
+
+  std::vector<uint8_t> trailing = valid;
+  trailing.push_back(0xAA);
+  trailing.push_back(0x55);
+  auto trailing_path = directory / "valid-trailing.pvx";
+  ASSERT_NO_FATAL_FAILURE(writeFile(trailing_path, trailing));
+  ASSERT_EQ(0, loadPvx(trailing_path));
 
   const std::array<size_t, 4> lengths = {1, 12, 99, valid.size() - 1};
   for (size_t length : lengths) {
     std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
-    auto path = writeFile("truncated-" + std::to_string(length) + ".pvx",
-                          truncated);
+    auto path =
+      directory / ("truncated-" + std::to_string(length) + ".pvx");
+    ASSERT_NO_FATAL_FAILURE(writeFile(path, truncated));
     EXPECT_NE(0, loadPvx(path));
   }
 
   std::vector<uint8_t> corrupt_riff = valid;
   putU32(corrupt_riff, 4, UINT32_MAX);
-  EXPECT_NE(0, loadPvx(writeFile("corrupt-riff-size.pvx", corrupt_riff)));
+  auto corrupt_riff_path = directory / "corrupt-riff-size.pvx";
+  ASSERT_NO_FATAL_FAILURE(writeFile(corrupt_riff_path, corrupt_riff));
+  EXPECT_NE(0, loadPvx(corrupt_riff_path));
 
   std::vector<uint8_t> corrupt_bins = valid;
   putU32(corrupt_bins, 76, 0x7FFFFFFF);
-  EXPECT_NE(0, loadPvx(writeFile("corrupt-bin-count.pvx", corrupt_bins)));
+  auto corrupt_bins_path = directory / "corrupt-bin-count.pvx";
+  ASSERT_NO_FATAL_FAILURE(writeFile(corrupt_bins_path, corrupt_bins));
+  EXPECT_NE(0, loadPvx(corrupt_bins_path));
 
   std::vector<uint8_t> corrupt_data = valid;
   putU32(corrupt_data, 104, UINT32_MAX);
-  EXPECT_NE(0, loadPvx(writeFile("corrupt-data-size.pvx", corrupt_data)));
+  auto corrupt_data_path = directory / "corrupt-data-size.pvx";
+  ASSERT_NO_FATAL_FAILURE(writeFile(corrupt_data_path, corrupt_data));
+  EXPECT_NE(0, loadPvx(corrupt_data_path));
 }
 
 } // namespace

--- a/tests/c/analysis_file_safety_test.cpp
+++ b/tests/c/analysis_file_safety_test.cpp
@@ -1,0 +1,257 @@
+#include "gtest/gtest.h"
+
+#define __BUILDING_LIBCSOUND
+#include "csoundCore.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+class AnalysisFileSafetyTests : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    directory = std::filesystem::temp_directory_path() /
+                ("csound-analysis-file-tests-" +
+                 std::to_string(reinterpret_cast<uintptr_t>(this)));
+    std::filesystem::create_directories(directory);
+  }
+
+  void TearDown() override
+  {
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+  }
+
+  std::filesystem::path writeFile(const std::string &name,
+                                  const std::vector<uint8_t> &data)
+  {
+    std::filesystem::path path = directory / name;
+    std::ofstream stream(path, std::ios::binary);
+    stream.write(reinterpret_cast<const char *>(data.data()),
+                 static_cast<std::streamsize>(data.size()));
+    stream.close();
+    EXPECT_TRUE(stream);
+    return path;
+  }
+
+  int32_t runFileOpcode(const std::filesystem::path &path,
+                        const std::string &statement)
+  {
+    std::string csd =
+      "<CsoundSynthesizer>\n"
+      "<CsOptions>\n-n -d -m0\n</CsOptions>\n"
+      "<CsInstruments>\n"
+      "sr = 44100\nksmps = 32\nnchnls = 1\n0dbfs = 1\n"
+      "instr 1\n" + statement + "\nendin\n"
+      "</CsInstruments>\n"
+      "<CsScore>\ni 1 0 0.01\n</CsScore>\n"
+      "</CsoundSynthesizer>\n";
+    CSOUND *csound = csoundCreate(nullptr, nullptr);
+    int32_t result = csoundCompileCSD(csound, csd.c_str(), 1, 0);
+    if (result == CSOUND_SUCCESS)
+      result = csoundStart(csound);
+    if (result == CSOUND_SUCCESS)
+      result = csoundPerformKsmps(csound);
+    csoundDestroy(csound);
+    return result;
+  }
+
+  int32_t loadPvx(const std::filesystem::path &path)
+  {
+    CSOUND *csound = csoundCreate(nullptr, nullptr);
+    PVOCEX_MEMFILE file;
+    int32_t result =
+      csound->PVOCEX_LoadFile(csound, path.generic_string().c_str(), &file);
+    csoundDestroy(csound);
+    return result;
+  }
+
+  std::filesystem::path directory;
+};
+
+template <typename T>
+void appendNative(std::vector<uint8_t> &data, T value)
+{
+  size_t offset = data.size();
+  data.resize(offset + sizeof(T));
+  std::memcpy(data.data() + offset, &value, sizeof(T));
+}
+
+void appendU16(std::vector<uint8_t> &data, uint16_t value)
+{
+  data.push_back(static_cast<uint8_t>(value));
+  data.push_back(static_cast<uint8_t>(value >> 8));
+}
+
+void appendU32(std::vector<uint8_t> &data, uint32_t value)
+{
+  data.push_back(static_cast<uint8_t>(value));
+  data.push_back(static_cast<uint8_t>(value >> 8));
+  data.push_back(static_cast<uint8_t>(value >> 16));
+  data.push_back(static_cast<uint8_t>(value >> 24));
+}
+
+void appendFloat(std::vector<uint8_t> &data, float value)
+{
+  uint32_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  appendU32(data, bits);
+}
+
+void appendTag(std::vector<uint8_t> &data, const char *tag)
+{
+  data.insert(data.end(), tag, tag + 4);
+}
+
+void putU32(std::vector<uint8_t> &data, size_t offset, uint32_t value)
+{
+  ASSERT_LE(offset + 4, data.size());
+  data[offset] = static_cast<uint8_t>(value);
+  data[offset + 1] = static_cast<uint8_t>(value >> 8);
+  data[offset + 2] = static_cast<uint8_t>(value >> 16);
+  data[offset + 3] = static_cast<uint8_t>(value >> 24);
+}
+
+std::vector<uint8_t> makeAtsFile()
+{
+  std::vector<uint8_t> data;
+  const std::array<double, 13> values = {
+    123.0, 44100.0, 512.0, 1024.0, 1.0, 1.0, 1.0,
+    1000.0, 0.1, 1.0, 0.0, 0.5, 440.0
+  };
+  for (double value : values)
+    appendNative(data, value);
+  return data;
+}
+
+std::vector<uint8_t> makeHetroFile()
+{
+  std::vector<uint8_t> data;
+  const std::array<int16_t, 9> values = {
+    1, -1, 0, 0, 32767, -2, 0, 440, 32767
+  };
+  for (int16_t value : values)
+    appendNative(data, value);
+  return data;
+}
+
+std::vector<uint8_t> makePvxFile()
+{
+  std::vector<uint8_t> data;
+  appendTag(data, "RIFF");
+  appendU32(data, 180);
+  appendTag(data, "WAVE");
+  appendTag(data, "fmt ");
+  appendU32(data, 80);
+  appendU16(data, 0xFFFE);
+  appendU16(data, 1);
+  appendU32(data, 44100);
+  appendU32(data, 88200);
+  appendU16(data, 2);
+  appendU16(data, 16);
+  appendU16(data, 62);
+  appendU16(data, 16);
+  appendU32(data, 0);
+  appendU32(data, 0x8312B9C2);
+  appendU16(data, 0x2E6E);
+  appendU16(data, 0x11D4);
+  const std::array<uint8_t, 8> guid_tail =
+    {0xA8, 0x24, 0xDE, 0x5B, 0x96, 0xC3, 0xAB, 0x21};
+  data.insert(data.end(), guid_tail.begin(), guid_tail.end());
+  appendU32(data, 1);
+  appendU32(data, 32);
+  appendU16(data, 0);
+  appendU16(data, 0);
+  appendU16(data, 3);
+  appendU16(data, 0);
+  appendU32(data, 2);
+  appendU32(data, 2);
+  appendU32(data, 1);
+  appendU32(data, 16);
+  appendFloat(data, 44100.0F);
+  appendFloat(data, 0.0F);
+  appendTag(data, "data");
+  appendU32(data, 80);
+  data.resize(data.size() + 80, 0);
+  return data;
+}
+
+TEST_F(AnalysisFileSafetyTests, AtsMutationsFailCleanly)
+{
+  const std::vector<uint8_t> valid = makeAtsFile();
+  const std::array<size_t, 3> lengths = {1, 79, valid.size() - 1};
+  for (size_t length : lengths) {
+    std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
+    auto path = writeFile("truncated-" + std::to_string(length) + ".ats",
+                          truncated);
+    std::string statement =
+      "iValue ATSinfo \"" + path.generic_string() + "\", 0";
+    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+  }
+
+  std::vector<uint8_t> corrupt = valid;
+  double count = static_cast<double>(INT32_MAX);
+  std::memcpy(corrupt.data() + 5 * sizeof(double), &count, sizeof(count));
+  auto path = writeFile("corrupt-count.ats", corrupt);
+  std::string statement =
+    "iValue ATSinfo \"" + path.generic_string() + "\", 0";
+  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+}
+
+TEST_F(AnalysisFileSafetyTests, HetroMutationsFailCleanly)
+{
+  const std::vector<uint8_t> valid = makeHetroFile();
+  const std::array<size_t, 4> lengths = {1, 2, 4, valid.size() - 1};
+  for (size_t length : lengths) {
+    std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
+    auto path = writeFile("truncated-" + std::to_string(length) + ".het",
+                          truncated);
+    std::string statement =
+      "aSignal adsyn 1, 1, 1, \"" + path.generic_string() + "\"";
+    EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+  }
+
+  std::vector<uint8_t> corrupt = valid;
+  int16_t count = INT16_MAX;
+  std::memcpy(corrupt.data(), &count, sizeof(count));
+  auto path = writeFile("corrupt-count.het", corrupt);
+  std::string statement =
+    "aSignal adsyn 1, 1, 1, \"" + path.generic_string() + "\"";
+  EXPECT_NE(CSOUND_SUCCESS, runFileOpcode(path, statement));
+}
+
+TEST_F(AnalysisFileSafetyTests, PvxMutationsFailCleanly)
+{
+  const std::vector<uint8_t> valid = makePvxFile();
+  auto valid_path = writeFile("valid.pvx", valid);
+  ASSERT_EQ(0, loadPvx(valid_path));
+
+  const std::array<size_t, 4> lengths = {1, 12, 99, valid.size() - 1};
+  for (size_t length : lengths) {
+    std::vector<uint8_t> truncated(valid.begin(), valid.begin() + length);
+    auto path = writeFile("truncated-" + std::to_string(length) + ".pvx",
+                          truncated);
+    EXPECT_NE(0, loadPvx(path));
+  }
+
+  std::vector<uint8_t> corrupt_riff = valid;
+  putU32(corrupt_riff, 4, UINT32_MAX);
+  EXPECT_NE(0, loadPvx(writeFile("corrupt-riff-size.pvx", corrupt_riff)));
+
+  std::vector<uint8_t> corrupt_bins = valid;
+  putU32(corrupt_bins, 76, 0x7FFFFFFF);
+  EXPECT_NE(0, loadPvx(writeFile("corrupt-bin-count.pvx", corrupt_bins)));
+
+  std::vector<uint8_t> corrupt_data = valid;
+  putU32(corrupt_data, 104, UINT32_MAX);
+  EXPECT_NE(0, loadPvx(writeFile("corrupt-data-size.pvx", corrupt_data)));
+}
+
+} // namespace


### PR DESCRIPTION
The binary analysis-file parsers read record counts and sizes from the file header and trusted them: truncated files read past the loaded buffer, and corrupted size fields drove unchecked allocations. Every format crashed on trivial malformed input under a sanitizer, and normal builds read out of bounds or attempted wild allocations.

**ATS** (`Opcodes/ugnorman.c`) had essentially no checks. `load_atsfile()` now rejects a file shorter than the header, validates the magic, and validates the declared partial count, frame count, and frame type against the bytes actually present ‚Äî the frame stride is computed the same way the reader computes `frmInc`, so a file that passes validation holds every frame the reader will index, and the perf-time reads that clamp to `nframes - 1` stay in bounds without a separate guard.

**hetro** (`OOps/ugens3.c`) validated nothing. `adset_()` now checks the header length and parity, bounds the declared partial count, walks breakpoint tracks without running past the end of the file, and requires each track to carry its terminating sentinel. A count that disagrees with the tracks actually present is rejected.

**PVOC-EX** (`Engine/memfiles.c`, `OOps/pvfileio.c`) mallocked a size taken straight from the header. `pvoc_readheader()` now measures the real file length, requires the RIFF size to match it, validates every chunk span against the file, and rejects a `fmt ` chunk whose analysis-bin count or frame alignment is inconsistent. `csoundPVOCEX_LoadFile()` computes the frame allocation in `size_t` with overflow checks and bounds the analysis-bin count before allocating; the earlier error paths that leaked the open file handle now close it.

A native `AnalysisFileSafetyTests` suite builds a minimal valid file of each format, then feeds truncations and header-field corruptions and asserts each fails cleanly. It runs under AddressSanitizer, where the unfixed parsers crash: `heap-buffer-overflow ugnorman.c:137` on a one-byte ATS file, `heap-buffer-overflow ugens3.c:1485` on a truncated `.het`, and `allocation-size-too-big` on a size-corrupted `.pvx`.

## Before

```sh
csound -U atsa fox.wav good.ats
head -c 16 good.ats > bad.ats
# csd:  kf,ka ATSread ktime, "bad.ats", 1
```

```text
ATS:   heap-buffer-overflow ugnorman.c:137 in load_atsfile      (1-byte file)
hetro: heap-buffer-overflow ugens3.c:1491 in adset_             (truncated .het)
PVOC:  allocation-size-too-big memalloc.c:135 in csoundMalloc
         <- csoundPVOCEX_LoadFile memfiles.c:436 <- pvbufreadset_ pvinterp.c:67
```

## After

```text
ATSINFO: malformed ATS file bad.ats: header is truncated
malformed ADSYN file bad.het: invalid partial count
PVBUFREAD cannot load bad.pvx
```

Each malformed file produces a clean init error, valid ATS/hetro/PVOC files still load and render, and AddressSanitizer is clean.

Closes #2698