### PR TITLE
add savgol opcodes

### DIFF
--- a/Android/CsoundAndroid/jni/Android.mk
+++ b/Android/CsoundAndroid/jni/Android.mk
@@ -307,7 +307,8 @@ $(CSOUND_SRC_ROOT)/Opcodes/paulstretch.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_new_dispatch.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_par_base.c \
 $(CSOUND_SRC_ROOT)/Engine/cs_par_orc_semantic_analysis.c \
-$(CSOUND_SRC_ROOT)/Java/cs_glue.cpp
+$(CSOUND_SRC_ROOT)/Java/cs_glue.cpp \
+$(CSOUND_SRC_ROOT)/Opcodes/savgol.c
 #CsoundObj.cpp
 
 LOCAL_LDLIBS += -llog -lOpenSLES -laaudio -lamidi -ldl -lm -lc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1162,6 +1162,7 @@ set(stdopcod_SRCS
     Opcodes/wterrain2.c
     Opcodes/stdopcod.c
     Opcodes/dbap.c
+    Opcodes/savgol.c
     )
 
 set(sock_ops_SRCS

--- a/Opcodes/README.md
+++ b/Opcodes/README.md
@@ -104,6 +104,7 @@ Opcodes: internal and plugin opcodes
 - quadbezier.c: bezier lines
 - repluck.c: plucked-string physical models
 - reverbsc.c: FDN reverb
+- savgol.c: Savitzky-Golay filter
 - scansyn.c: scanned synthesis
 - scansynx.c: scanned synthesis
 - scoreline.c: event triggering

--- a/Opcodes/savgol.c
+++ b/Opcodes/savgol.c
@@ -1,0 +1,425 @@
+/*
+    savgol.c:
+
+    Copyright (C) 2026 Pasquale Mainolfi
+
+    This file is part of Csound.
+
+    The Csound Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    Csound is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with Csound; if not, write to the Free Software
+    Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+/*
+    Savitzky-Golay filter. See savgol.h for the opcode interface.
+
+    Fitting a degree-o polynomial to the w samples of a window, in the
+    least-squares sense, means solving A * p = y for the coefficient vector
+    p, where y holds the samples and A is the Vandermonde design matrix
+
+        A[i][j] = (i - centre)^j,   i in [0, w),  j in [0, o],
+
+    with the abscissae centred so that evaluating the fit at the middle of
+    the window is just reading p back. The least-squares solution is
+    p = C * y with C the pseudo-inverse
+
+        C = (A^T A)^-1 A^T,
+
+    an (o + 1) by w matrix that depends only on w and o, never on the
+    samples. So the fit costs one dot product per output: row d of C
+    convolved with the window yields p[d], and the d-th derivative of the
+    fit at the centre is d! * p[d] / delta^d. calculate_savgol_coeffs()
+    builds C once at init time and get_coeffs() folds that scaling into the
+    single row the perf pass needs.
+
+    The normal equations are inverted by Gauss-Jordan elimination with
+    partial pivoting. A^T A inherits the poor conditioning of the
+    Vandermonde matrix, but it is only (o + 1) square and o stays small in
+    practice, so the pivoting is enough and the cost is irrelevant next to
+    an init-time allocation.
+
+    At perf time both variants are a direct convolution, w multiply-adds per
+    output sample, which stays well below the cost of the surrounding
+    orchestra for any window a musician would choose. They differ only in
+    how the history is kept: the a-rate variant keeps the w - 1 carried
+    samples immediately ahead of the current block so the window is
+    contiguous for every sample in it, while the k-rate variant, producing
+    one sample per call, uses a ring of w samples instead. Either way the
+    oldest sample comes first, matching the order of the coefficients.
+*/
+
+
+#include "Opcodes/savgol.h"
+#include "arrays.h"
+#include "coreDefs.h"
+#include "csound.h"
+#include "sysdep.h"
+#include <csdl.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+static void matrix_mult(const double *a, const double *b, double *c, uint32_t row_a, uint32_t col_a, uint32_t col_b) {
+    for (uint32_t i = 0; i < row_a; i++) {
+        for (uint32_t j = 0; j < col_b; j++) {
+            double sum = 0.0;
+            for (uint32_t k = 0; k < col_a; k++) {
+                sum += a[i * col_a + k] * b[k * col_b + j];
+            }
+            c[i * col_b + j] = sum;
+        }
+    }
+}
+
+static int32_t matrix_inverse(CSOUND *csound, const double *matrix, double *inverse, uint32_t n) {
+    double *work = (double *) csound->Calloc(csound, sizeof(double) * (size_t) n * n);
+
+    for (uint32_t i = 0; i < n; ++i) {
+        for (uint32_t j = 0; j < n; ++j) {
+            work[i * n + j] = matrix[i * n + j];
+            inverse[i * n + j] = (i == j) ? 1.0 : 0.0;
+        }
+    }
+
+    for (uint32_t col = 0; col < n; ++col) {
+        uint32_t pivot_row = col;
+        double max_value = fabs(work[col * n + col]);
+
+        for (uint32_t row = col + 1; row < n; ++row) {
+            double value = fabs(work[row * n + col]);
+
+            if (value > max_value) {
+                max_value = value;
+                pivot_row = row;
+            }
+        }
+
+        if (max_value <= 1.0e-12) {
+            csound->Free(csound, work);
+            return NOTOK;
+        }
+
+        if (pivot_row != col) {
+            for (uint32_t j = 0; j < n; ++j) {
+                double tmp;
+
+                tmp = work[col * n + j];
+                work[col * n + j] = work[pivot_row * n + j];
+                work[pivot_row * n + j] = tmp;
+
+                tmp = inverse[col * n + j];
+                inverse[col * n + j] = inverse[pivot_row * n + j];
+                inverse[pivot_row * n + j] = tmp;
+            }
+        }
+
+        double pivot = work[col * n + col];
+
+        for (uint32_t j = 0; j < n; ++j) {
+            work[col * n + j] /= pivot;
+            inverse[col * n + j] /= pivot;
+        }
+
+        for (uint32_t row = 0; row < n; ++row) {
+            if (row == col) continue;
+
+            double factor = work[row * n + col];
+            for (uint32_t j = 0; j < n; ++j) {
+                work[row * n + j] -= factor * work[col * n + j];
+                inverse[row * n + j] -= factor * inverse[col * n + j];
+            }
+        }
+    }
+
+    csound->Free(csound, work);
+    return OK;
+}
+
+static void deallocate_temp_buffer(CSOUND *csound, TEMP_BUFFER *buffer) {
+    csound->Free(csound, buffer->data);
+    csound->Free(csound, buffer->transposed);
+    csound->Free(csound, buffer->normal);
+    csound->Free(csound, buffer->inversed);
+    csound->Free(csound, buffer->pinversed);
+    memset(buffer, 0, sizeof(*buffer));
+}
+
+static void allocate_temp_buffer(CSOUND *csound, TEMP_BUFFER *buffer, uint32_t winsize, uint32_t ncoef) {
+    size_t design = sizeof(double) * (size_t) winsize * ncoef;
+    size_t square = sizeof(double) * (size_t) ncoef * ncoef;
+
+    buffer->data       = (double *) csound->Calloc(csound, design);
+    buffer->transposed = (double *) csound->Calloc(csound, design);
+    buffer->normal     = (double *) csound->Calloc(csound, square);
+    buffer->inversed   = (double *) csound->Calloc(csound, square);
+    buffer->pinversed  = (double *) csound->Calloc(csound, design);
+}
+
+/* Fills sg->coeffs (ncoef * winsize doubles, allocated by the caller) with
+   the pseudo-inverse of the Vandermonde design matrix. */
+static int32_t calculate_savgol_coeffs(CSOUND *csound, SAVGOL_BUFFER *sg, uint32_t winsize, uint32_t ncoef) {
+    TEMP_BUFFER temp = {0};
+    allocate_temp_buffer(csound, &temp, winsize, ncoef);
+
+    // Vandermonde matrix: A[i][j] = (i - center)^j
+    double center = (double) (winsize - 1U) * 0.5;
+    double value = 1.0;
+    for (uint32_t i = 0; i < winsize; i++) {
+        double x = (double) i - center;
+        for (uint32_t j = 0; j < ncoef; j++) {
+            value = j == 0 ? 1.0 : value * x;
+            temp.data[i * ncoef + j] = value;
+            temp.transposed[j * winsize + i] = value;
+        }
+    }
+
+    // normal = A^T * A
+    matrix_mult(temp.transposed, temp.data, temp.normal, ncoef, winsize, ncoef);
+
+    if (matrix_inverse(csound, temp.normal, temp.inversed, ncoef) != OK) {
+        deallocate_temp_buffer(csound, &temp);
+        return NOTOK;
+    }
+
+    // pinversed = (A^T A)^-1 * A^T
+    matrix_mult(temp.inversed, temp.transposed, temp.pinversed, ncoef, ncoef, winsize);
+    memcpy(sg->coeffs, temp.pinversed, sizeof(double) * (size_t) ncoef * winsize);
+    sg->nrows = ncoef;
+    sg->ncols = winsize;
+
+    deallocate_temp_buffer(csound, &temp);
+    return OK;
+}
+
+static double factorial(uint32_t n) {
+    double fac = 1.0;
+    for (uint32_t i = 2; i <= n; i++) {
+        fac *= (double) i;
+    }
+
+    return fac;
+}
+
+/* Row deriv of the coefficient matrix, scaled by deriv! / delta^deriv so that
+   the convolution yields the deriv-th derivative of the fitted polynomial. */
+static void get_coeffs(const SAVGOL_BUFFER *sg, double *coeffs_buffer, uint32_t deriv, double delta) {
+    double scale = factorial(deriv) / pow(delta, (double) deriv);
+    const double *row = sg->coeffs + (size_t) deriv * sg->ncols;
+    for (uint32_t i = 0; i < sg->ncols; i++) {
+        coeffs_buffer[i] = row[i] * scale;
+    }
+}
+
+static int32_t validate_params(CSOUND *csound, MYFLT winsize_arg, MYFLT order_arg, MYFLT delta_arg, uint32_t *winsize, uint32_t *ncoef) {
+    int32_t w = (int32_t) winsize_arg;
+    int32_t o = (int32_t) order_arg;
+
+    if (UNLIKELY(w < 3 || (w & 1) == 0)) {
+        return csound->InitError(csound, "[savgol] winsize must be odd and at least 3");
+    }
+
+    if (UNLIKELY(o < 0 || o >= w)) {
+        return csound->InitError(csound, "[savgol] order must be >= 0 and less than winsize");
+    }
+
+    if (UNLIKELY(delta_arg <= FL(0.0))) {
+        return csound->InitError(csound, "[savgol] delta must be greater than 0");
+    }
+
+    *winsize = (uint32_t) w;
+    *ncoef = (uint32_t) o + 1U;
+    return OK;
+}
+
+/* Shared i-time work: validate, build the coefficient matrix and store the
+   single scaled row the perf pass convolves with. Leaves the sample history
+   to the caller, whose layout differs between the a- and k-rate variants. */
+static int32_t savgol_setup(CSOUND *csound, SAVGOL *p) {
+    uint32_t winsize, ncoef;
+    int32_t res = validate_params(csound, *p->winsize, *p->order, *p->delta, &winsize, &ncoef);
+    if (UNLIKELY(res != OK)) {
+        return res;
+    }
+
+    int32_t deriv = (int32_t) *p->deriv;
+    if (UNLIKELY(deriv < 0 || (uint32_t) deriv >= ncoef)) {
+        return csound->InitError(csound, "[savgol] deriv must be >= 0 and <= order");
+    }
+
+    SAVGOL_BUFFER sg = { NULL, 0, 0 };
+    sg.coeffs = (double *) csound->Calloc(csound, sizeof(double) * (size_t) ncoef * winsize);
+
+    if (UNLIKELY(calculate_savgol_coeffs(csound, &sg, winsize, ncoef) != OK)) {
+        csound->Free(csound, sg.coeffs);
+        return csound->InitError(csound, "[savgol] could not compute savgol coefficients");
+    }
+
+    csound->AuxAlloc(csound, sizeof(double) * (size_t) winsize, &p->coeffs);
+    get_coeffs(&sg, (double *) p->coeffs.auxp, (uint32_t) deriv, (double) *p->delta);
+    csound->Free(csound, sg.coeffs);
+
+    p->winsize_i = winsize;
+    return OK;
+}
+
+int32_t savgol_audio_init(CSOUND *csound, SAVGOL *p) {
+    int32_t res = savgol_setup(csound, p);
+    if (UNLIKELY(res != OK)) {
+        return res;
+    }
+
+    csound->AuxAlloc(csound, sizeof(MYFLT) * (size_t) ((p->winsize_i - 1U) + CS_KSMPS), &p->buffer_mem);
+    p->buffer_ptr = (MYFLT *) p->buffer_mem.auxp;
+
+    return OK;
+}
+
+int32_t savgol_audio_perf(CSOUND *csound, SAVGOL *p) {
+    (void) csound;
+
+    MYFLT *out = p->y;
+    const MYFLT *in = p->signal;
+    const double *coeffs = (const double *) p->coeffs.auxp;
+    uint32_t winsize = p->winsize_i;
+    uint32_t win_offset = winsize - 1U;
+
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
+    uint32_t nsmps = CS_KSMPS;
+
+    if (UNLIKELY(offset)) {
+        memset(out, 0, sizeof(MYFLT) * (size_t) offset);
+    }
+
+    if (UNLIKELY(early)) {
+        nsmps -= early;
+        memset(out + nsmps, 0, sizeof(MYFLT) * (size_t) early);
+    }
+
+    memcpy(p->buffer_ptr + win_offset, in, sizeof(MYFLT) * (size_t) nsmps);
+
+    /* buffer_ptr[i .. i + winsize - 1] runs oldest to newest, matching the
+       coefficient order; out[i] is the fit at the window centre, so the
+       opcode has a latency of (winsize - 1) / 2 samples. */
+    for (uint32_t i = offset; i < nsmps; i++) {
+        double sum = 0.0;
+        for (uint32_t j = 0; j < winsize; j++) {
+            sum += coeffs[j] * (double) p->buffer_ptr[i + j];
+        }
+        out[i] = (MYFLT) sum;
+    }
+
+    memmove(p->buffer_ptr, p->buffer_ptr + nsmps, sizeof(MYFLT) * (size_t) win_offset);
+
+    return OK;
+}
+
+int32_t savgol_control_init(CSOUND *csound, SAVGOL *p) {
+    int32_t res = savgol_setup(csound, p);
+    if (UNLIKELY(res != OK)) {
+        return res;
+    }
+
+    csound->AuxAlloc(csound, sizeof(MYFLT) * (size_t) p->winsize_i, &p->buffer_mem);
+    p->buffer_ptr = (MYFLT *) p->buffer_mem.auxp;
+    p->write_pos = 0;
+
+    return OK;
+}
+
+int32_t savgol_control_perf(CSOUND *csound, SAVGOL *p) {
+    (void) csound;
+
+    const double *coeffs = (const double *) p->coeffs.auxp;
+    MYFLT *buffer = p->buffer_ptr;
+    uint32_t winsize = p->winsize_i;
+    uint32_t oldest = p->write_pos;
+
+    buffer[oldest] = *p->signal;
+    if (++oldest >= winsize) oldest = 0;
+    p->write_pos = oldest;
+
+    /* The slot due to be overwritten next holds the oldest sample, so walking
+       from it wraps around into the newest one, matching the coefficient
+       order. The ring starts zeroed, which makes the first winsize - 1 outputs
+       the same zero-padded transient the a-rate variant produces. Two
+       contiguous runs keep the wrap out of the inner loop. */
+    uint32_t head = winsize - oldest;
+    double sum = 0.0;
+
+    for (uint32_t i = 0; i < head; i++) {
+        sum += coeffs[i] * (double) buffer[oldest + i];
+    }
+
+    for (uint32_t i = 0; i < oldest; i++) {
+        sum += coeffs[head + i] * (double) buffer[i];
+    }
+
+    *p->y = (MYFLT) sum;
+    return OK;
+}
+
+int32_t savgol_matrix(CSOUND *csound, SAVGOL_MATRIX *p) {
+    uint32_t winsize, ncoef;
+    int32_t res = validate_params(csound, *p->winsize, *p->order, *p->delta, &winsize, &ncoef);
+    if (UNLIKELY(res != OK)) {
+        return res;
+    }
+
+    SAVGOL_BUFFER sg = { NULL, 0, 0 };
+    sg.coeffs = (double *) csound->Calloc(csound, sizeof(double) * (size_t) ncoef * winsize);
+
+    if (UNLIKELY(calculate_savgol_coeffs(csound, &sg, winsize, ncoef) != OK)) {
+        csound->Free(csound, sg.coeffs);
+        return csound->InitError(csound, "[savgol] could not compute savgol coefficients");
+    }
+
+    /* tabinit only maintains sizes[] for 1-D arrays, so the 2-D shape is set
+       here; sizes must already be valid when tabinit sees dimensions > 1. */
+    if (p->mat->dimensions != 2) {
+        p->mat->sizes = (int32_t *) csound->ReAlloc(csound, p->mat->sizes, sizeof(int32_t) * 2);
+        p->mat->dimensions = 2;
+    }
+    p->mat->sizes[0] = (int32_t) sg.nrows;
+    p->mat->sizes[1] = (int32_t) sg.ncols;
+    tabinit(csound, p->mat, (int32_t) (ncoef * winsize), p->h.insdshead);
+
+    MYFLT *out = (MYFLT *) p->mat->data;
+    double *row = (double *) csound->Calloc(csound, sizeof(double) * (size_t) sg.ncols);
+
+    for (uint32_t i = 0; i < sg.nrows; i++) {
+        get_coeffs(&sg, row, i, (double) *p->delta);
+        for (uint32_t j = 0; j < sg.ncols; j++) {
+            out[i * sg.ncols + j] = (MYFLT) row[j];
+        }
+    }
+
+    csound->Free(csound, row);
+    csound->Free(csound, sg.coeffs);
+    return OK;
+}
+
+
+#define S(x) sizeof(x)
+
+static OENTRY localops[] = {
+    { "savgol.a",    S(SAVGOL),        0, "a",     "aiiop", (SUBR) savgol_audio_init,   (SUBR) savgol_audio_perf,   NULL, NULL, 0 },
+    { "savgol.k",    S(SAVGOL),        0, "k",     "kiiop", (SUBR) savgol_control_init, (SUBR) savgol_control_perf, NULL, NULL, 0 },
+    { "savgolmat.i", S(SAVGOL_MATRIX), 0, "i[][]", "iip",   (SUBR) savgol_matrix,       NULL,                       NULL, NULL, 0 }
+};
+
+int32_t savgol_init_(CSOUND *csound) {
+    return csound->AppendOpcodes(csound, &(localops[0]), (int32_t) (S(localops) / S(OENTRY)));
+}

