### PR TITLE
Fix qinf/qnan classification under fast math

### DIFF
--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -2229,66 +2229,67 @@ int32_t divinak(CSOUND *csound, ASSIGN *p)
 /**
  * Identifies both signaling NaN (sNaN) and quiet NaN (qNaN).
  *
- * According to the IEEE 754 standard, all NaN have the sign bit set to 0 and
+ * IEEE 754 NaNs can have either sign bit, and
  * all exponent bits set to 1. qNaN has the most significant bit of the
- * fractional set to 1, while sNaN has most the significant bit of the
- * fraction set to 0 -- but the NEXT most significant bit of the fraction must
- * be set to 1! This is necessary in order to distinguish sNaN from positive
- * infinity. Hence, there are 2 bit masks to test. Doubles have the most
- * significant bit of the fraction in (0-based) bit 52, floats have the most
+ * fractional set to 1, while sNaN has the most significant bit of the
+ * fraction set to 0. In both cases, the remaining fraction bits contain a
+ * nonzero payload that distinguishes NaN from infinity. Doubles have the most
+ * significant bit of the fraction in (0-based) bit 51, floats have the most
  * significant bit of the fraction in bit 22.
  * double qNaN:
- * 0111111111110000000000000000000000000000000000000000000000000000
- * 0x7FF0000000000000ULL
+ * 0111111111111000000000000000000000000000000000000000000000000000
+ * 0x7FF8000000000000ULL
  * double sNaN:
- * 0111111111101000000000000000000000000000000000000000000000000000
- * 0x7FE8000000000000ULL
+ * 0111111111110000000000000000000000000000000000000000000000000001
+ * 0x7FF0000000000001ULL
  * float qNaN:
  * 01111111110000000000000000000000
  * 0x7FC00000
  * float sNaN:
  * 01111111101000000000000000000000
  * 0x7FA00000
+ * Fast-math may fold isnan() and isinf() to false, so test the bits directly.
  * NOTE: Not all compilers permit type casting a type-punned pointer. So, we
  * must explicitly copy rather than assign the data to test.
  */
