### PR TITLE
Fix WASM plugin function table relocation

### DIFF
--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -17,11 +17,25 @@ import { dlinit } from "./dlinit";
 import { WASI } from "./filesystem/wasi";
 import { clearArray } from "./utils/clear-array";
 import { decoder, uint2String } from "./utils/text-encoders.js";
+import { getBinaryHeaderData as parseBinaryHeaderData } from "./utils/wasm-dylink.js";
 import { Inflate } from "./zlib/inflate.js";
+
+export const getBinaryHeaderData = (input) => parseBinaryHeaderData(input, decoder);
 
 const PAGE_SIZE = 65536;
 const PAGES_PER_MB = 16; // 1048576 bytes per MB / PAGE_SIZE
 const WASI_LONGJMP_PREFIX = "CSOUND_WASI_LONGJMP:";
+const MAX_ALIGNMENT_EXPONENT = 30;
+const MAX_SIGNED_WASM_I32 = 0x7fffffff;
+
+const alignmentFromExponent = (exponent) => {
+  if (!Number.isInteger(exponent) || exponent < 0 || exponent > MAX_ALIGNMENT_EXPONENT) {
+    throw new Error(`Invalid WebAssembly alignment exponent: ${exponent}`);
+  }
+  return 2 ** exponent;
+};
+
+const alignUp = (value, alignment) => Math.ceil(value / alignment) * alignment;
 
 const wasmLongjmp = (_, value) => {
   throw new Error(`csound exit with code: ${value}`);
@@ -112,109 +126,6 @@ const assertPluginExports = (pluginInstance) => {
   }
 };
 