--- a/Opcodes/savgol.h
+++ b/Opcodes/savgol.h
@@ -1,0 +1,125 @@
+/*
+    savgol.h:
+
+    Copyright (C) 2026 Pasquale Mainolfi
+
+    This file is part of Csound.
+
+    The Csound Library is free software; you can redistribute it
+    and/or modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    Csound is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with Csound; if not, write to the Free Software
+    Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
+*/
+
+/*
+    Savitzky-Golay smoothing and differentiation filter.
+
+        ares savgol    asig, iwinsize, iorder [, ideriv] [, idelta]
+        kres savgol    ksig, iwinsize, iorder [, ideriv] [, idelta]
+        imat[][] savgolmat iwinsize, iorder [, idelta]
+
+    A polynomial of degree iorder is fitted, in the least-squares sense, to
+    the iwinsize samples of a sliding window, and the output is that
+    polynomial evaluated at the centre of the window. Because the fit is
+    linear in the samples the whole operation collapses to a fixed FIR
+    kernel, computed once at init time.
+
+    Compared with a plain lowpass of similar bandwidth the fit preserves the
+    height and width of peaks, which is what makes the filter useful for
+    envelopes, control signals and any material where the shape of a
+    transient matters more than the stopband depth.
+
+    ideriv selects which derivative of the fitted polynomial to output:
+    0 (the default) smooths, 1 gives the slope, 2 the curvature, and so on
+    up to iorder. idelta is the spacing between samples and defaults to 1,
+    so derivatives come out per sample; pass 1/sr at a-rate or 1/kr at
+    k-rate to get them per second.
+
+    iwinsize must be odd and at least 3, iorder must be less than iwinsize,
+    ideriv must not exceed iorder, and idelta must be positive. Since the
+    result belongs to the centre of the window, the output lags the input by
+    (iwinsize - 1) / 2 samples at a-rate, or the same number of k-cycles at
+    k-rate. The history starts at zero, so the first (iwinsize - 1) outputs
+    are the filter's response to a signal that was silent beforehand.
+
+    savgolmat returns the whole kernel bank instead of filtering: an
+    (iorder + 1) by iwinsize array whose row d holds the coefficients for
+    the d-th derivative, already scaled by d! / idelta^d. Row 0 is the
+    smoothing kernel; for iwinsize 5 and iorder 2 it is the familiar
+    [-3, 12, 17, 12, -3] / 35.
+*/
+
+
+#ifndef __SAVGOL_H
+#define __SAVGOL_H
+
+
+#include "csdl.h"
+#include "csound.h"
+#include "sysdep.h"
+#include <stdint.h>
+
+
+/* Savitzky-Golay coefficient matrix C = (A^T A)^-1 A^T, row-major.
+   Row d holds the least-squares coefficients of the d-th derivative,
+   before the d! / delta^d scaling applied by get_coeffs(). */
+typedef struct {
+    double *coeffs;
+    uint32_t nrows; // order + 1
+    uint32_t ncols; // winsize
+} SAVGOL_BUFFER;
+
+typedef struct {
+    double *data;
+    double *transposed;
+    double *normal;
+    double *inversed;
+    double *pinversed;
+} TEMP_BUFFER;
+
+typedef struct {
+    OPDS h;
+    // outputs
+    MYFLT *y;
+    // inputs;
+    MYFLT *signal;
+    MYFLT *winsize; // must be odd
+    MYFLT *order;   // order + 1 coefficient rows
+    MYFLT *deriv;
+    MYFLT *delta;
+    // private
+    AUXCH coeffs;     // winsize scaled doubles for the requested derivative
+    AUXCH buffer_mem; // a-rate: (winsize - 1) history samples + ksmps
+                      // k-rate: winsize samples used as a ring buffer
+    MYFLT *buffer_ptr;
+    uint32_t winsize_i;
+    uint32_t write_pos; // k-rate only: next ring slot to overwrite
+} SAVGOL;
+
+typedef struct {
+    OPDS h;
+    // outputs
+    ARRAYDAT *mat;
+    // inputs;
+    MYFLT *winsize;
+    MYFLT *order;
+    MYFLT *delta;
+} SAVGOL_MATRIX;
+
+
+int32_t savgol_audio_init(CSOUND *csound, SAVGOL *p);
+int32_t savgol_control_init(CSOUND *csound, SAVGOL *p);
+int32_t savgol_audio_perf(CSOUND *csound, SAVGOL *p);
+int32_t savgol_control_perf(CSOUND *csound, SAVGOL *p);
+int32_t savgol_matrix(CSOUND *csound, SAVGOL_MATRIX *p); // i-rate
+
+#endif

