### PR TITLE
fix(wasm): enable signal-flow graph opcodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1242,7 +1242,8 @@ else()
     # Limited C++ opcodes for WASI builds
     set(cppops_SRCS
         Opcodes/bformdec2.cpp
-        Opcodes/padsynth_gen.cpp)
+        Opcodes/padsynth_gen.cpp
+        Opcodes/signalflowgraph.cpp)
 endif()
 
 list(APPEND libcsound_SRCS)

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -1343,11 +1343,12 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
   }
   SignalFlowGraphState *sfg_globals = nullptr;
   QueryGlobalPointer(csound, "sfg_globals", sfg_globals);
-#ifndef __wasi__
+#ifdef __wasi__
+  // signal_flow_ftables_lock is expected to be NULL on WASI.
+  if (UNLIKELY(sfg_globals == nullptr)) {
+#else
   if (UNLIKELY(sfg_globals == nullptr ||
                sfg_globals->signal_flow_ftables_lock == nullptr)) {
-#else
-  if (UNLIKELY(sfg_globals == nullptr)) {
 #endif
     return csound->InitError(csound, "%s",
                              Str("ftgenonce: not initialized"));

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -1343,11 +1343,12 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
   }
   SignalFlowGraphState *sfg_globals = nullptr;
   QueryGlobalPointer(csound, "sfg_globals", sfg_globals);
-  if (UNLIKELY(sfg_globals == nullptr
 #ifndef __wasi__
-               || sfg_globals->signal_flow_ftables_lock == nullptr
+  if (UNLIKELY(sfg_globals == nullptr ||
+               sfg_globals->signal_flow_ftables_lock == nullptr)) {
+#else
+  if (UNLIKELY(sfg_globals == nullptr)) {
 #endif
-               )) {
     return csound->InitError(csound, "%s",
                              Str("ftgenonce: not initialized"));
   }

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -1343,8 +1343,11 @@ static int32_t ftgenonce_(CSOUND *csound, FTGEN *p, bool isNamedGenerator,
   }
   SignalFlowGraphState *sfg_globals = nullptr;
   QueryGlobalPointer(csound, "sfg_globals", sfg_globals);
-  if (UNLIKELY(sfg_globals == nullptr ||
-               sfg_globals->signal_flow_ftables_lock == nullptr)) {
+  if (UNLIKELY(sfg_globals == nullptr
+#ifndef __wasi__
+               || sfg_globals->signal_flow_ftables_lock == nullptr
+#endif
+               )) {
     return csound->InitError(csound, "%s",
                              Str("ftgenonce: not initialized"));
   }

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -1215,12 +1215,12 @@ typedef int32_t (*INITFN2)(CSOUND *);
  int32_t sfont_ModuleInit(CSOUND *csound);
  int32_t sfont_ModuleCreate(CSOUND *csound);
  int32_t newgabopc_ModuleInit(CSOUND *csound);
+ int32_t csoundModuleInit_signalflowgraph(CSOUND *csound);
  #ifndef __wasi__
  int32_t csoundModuleInit_ampmidid(CSOUND *csound);
  int32_t csoundModuleCreate_mixer(CSOUND *csound);
  int32_t csoundModuleInit_mixer(CSOUND *csound);
  int32_t csoundModuleInit_doppler(CSOUND *csound);
- int32_t csoundModuleInit_signalflowgraph(CSOUND *csound);
  int32_t arrayops_init_modules(CSOUND *csound);
  int32_t lfsr_init_modules(CSOUND *csound);
  int32_t pvsops_init_modules(CSOUND *csound);
@@ -1318,12 +1318,12 @@ CS_NOINLINE int32_t csoundInitStaticModules(CSOUND *csound)
     pvsopc_ModuleInit,
     sfont_ModuleCreate,
     sfont_ModuleInit,
+    csoundModuleInit_signalflowgraph,
 #if !defined(__wasi__)
     csoundModuleInit_ampmidid,
     csoundModuleCreate_mixer,
     csoundModuleInit_mixer,
     csoundModuleInit_doppler,
-    csoundModuleInit_signalflowgraph,
     arrayops_init_modules,
     lfsr_init_modules,
     pvsops_init_modules,

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -799,15 +799,12 @@ def runTest():
             "-nd",
             '-- concert.orc "first violin" --logfile=ignored ""',
         ],
+        ["signalflowgraphtest.csd", "test signal-flow graph opcodes"],
+        [
+            "test_signalflowgraph_lifetime.csd",
+            "test signal-flow graph cleanup and ftgenonce",
+        ],
     ]
-
-    if not csoundExecutable.lower().endswith((".wasm", ".cwasm")):
-        tests.append(
-            [
-                "test_signalflowgraph_lifetime.csd",
-                "test signal-flow graph cleanup and ftgenonce",
-            ]
-        )
 
     arrayTests = [
         ["arrays/arrays_i_local.csd", "local i[]"],


### PR DESCRIPTION
## What

- Build the existing `signalflowgraph.cpp` in WASI command and browser builds.
- Register the module in the WASI static module list.
- Skip the null mutex check only for WASI.
- Run both signal-flow graph command-line tests on WASM and native builds.

## Why

PR #2717 added a second C implementation because the C++ file was thought not to work with WASI.

The [PR discussion](https://github.com/csound/csound/pull/2717#issuecomment-5107978698) raised the cost of keeping two versions. Testing showed that the current WASI toolchain builds the C++ file.

The only runtime issue was `Create_Mutex()` returning null on WASI. WASI mutex calls are no-ops, but `ftgenonce_()` treated the null value as an init failure. This change skips that check only under `__wasi__`.

This keeps one signal-flow graph implementation.

## Checks

- WASI command build
- WASI browser build
- WASI command-line tests: 317 passed, 0 failed
- Native signal-flow graph opcode test
- Native signal-flow graph lifetime and `ftgenonce` test