-// Accepts ArrayBuffer or Uint8Array
-export function getBinaryHeaderData(input) {
-  const wasmBytes = input instanceof Uint8Array ? input : new Uint8Array(input);
-
-  // Check magic \0asm (little-endian 0x6d736100)
-  if (wasmBytes.length < 8) {
-    return { hasDylink: false, sectionSize: 0, memorySize: 0, memoryAlign: 0, tableSize: 0, tableAlign: 0, neededDynlibsCount: 0, neededDynlibs: [] };
-  }
-  if (!isWasmBinary(wasmBytes)) {
-    return { hasDylink: false, sectionSize: 0, memorySize: 0, memoryAlign: 0, tableSize: 0, tableAlign: 0, neededDynlibsCount: 0, neededDynlibs: [] };
-  }
-
-  // Cursor after magic(4) + version(4)
-  let pos = 8;
-
-  // helpers
-  function readULEB() {
-    let result = 0;
-    let shift = 0;
-    for (;;) {
-      if (pos >= wasmBytes.length) throw new Error("Unexpected EOF reading ULEB");
-      const byte = wasmBytes[pos++];
-      result |= (byte & 0x7f) << shift;
-      if ((byte & 0x80) === 0) break;
-      shift += 7;
-    }
-    return result;
-  }
-
-  function readBytes(n) {
-    if (pos + n > wasmBytes.length) throw new Error("Unexpected EOF reading bytes");
-    const sub = wasmBytes.subarray(pos, pos + n);
-    pos += n;
-    return sub;
-  }
-
-  function readName() {
-    const len = readULEB();
-    const bytes = readBytes(len);
-    return decoder.decode(bytes);
-  }
-
-  // Defaults for static WASM (no dylink)
-  const defaults = { hasDylink: false, sectionSize: 0, memorySize: 0, memoryAlign: 0, tableSize: 0, tableAlign: 0, neededDynlibsCount: 0, neededDynlibs: [] };
-
-  // Iterate sections
-  while (pos < wasmBytes.length) {
-    const id = wasmBytes[pos++];                 // section id (0 = custom)
-    const size = readULEB();                      // section size (bytes)
-    const sectionStart = pos;
-
-    if (id === 0 /* custom */) {
-      const namePos = pos;                        // remember to compute name+payload size
-      const name = readName();                    // custom section name
-      if (name === "dylink" || name === "dylink.0") {
-        // Parse dylink(.0) payload
-        // Spec (Emscripten): ULEB memorySize, ULEB memoryAlign, ULEB tableSize, ULEB tableAlign, ULEB neededDynlibsCount, then that many length-prefixed names
-        const memorySize = readULEB();
-        const memoryAlign = readULEB();
-        const tableSize = readULEB();
-        const tableAlign = readULEB();
-        const neededDynlibsCount = readULEB();
-
-        const neededDynlibs = [];
-        for (let i = 0; i < neededDynlibsCount; i++) {
-          neededDynlibs.push(readName());
-        }
-
-        const sectionSize = size; // raw size field for the custom section
-
-        // Done — return immediately
-        return {
-          hasDylink: true,
-          sectionSize,
-          memorySize,
-          memoryAlign,
-          tableSize,
-          tableAlign,
-          neededDynlibsCount,
-          neededDynlibs,
-        };
-      } else {
-        // Not the dylink section; skip remainder of this custom section payload
-        const consumed = pos - namePos; // bytes after we started inside payload
-        const remaining = size - consumed;
-        pos += Math.max(0, remaining);
-      }
-    } else {
-      // Non-custom: just skip the payload
-      pos += size;
-    }
-
-    // Safety: ensure we don't desync
-    if (pos !== sectionStart + size) {
-      pos = sectionStart + size;
-    }
-  }
-
-  // No dylink section found => static binary
-  return defaults;
-}
-
-
 export default async function loadWasm({ wasmDataURI, withPlugins = [], messagePort }) {
   const wasi = new WASI({ preopens: { "/": "/" } });
   const jumpTable = new Map(); // maps jmpbuf pointers to JS frames
@@ -287,11 +198,15 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
   // write over anything if it overflows.
   //
   const fixedMemoryBase = 128 * PAGES_PER_MB;
-  const initialMemory = Math.ceil((memorySize + 2 ** memoryAlign) / PAGE_SIZE);
+  const initialMemory = Math.ceil(
+    (memorySize + alignmentFromExponent(memoryAlign)) / PAGE_SIZE,
+  );
   const pluginsMemory = Math.ceil(
     withPlugins.reduce(
       (accumulator, { headerData }) =>
-        accumulator + headerData.memorySize + 2 ** headerData.memoryAlign,
+        accumulator +
+        headerData.memorySize +
+        alignmentFromExponent(headerData.memoryAlign),
       0,
     ) / PAGE_SIZE,
   );
@@ -318,7 +233,6 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
   let withPlugins_ = [];
 
   const hostRuntime = { instance: undefined };
-  let currentMemoryOffset = initialMemory * PAGE_SIZE;
 
   const csoundLoadModules = (csoundInstance) => {
     withPlugins_.forEach((pluginItem) => {
@@ -392,27 +306,68 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
   const hasLegacyWasiPluginLoader =
     typeof instance_["exports"]["csoundWasiLoadPlugin"] === "function" ||
     typeof instance_["exports"]["csoundWasiLoadOpcodeLibrary"] === "function";
+  const pluginMemoryAllocations = [];
+
+  wasi.start(instance_);
+
+  const allocatePluginMemory = (size, alignmentExponent) => {
+    if (size === 0) {
+      return 0;
+    }
+
+    const allocate = instance_["exports"]["allocStringMem"];
+    if (typeof allocate !== "function") {
+      throw new TypeError("The WebAssembly host does not export allocStringMem");
+    }
+
+    const alignment = alignmentFromExponent(alignmentExponent);
+    const allocationSize = size + alignment - 1;
+    if (!Number.isSafeInteger(allocationSize) || allocationSize > MAX_SIGNED_WASM_I32) {
+      throw new TypeError("The WebAssembly plugin memory request is too large");
+    }
+
+    const allocation = allocate(allocationSize);
+    if (allocation === 0) {
+      throw new Error(`Could not reserve ${allocationSize} bytes for a WebAssembly plugin`);
+    }
+
+    const memoryBaseValue = alignUp(allocation, alignment);
+    new Uint8Array(memory.buffer, memoryBaseValue, size).fill(0);
+    pluginMemoryAllocations.push(allocation);
+    return memoryBaseValue;
+  };
 
   withPlugins_ = await withPlugins.reduce(async (accumulator, { headerData, wasmPluginBytes }) => {
     accumulator = await accumulator;
     try {
       const {
+        hasDylink,
         memorySize: pluginMemorySize,
         memoryAlign: pluginMemoryAlign,
         tableSize: pluginTableSize,
+        tableAlign: pluginTableAlign,
+        neededDynlibs,
       } = headerData;
+      if (neededDynlibs.length > 0) {
+        throw new Error(
+          `WebAssembly plugin dependencies are not supported: ${neededDynlibs.join(", ")}`,
+        );
+      }
 
       /** @suppress {checkTypes} */
       const plugin = await WebAssembly.compile(wasmPluginBytes);
       const pluginOptions = wasi.getImports(plugin);
+      const pluginImports = WebAssembly.Module.imports(plugin);
       const pluginExports = WebAssembly.Module.exports(plugin);
       const hasOpcodeInit = pluginExports.some(
         ({ name }) => name === "csound_opcode_init" || name === "csound_fgen_init",
       );
       const hasModuleInit = pluginExports.some(({ name }) => name === "csoundModuleInit");
-      const useIsolatedPluginTable = !hasLegacyWasiPluginLoader || (hasOpcodeInit && !hasModuleInit);
+      const useIsolatedPluginTable =
+        !hasDylink &&
+        (!hasLegacyWasiPluginLoader || (hasOpcodeInit && !hasModuleInit));
       let pluginTable = table;
-      const pluginTableBaseValue = table.length;
+      let pluginTableBaseValue = table.length;
 
       if (useIsolatedPluginTable) {
         const isolatedInitial = Math.max(table.length + Math.max(pluginTableSize, 0) + 16, 16);
@@ -423,16 +378,21 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
             pluginTable.set(tableIndex, tableFn);
           }
         }
-      } else if (pluginTableSize > 0) {
-        table.grow(pluginTableSize);
+      } else {
+        const pluginTableAlignment = alignmentFromExponent(pluginTableAlign);
+        pluginTableBaseValue = alignUp(table.length, pluginTableAlignment);
+        const tableGrowth = pluginTableBaseValue + pluginTableSize - table.length;
+        if (tableGrowth > 0) {
+          table.grow(tableGrowth);
+        }
       }
 
       pluginOptions["env"] = Object.assign({}, pluginOptions["env"]);
       pluginOptions["env"]["memory"] = memory;
       pluginOptions["env"]["__indirect_function_table"] = pluginTable;
-      const pluginMemoryAlignment = 2 ** pluginMemoryAlign;
-      const pluginMemoryBaseValue =
-        Math.ceil(currentMemoryOffset / pluginMemoryAlignment) * pluginMemoryAlignment;
+      const pluginMemoryBaseValue = hasDylink
+        ? allocatePluginMemory(pluginMemorySize, pluginMemoryAlign)
+        : 0;
       pluginOptions["env"]["__memory_base"] = new WebAssembly.Global(
         { value: "i32", mutable: false },
         pluginMemoryBaseValue,
@@ -441,9 +401,29 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
         { value: "i32", mutable: false },
         pluginTableBaseValue,
       );
-      delete pluginOptions["env"]["csoundWasiJsMessageCallback"];
 
-      currentMemoryOffset = pluginMemoryBaseValue + pluginMemorySize;
+      for (const pluginImport of pluginImports) {
+        if (pluginImport.module !== "env") {
+          continue;
+        }
+        if (pluginImport.kind === "function" && !pluginOptions["env"][pluginImport.name]) {
+          const hostFunction = instance_["exports"][pluginImport.name];
+          if (typeof hostFunction !== "function") {
+            throw new TypeError(`Missing WebAssembly host function: env.${pluginImport.name}`);
+          }
+          pluginOptions["env"][pluginImport.name] = hostFunction;
+        } else if (
+          pluginImport.kind === "global" &&
+          pluginImport.name === "__stack_pointer"
+        ) {
+          const hostStackPointer = instance_["exports"]["__stack_pointer"];
+          if (!hostStackPointer) {
+            throw new Error("The WebAssembly host does not export __stack_pointer");
+          }
+          pluginOptions["env"]["__stack_pointer"] = hostStackPointer;
+        }
+      }
+      delete pluginOptions["env"]["csoundWasiJsMessageCallback"];
 
       /**
        * @suppress {checkTypes}
@@ -451,6 +431,9 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
       const pluginInstance = await WebAssembly.instantiate(plugin, pluginOptions);
 
       if (assertPluginExports(pluginInstance)) {
+        if (typeof pluginInstance.exports.__wasm_apply_data_relocs === "function") {
+          pluginInstance.exports.__wasm_apply_data_relocs();
+        }
         pluginInstance.exports.__wasm_call_ctors();
         accumulator.push({ instance: pluginInstance, table: pluginTable });
       }
@@ -460,7 +443,6 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
     return accumulator;
   }, []);
 
-  wasi.start(instance_);
   instance_["exports"]["__wasi_js_csoundSetMessageStringCallback"]();
   return [instance_, wasi];
 }

--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -306,7 +306,6 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
   const hasLegacyWasiPluginLoader =
     typeof instance_["exports"]["csoundWasiLoadPlugin"] === "function" ||
     typeof instance_["exports"]["csoundWasiLoadOpcodeLibrary"] === "function";
-  const pluginMemoryAllocations = [];
 
   wasi.start(instance_);
 
@@ -333,7 +332,6 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
 
     const memoryBaseValue = alignUp(allocation, alignment);
     new Uint8Array(memory.buffer, memoryBaseValue, size).fill(0);
-    pluginMemoryAllocations.push(allocation);
     return memoryBaseValue;
   };
 

--- a/wasm/browser/src/utils/wasm-dylink.js
+++ b/wasm/browser/src/utils/wasm-dylink.js
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) The Csound Developers
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const emptyHeader = () => ({
+  hasDylink: false,
+  sectionSize: 0,
+  memorySize: 0,
+  memoryAlign: 0,
+  tableSize: 0,
+  tableAlign: 0,
+  neededDynlibsCount: 0,
+  neededDynlibs: [],
+});
+
+const isWasmBinary = (wasmBytes) =>
+  wasmBytes.length >= 8 &&
+  wasmBytes[0] === 0x00 &&
+  wasmBytes[1] === 0x61 &&
+  wasmBytes[2] === 0x73 &&
+  wasmBytes[3] === 0x6d;
+
+export const getBinaryHeaderData = (
+  input,
+  nameDecoder = new TextDecoder("utf8"),
+) => {
+  const wasmBytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  if (!isWasmBinary(wasmBytes)) {
+    return emptyHeader();
+  }
+
+  let position = 8;
+
+  const readULEB = (limit) => {
+    let result = 0;
+    let multiplier = 1;
+
+    for (let byteIndex = 0; byteIndex < 5; byteIndex += 1) {
+      if (position >= limit) {
+        throw new Error("Unexpected end of WebAssembly data while reading ULEB");
+      }
+
+      const byte = wasmBytes[position];
+      position += 1;
+      result += (byte & 0x7f) * multiplier;
+
+      if (result > 0xffffffff) {
+        throw new Error("WebAssembly ULEB value exceeds uint32");
+      }
+      if ((byte & 0x80) === 0) {
+        return result;
+      }
+
+      multiplier *= 128;
+    }
+
+    throw new Error("WebAssembly ULEB value is too long");
+  };
+
+  const readName = (limit) => {
+    const length = readULEB(limit);
+    if (position + length > limit) {
+      throw new Error("Unexpected end of WebAssembly data while reading a name");
+    }
+    const name = nameDecoder.decode(wasmBytes.subarray(position, position + length));
+    position += length;
+    return name;
+  };
+
+  const parseLegacyDylink = (sectionSize, sectionEnd) => {
+    const memorySize = readULEB(sectionEnd);
+    const memoryAlign = readULEB(sectionEnd);
+    const tableSize = readULEB(sectionEnd);
+    const tableAlign = readULEB(sectionEnd);
+    const neededDynlibsCount = readULEB(sectionEnd);
+    const neededDynlibs = [];
+
+    for (let index = 0; index < neededDynlibsCount; index += 1) {
+      neededDynlibs.push(readName(sectionEnd));
+    }
+    if (position !== sectionEnd) {
+      throw new Error("Unexpected data at the end of the dylink section");
+    }
+
+    return {
+      hasDylink: true,
+      sectionSize,
+      memorySize,
+      memoryAlign,
+      tableSize,
+      tableAlign,
+      neededDynlibsCount,
+      neededDynlibs,
+    };
+  };
+
+  const parseDylink0 = (sectionSize, sectionEnd) => {
+    const header = emptyHeader();
+    header.hasDylink = true;
+    header.sectionSize = sectionSize;
+    let hasMemoryInfo = false;
+
+    while (position < sectionEnd) {
+      const subsectionType = wasmBytes[position];
+      position += 1;
+      const subsectionSize = readULEB(sectionEnd);
+      const subsectionEnd = position + subsectionSize;
+      if (subsectionEnd > sectionEnd) {
+        throw new Error("dylink.0 subsection extends past its section");
+      }
+
+      if (subsectionType === 1) {
+        if (hasMemoryInfo) {
+          throw new Error("dylink.0 contains more than one memory info subsection");
+        }
+        hasMemoryInfo = true;
+        header.memorySize = readULEB(subsectionEnd);
+        header.memoryAlign = readULEB(subsectionEnd);
+        header.tableSize = readULEB(subsectionEnd);
+        header.tableAlign = readULEB(subsectionEnd);
+        if (position !== subsectionEnd) {
+          throw new Error("Unexpected data in the dylink.0 memory info subsection");
+        }
+      } else if (subsectionType === 2) {
+        const neededCount = readULEB(subsectionEnd);
+        for (let index = 0; index < neededCount; index += 1) {
+          header.neededDynlibs.push(readName(subsectionEnd));
+        }
+        if (position !== subsectionEnd) {
+          throw new Error("Unexpected data in the dylink.0 needed libraries subsection");
+        }
+      }
+
+      position = subsectionEnd;
+    }
+
+    header.neededDynlibsCount = header.neededDynlibs.length;
+    return header;
+  };
+
+  while (position < wasmBytes.length) {
+    const sectionId = wasmBytes[position];
+    position += 1;
+    const sectionSize = readULEB(wasmBytes.length);
+    const sectionEnd = position + sectionSize;
+    if (sectionEnd > wasmBytes.length) {
+      throw new Error("WebAssembly section extends past the end of the binary");
+    }
+
+    if (sectionId === 0) {
+      const sectionName = readName(sectionEnd);
+      if (sectionName === "dylink") {
+        return parseLegacyDylink(sectionSize, sectionEnd);
+      }
+      if (sectionName === "dylink.0") {
+        return parseDylink0(sectionSize, sectionEnd);
+      }
+    }
+
+    position = sectionEnd;
+  }
+
+  return emptyHeader();
+};

--- a/wasm/browser/src/utils/wasm-dylink.js
+++ b/wasm/browser/src/utils/wasm-dylink.js
@@ -145,6 +145,10 @@ export const getBinaryHeaderData = (
       position = subsectionEnd;
     }
 
+    if (!hasMemoryInfo) {
+      throw new Error("dylink.0 is missing its memory info subsection");
+    }
+
     header.neededDynlibsCount = header.neededDynlibs.length;
     return header;
   };

--- a/wasm/browser/tests/unit/wasm-dylink.test.js
+++ b/wasm/browser/tests/unit/wasm-dylink.test.js
@@ -1,0 +1,128 @@
+/* eslint-env mocha */
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { getBinaryHeaderData } from "../../src/utils/wasm-dylink.js";
+
+const encodeULEB = (input) => {
+  const bytes = [];
+  let value = input;
+  do {
+    let byte = value % 128;
+    value = Math.floor(value / 128);
+    if (value > 0) {
+      byte += 128;
+    }
+    bytes.push(byte);
+  } while (value > 0);
+  return bytes;
+};
+
+const encodeName = (value) => {
+  const bytes = [...new TextEncoder().encode(value)];
+  return [...encodeULEB(bytes.length), ...bytes];
+};
+
+const customSection = (name, payload) => {
+  const contents = [...encodeName(name), ...payload];
+  return [0, ...encodeULEB(contents.length), ...contents];
+};
+
+const subsection = (type, payload) => [type, ...encodeULEB(payload.length), ...payload];
+
+const wasmWith = (...sections) =>
+  new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, ...sections.flat()]);
+
+describe("WebAssembly dynamic link metadata", () => {
+  it("returns empty metadata for a static module", () => {
+    assert.deepEqual(getBinaryHeaderData(wasmWith()), {
+      hasDylink: false,
+      sectionSize: 0,
+      memorySize: 0,
+      memoryAlign: 0,
+      tableSize: 0,
+      tableAlign: 0,
+      neededDynlibsCount: 0,
+      neededDynlibs: [],
+    });
+  });
+
+  it("parses the legacy dylink layout", () => {
+    const payload = [
+      ...encodeULEB(1024),
+      ...encodeULEB(4),
+      ...encodeULEB(3),
+      ...encodeULEB(1),
+      ...encodeULEB(1),
+      ...encodeName("libfoo.so"),
+    ];
+
+    assert.deepEqual(getBinaryHeaderData(wasmWith(customSection("dylink", payload))), {
+      hasDylink: true,
+      sectionSize: encodeName("dylink").length + payload.length,
+      memorySize: 1024,
+      memoryAlign: 4,
+      tableSize: 3,
+      tableAlign: 1,
+      neededDynlibsCount: 1,
+      neededDynlibs: ["libfoo.so"],
+    });
+  });
+
+  it("parses dylink.0 subsections and skips unknown ones", () => {
+    const memoryInfo = [
+      ...encodeULEB(2048),
+      ...encodeULEB(5),
+      ...encodeULEB(7),
+      ...encodeULEB(2),
+    ];
+    const needed = [...encodeULEB(2), ...encodeName("libfoo.so"), ...encodeName("libbar.so")];
+    const payload = [
+      ...subsection(3, [1, 2, 3]),
+      ...subsection(1, memoryInfo),
+      ...subsection(2, needed),
+    ];
+
+    assert.deepEqual(getBinaryHeaderData(wasmWith(customSection("dylink.0", payload))), {
+      hasDylink: true,
+      sectionSize: encodeName("dylink.0").length + payload.length,
+      memorySize: 2048,
+      memoryAlign: 5,
+      tableSize: 7,
+      tableAlign: 2,
+      neededDynlibsCount: 2,
+      neededDynlibs: ["libfoo.so", "libbar.so"],
+    });
+  });
+
+  it("rejects a truncated dylink.0 subsection", () => {
+    const payload = [1, 10, 1];
+    assert.throws(
+      () => getBinaryHeaderData(wasmWith(customSection("dylink.0", payload))),
+      /subsection extends past its section/,
+    );
+  });
+
+  const pluginPath = fileURLToPath(
+    new URL("../../../lib/plugin_example_cpp.wasm", import.meta.url),
+  );
+  const pluginTest = existsSync(pluginPath) ? it : it.skip;
+
+  pluginTest("builds the C++ plugin with a relocatable table", () => {
+    const bytes = readFileSync(pluginPath);
+    const module = new WebAssembly.Module(bytes);
+    const imports = WebAssembly.Module.imports(module);
+    const header = getBinaryHeaderData(bytes);
+
+    assert.equal(header.hasDylink, true);
+    assert.ok(header.tableSize > 0);
+    assert.ok(
+      imports.some(
+        ({ module: namespace, name, kind }) =>
+          namespace === "env" && name === "__table_base" && kind === "global",
+      ),
+    );
+  });
+});

--- a/wasm/browser/tests/unit/wasm-dylink.test.js
+++ b/wasm/browser/tests/unit/wasm-dylink.test.js
@@ -105,6 +105,13 @@ describe("WebAssembly dynamic link metadata", () => {
     );
   });
 
+  it("rejects dylink.0 without memory info", () => {
+    assert.throws(
+      () => getBinaryHeaderData(wasmWith(customSection("dylink.0", []))),
+      /missing its memory info subsection/,
+    );
+  });
+
   const pluginPath = fileURLToPath(
     new URL("../../../lib/plugin_example_cpp.wasm", import.meta.url),
   );

--- a/wasm/src/csound.nix
+++ b/wasm/src/csound.nix
@@ -123,6 +123,9 @@ in
         "--export-table" # plugins do the reverse and import
         "--growable-table" # required so dlinit can append plugin function pointers
         "--import-memory"
+        "--export=__stack_pointer"
+        "--export-if-defined=sin"
+        "--export-if-defined=strcmp"
         "--export=__heap_base"
         "--export=__data_end"
       ]

--- a/wasm/src/plugin_example_cpp.nix
+++ b/wasm/src/plugin_example_cpp.nix
@@ -37,15 +37,18 @@ in
 
       echo "Link together plugin_example_cpp.wasm"
       $CXX \
-        -Wl,-z,stack-size=128 \
+        -shared \
+        -nostdlib \
+        -nostartfiles \
+        -Wl,--experimental-pic \
         -Wl,--no-entry \
         -Wl,--import-table \
         -Wl,--import-memory \
+        -Wl,--import-undefined \
         -Wl,--export=__wasm_call_ctors \
         -Wl,--export=csoundModuleInit \
         -Wl,--export-if-defined=csoundModuleCreate \
         -Wl,--export-if-defined=csoundModuleDestroy \
-        -lwasi-emulated-getpid -lwasi-emulated-signal -lwasi-emulated-mman -lwasi-emulated-process-clocks \
         plugin_example_cpp.o -o plugin_example_cpp.wasm
     '';
 


### PR DESCRIPTION
## Summary

Fix WASM plugin loading so plugins do not overwrite function table slots used by the main module.

The C++ example plugin now builds as a relocatable side module. The browser loader reads `dylink.0`, reserves aligned memory and table ranges, and supplies the required host exports.

PR #2725 exposed this bug after it added function table entries to the main module. The browser test then failed with `function signature mismatch`.

Fixes #2727.