--- a/Opcodes/stdopcod.c
+++ b/Opcodes/stdopcod.c
@@ -98,6 +98,7 @@ int32_t stdopc_ModuleInit(CSOUND *csound)
     err |= wave_terrain_init_(csound);
     err |= wter2_init_(csound);
     err |= dbap_init_(csound);
+    err |= savgol_init_(csound);
 
     return (err ? CSOUND_ERROR : CSOUND_SUCCESS);
 }

--- a/Opcodes/stdopcod.h
+++ b/Opcodes/stdopcod.h
@@ -121,6 +121,7 @@ wave_terrain_init_(CSOUND *);
 extern int32_t
 wter2_init_(CSOUND *);
 extern int32_t dbap_init_(CSOUND *);
+extern int32_t savgol_init_(CSOUND *);
 
 
 #endif  /* CSOUND_STDOPCOD_H */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -804,6 +804,37 @@ def runTest():
             "test_signalflowgraph_lifetime.csd",
             "test signal-flow graph cleanup and ftgenonce",
         ],
+        ["test_savgol.csd", "test savgol filter and savgol matrix"],
+        [
+            "test_savgol_fail_winsize_even.csd",
+            "expected failure: savgol winsize must be odd",
+            1,
+        ],
+        [
+            "test_savgol_fail_winsize_small.csd",
+            "expected failure: savgol winsize must be at least 3",
+            1,
+        ],
+        [
+            "test_savgol_fail_order.csd",
+            "expected failure: savgol order must be less than winsize",
+            1,
+        ],
+        [
+            "test_savgol_fail_deriv.csd",
+            "expected failure: savgol deriv must not exceed order",
+            1,
+        ],
+        [
+            "test_savgol_fail_delta.csd",
+            "expected failure: savgol delta must be positive",
+            1,
+        ],
+        [
+            "test_savgol_fail_mat.csd",
+            "expected failure: savgolmat rejects an even winsize",
+            1,
+        ],
     ]
 
     arrayTests = [

--- a/tests/commandline/test_savgol.csd
+++ b/tests/commandline/test_savgol.csd
@@ -1,0 +1,341 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Savitzky-Golay filter: savgol (a- and k-rate) and savgolmat (i-rate).
+;
+; Reference coefficients below were derived in exact rational arithmetic from
+; C = (A^T A)^-1 A^T scaled by deriv!, independently of the opcode.
+
+opcode assert_close(got:i, want:i, tol:i, msg:S):void
+  if abs(got - want) > tol then
+    prints("FAIL %s: got %.14f, expected %.14f\n", msg, got, want)
+    exitnow(-1)
+  endif
+endop
+
+; Counted, so that a perf-rate test silently never reaching its assertion is
+; itself a failure rather than a pass.
+gk_checks@global:k = init(0)
+
+opcode assert_close_k(got:k, want:k, tol:k, id:i):void
+  gk_checks += 1
+  if abs(got - want) > tol then
+    printf("FAIL test %d: got %.14f, expected %.14f\n", 1, id, got, want)
+    exitnowk(1)
+  endif
+endop
+
+opcode assert_shape(mat:i[][], rows:i, cols:i, msg:S):void
+  if lenarray(mat, 1) != rows || lenarray(mat, 2) != cols then
+    prints("FAIL %s: shape %dx%d, expected %dx%d\n", msg, lenarray(mat, 1), lenarray(mat, 2), rows, cols)
+    exitnow(-1)
+  endif
+endop
+
+opcode assert_row(mat:i[][], row:i, want:i[], msg:S):void
+  n:i = lenarray(want)
+  assert_shape(mat, lenarray(mat, 1), n, msg)
+  j:i = 0
+  while j < n do
+    if abs(mat[row][j] - want[j]) > 1.0e-12 then
+      prints("FAIL %s row %d col %d: got %.14f, expected %.14f\n", msg, row, j, mat[row][j], want[j])
+      exitnow(-1)
+    endif
+    j += 1
+  od
+endop
+
+opcode factorial(n:i):i
+  f:i = 1
+  i:i = 2
+  while i <= n do
+    f *= i
+    i += 1
+  od
+  xout(f)
+endop
+
+; Repeated multiplication, because ^ rejects a negative base.
+opcode int_pow(x:i, n:i):i
+  r:i = 1
+  i:i = 0
+  while i < n do
+    r *= x
+    i += 1
+  od
+  xout(r)
+endop
+
+; Defining property of the filter: for coefficient row d,
+;   sum_k c[d][k] * (k - centre)^m  ==  d!  when m == d, and 0 otherwise,
+; for every m up to the polynomial order. Catches wrong rows, wrong stride,
+; wrong scaling and reversed coefficient order at any window size.
+opcode assert_moments(w:i, o:i):void
+  mat:i[][] = savgolmat(w, o)
+  centre:i = (w - 1) / 2
+  d:i = 0
+  while d <= o do
+    m:i = 0
+    while m <= o do
+      s:i = 0
+      k:i = 0
+      while k < w do
+        s += mat[d][k] * int_pow(k - centre, m)
+        k += 1
+      od
+      want:i = (m == d ? factorial(d) : 0)
+      if abs(s - want) > 1.0e-8 then
+        prints("FAIL moment w=%d o=%d deriv=%d m=%d: got %.14f, expected %.14f\n", w, o, d, m, s, want)
+        exitnow(-1)
+      endif
+      m += 1
+    od
+    d += 1
+  od
+endop
+
+; Even-order derivative rows are symmetric, odd-order rows antisymmetric.
+opcode assert_symmetry(w:i, o:i):void
+  mat:i[][] = savgolmat(w, o)
+  d:i = 0
+  while d <= o do
+    sgn:i = (d % 2 == 0 ? 1 : -1)
+    k:i = 0
+    while k < w do
+      if abs(mat[d][k] - sgn * mat[d][w - 1 - k]) > 1.0e-12 then
+        prints("FAIL symmetry w=%d o=%d deriv=%d col=%d\n", w, o, d, k)
+        exitnow(-1)
+      endif
+      k += 1
+    od
+    d += 1
+  od
+endop
+
+; Sample-by-sample reference: recompute the filter at local ksmps 1 and compare
+; against the block-processed signal produced at the orchestra ksmps.
+opcode assert_block_matches(sig:a, blocked:a, w:i, o:i, d:i, dt:i, id:i):void
+  setksmps(1)
+  ref:a = savgol(sig, w, o, d, dt)
+  assert_close_k(downsamp(blocked, 1), downsamp(ref, 1), 1.0e-12, id)
+endop
+
+; The k-rate variant must produce exactly the same sequence as the a-rate one
+; when a k-cycle is a single sample.
+opcode assert_rates_agree(sig:a, w:i, o:i, d:i, dt:i, id:i):void
+  setksmps(1)
+  ya:a = savgol(sig, w, o, d, dt)
+  xk:k = downsamp(sig, 1)
+  yk:k = savgol(xk, w, o, d, dt)
+  assert_close_k(downsamp(ya, 1), yk, 1.0e-12, id)
+endop
+
+
+; ---------------------------------------------------------------- savgolmat
+
+instr 1  ; reference coefficients, winsize 5 order 2
+  mat:i[][] = savgolmat(5, 2)
+  assert_shape(mat, 3, 5, "savgolmat(5,2) shape")
+  assert_row(mat, 0, fillarray(-3/35, 12/35, 17/35, 12/35, -3/35), "savgolmat(5,2) deriv 0")
+  assert_row(mat, 1, fillarray(-1/5, -1/10, 0, 1/10, 1/5), "savgolmat(5,2) deriv 1")
+  assert_row(mat, 2, fillarray(2/7, -1/7, -2/7, -1/7, 2/7), "savgolmat(5,2) deriv 2")
+  prints("savgolmat(5,2): ok\n")
+endin
+
+instr 2  ; reference coefficients, winsize 7 order 2
+  mat:i[][] = savgolmat(7, 2)
+  assert_shape(mat, 3, 7, "savgolmat(7,2) shape")
+  assert_row(mat, 0, fillarray(-2/21, 1/7, 2/7, 1/3, 2/7, 1/7, -2/21), "savgolmat(7,2) deriv 0")
+  assert_row(mat, 1, fillarray(-3/28, -1/14, -1/28, 0, 1/28, 1/14, 3/28), "savgolmat(7,2) deriv 1")
+  assert_row(mat, 2, fillarray(5/42, 0, -1/14, -2/21, -1/14, 0, 5/42), "savgolmat(7,2) deriv 2")
+  prints("savgolmat(7,2): ok\n")
+endin
+
+instr 3  ; higher order, winsize 9 order 4
+  mat:i[][] = savgolmat(9, 4)
+  assert_shape(mat, 5, 9, "savgolmat(9,4) shape")
+  assert_row(mat, 0, fillarray(5/143, -5/39, 10/143, 45/143, 179/429, 45/143, 10/143, -5/39, 5/143), "savgolmat(9,4) deriv 0")
+  assert_row(mat, 1, fillarray(43/594, -71/594, -193/1188, -7/66, 0, 7/66, 193/1188, 71/594, -43/594), "savgolmat(9,4) deriv 1")
+  assert_row(mat, 4, fillarray(14/143, -21/143, -1/13, 9/143, 18/143, 9/143, -1/13, -21/143, 14/143), "savgolmat(9,4) deriv 4")
+  prints("savgolmat(9,4): ok\n")
+endin
+
+instr 4  ; order 0 degenerates to a moving average
+  mat:i[][] = savgolmat(5, 0)
+  assert_shape(mat, 1, 5, "savgolmat(5,0) shape")
+  assert_row(mat, 0, fillarray(1/5, 1/5, 1/5, 1/5, 1/5), "savgolmat(5,0) deriv 0")
+  prints("savgolmat order 0: ok\n")
+endin
+
+instr 5  ; order == winsize-1 interpolates every point, so smoothing is identity
+  mat:i[][] = savgolmat(5, 4)
+  assert_shape(mat, 5, 5, "savgolmat(5,4) shape")
+  assert_row(mat, 0, fillarray(0, 0, 1, 0, 0), "savgolmat(5,4) deriv 0")
+  prints("savgolmat order == winsize-1: ok\n")
+endin
+
+instr 6  ; moment conditions across several window/order combinations
+  assert_moments(5, 2)
+  assert_moments(7, 3)
+  assert_moments(11, 4)
+  assert_moments(31, 4)
+  assert_moments(101, 2)
+  prints("savgolmat moment conditions: ok\n")
+endin
+
+instr 7  ; parity of the derivative rows
+  assert_symmetry(5, 2)
+  assert_symmetry(9, 4)
+  assert_symmetry(21, 3)
+  prints("savgolmat symmetry: ok\n")
+endin
+
+instr 8  ; row d scales with 1/delta^d
+  unit:i[][] = savgolmat(9, 3, 1)
+  half:i[][] = savgolmat(9, 3, 0.5)
+  twice:i[][] = savgolmat(9, 3, 2)
+  d:i = 0
+  while d <= 3 do
+    k:i = 0
+    while k < 9 do
+      assert_close(half[d][k], unit[d][k] * int_pow(2, d), 1.0e-12, "delta 0.5 scaling")
+      assert_close(twice[d][k], unit[d][k] / int_pow(2, d), 1.0e-12, "delta 2 scaling")
+      k += 1
+    od
+    d += 1
+  od
+  prints("savgolmat delta scaling: ok\n")
+endin
+
+
+; ------------------------------------------------------------------ savgol.a
+
+instr 20  ; unity DC gain, and rejection of a full-scale Nyquist component
+  sig:a = 1 + oscils(0.5, sr/2, 0)
+  y:a = savgol(sig, 9, 2)
+  if timeinstk() > 2 then
+    assert_close_k(downsamp(y, 1), 1, 1.0e-9, 20)
+  endif
+endin
+
+instr 21  ; a linear input is reproduced exactly, delayed by (winsize-1)/2
+  slope:i = 3
+  sig:a = line(0, p3, slope * p3)
+  y:a = savgol(sig, 11, 2)
+  ref:a = delay(sig, 5 / sr)
+  if timeinstk() > 2 then
+    assert_close_k(downsamp(y, 1), downsamp(ref, 1), 1.0e-9, 21)
+  endif
+endin
+
+instr 22  ; first derivative of that ramp is its slope, in units per second
+  slope:i = 3
+  sig:a = line(0, p3, slope * p3)
+  y:a = savgol(sig, 7, 2, 1, 1/sr)
+  if timeinstk() > 2 then
+    assert_close_k(downsamp(y, 1), slope, 1.0e-6, 22)
+  endif
+endin
+
+instr 23  ; derivative of a constant is zero
+  y:a = savgol(a(1), 9, 3, 1, 1/sr)
+  if timeinstk() > 2 then
+    assert_close_k(downsamp(y, 1), 0, 1.0e-6, 23)
+  endif
+endin
+
+instr 24  ; block processing must equal sample-by-sample processing
+  sig:a = oscili(0.7, 440) + oscili(0.3, 1234.5)
+  y:a = savgol(sig, 11, 3)
+  assert_block_matches(sig, y, 11, 3, 0, 1, 24)
+endin
+
+instr 25  ; same, for a derivative row
+  sig:a = oscili(0.7, 137) + oscili(0.3, 911)
+  y:a = savgol(sig, 15, 4, 2, 1/sr)
+  assert_block_matches(sig, y, 15, 4, 2, 1/sr, 25)
+endin
+
+
+; ------------------------------------------------------------------ savgol.k
+
+instr 30  ; unity DC gain at k-rate
+  y:k = savgol(k(1), 9, 2)
+  if timeinstk() > 12 then
+    assert_close_k(y, 1, 1.0e-9, 30)
+  endif
+endin
+
+instr 31  ; first derivative of a k-rate ramp, in units per second
+  slope:k = 5
+  x:k = slope * times()
+  y:k = savgol(x, 7, 2, 1, 1/kr)
+  if timeinstk() > 10 then
+    assert_close_k(y, slope, 1.0e-6, 31)
+  endif
+endin
+
+instr 32  ; second derivative of a quadratic, exact for order >= 2
+  t:k = times()
+  y:k = savgol(t * t, 9, 2, 2, 1/kr)
+  if timeinstk() > 12 then
+    assert_close_k(y, 2, 1.0e-4, 32)
+  endif
+endin
+
+instr 33  ; k- and a-rate variants agree sample for sample
+  sig:a = oscili(0.6, 220) + oscili(0.4, 777)
+  assert_rates_agree(sig, 9, 2, 0, 1, 33)
+  assert_rates_agree(sig, 13, 3, 1, 1, 34)
+endin
+
+
+instr 90
+  if timeinstk() == 1 then
+    ; The score is deterministic and currently yields 1860393 checks; the bound
+    ; is tight enough that a whole instrument going silent trips it.
+    if gk_checks < 1850000 then
+      printf("FAIL: only %d perf-rate assertions ran, expected at least 1850000\n", 1, gk_checks)
+      exitnowk(1)
+    endif
+    printf("savgol: all tests passed (%d perf-rate assertions)\n", 1, gk_checks)
+  endif
+endin
+
+</CsInstruments>
+<CsScore>
+i 1  0 0.1
+i 2  0 0.1
+i 3  0 0.1
+i 4  0 0.1
+i 5  0 0.1
+i 6  0 0.1
+i 7  0 0.1
+i 8  0 0.1
+
+; Ten seconds of audio-rate filtering, then ten of control-rate, so that ring
+; wrap-around, history shifting and coefficient scaling are exercised over
+; hundreds of thousands of cycles rather than a handful.
+i 20 0.1 10
+i 21 0.1 10
+i 22 0.1 10
+i 23 0.1 10
+i 24 0.1 10
+i 25 0.1 10
+
+i 30 10.2 10
+i 31 10.2 10
+i 32 10.2 10
+i 33 10.2 10
+
+i 90 20.3 0.1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol.csd
+++ b/tests/commandline/test_savgol.csd
@@ -13,6 +13,25 @@ nchnls = 1
 ; Reference coefficients below were derived in exact rational arithmetic from
 ; C = (A^T A)^-1 A^T scaled by deriv!, independently of the opcode.
 
+; MYFLT is float in single-precision builds (USE_DOUBLE=0), which the CI does
+; build and test. Anything that survives on seven significant digits is
+; compared at a fixed tolerance; anything whose accuracy is set by
+; cancellation gets a tolerance derived from the actual MYFLT epsilon.
+opcode machine_eps():i
+  e:i = 1
+  while 1 + e/2 != 1 do
+    e /= 2
+  od
+  xout(e)
+endop
+
+gi_eps@global:i = machine_eps()
+gi_single@global:i = (gi_eps > 1.0e-10 ? 1 : 0)
+
+opcode prec_tol(dbl:i, flt:i):i
+  xout(gi_single == 1 ? flt : dbl)
+endop
+
 opcode assert_close(got:i, want:i, tol:i, msg:S):void
   if abs(got - want) > tol then
     prints("FAIL %s: got %.14f, expected %.14f\n", msg, got, want)
@@ -85,13 +104,20 @@ opcode assert_moments(w:i, o:i):void
     m:i = 0
     while m <= o do
       s:i = 0
+      scale:i = 0
       k:i = 0
       while k < w do
-        s += mat[d][k] * int_pow(k - centre, m)
+        term:i = mat[d][k] * int_pow(k - centre, m)
+        s += term
+        scale += abs(term)
         k += 1
       od
       want:i = (m == d ? factorial(d) : 0)
-      if abs(s - want) > 1.0e-8 then
+      ; The sum cancels terms of magnitude `scale` down to `want`, so the
+      ; residual is bounded by a few ulps of `scale`, not by a fixed constant:
+      ; on w=31 o=4 that is 5e-11 in double and 2e-4 in single precision.
+      tol:i = 1024 * gi_eps * (scale > 1 ? scale : 1)
+      if abs(s - want) > tol then
         prints("FAIL moment w=%d o=%d deriv=%d m=%d: got %.14f, expected %.14f\n", w, o, d, m, s, want)
         exitnow(-1)
       endif
@@ -197,6 +223,25 @@ instr 7  ; parity of the derivative rows
   prints("savgolmat symmetry: ok\n")
 endin
 
+instr 9  ; frequency response at the two ends of the spectrum
+  mat:i[][] = savgolmat(9, 2)
+  dc:i = 0
+  nyq:i = 0
+  k:i = 0
+  while k < 9 do
+    dc += mat[0][k]
+    nyq += mat[0][k] * (k % 2 == 0 ? 1 : -1)
+    k += 1
+  od
+  ; Unity at DC, and -41/231 at Nyquist: a Savitzky-Golay kernel attenuates
+  ; the top of the spectrum by only about 15 dB, which is the shallow stopband
+  ; that pays for the peak preservation.
+  ; summing nine coefficients costs a few ulps, which is 1e-7 in single precision
+  assert_close(dc, 1, 64 * gi_eps, "smoothing kernel DC gain")
+  assert_close(nyq, -41/231, 64 * gi_eps, "smoothing kernel Nyquist gain")
+  prints("savgolmat frequency response: ok\n")
+endin
+
 instr 8  ; row d scales with 1/delta^d
   unit:i[][] = savgolmat(9, 3, 1)
   half:i[][] = savgolmat(9, 3, 0.5)
@@ -217,11 +262,10 @@ endin
 
 ; ------------------------------------------------------------------ savgol.a
 
-instr 20  ; unity DC gain, and rejection of a full-scale Nyquist component
-  sig:a = 1 + oscils(0.5, sr/2, 0)
-  y:a = savgol(sig, 9, 2)
+instr 20  ; unity DC gain
+  y:a = savgol(a(1), 9, 2)
   if timeinstk() > 2 then
-    assert_close_k(downsamp(y, 1), 1, 1.0e-9, 20)
+    assert_close_k(downsamp(y, 1), 1, prec_tol(1.0e-9, 1.0e-4), 20)
   endif
 endin
 
@@ -231,7 +275,7 @@ instr 21  ; a linear input is reproduced exactly, delayed by (winsize-1)/2
   y:a = savgol(sig, 11, 2)
   ref:a = delay(sig, 5 / sr)
   if timeinstk() > 2 then
-    assert_close_k(downsamp(y, 1), downsamp(ref, 1), 1.0e-9, 21)
+    assert_close_k(downsamp(y, 1), downsamp(ref, 1), prec_tol(1.0e-9, 1.0e-3), 21)
   endif
 endin
 
@@ -240,14 +284,14 @@ instr 22  ; first derivative of that ramp is its slope, in units per second
   sig:a = line(0, p3, slope * p3)
   y:a = savgol(sig, 7, 2, 1, 1/sr)
   if timeinstk() > 2 then
-    assert_close_k(downsamp(y, 1), slope, 1.0e-6, 22)
+    assert_close_k(downsamp(y, 1), slope, prec_tol(1.0e-6, 5.0e-2), 22)
   endif
 endin
 
 instr 23  ; derivative of a constant is zero
   y:a = savgol(a(1), 9, 3, 1, 1/sr)
   if timeinstk() > 2 then
-    assert_close_k(downsamp(y, 1), 0, 1.0e-6, 23)
+    assert_close_k(downsamp(y, 1), 0, prec_tol(1.0e-6, 1.0e-2), 23)
   endif
 endin
 
@@ -269,24 +313,28 @@ endin
 instr 30  ; unity DC gain at k-rate
   y:k = savgol(k(1), 9, 2)
   if timeinstk() > 12 then
-    assert_close_k(y, 1, 1.0e-9, 30)
+    assert_close_k(y, 1, prec_tol(1.0e-9, 1.0e-4), 30)
   endif
 endin
 
 instr 31  ; first derivative of a k-rate ramp, in units per second
   slope:k = 5
-  x:k = slope * times()
+  x:k = slope * timeinsts()
   y:k = savgol(x, 7, 2, 1, 1/kr)
   if timeinstk() > 10 then
-    assert_close_k(y, slope, 1.0e-6, 31)
+    assert_close_k(y, slope, prec_tol(1.0e-6, 5.0e-2), 31)
   endif
 endin
 
 instr 32  ; second derivative of a quadratic, exact for order >= 2
-  t:k = times()
+  ; Centred on the note so |t| stays small: a second derivative cancels terms
+  ; of magnitude (t/delta)^2, which in single precision leaves a few percent
+  ; even at |t| <= 5 and is hopeless if absolute score time is used instead.
+  t:k = frac(timeinsts()) - 0.5
   y:k = savgol(t * t, 9, 2, 2, 1/kr)
-  if timeinstk() > 12 then
-    assert_close_k(y, 2, 1.0e-4, 32)
+  if timeinstk() > 12 && abs(t) < 0.4 then
+    ; measured worst error: 1.1e-10 in double, 0.11 in single precision
+    assert_close_k(y, 2, prec_tol(1.0e-6, 0.3), 32)
   endif
 endin
 
@@ -299,7 +347,8 @@ endin
 
 instr 90
   if timeinstk() == 1 then
-    ; The score is deterministic and currently yields 1860393 checks; the bound
+    ; The score is deterministic and yields 1857650 checks in both the double
+    ; and the single-precision build; the bound
     ; is tight enough that a whole instrument going silent trips it.
     if gk_checks < 1850000 then
       printf("FAIL: only %d perf-rate assertions ran, expected at least 1850000\n", 1, gk_checks)
@@ -319,6 +368,7 @@ i 5  0 0.1
 i 6  0 0.1
 i 7  0 0.1
 i 8  0 0.1
+i 9  0 0.1
 
 ; Ten seconds of audio-rate filtering, then ten of control-rate, so that ring
 ; wrap-around, history shifting and coefficient scaling are exercised over

--- a/tests/commandline/test_savgol_fail_delta.csd
+++ b/tests/commandline/test_savgol_fail_delta.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: delta is the sample spacing the derivative is scaled by,
+; so zero would divide by zero rather than produce a finite result.
+
+instr 1
+  prints("expecting: delta must be greater than 0\n")
+  y:a = savgol(a(1), 9, 2, 1, 0)
+  out(y)
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol_fail_deriv.csd
+++ b/tests/commandline/test_savgol_fail_deriv.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: the coefficient matrix only holds order + 1 derivative
+; rows, so a deriv above the polynomial order has nothing to read.
+
+instr 1
+  prints("expecting: deriv must be >= 0 and <= order\n")
+  y:a = savgol(a(1), 9, 2, 3)
+  out(y)
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol_fail_mat.csd
+++ b/tests/commandline/test_savgol_fail_mat.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: savgolmat validates its arguments the same way the filter
+; does, so an even winsize is rejected there too.
+
+instr 1
+  prints("expecting: winsize must be odd and at least 3\n")
+  mat:i[][] = savgolmat(6, 2)
+  prints("unreachable: %d rows\n", lenarray(mat, 1))
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol_fail_order.csd
+++ b/tests/commandline/test_savgol_fail_order.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: the polynomial order must stay below the window size.
+; order == winsize - 1 is the largest value accepted, so winsize itself is out.
+
+instr 1
+  prints("expecting: order must be >= 0 and less than winsize\n")
+  y:a = savgol(a(1), 5, 5)
+  out(y)
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol_fail_winsize_even.csd
+++ b/tests/commandline/test_savgol_fail_winsize_even.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: a Savitzky-Golay window has to be centred on a sample, so
+; an even winsize must be rejected at init time.
+
+instr 1
+  prints("expecting: winsize must be odd and at least 3\n")
+  y:a = savgol(a(1), 4, 2)
+  out(y)
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_savgol_fail_winsize_small.csd
+++ b/tests/commandline/test_savgol_fail_winsize_small.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Expected failure: a window shorter than 3 samples cannot support a fit.
+; Checked through the k-rate entry point, which validates the same way.
+
+instr 1
+  prints("expecting: winsize must be odd and at least 3\n")
+  y:k = savgol(k(1), 1, 0)
+  printk2(y)
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
# Add `savgol` and `savgolmat`: Savitzky-Golay smoothing and differentiation

This adds a Savitzky-Golay filter.
A Savitzky-Golay filter fits a polynomial of degree `order:i` to the
`winsize:i` most recent samples, in the least-squares sense, and outputs that
polynomial evaluated at the centre of the window.

```csound
res:a = savgol(sig:a, winsize:i, order:i [, deriv:i] [, delta:i])
res:k = savgol(sig:k, winsize:i, order:i [, deriv:i] [, delta:i])
mat:i[][] = savgolmat(winsize:i, order:i [, delta:i])
```

Csound already provides many ways to smooth a signal. 
The reason to add Savitzky–Golay `savgol` is that it smooths without significantly 
distorting local features.  A moving average reduces the height of peaks in 
proportion to the window length;  a local polynomial fit preserves the height, 
width, and position of peaks whenever  they can be represented by the fitted polynomial. 
The price is a relatively shallow,  rippled stopband. That makes it a poor replacement 
for a conventional low-pass filter,  but an excellent smoother for control signals, 
envelopes, gesture and sensor data,  breakpoint functions, and spectral envelopes, 
where preserving the shape of a signal  matters more than aggressive frequency rejection.

The second distinguishing feature is `deriv:i`, which selects which derivative of the 
fitted polynomial to evaluate. The default, 0, returns the fitted polynomial itself, 
corresponding to the smoothing case. Values of 1, 2, …, order instead return the first, 
second, and higher derivatives. Unlike finite-difference differentiation, which strongly 
amplifies high-frequency noise, Savitzky–Golay computes derivatives directly from the local 
least-squares polynomial fit, providing much more stable estimates. Smoothing and 
differentiation are therefore two views of the same local approximation, making a 
single opcode suitable both for denoising and for estimating slopes, curvature, 
and higher-order local features.

In practice, the opcode is useful both as a high-quality smoother and as a 
feature extractor. The smoothing mode (`deriv = 0`) removes small-scale noise 
while preserving the overall geometry of the signal, whereas higher derivatives 
can be used to detect extrema, estimate velocity or acceleration, 
measure curvature, or analyze the local evolution of a control signal.

The scale of these derivatives is controlled by `delta`. 
By default delta = 1, so derivatives are expressed per sample. 
Passing 1/sr at a-rate or 1/kr at k-rate instead expresses them per second, 
matching the physical time scale of the signal.

While `savgol` applies the filter directly, `savgolmat` returns the whole kernel 
bank instead of filtering: an`(order + 1)` by `winsize` array whose row `d` 
is the convolution kernel for the `d`-th derivative, already scaled by `d! / delta^d`. 
Row 0 for `winsize = 5, order = 2` is the textbook `[-3, 12, 17, 12, -3] / 35`. It is
useful for inspecting what the filter is doing, and for driving a table-based
convolution.

One ordering detail worth stating, since it is the one thing about these
kernels that can bite. The rows are stored oldest sample first, which is both
the order `savgol` applies them in and the order they are tabulated in in the
literature. A convolution reverses its kernel, so `dconv` and friends apply a
row backwards. Even-derivative rows are symmetric and do not care;
odd-derivative rows are antisymmetric, so they come out **negated** and have
to be reversed, or equivalently sign-flipped, before use. This affects only
`savgolmat` output routed through a convolution opcode, `savgol` itself
applies its kernel in the right order, and an increasing ramp yields a
positive first derivative.

## Design notes

**Centred window, hence latency.** The output belongs to the centre of the
window, so the filter lags the input by `(winsize - 1) / 2` samples at
a-rate, or the same number of k-cycles at k-rate. This is inherent to a
centred fit rather than an implementation artefact, and it is documented.
A one-sided fit would remove the latency at a considerable cost in accuracy;
that seemed the wrong default, and it can be built on top of `savgolmat` by
anyone who wants it.

**Zero-initialised history, no start-up gate.** The first `winsize - 1`
outputs are the filter's response to a signal that was silent beforehand. An
earlier draft of the k-rate variant suppressed those outputs until the window
filled, which produced a hard discontinuity when the gate released, and made
the two rates disagree. Letting the zero-padded transient through is both the
mathematically correct answer and the behaviour the a-rate path already had.

**Direct convolution at perf time.** `winsize` multiply-adds per output
sample, no allocation, no locks, no branching in the inner loop. Everything, 
validation, the pseudo-inverse, the scaled kernel row, happens once at init.
A microbenchmark of the inner loop with the project's own flags (`-O3
-ffast-math`, Apple M1) renders 10 seconds of 44.1 kHz audio in 2.1 ms at
`winsize = 5`, 3.9 ms at 31, 8.6 ms at 127, and 110 ms at 2001, that is
0.02 % to 1.1 % of one core. Realistic windows are 5 to 51, so an FFT-based
overlap-save path would not pay for itself.

`NOTE`: There is no upper bound on `winsize` beyond available memory. A window of
several thousand taps is legal... but I am happy to add one if needed.