-#ifndef __MINGW32__
-static inline int32_t _isnan(MYFLT x) {
+static inline int32_t csound_isnan(const void *value)
+{
 #ifdef USE_DOUBLE
   uint64_t bits;
-  memcpy(&bits, &x, sizeof(MYFLT));
-  if ((bits & 0x7FF0000000000000ULL) == 0x7FF0000000000000ULL) {
-    return 1;
-  }
-  if ((bits & 0x7FE8000000000000ULL) == 0x7FE8000000000000ULL) {
-    return 1;
-  }
-  return 0;
+  memcpy(&bits, value, sizeof(MYFLT));
+  return (bits & 0x7FFFFFFFFFFFFFFFULL) > 0x7FF0000000000000ULL;
 #else
   uint32_t bits;
-  memcpy(&bits, &x, sizeof(MYFLT));
-  if ((bits & 0x7FC00000) == 0x7FC00000) {
-    return 1;
-  }
-  if ((bits & 0x7FA00000) == 0x7FA00000) {
-    return 1;
-  }
-  return 0;
+  memcpy(&bits, value, sizeof(MYFLT));
+  return (bits & 0x7FFFFFFFU) > 0x7F800000U;
 #endif
 }
-#endif
 
+static inline int32_t csound_isinf(const void *value)
+{
+#ifdef USE_DOUBLE
+  uint64_t bits;
+  memcpy(&bits, value, sizeof(MYFLT));
+  if ((bits & 0x7FFFFFFFFFFFFFFFULL) != 0x7FF0000000000000ULL)
+    return 0;
+  return (bits & 0x8000000000000000ULL) ? -1 : 1;
+#else
+  uint32_t bits;
+  memcpy(&bits, value, sizeof(MYFLT));
+  if ((bits & 0x7FFFFFFFU) != 0x7F800000U)
+    return 0;
+  return (bits & 0x80000000U) ? -1 : 1;
+#endif
+}
 
 int32_t is_NaN(CSOUND *csound, ASSIGN *p)
 {
   IGN(csound);
-  // *p->r = isnan(*p->a);
-  *p->r = _isnan(*p->a);
+  *p->r = csound_isnan(p->a);
   return OK;
 }
 
 
-/* ********COULD BE IMPROVED******** */
 int32_t is_NaNa(CSOUND *csound, ASSIGN *p)
 {
   IGN(csound);
@@ -2298,18 +2299,17 @@ int32_t is_NaNa(CSOUND *csound, ASSIGN *p)
   MYFLT *a = p->a;
   *p->r = FL(0.0);
   for (k=offset; k<early; k++)
-    *p->r += _isnan(a[k]);
+    *p->r += csound_isnan(&a[k]);
   return OK;
 }
 
 int32_t is_inf(CSOUND *csound, ASSIGN *p)
 {
   IGN(csound);
-  *p->r = isinf(*p->a);
+  *p->r = csound_isinf(p->a);
   return OK;
 }
 
-/* ********COULD BE IMPROVED******** */
 int32_t is_infa(CSOUND *csound, ASSIGN *p)
 {
   IGN(csound);
@@ -2320,9 +2320,12 @@ int32_t is_infa(CSOUND *csound, ASSIGN *p)
   MYFLT ans = FL(0.0);
   int32_t sign = 1;
   for (k=offset; k<early; k++) {
-    if (isinf(a[k]))
-      if (ans==FL(0.0)) sign = (int32_t)isinf(a[k]);
-    ans++;
+    int32_t value_sign = csound_isinf(&a[k]);
+    if (value_sign != 0) {
+      if (ans == FL(0.0))
+        sign = value_sign;
+      ans++;
+    }
   }
   *p->r = ans*sign;
   return OK;

--- a/tests/c/engine_test.cpp
+++ b/tests/c/engine_test.cpp
@@ -2,11 +2,19 @@
 #include "csoundCore.h"
 #include "csound_graph_display.h"
 #include "fftlib.h"
+extern "C" {
+#include "aops.h"
+int32_t is_NaN(CSOUND *, void *);
+int32_t is_NaNa(CSOUND *, void *);
+int32_t is_inf(CSOUND *, void *);
+int32_t is_infa(CSOUND *, void *);
+}
 #include <algorithm>
 #include <atomic>
 #include <clocale>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <stdio.h>
 #include <string>
 #include <thread>
@@ -15,6 +23,16 @@
 #include "time.h"
 
 namespace {
+
+MYFLT myfltFromBits(uint64_t doubleBits, uint32_t floatBits)
+{
+    MYFLT value;
+    if constexpr (sizeof(MYFLT) == sizeof(doubleBits))
+        std::memcpy(&value, &doubleBits, sizeof(value));
+    else
+        std::memcpy(&value, &floatBits, sizeof(value));
+    return value;
+}
 
 std::vector<MYFLT> directComplexDft(const std::vector<MYFLT>& input,
                                     bool inverse)
@@ -158,6 +176,93 @@ TEST_F (EngineTests, testComplexFftMatchesDirectDft)
               << "round trip size " << size << ", component " << i;
         }
     }
+}
+
+TEST_F (EngineTests, testQinfClassifiesScalarAndAudioValues)
+{
+    const MYFLT positiveInfinity =
+      myfltFromBits(0x7FF0000000000000ULL, 0x7F800000U);
+    const MYFLT negativeInfinity =
+      myfltFromBits(0xFFF0000000000000ULL, 0xFF800000U);
+    const MYFLT nan = myfltFromBits(0x7FF8000000000000ULL, 0x7FC00000U);
+    MYFLT input = positiveInfinity;
+    MYFLT result = FL(0.0);
+    ASSIGN scalar {};
+    scalar.r = &result;
+    scalar.a = &input;
+
+    ASSERT_EQ(is_inf(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(1.0));
+
+    input = negativeInfinity;
+    ASSERT_EQ(is_inf(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(-1.0));
+
+    input = nan;
+    ASSERT_EQ(is_inf(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(0.0));
+
+    input = (std::numeric_limits<MYFLT>::max)();
+    ASSERT_EQ(is_inf(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(0.0));
+
+    MYFLT audio[] = {
+      positiveInfinity, FL(1.0), negativeInfinity, nan,
+      positiveInfinity, negativeInfinity
+    };
+    INSDS insds {};
+    insds.ksmps = static_cast<uint32_t>(sizeof(audio) / sizeof(audio[0]));
+    insds.ksmps_offset = 1;
+    insds.ksmps_no_end = 1;
+    ASSIGN audioOp {};
+    audioOp.h.insdshead = &insds;
+    audioOp.r = &result;
+    audioOp.a = audio;
+
+    ASSERT_EQ(is_infa(csound, &audioOp), OK);
+    EXPECT_EQ(result, FL(-2.0));
+}
+
+TEST_F (EngineTests, testQnanClassifiesScalarAndAudioValues)
+{
+    const MYFLT positiveInfinity =
+      myfltFromBits(0x7FF0000000000000ULL, 0x7F800000U);
+    const MYFLT negativeInfinity =
+      myfltFromBits(0xFFF0000000000000ULL, 0xFF800000U);
+    const MYFLT nan = myfltFromBits(0x7FF8000000000000ULL, 0x7FC00000U);
+    MYFLT input = nan;
+    MYFLT result = FL(0.0);
+    ASSIGN scalar {};
+    scalar.r = &result;
+    scalar.a = &input;
+
+    ASSERT_EQ(is_NaN(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(1.0));
+
+    input = positiveInfinity;
+    ASSERT_EQ(is_NaN(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(0.0));
+
+    input = negativeInfinity;
+    ASSERT_EQ(is_NaN(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(0.0));
+
+    input = (std::numeric_limits<MYFLT>::max)();
+    ASSERT_EQ(is_NaN(csound, &scalar), OK);
+    EXPECT_EQ(result, FL(0.0));
+
+    MYFLT audio[] = {nan, FL(1.0), nan, positiveInfinity, nan, nan};
+    INSDS insds {};
+    insds.ksmps = static_cast<uint32_t>(sizeof(audio) / sizeof(audio[0]));
+    insds.ksmps_offset = 1;
+    insds.ksmps_no_end = 1;
+    ASSIGN audioOp {};
+    audioOp.h.insdshead = &insds;
+    audioOp.r = &result;
+    audioOp.a = audio;
+
+    ASSERT_EQ(is_NaNa(csound, &audioOp), OK);
+    EXPECT_EQ(result, FL(2.0));
 }
 
 TEST_F (EngineTests, testSscanfUsesCLocale)


### PR DESCRIPTION
## Summary

`qinf` and `qnan` were not reliable in optimized builds that use finite-math assumptions. `qinf` called `isinf()`, and `qnan` used bit masks that could treat infinities as NaNs. Under fast-math style flags, those paths can report the wrong class for values that CSD code uses as guards.

Before:

```text
qinf(+inf): 1
qinf(-inf): 1
qnan(nan): 1
qnan(+inf): 1
```

After:

```text
qinf(+inf): 1
qinf(-inf): -1
qnan(nan): 1
qnan(+inf): 0
```

## Fix

This changes scalar and audio-rate `qinf`/`qnan` to inspect the `MYFLT` bit pattern directly. The exponent and fraction bits identify infinity and NaN without relying on `isinf()` or `isnan()`, so the result stays stable when the compiler assumes finite math.

The audio-rate variants use the same helpers, so they keep the same behavior as the scalar opcodes while counting the active samples.

Closes #2720