### PR TITLE
add remap opcode

### DIFF
--- a/Android/CsoundAndroid/jni/Android.mk
+++ b/Android/CsoundAndroid/jni/Android.mk
@@ -307,7 +307,8 @@ $(CSOUND_SRC_ROOT)/Opcodes/paulstretch.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_new_dispatch.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_par_base.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_par_orc_semantic_analysis.c \
-$(CSOUND_SRC_ROOT)/Java/cs_glue.cpp
+$(CSOUND_SRC_ROOT)/Java/cs_glue.cpp \
+$(CSOUND_SRC_ROOT)/Opcodes/remap.c
 #CsoundObj.cpp
 
 LOCAL_LDLIBS += -llog -lOpenSLES -laaudio -lamidi -ldl -lm -lc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1191,6 +1191,7 @@ set(stdopcod_SRCS
     Opcodes/wterrain2.c
     Opcodes/stdopcod.c
     Opcodes/dbap.c
+    Opcodes/remap.c
     )
 
 set(sock_ops_SRCS

--- a/Opcodes/README.md
+++ b/Opcodes/README.md
@@ -102,6 +102,7 @@ Opcodes: internal and plugin opcodes
 - pvsgendy.c: streaming phase vocoder GENDY processing
 - pvsops.cpp: phase vocoder opcodes, time-varying convolution
 - quadbezier.c: bezier lines
+- remap.c: remaps values through an interpolated lookup curve
 - repluck.c: plucked-string physical models
 - reverbsc.c: FDN reverb
 - scansyn.c: scanned synthesis

--- a/Opcodes/remap.c
+++ b/Opcodes/remap.c
@@ -1,0 +1,668 @@
+/*
+    remap.c:
+
+    Copyright (C) 2026 Pasquale Mainolfi.
+
+    This file is part of Csound.
+
+    The Csound Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    Csound is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with Csound; if not, write to the Free Software
+    Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+/*
+    remap - map a value onto an arbitrary curve defined by a breakpoint table.
+
+    Given a table of breakpoints (xdata, ydata), remap returns the y matching
+    the input x, interpolating between the two breakpoints that bracket it.
+    The x table must be strictly increasing; both tables must hold at least
+    two points and have the same length.
+
+    SYNTAX
+
+      y:k   = remap(x:k,   xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
+      y:k[] = remap(x:k[], xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
+      y:a   = remap(x:a,   xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
+
+    The two tables may be i- or k-rate arrays. With i-rate tables the
+    breakpoints cannot change during the note, so they are validated once at
+    init; with k-rate tables they may be rewritten at any control period and
+    are re-checked every time.
+
+    imode - how to interpolate between the two bracketing breakpoints
+
+      0  linear
+      1  nearest      the y of the closer breakpoint
+      2  previous     the y of the left breakpoint
+      3  next         the y of the right breakpoint
+      4  cubic        shape-preserving cubic (PCHIP, Fritsch-Carlson):
+                      smooth, but without the overshoot a natural cubic
+                      spline introduces, so a monotonic table stays monotonic
+
+    ibounds - what to do when x falls outside the table
+
+      0  error        raise a performance error and stop the instrument
+      1  clamp        hold the first or the last y
+      2  fill         output ifill
+      3  extrapolate  carry on along the first or the last segment
+
+    ifill - the value emitted when ibounds is 2. Optional, defaults to 0.
+
+    IMPLEMENTATION NOTES
+
+    The interval search is branchless, so its cost depends only on the table
+    size and not on how the input moves through the table: an unsorted input
+    array costs the same as a ramp.
+
+    Cubic mode relies on PCHIP being a local scheme - the slope at a
+    breakpoint depends only on the adjacent intervals - so the coefficients of
+    a single segment are derived on demand rather than tabulating the whole
+    curve. This keeps the opcode free of any auxiliary allocation even when
+    the breakpoints change at k-rate. The array and audio versions rebuild the
+    coefficients only when consecutive inputs cross into a different segment.
+*/
+
+
+#include "remap.h"
+#include "Opcodes/stdopcod.h"
+#include "arrays.h"
+#include "coreDefs.h"
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+static int32_t check_vector(ARRAYDAT *vec) {
+    if (vec == NULL || vec->sizes[0] < 2) {
+        return NOTOK;
+    }
+    return OK;
+}
+
+static int32_t check_mode(int32_t mode) {
+    int32_t is_valid_mode = mode >= REMAP_LINEAR && mode <= REMAP_CUBIC;
+    if (!is_valid_mode) return NOTOK;
+    return OK;
+}
+
+static int32_t check_bounds(int32_t bounds) {
+    int32_t is_valid_bounds = bounds >= REMAP_ERROR && bounds <= REMAP_EXTRAPOLATE;
+    if (!is_valid_bounds) return NOTOK;
+    return OK;
+}
+
+/*
+ * Largest i in [0, data_size - 2] with xdata[i] <= x.
+ *
+ * Branchless: the trip count depends only on data_size, so the loop is
+ * perfectly predicted and the single data-dependent step compiles to a
+ * conditional move. That makes the cost insensitive to the access pattern,
+ * unlike a plain left/right binary search whose comparison branch mispredicts
+ * on unsorted input.
+ * Requires xdata[0] <= x <= xdata[data_size - 1].
+ */
+static int32_t find_interval(double x, const MYFLT *xdata, int32_t data_size) {
+    int32_t base = 0;
+    int32_t len = data_size - 1;
+
+    while (len > 1) {
+        const int32_t half = len >> 1;
+        base += (x >= xdata[base + half]) ? half : 0;
+        len -= half;
+    }
+
+    return base;
+}
+
+static void find_lerp_interval(LERP_INTERVAL *interval, double x, const MYFLT *xdata, const MYFLT *ydata, int32_t data_size, INTERP_BOUNDS bounds) {
+
+    if (x < xdata[0] || x > xdata[data_size - 1]) {
+        switch (bounds) {
+            case REMAP_ERROR:
+                interval->bmode = REMAP_NOT_VALID;
+                return;
+            case REMAP_CLAMP:
+                if (x < xdata[0]) {
+                    interval->bmode = REMAP_CLAMP_LEFT;
+                } else {
+                    interval->bmode = REMAP_CLAMP_RIGHT;
+                }
+                return;
+            case REMAP_FILL:
+                interval->bmode = REMAP_FILL_VALUE;
+                return;
+            case REMAP_EXTRAPOLATE:
+                if (x < xdata[0]) {
+                    interval->x0 = xdata[0];
+                    interval->x1 = xdata[1];
+                    interval->y0 = ydata[0];
+                    interval->y1 = ydata[1];
+                    interval->index = 0;
+                    interval->bmode = REMAP_EXTRAPOLATE_LEFT;
+                } else {
+                    interval->x0 = xdata[data_size - 2];
+                    interval->x1 = xdata[data_size - 1];
+                    interval->y0 = ydata[data_size - 2];
+                    interval->y1 = ydata[data_size - 1];
+                    interval->index = data_size - 2;
+                    interval->bmode = REMAP_EXTRAPOLATE_RIGHT;
+                }
+                return;
+        }
+    }
+
+    const int32_t left = find_interval(x, xdata, data_size);
+
+    interval->x0 = xdata[left];
+    interval->x1 = xdata[left + 1];
+    interval->y0 = ydata[left];
+    interval->y1 = ydata[left + 1];
+    interval->index = left;
+    interval->bmode = REMAP_VALID;
+    return;
+}
+
+
+/*
+ * LINEAR INTERPOLATION
+ * y = (y0 (x1 - x) + y1 (x - x0)) / (x1 - x0)
+ */
+static double lerp(double x, double x0, double x1, double y0, double y1) {
+    return (y0 * (x1 - x) + y1 * (x - x0)) / (x1 - x0);
+}
+
+/*
+ * NEAREST INTERPOLATION
+ *     | y0 if (x - x0) <= (x1 - x)
+ * y = |
+ *     | y1 if (x - x0) > (x1 - x)
+ */
+static double nearest(double x, double x0, double x1, double y0, double y1) {
+    return ((x - x0) <= (x1 - x)) ? y0 : y1;
+}
+
+/*
+ * CUBIC PCHIP
+ */
+static double pchip_endpoint(double h0, double h1, double d0, double d1) {
+    double m = ((2.0 * h0 + h1) * d0 - h0 * d1) / (h0 + h1);
+    if ((m > 0.0) != (d0 > 0.0)) {
+        return 0.0;
+    }
+
+    if (((d0 > 0.0) != (d1 > 0.0)) && fabs(m) > 3.0 * fabs(d0)) {
+        return 3.0 * d0;
+    }
+
+    return m;
+}
+
+/*
+ * PCHIP slope at breakpoint i.
+ *
+ * The Fritsch-Carlson scheme is local: m[i] only depends on the one or two
+ * intervals adjacent to i. Evaluating it on demand therefore costs O(1) and
+ * removes the need to tabulate (and re-tabulate) the whole curve whenever the
+ * breakpoints change at k-rate.
+ */
+static double pchip_slope(const MYFLT *x, const MYFLT *y, int32_t n, int32_t i) {
+    double h0, h1, d0, d1;
+
+    if (n == 2) {
+        return ((double) y[1] - (double) y[0]) / ((double) x[1] - (double) x[0]);
+    }
+
+    if (i == 0) {
+        h0 = (double) x[1] - (double) x[0];
+        h1 = (double) x[2] - (double) x[1];
+        d0 = ((double) y[1] - (double) y[0]) / h0;
+        d1 = ((double) y[2] - (double) y[1]) / h1;
+        return pchip_endpoint(h0, h1, d0, d1);
+    }
+
+    if (i == n - 1) {
+        h0 = (double) x[n - 1] - (double) x[n - 2];
+        h1 = (double) x[n - 2] - (double) x[n - 3];
+        d0 = ((double) y[n - 1] - (double) y[n - 2]) / h0;
+        d1 = ((double) y[n - 2] - (double) y[n - 3]) / h1;
+        return pchip_endpoint(h0, h1, d0, d1);
+    }
+
+    h0 = (double) x[i] - (double) x[i - 1];
+    h1 = (double) x[i + 1] - (double) x[i];
+    d0 = ((double) y[i] - (double) y[i - 1]) / h0;
+    d1 = ((double) y[i + 1] - (double) y[i]) / h1;
+    if (d0 == 0.0 || d1 == 0.0 || ((d0 > 0.0) != (d1 > 0.0))) {
+        return 0.0;
+    }
+
+    const double w1 = 2.0 * h1 + h0;
+    const double w2 = h1 + 2.0 * h0;
+    return (w1 + w2) / (w1 / d0 + w2 / d1);
+}
+
+/*
+ * Cubic Hermite coefficients of segment i, with the PCHIP slopes resolved on
+ * the fly. Kept separate from the evaluation so that the vector opcode can
+ * reuse them across every input value falling in the same segment.
+ */
+static void pchip_segment(PCHIP_SEGMENT *s, const MYFLT *xdata, const MYFLT *ydata, int32_t n, int32_t i) {
+    const double x0 = (double) xdata[i];
+    const double y0 = (double) ydata[i];
+    const double h = (double) xdata[i + 1] - x0;
+
+    s->x0 = x0;
+    s->a = y0;
+
+    if (h <= 0.0) {               /* non-increasing x: no usable segment */
+        s->b = s->c = s->d = 0.0;
+        return;
+    }
+
+    const double delta = ((double) ydata[i + 1] - y0) / h;
+    const double m0 = pchip_slope(xdata, ydata, n, i);
+    const double m1 = pchip_slope(xdata, ydata, n, i + 1);
+
+    s->b = m0;
+    s->c = (3.0 * delta - 2.0 * m0 - m1) / h;
+    s->d = (m0 + m1 - 2.0 * delta) / (h * h);
+}
+
+/*
+ * Outside [x[i], x[i+1]] this extrapolates along the same cubic.
+ */
+static double pchip_segment_eval(const PCHIP_SEGMENT *s, double x) {
+    const double t = x - s->x0;
+    return ((s->d * t + s->c) * t + s->b) * t + s->a;
+}
+
+static double pchip_eval(double x, const MYFLT *xdata, const MYFLT *ydata, int32_t n, int32_t i) {
+    PCHIP_SEGMENT s;
+    pchip_segment(&s, xdata, ydata, n, i);
+    return pchip_segment_eval(&s, x);
+}
+
+/*
+ * True when the resolved overload takes i-rate arrays for both data inputs:
+ * the breakpoints are then fixed for the whole note.
+ */
+static int32_t data_is_static(OPDS *h) {
+    const char *t = h->optext->t.oentry->intypes;
+    int32_t arg = 0;
+    int32_t x_static = 0;
+    int32_t y_static = 0;
+
+    while (*t != '\0') {
+        char base = *t++;
+        int32_t is_array = 0;
+        if (*t == '[') {
+            t += 2;             /* skip the "[]" suffix */
+            is_array = 1;
+        }
+        if (arg == 1) x_static = is_array && base == 'i';
+        if (arg == 2) y_static = is_array && base == 'i';
+        arg++;
+    }
+
+    return x_static && y_static;
+}
+
+/*
+ * The interval search assumes strictly increasing breakpoints, for every
+ * interpolation mode. Only checked for i-rate data, where it costs nothing
+ * at performance time.
+ */
+static int32_t check_increasing(ARRAYDAT *vec) {
+    const MYFLT *v = vec->data;
+    for (int32_t i = 0; i < vec->sizes[0] - 1; ++i) {
+        if (v[i + 1] <= v[i]) {
+            return NOTOK;
+        }
+    }
+    return OK;
+}
+
+
+int32_t remap_value_init(CSOUND *csound, REMAP_VALUE *p) {
+    p->imode = (int32_t) *p->mode;
+    p->ibounds = (int32_t) *p->bounds;
+    p->fill_value = (double) *p->fill;
+
+    if (check_mode(p->imode) == NOTOK) {
+        return csound->InitError(csound, "[remap] Invalid interpolation mode");
+    }
+
+    if (check_bounds(p->ibounds) == NOTOK) {
+        return csound->InitError(csound, "[remap] Invalid interpolation bounds");
+    }
+
+    if (p->xdata->sizes == NULL || p->ydata->sizes == NULL)
+        return csound->InitError(csound, "[remap] array not initialised");
+
+    p->static_data = data_is_static(&p->h);
+
+    if (p->static_data) {
+        if (check_vector(p->xdata) != OK) {
+            return csound->InitError(csound, "[remap] Invalid x data array");
+        }
+
+        if (check_vector(p->ydata) != OK) {
+            return csound->InitError(csound, "[remap] Invalid y data array");
+        }
+
+        if (p->xdata->sizes[0] != p->ydata->sizes[0]) {
+            return csound->InitError(csound, "[remap] x and y must have same length");
+        }
+
+        if (check_increasing(p->xdata) != OK) {
+            return csound->InitError(csound, "[remap] x data must be strictly increasing");
+        }
+    }
+
+    return OK;
+}
+
+int32_t remap_value_perf(CSOUND *csound, REMAP_VALUE *p) {
+    if (!p->static_data) {
+        if (check_vector(p->xdata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid x data array");
+        }
+
+        if (check_vector(p->ydata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid y data array");
+        }
+
+        if (p->xdata->sizes[0] != p->ydata->sizes[0]) {
+            return csound->PerfError(csound, &(p->h), "[remap] x and y must have same length");
+        }
+    }
+
+    const MYFLT *xdata = p->xdata->data;
+    const MYFLT *ydata = p->ydata->data;
+    const double x = (double) *p->x;
+    int32_t size = p->ydata->sizes[0];
+
+    LERP_INTERVAL l_interval = {0};
+    find_lerp_interval(&l_interval, x, xdata, ydata, size, (INTERP_BOUNDS) p->ibounds);
+    switch (l_interval.bmode) {
+        case REMAP_NOT_VALID:
+            return csound->PerfError(csound, &(p->h), "[remap] x value out of bounds");
+        case REMAP_CLAMP_LEFT:
+            *p->y = ydata[0];
+            break;
+        case REMAP_CLAMP_RIGHT:
+            *p->y = ydata[size - 1];
+            break;
+        case REMAP_FILL_VALUE:
+            *p->y = (MYFLT) p->fill_value;
+            break;
+        case REMAP_VALID:
+        case REMAP_EXTRAPOLATE_LEFT:
+        case REMAP_EXTRAPOLATE_RIGHT:
+            switch (p->imode) {
+                case REMAP_LINEAR:
+                    *p->y = (MYFLT) lerp(x, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                    break;
+                case REMAP_NEAREST:
+                    *p->y = (MYFLT) nearest(x, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                    break;
+                case REMAP_PREVIOUS:
+                    *p->y = (MYFLT) l_interval.y0;
+                    break;
+                case REMAP_NEXT:
+                    *p->y = (MYFLT) l_interval.y1;
+                    break;
+                case REMAP_CUBIC:
+                    *p->y = (MYFLT) pchip_eval(x, xdata, ydata, size, l_interval.index);
+                    break;
+            }
+            break;
+    }
+
+    return OK;
+
+}
+
+int32_t remap_vec_init(CSOUND *csound, REMAP_VEC *p) {
+    p->imode = (int32_t) *p->mode;
+    p->ibounds = (int32_t) *p->bounds;
+    p->fill_value = (double) *p->fill;
+
+    if (check_mode(p->imode) == NOTOK) {
+        return csound->InitError(csound, "[remap] Invalid interpolation mode");
+    }
+
+    if (check_bounds(p->ibounds) == NOTOK) {
+        return csound->InitError(csound, "[remap] Invalid interpolation bounds");
+    }
+
+    if (p->xdata->sizes == NULL || p->ydata->sizes == NULL || p->x->sizes == NULL) {
+        return csound->InitError(csound, "[remap] array not initialised");
+    }
+
+    p->static_data = data_is_static(&p->h);
+
+    if (p->static_data) {
+        if (check_vector(p->xdata) != OK) {
+            return csound->InitError(csound, "[remap] Invalid x data array");
+        }
+
+        if (check_vector(p->ydata) != OK) {
+            return csound->InitError(csound, "[remap] Invalid y data array");
+        }
+
+        if (p->xdata->sizes[0] != p->ydata->sizes[0]) {
+            return csound->InitError(csound, "[remap] x and y must have same length");
+        }
+
+        if (check_increasing(p->xdata) != OK) {
+            return csound->InitError(csound, "[remap] x data must be strictly increasing");
+        }
+    }
+
+    tabinit(csound, p->y, p->x->sizes[0], p->h.insdshead);
+    return OK;
+}
+
+int32_t remap_vec_perf(CSOUND *csound, REMAP_VEC *p) {
+    if (p->x == NULL || p->x->sizes == NULL || p->x->sizes[0] < 1) {
+        return csound->PerfError(csound, &(p->h), "[remap] Invalid x array");
+    }
+
+    if (!p->static_data) {
+        if (check_vector(p->xdata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid x data array");
+        }
+
+        if (check_vector(p->ydata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid y data array");
+        }
+
+        if (p->xdata->sizes[0] != p->ydata->sizes[0]) {
+            return csound->PerfError(csound, &(p->h), "[remap] x and y must have same length");
+        }
+    }
+
+    const MYFLT *xdata = p->xdata->data;
+    const MYFLT *ydata = p->ydata->data;
+    const MYFLT *x = p->x->data;
+    int32_t size = p->ydata->sizes[0];
+    int32_t out_size = p->x->sizes[0];
+
+    if (p->y->sizes[0] != out_size) {       /* the input array may be resized */
+        tabinit(csound, p->y, out_size, p->h.insdshead);
+    }
+    MYFLT *y = p->y->data;
+
+    /* The PCHIP coefficients are rebuilt only when the segment changes, so at
+       most min(out_size, size - 1) times: never more work than tabulating the
+       whole curve, and much less whenever consecutive inputs are close. */
+    PCHIP_SEGMENT segment;
+    int32_t cached = -1;
+
+    for (int32_t k = 0; k < out_size; ++k) {
+        const double xv = (double) x[k];
+        LERP_INTERVAL l_interval = {0};
+
+        find_lerp_interval(&l_interval, xv, xdata, ydata, size, (INTERP_BOUNDS) p->ibounds);
+        switch (l_interval.bmode) {
+            case REMAP_NOT_VALID:
+                return csound->PerfError(csound, &(p->h), "[remap] x value out of bounds");
+            case REMAP_CLAMP_LEFT:
+                y[k] = ydata[0];
+                break;
+            case REMAP_CLAMP_RIGHT:
+                y[k] = ydata[size - 1];
+                break;
+            case REMAP_FILL_VALUE:
+                y[k] = (MYFLT) p->fill_value;
+                break;
+            case REMAP_VALID:
+            case REMAP_EXTRAPOLATE_LEFT:
+            case REMAP_EXTRAPOLATE_RIGHT:
+                switch (p->imode) {
+                    case REMAP_LINEAR:
+                        y[k] = (MYFLT) lerp(xv, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                        break;
+                    case REMAP_NEAREST:
+                        y[k] = (MYFLT) nearest(xv, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                        break;
+                    case REMAP_PREVIOUS:
+                        y[k] = (MYFLT) l_interval.y0;
+                        break;
+                    case REMAP_NEXT:
+                        y[k] = (MYFLT) l_interval.y1;
+                        break;
+                    case REMAP_CUBIC:
+                        if (l_interval.index != cached) {
+                            pchip_segment(&segment, xdata, ydata, size, l_interval.index);
+                            cached = l_interval.index;
+                        }
+                        y[k] = (MYFLT) pchip_segment_eval(&segment, xv);
+                        break;
+                }
+                break;
+        }
+    }
+
+    return OK;
+
+}
+
+int32_t remap_audio_perf(CSOUND *csound, REMAP_VALUE *p) {
+    if (!p->static_data) {
+        if (check_vector(p->xdata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid x data array");
+        }
+
+        if (check_vector(p->ydata) != OK) {
+            return csound->PerfError(csound, &(p->h), "[remap] Invalid y data array");
+        }
+
+        if (p->xdata->sizes[0] != p->ydata->sizes[0]) {
+            return csound->PerfError(csound, &(p->h), "[remap] x and y must have same length");
+        }
+    }
+
+    const MYFLT *xdata = p->xdata->data;
+    const MYFLT *ydata = p->ydata->data;
+    int32_t size = p->ydata->sizes[0];
+
+    PCHIP_SEGMENT segment;
+    int32_t cached = -1;
+
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
+    uint32_t nsamples = CS_KSMPS;
+
+    MYFLT *y = p->y;
+
+    if (UNLIKELY(offset)) {
+        memset(y, 0, sizeof(MYFLT) * offset);
+    }
+
+    if (UNLIKELY(early)) {
+        nsamples -= early;
+        memset(y + nsamples, 0, sizeof(MYFLT) * early);
+    }
+
+    for (uint32_t k = offset; k < nsamples; ++k) {
+        const double xv = (double) p->x[k];
+        LERP_INTERVAL l_interval = {0};
+
+        find_lerp_interval(&l_interval, xv, xdata, ydata, size, (INTERP_BOUNDS) p->ibounds);
+        switch (l_interval.bmode) {
+            case REMAP_NOT_VALID:
+                return csound->PerfError(csound, &(p->h), "[remap] x value out of bounds");
+            case REMAP_CLAMP_LEFT:
+                y[k] = ydata[0];
+                break;
+            case REMAP_CLAMP_RIGHT:
+                y[k] = ydata[size - 1];
+                break;
+            case REMAP_FILL_VALUE:
+                y[k] = (MYFLT) p->fill_value;
+                break;
+            case REMAP_VALID:
+            case REMAP_EXTRAPOLATE_LEFT:
+            case REMAP_EXTRAPOLATE_RIGHT:
+                switch (p->imode) {
+                    case REMAP_LINEAR:
+                        y[k] = (MYFLT) lerp(xv, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                        break;
+                    case REMAP_NEAREST:
+                        y[k] = (MYFLT) nearest(xv, l_interval.x0, l_interval.x1, l_interval.y0, l_interval.y1);
+                        break;
+                    case REMAP_PREVIOUS:
+                        y[k] = (MYFLT) l_interval.y0;
+                        break;
+                    case REMAP_NEXT:
+                        y[k] = (MYFLT) l_interval.y1;
+                        break;
+                    case REMAP_CUBIC:
+                        if (l_interval.index != cached) {
+                            pchip_segment(&segment, xdata, ydata, size, l_interval.index);
+                            cached = l_interval.index;
+                        }
+                        y[k] = (MYFLT) pchip_segment_eval(&segment, xv);
+                        break;
+                }
+                break;
+        }
+    }
+
+    return OK;
+
+}
+
+#define S(x) sizeof(x)
+
+static OENTRY remap[] = {
+    { "remap.kk",  S(REMAP_VALUE), 0, "k",   "kk[]k[]iio",   (SUBR) remap_value_init, (SUBR) remap_value_perf, NULL },
+    { "remap.ik",  S(REMAP_VALUE), 0, "k",   "ki[]k[]iio",   (SUBR) remap_value_init, (SUBR) remap_value_perf, NULL },
+    { "remap.ki",  S(REMAP_VALUE), 0, "k",   "ki[]i[]iio",   (SUBR) remap_value_init, (SUBR) remap_value_perf, NULL },
+    { "remap.kkk", S(REMAP_VEC),   0, "k[]", "k[]k[]k[]iio", (SUBR) remap_vec_init,   (SUBR) remap_vec_perf,   NULL },
+    { "remap.kik", S(REMAP_VEC),   0, "k[]", "k[]i[]k[]iio", (SUBR) remap_vec_init,   (SUBR) remap_vec_perf,   NULL },
+    { "remap.kii", S(REMAP_VEC),   0, "k[]", "k[]i[]i[]iio", (SUBR) remap_vec_init,   (SUBR) remap_vec_perf,   NULL },
+    { "remap.akk", S(REMAP_VALUE), 0, "a",   "ak[]k[]iio",   (SUBR) remap_value_init, (SUBR) remap_audio_perf,   NULL },
+    { "remap.aik", S(REMAP_VALUE), 0, "a",   "ai[]k[]iio",   (SUBR) remap_value_init, (SUBR) remap_audio_perf,   NULL },
+    { "remap.aii", S(REMAP_VALUE), 0, "a",   "ai[]i[]iio",   (SUBR) remap_value_init, (SUBR) remap_audio_perf,   NULL },
+};
+
+int32_t remap_init_(CSOUND *csound) {
+    return csound->AppendOpcodes(csound, &(remap[0]), (int32_t) (sizeof(remap) / sizeof(OENTRY)));
+}

--- a/Opcodes/remap.h
+++ b/Opcodes/remap.h
@@ -132,8 +132,10 @@ typedef struct {
 
 // REMAP
 
-int32_t remap_value(CSOUND *csound, REMAP_VALUE *p);
-int32_t remap_vec(CSOUND *csound, REMAP_VEC *p);
-int32_t remap_audio(CSOUND *csound, REMAP_VALUE *p);
+int32_t remap_value_init(CSOUND *csound, REMAP_VALUE *p);
+int32_t remap_vec_init(CSOUND *csound, REMAP_VEC *p);
+int32_t remap_value_perf(CSOUND *csound, REMAP_VALUE *p);
+int32_t remap_vec_perf(CSOUND *csound, REMAP_VEC *p);
+int32_t remap_audio_perf(CSOUND *csound, REMAP_VALUE *p);
 
 #endif

--- a/Opcodes/remap.h
+++ b/Opcodes/remap.h
@@ -1,0 +1,139 @@
+/*
+    remap.h:
+
+    Copyright (C) 2026 Pasquale Mainolfi.
+
+    This file is part of Csound.
+
+    The Csound Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    Csound is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with Csound; if not, write to the Free Software
+    Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+/*
+    remap - shared declarations. See remap.c for what the opcode does.
+
+    The interpolation mode and the out-of-bounds policy reach the opcode from
+    the orchestra as plain integers, so the two enums below fix that encoding:
+    their numeric values are part of the opcode interface and must not be
+    reordered or renumbered.
+
+    LERP_INTERVAL carries the outcome of one table lookup: the bracketing
+    breakpoints, the index of the segment they delimit, and how the bounds
+    policy resolved the request. PCHIP_SEGMENT holds the cubic Hermite
+    coefficients of one segment, kept apart from the evaluation so that the
+    array and audio versions can reuse them across consecutive inputs landing
+    in the same segment.
+
+    REMAP_VALUE backs the scalar and the audio overloads, REMAP_VEC the array
+    ones.
+*/
+
+
+#ifndef __REMAP_H
+#define __REMAP_H
+
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
+#include <stdint.h>
+
+
+typedef enum {
+    REMAP_LINEAR   = 0,
+    REMAP_NEAREST  = 1,
+    REMAP_PREVIOUS = 2,
+    REMAP_NEXT     = 3,
+    REMAP_CUBIC    = 4
+} INTERP_MODE;
+
+typedef enum {
+    REMAP_ERROR       = 0,
+    REMAP_CLAMP       = 1,
+    REMAP_FILL        = 2,
+    REMAP_EXTRAPOLATE = 3
+} INTERP_BOUNDS;
+
+typedef enum {
+    REMAP_VALID = 0,
+    REMAP_NOT_VALID,
+    REMAP_CLAMP_LEFT,
+    REMAP_CLAMP_RIGHT,
+    REMAP_FILL_VALUE,
+    REMAP_EXTRAPOLATE_LEFT,
+    REMAP_EXTRAPOLATE_RIGHT
+} INTERVAL_BOUNDS_MODE;
+
+typedef struct{
+   double x0;
+   double x1;
+   double y0;
+   double y1;
+   int32_t index;
+   INTERVAL_BOUNDS_MODE bmode;
+} LERP_INTERVAL;
+
+/* cubic Hermite coefficients of a single PCHIP segment, relative to x0 */
+typedef struct {
+    double x0;
+    double a;
+    double b;
+    double c;
+    double d;
+} PCHIP_SEGMENT;
+
+typedef struct {
+    OPDS h;
+    // outputs
+    MYFLT *y;
+    // inputs
+    MYFLT *x;
+    ARRAYDAT *xdata;
+    ARRAYDAT *ydata;
+    MYFLT *mode;
+    MYFLT *bounds;
+    MYFLT *fill;
+    // private
+    double fill_value;
+    int32_t imode;
+    int32_t ibounds;
+    /* set when both data arrays are i-rate: the breakpoints cannot change
+       during performance, so they are validated once at init */
+    int32_t static_data;
+} REMAP_VALUE;
+
+typedef struct {
+    OPDS h;
+    // outputs
+    ARRAYDAT *y;
+    // inputs
+    ARRAYDAT *x;
+    ARRAYDAT *xdata;
+    ARRAYDAT *ydata;
+    MYFLT *mode;
+    MYFLT *bounds;
+    MYFLT *fill;
+    // private
+    double fill_value;
+    int32_t imode;
+    int32_t ibounds;
+    int32_t static_data;
+} REMAP_VEC;
+
+// REMAP
+
+int32_t remap_value(CSOUND *csound, REMAP_VALUE *p);
+int32_t remap_vec(CSOUND *csound, REMAP_VEC *p);
+int32_t remap_audio(CSOUND *csound, REMAP_VALUE *p);
+
+#endif

--- a/Opcodes/stdopcod.c
+++ b/Opcodes/stdopcod.c
@@ -98,6 +98,7 @@ int32_t stdopc_ModuleInit(CSOUND *csound)
     err |= wave_terrain_init_(csound);
     err |= wter2_init_(csound);
     err |= dbap_init_(csound);
+    err |= remap_init_(csound);
 
     return (err ? CSOUND_ERROR : CSOUND_SUCCESS);
 }

--- a/Opcodes/stdopcod.h
+++ b/Opcodes/stdopcod.h
@@ -121,6 +121,7 @@ wave_terrain_init_(CSOUND *);
 extern int32_t
 wter2_init_(CSOUND *);
 extern int32_t dbap_init_(CSOUND *);
+extern int32_t remap_init_(CSOUND *);
 
 
 #endif  /* CSOUND_STDOPCOD_H */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -852,6 +852,12 @@ def runTest():
             "test_signalflowgraph_lifetime.csd",
             "test signal-flow graph cleanup and ftgenonce",
         ],
+        ["test_remap.csd", "test remap opcodes"],
+        [
+            "test_remap_bounds_error.csd",
+            "expected failure: remap bounds=error with x out of range",
+            1,
+        ],
     ]
 
     parcsTests = [

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -853,6 +853,7 @@ def runTest():
             "test signal-flow graph cleanup and ftgenonce",
         ],
         ["test_remap.csd", "test remap opcodes"],
+        ["test_remap_sample_accurate.csd", "test remap audio with sample-accurate timing"],
         [
             "test_remap_bounds_error.csd",
             "expected failure: remap bounds=error with x out of range",

--- a/tests/commandline/test_remap.csd
+++ b/tests/commandline/test_remap.csd
@@ -1,0 +1,372 @@
+<CsoundSynthesizer>
+<CsOptions>
+
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; remap opcode tests.
+;
+; Reference table for most tests:
+;
+;     x = [0, 1, 3, 4]
+;     y = [0, 2, 2, 6]
+;
+; The flat middle segment (y goes 2 -> 2) is deliberate: it pins down the
+; shape-preserving property of the cubic mode, where a natural cubic spline
+; would bulge away from 2.
+;
+; Expected values were derived from the interpolation formulas and checked
+; against scipy.interpolate.PchipInterpolator for the cubic mode.
+
+#define TOL # 0.0001 #
+
+#define MODE_LINEAR   # 0 #
+#define MODE_NEAREST  # 1 #
+#define MODE_PREVIOUS # 2 #
+#define MODE_NEXT     # 3 #
+#define MODE_CUBIC    # 4 #
+
+#define BOUNDS_ERROR       # 0 #
+#define BOUNDS_CLAMP       # 1 #
+#define BOUNDS_FILL        # 2 #
+#define BOUNDS_EXTRAPOLATE # 3 #
+
+; A UDO cannot reach a global, so the assertions return a failure flag and each
+; instrument sums it into its own counter. printf only emits when its trigger
+; changes, so a constant trigger of 1 reports a failing call site once rather
+; than once per control period.
+opcode assert_k(got:k, want:i, id:i):k
+  bad:k = 0
+  if abs(got - want) > $TOL then
+    bad = 1
+    printf("remap FAIL test %d: expected %f, got %f\n", 1, id, want, got)
+  endif
+  xout bad
+endop
+
+opcode assert_range(got:k, lo:i, hi:i, id:i):k
+  bad:k = 0
+  if got < lo - $TOL || got > hi + $TOL then
+    bad = 1
+    printf("remap FAIL test %d: %f outside [%f, %f]\n", 1, id, got, lo, hi)
+  endif
+  xout bad
+endop
+
+; exitnow is an i-time opcode, so it cannot fire from inside a k-rate branch.
+; A failing instrument schedules instr 99 instead, and the exit happens in its
+; init pass. Nothing is polled after the fact, so no state has to survive the
+; end of a note and no k-to-i conversion is involved.
+opcode abort_on_fail(bad:k):void
+  latch:k init 0
+  if bad > 0 && latch == 0 then
+    latch = 1
+    schedulek(99, 0, 0.01)
+  endif
+endop
+
+
+; ---------------------------------------------------------------- modes
+; i-rate tables, k-rate scalar input -> remap.ki
+instr 1
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:i[] = fillarray(0, 2, 2, 6)
+  fails:k = 0
+
+  ; linear, nearest and cubic pass exactly through every breakpoint
+  fails += assert_k(remap(k(0), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 0, 100)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 2, 101)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 2, 102)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 6, 103)
+
+  fails += assert_k(remap(k(0), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 0, 110)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 2, 111)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 2, 112)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 6, 113)
+
+  fails += assert_k(remap(k(0), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0, 120)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 121)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 122)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 6, 123)
+
+  ; previous and next are step functions: on a breakpoint they return the end
+  ; of the segment the search lands on, not the breakpoint itself
+  fails += assert_k(remap(k(0), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 0, 130)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 2, 131)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 2, 132)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 2, 133)
+
+  fails += assert_k(remap(k(0), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 2, 140)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 2, 141)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 6, 142)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 6, 143)
+
+  ; linear
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 1, 200)
+  fails += assert_k(remap(k(2.0), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 2, 201)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 4, 202)
+
+  ; nearest: a tie resolves to the left breakpoint
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 0, 210)
+  fails += assert_k(remap(k(0.6), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 2, 211)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 2, 212)
+  fails += assert_k(remap(k(3.6), xd, yd, $MODE_NEAREST, $BOUNDS_EXTRAPOLATE), 6, 213)
+
+  ; previous / next inside a segment
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 0, 220)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_PREVIOUS, $BOUNDS_EXTRAPOLATE), 2, 221)
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 2, 230)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_NEXT, $BOUNDS_EXTRAPOLATE), 6, 231)
+
+  ; cubic (PCHIP)
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 4/3, 240)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 10/3, 241)
+
+  ; across the flat segment the cubic stays flat: no overshoot
+  fails += assert_k(remap(k(1.25), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 250)
+  fails += assert_k(remap(k(1.5),  xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 251)
+  fails += assert_k(remap(k(2.0),  xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 252)
+  fails += assert_k(remap(k(2.5),  xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 253)
+  fails += assert_k(remap(k(2.75), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 254)
+
+  abort_on_fail(fails)
+endin
+
+
+; ---------------------------------------------------- overload resolution
+; k-rate tables -> remap.kk
+instr 2
+  xd:k[] = fillarray:k[](0, 1, 3, 4)
+  yd:k[] = fillarray:k[](0, 2, 2, 6)
+  fails:k = 0
+
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 1, 300)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 4, 301)
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 4/3, 302)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 10/3, 303)
+
+  abort_on_fail(fails)
+endin
+
+; i-rate x table, k-rate y table -> remap.ik
+instr 3
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:k[] = fillarray:k[](0, 2, 2, 6)
+  fails:k = 0
+
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 1, 310)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 4, 311)
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 4/3, 312)
+  fails += assert_k(remap(k(3.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 10/3, 313)
+
+  abort_on_fail(fails)
+endin
+
+; a k-rate table may be rewritten during performance and must be picked up
+instr 4
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:k[] = fillarray:k[](0, 2, 2, 6)
+  fails:k = 0
+
+  if timeinstk() > 1 then
+    yd[1] = 4
+    yd[2] = 4
+    yd[3] = 12
+  endif
+
+  a:k = remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE)
+  b:k = remap(k(3.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE)
+
+  if timeinstk() > 1 then
+    fails += assert_k(a, 2, 320)
+    fails += assert_k(b, 8, 321)
+  else
+    fails += assert_k(a, 1, 322)
+    fails += assert_k(b, 4, 323)
+  endif
+
+  abort_on_fail(fails)
+endin
+
+
+; --------------------------------------------------------------- bounds
+instr 5
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:i[] = fillarray(0, 2, 2, 6)
+  fails:k = 0
+
+  ; clamp: hold the first or the last y
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_LINEAR, $BOUNDS_CLAMP), 0, 400)
+  fails += assert_k(remap(k(5),  xd, yd, $MODE_LINEAR, $BOUNDS_CLAMP), 6, 401)
+
+  ; fill: the optional argument defaults to 0
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_LINEAR, $BOUNDS_FILL), 0, 410)
+  fails += assert_k(remap(k(5),  xd, yd, $MODE_LINEAR, $BOUNDS_FILL), 0, 411)
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_LINEAR, $BOUNDS_FILL, -99), -99, 412)
+  fails += assert_k(remap(k(5),  xd, yd, $MODE_LINEAR, $BOUNDS_FILL, -99), -99, 413)
+
+  ; the fill value is ignored while x stays inside the table
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_FILL, -99), 1, 414)
+
+  ; extrapolate: carry on along the first or the last segment
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), -2, 420)
+  fails += assert_k(remap(k(5),  xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 10, 421)
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), -2/3, 422)
+  fails += assert_k(remap(k(5),  xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 22/3, 423)
+
+  abort_on_fail(fails)
+endin
+
+
+; --------------------------------------------------------------- arrays
+instr 6
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:i[] = fillarray(0, 2, 2, 6)
+  xs:k[] = fillarray:k[](0.5, 2, 3.5)
+  fails:k = 0
+
+  ys:k[] = remap(xs, xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE)
+
+  fails += assert_k(lenarray(ys), 3, 500)
+  fails += assert_k(ys[0], 1, 501)
+  fails += assert_k(ys[1], 2, 502)
+  fails += assert_k(ys[2], 4, 503)
+
+  ; the array version must agree with the scalar one, element by element
+  yc:k[] = remap(xs, xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE)
+  fails += assert_k(yc[0] - remap(k(0.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0, 510)
+  fails += assert_k(yc[1] - remap(k(2.0), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0, 511)
+  fails += assert_k(yc[2] - remap(k(3.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0, 512)
+
+  ; unsorted input: every element is resolved on its own
+  xu:k[] = fillarray:k[](3.5, 0.5, 2)
+  yu:k[] = remap(xu, xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE)
+  fails += assert_k(yu[0], 4, 520)
+  fails += assert_k(yu[1], 1, 521)
+  fails += assert_k(yu[2], 2, 522)
+
+  ; out-of-range elements follow the bounds policy without disturbing the rest
+  xb:k[] = fillarray:k[](-1, 0.5, 5)
+  yb:k[] = remap(xb, xd, yd, $MODE_LINEAR, $BOUNDS_CLAMP)
+  fails += assert_k(yb[0], 0, 530)
+  fails += assert_k(yb[1], 1, 531)
+  fails += assert_k(yb[2], 6, 532)
+
+  abort_on_fail(fails)
+endin
+
+
+; ---------------------------------------------------------------- audio
+instr 7
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:i[] = fillarray(0, 2, 2, 6)
+  fails:k = 0
+
+  y1:a = remap(a(k(0.5)), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE)
+  y2:a = remap(a(k(3.5)), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE)
+  y3:a = remap(a(k(-1)),  xd, yd, $MODE_LINEAR, $BOUNDS_CLAMP)
+  y4:a = remap(a(k(5)),   xd, yd, $MODE_LINEAR, $BOUNDS_FILL, -99)
+
+  ; a(k) ramps from the previous control value across the block, so the a-rate
+  ; input only settles on a constant from the second control period onwards.
+  ; k(a) then reads the first sample of the block.
+  if timeinstk() > 1 then
+    fails += assert_k(k(y1), 1,    600)
+    fails += assert_k(k(y2), 10/3, 601)
+    fails += assert_k(k(y3), 0,    602)
+    fails += assert_k(k(y4), -99,  603)
+  endif
+
+  ; sweeping input, clamped: every sample must stay inside the tabulated range.
+  ; maxk flags: 2 = running maximum, 3 = running minimum, reset on each trigger
+  x:k = line(0, p3, 4)
+  ys:a = remap(a(x), xd, yd, $MODE_CUBIC, $BOUNDS_CLAMP)
+  fails += assert_range(maxk(ys, 1, 2), 0, 6, 610)
+  fails += assert_range(maxk(ys, 1, 3), 0, 6, 611)
+
+  abort_on_fail(fails)
+endin
+
+
+; ------------------------------------------------- cubic shape preservation
+; PCHIP must not overshoot: a monotone table stays monotone and the output
+; never leaves the range of the tabulated y. The steep step between 0.15 and 3
+; is exactly where a natural cubic spline would ring.
+instr 8
+  xd:i[] = fillarray(0, 1, 2, 3, 4)
+  yd:i[] = fillarray(0, 0.1, 0.15, 3, 3.2)
+  fails:k = 0
+
+  x:k = line(0, p3, 4)
+  y:k = remap(x, xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE)
+
+  ; never decreasing, and never outside the tabulated range
+  prev:k init 0
+  fails += assert_range(y - prev, 0, 4, 700)
+  fails += assert_range(y, 0, 3.2, 701)
+  prev = y
+
+  ; and the curve still passes exactly through every breakpoint
+  fails += assert_k(remap(k(0), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0,    710)
+  fails += assert_k(remap(k(1), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0.1,  711)
+  fails += assert_k(remap(k(2), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 0.15, 712)
+  fails += assert_k(remap(k(3), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 3,    713)
+  fails += assert_k(remap(k(4), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 3.2,  714)
+
+  abort_on_fail(fails)
+endin
+
+
+; -------------------------------------------- smallest table: two points
+instr 9
+  xd:i[] = fillarray(0, 2)
+  yd:i[] = fillarray(1, 5)
+  fails:k = 0
+
+  ; with two breakpoints the cubic degenerates to the straight line
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 2, 800)
+  fails += assert_k(remap(k(0.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 2, 801)
+  fails += assert_k(remap(k(1.5), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 4, 802)
+  fails += assert_k(remap(k(1.5), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 4, 803)
+
+  ; and extrapolation carries on along the same line
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), -1, 810)
+  fails += assert_k(remap(k(-1), xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), -1, 811)
+  fails += assert_k(remap(k(3),  xd, yd, $MODE_LINEAR, $BOUNDS_EXTRAPOLATE), 7, 812)
+  fails += assert_k(remap(k(3),  xd, yd, $MODE_CUBIC, $BOUNDS_EXTRAPOLATE), 7, 813)
+
+  abort_on_fail(fails)
+endin
+
+
+; --------------------------------------------------------------- verdict
+; instr 98 is only reached when no instrument aborted the run before it
+instr 98
+  prints("remap: all tests passed\n")
+endin
+
+instr 99
+  prints("remap: assertions failed, see the FAIL lines above\n")
+  exitnow(-1)
+endin
+
+</CsInstruments>
+<CsScore>
+i1  0   0.5
+i2  0   0.5
+i3  0   0.5
+i4  0   0.5
+i5  0   0.5
+i6  0   0.5
+i7  0   0.5
+i8  0   1
+i9  0   0.5
+i98 5.2 0.1
+e 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_remap.csd
+++ b/tests/commandline/test_remap.csd
@@ -1,6 +1,6 @@
 <CsoundSynthesizer>
 <CsOptions>
-
+-n -m0 --sample-accurate
 </CsOptions>
 <CsInstruments>
 
@@ -344,6 +344,82 @@ instr 9
 endin
 
 
+; ------------------------------------------------- waveshaping (audio input)
+; Running an a-rate signal through the table is a waveshaper, which only holds
+; if every sample is transformed on its own. So an identity table has to give
+; the input back sample for sample, and a clipping table has to really clip.
+;
+; The drive is deliberately fast - 2 kHz is about 22 samples per cycle, so a
+; 32-sample block spans nearly a cycle and a half. Anything that handled the
+; signal per block instead of per sample would show up here as an error close
+; to the full peak-to-peak swing, not as a rounding difference.
+instr 10
+  fails:k = 0
+
+  drive:a = oscili(0.8, 2000)
+
+  ; identity transfer function: the output must be the input
+  ix:i[] = fillarray(-1, 1)
+  iy:i[] = fillarray(-1, 1)
+  through:a = remap(drive, ix, iy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  fails += assert_range(max_k(through - drive, 1, 1), 0, 0, 900)
+
+  ; doubling transfer function: every sample scaled by 2
+  gx:i[] = fillarray(-1, 1)
+  gy:i[] = fillarray(-2, 2)
+  doubled:a = remap(drive, gx, gy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  fails += assert_range(max_k(doubled - drive * 2, 1, 1), 0, 0, 901)
+
+  ; hard clip at +-0.5: the transfer curve is flat past the knee, so a steady
+  ; drive beyond it lands exactly on the ceiling or the floor. Constants are
+  ; used here rather than the oscillator because the last block of a note is
+  ; partial under --sample-accurate, and a peak is not guaranteed to fall in it.
+  ; 0.8 in giving 0.5 out is also the nonlinearity itself: a linear map through
+  ; this table would have returned the input untouched.
+  cx:i[] = fillarray(-1, -0.5, 0.5, 1)
+  cy:i[] = fillarray(-0.5, -0.5, 0.5, 0.5)
+  above:a = remap(a(k(0.8)),  cx, cy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  below:a = remap(a(k(-0.8)), cx, cy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  if timeinstk() > 1 then
+    fails += assert_k(k(above),  0.5, 910)
+    fails += assert_k(k(below), -0.5, 911)
+  endif
+
+  ; and a moving signal never leaves the knee either
+  clipped:a = remap(drive, cx, cy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  fails += assert_range(max_k(clipped, 1, 1), 0, 0.5, 912)
+
+  ; the cubic transfer curve stays inside the tabulated range, so a waveshaper
+  ; built on it cannot exceed the ceiling the user drew
+  sx:i[] = fillarray(-1, -0.5, 0, 0.5, 1)
+  sy:i[] = fillarray(-0.8, -0.6, 0, 0.6, 0.8)
+  soft:a = remap(drive, sx, sy, $MODE_CUBIC, $BOUNDS_CLAMP)
+  fails += assert_range(max_k(soft, 1, 1), 0, 0.8, 920)
+
+  abort_on_fail(fails)
+endin
+
+
+; ------------------------------------------- sample-accurate note start
+; --sample-accurate is on, so a note starting off a block boundary reaches the
+; opcode with a non-zero ksmps_offset. The samples it does compute still have
+; to line up with the input, so an identity table must reproduce the input
+; exactly. max_k scans only the active part of the block, which is precisely
+; the region an indexing mistake in the audio loop would corrupt.
+instr 11
+  fails:k = 0
+
+  ix:i[] = fillarray(-1, 1)
+  iy:i[] = fillarray(-1, 1)
+
+  drive:a = oscili(0.8, 2000)
+  through:a = remap(drive, ix, iy, $MODE_LINEAR, $BOUNDS_CLAMP)
+  fails += assert_range(max_k(through - drive, 1, 1), 0, 0, 930)
+
+  abort_on_fail(fails)
+endin
+
+
 ; --------------------------------------------------------------- verdict
 ; instr 98 is only reached when no instrument aborted the run before it
 instr 98
@@ -366,6 +442,9 @@ i6  0   0.5
 i7  0   0.5
 i8  0   1
 i9  0   0.5
+i10 0   0.5
+; starts 10 samples into a block, so instr 11 runs with ksmps_offset = 10
+i11 0.00022675736961451248 0.5
 i98 5.2 0.1
 e 1
 </CsScore>

--- a/tests/commandline/test_remap.csd
+++ b/tests/commandline/test_remap.csd
@@ -1,6 +1,6 @@
 <CsoundSynthesizer>
 <CsOptions>
--n -m0 --sample-accurate
+-n -m0
 </CsOptions>
 <CsInstruments>
 
@@ -400,26 +400,6 @@ instr 10
 endin
 
 
-; ------------------------------------------- sample-accurate note start
-; --sample-accurate is on, so a note starting off a block boundary reaches the
-; opcode with a non-zero ksmps_offset. The samples it does compute still have
-; to line up with the input, so an identity table must reproduce the input
-; exactly. max_k scans only the active part of the block, which is precisely
-; the region an indexing mistake in the audio loop would corrupt.
-instr 11
-  fails:k = 0
-
-  ix:i[] = fillarray(-1, 1)
-  iy:i[] = fillarray(-1, 1)
-
-  drive:a = oscili(0.8, 2000)
-  through:a = remap(drive, ix, iy, $MODE_LINEAR, $BOUNDS_CLAMP)
-  fails += assert_range(max_k(through - drive, 1, 1), 0, 0, 930)
-
-  abort_on_fail(fails)
-endin
-
-
 ; --------------------------------------------------------------- verdict
 ; instr 98 is only reached when no instrument aborted the run before it
 instr 98
@@ -443,9 +423,9 @@ i7  0   0.5
 i8  0   1
 i9  0   0.5
 i10 0   0.5
-; starts 10 samples into a block, so instr 11 runs with ksmps_offset = 10
-i11 0.00022675736961451248 0.5
-i98 5.2 0.1
-e 1
+; the verdict runs once every test note is over; instr 99 only ever exists if
+; an assertion scheduled it, and its exitnow stops the run before this point
+i98 1.2 0.1
+e 2
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_remap_bounds_error.csd
+++ b/tests/commandline/test_remap_bounds_error.csd
@@ -1,0 +1,37 @@
+<CsoundSynthesizer>
+<CsOptions>
+
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; remap with bounds = error must raise a performance error as soon as x falls
+; outside the breakpoint table. The error aborts the event and csound returns
+; a non-zero code, so this case cannot live alongside the other remap tests:
+; it is registered as an expected failure instead.
+;
+; Everything else in this file is deliberately kept out, so a non-zero return
+; can only come from the out-of-range lookup below.
+
+#define MODE_LINEAR  # 0 #
+#define BOUNDS_ERROR # 0 #
+
+instr 1
+  xd:i[] = fillarray(0, 1, 3, 4)
+  yd:i[] = fillarray(0, 2, 2, 6)
+
+  ; 5 is past the last breakpoint
+  y:k = remap(k(5), xd, yd, $MODE_LINEAR, $BOUNDS_ERROR)
+  printf("remap: bounds=error did not abort, got %f\n", 1, y)
+endin
+
+</CsInstruments>
+<CsScore>
+i1 0 0.5
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_remap_sample_accurate.csd
+++ b/tests/commandline/test_remap_sample_accurate.csd
@@ -1,0 +1,62 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; remap: audio input under --sample-accurate.
+;
+; A note starting away from a control-period boundary reaches the opcode with a
+; non-zero ksmps_offset. The samples it does compute still have to line up with
+; the input, so an identity table must reproduce the input exactly. max_k scans
+; only the active part of the block, which is precisely the region an indexing
+; mistake in the audio loop would corrupt.
+;
+; The drive is fast on purpose - 2 kHz is about 22 samples per cycle - so a
+; misalignment shows up as a large error rather than a rounding difference.
+;
+; This lives apart from test_remap.csd because --sample-accurate is enough on
+; its own to keep a single-precision build from ever ending the performance,
+; whatever the score says. The explicit `e` below is what terminates the run.
+
+#define TOL # 0.0001 #
+
+#define MODE_LINEAR  # 0 #
+#define BOUNDS_CLAMP # 1 #
+
+instr 1
+  ix:i[] = fillarray(-1, 1)
+  iy:i[] = fillarray(-1, 1)
+
+  drive:a = oscili(0.8, 2000)
+  through:a = remap(drive, ix, iy, $MODE_LINEAR, $BOUNDS_CLAMP)
+
+  err:k = max_k(through - drive, 1, 1)
+  if err > $TOL then
+    printf("remap FAIL test 930: identity table drifted by %f\n", 1, err)
+    schedulek(99, 0, 0.01)
+  endif
+endin
+
+instr 98
+  prints("remap sample-accurate: all tests passed\n")
+endin
+
+instr 99
+  prints("remap sample-accurate: assertions failed, see the FAIL lines above\n")
+  exitnow(-1)
+endin
+
+</CsInstruments>
+<CsScore>
+; starts 10 samples into a block, so instr 1 runs with ksmps_offset = 10
+i1  0.00022675736961451248 0.2
+i98 0.3 0.01
+e 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
# Add the `remap` opcode

This adds `remap`, an opcode that maps a value onto an arbitrary curve defined by
a breakpoint table. Given a pair of arrays holding the breakpoints (`xdata`,
`ydata`), it returns the `y` matching the input `x`, interpolating between the
two breakpoints that bracket it.

It is directly inspired by `scipy.interpolate.interp1d`, and the argument list
mirrors it on purpose: `mode` corresponds to `kind`, and `bounds` plus the
optional `fill` cover what SciPy splits between `bounds_error` and `fill_value`
(including `fill_value="extrapolate"`). The four non-cubic modes are named after
SciPy's and produce the same values.

The reason I think this is worth having in Csound is that arbitrary mappings are
everywhere in practice and there is currently no single opcode for them. `remap` takes the
breakpoints as plain arrays, so they can be irregular, computed in the
orchestra, and rewritten during performance simply by assigning to the array.

It also covers the three shapes of the problem with the same opcode: a single
control value, a whole array in one call, and an audio signal. That last case is
the one I find most interesting: mapping an a-rate signal through a breakpoint
table *is* a waveshaper whose transfer function is an ordinary Csound array.

```csound
xd:i[] = fillarray(-1, -0.5, 0, 0.5, 1)
yd:i[] = fillarray(-1, -0.7, 0, 0.7, 1)

sig:a = oscili(0.8, 220)
out(remap(sig, xd, yd, 4, 1))      ; cubic, clamp
```

Changing the curve means writing into `yd`, so the transfer function can be
drawn, morphed or modulated at k-rate without rebuilding a table. The
shape-preserving cubic matters here: it keeps the transfer curve free of the
overshoot a natural spline would add between the points the user actually chose.

## What it does

```
y:k   = remap(x:k,   xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
y:k[] = remap(x:k[], xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
y:a   = remap(x:a,   xdata:k[], ydata:k[], mode:i, bounds:i [, fill:i])
```

Nine overloads: scalar, array and audio input, each accepting the breakpoint
tables at i- or k-rate. Five interpolation modes (linear, nearest, previous,
next, shape-preserving cubic) and four out-of-range policies (error, clamp,
fill, extrapolate).

The `x` table must be strictly increasing; both tables must hold at least two
points and have the same length.

## Design notes

### The cubic mode is PCHIP, evaluated locally

This is the one place where the opcode deliberately departs from `interp1d`.
SciPy's `kind='cubic'` is a natural cubic spline; `remap` uses the
shape-preserving Fritsch-Carlson cubic instead, the scheme SciPy exposes
separately as `PchipInterpolator`. On a monotonic table the result stays
monotonic and never leaves the range of the tabulated values, which matters when
the curve drives an amplitude or a frequency and an overshoot would be audible as
a bump the user never asked for.

The difference is not academic. On the table `x = [0, 1, 3, 4]`,
`y = [0, 2, 2, 6]`, whose middle segment is flat, the spline dips to 1.5625
between two breakpoints that both hold 2 — a deviation of 0.44 invented out of
nothing. PCHIP stays at exactly 2 across the whole segment.
PCHIP is a *local* scheme: the slope at a breakpoint depends only on the one or 
two intervals adjacent to it, so the coefficients of a single segment can be derived 
on demand from a four-point stencil. 
Evaluating a segment costs a fixed number of operations regardless of
table size, and the opcode needs no auxiliary allocation at all, which also
removes the whole question of allocating from the audio thread when a k-rate
table is resized mid-note.

The array and audio versions memoize the coefficients of the current segment and
rebuild them only when consecutive inputs cross into a different one, so the work
per call is bounded by `min(number of inputs, number of segments)`, never more
than tabulating the whole curve would cost, and usually far less.

### The interval search is branchless

The search is the branchless form of binary search: the trip count depends only
on the table size, so the loop is perfectly predicted and the single
data-dependent step compiles to a conditional move.

The branchless form is faster than a plain binary search on *every* table size and *both*
access patterns, and its cost barely differs between them:

| n | pattern | branchy | branchless |
|---|---|---|---|
| 16 | coherent ramp | 1.89 ns | 1.67 ns |
| 16 | random | 2.54 ns | 1.75 ns |
| 256 | random | 5.38 ns | 4.81 ns |

Predictable behaviour under any input seemed worth more than a best case that
depends on how the user drives the opcode.

### Validation happens where it is free

When both tables are i-rate the breakpoints cannot change during the note, so
they are validated once at init, including a strict-increase check that fails
loudly before the note starts. With k-rate tables the same check would cost O(n)
per control period, so it is not performed and the precondition is documented
instead. The opcode detects which case applies by inspecting the `intypes` of
the resolved overload.

## Notes and limitations

- With k-rate tables the strict-increase precondition on `xdata` is not checked.
  A non-increasing table yields undefined values rather than an error, in every
  mode. Validating it would cost an O(n) scan per control period.
- `previous` and `next` are step functions, so on a breakpoint they return the
  end of the segment the search lands on rather than the breakpoint itself. The
  tests pin this down explicitly so it is not mistaken for a rounding issue.
- `bounds = error` reports through `PerfError`, so it terminates the instrument
  instance rather than clamping and continuing.