### PR TITLE
Honor optional i-rate connect gain in signal-flow graph inlets.

### DIFF
--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -762,6 +762,8 @@ struct Inletf : public OpcodeBase<Inletf> {
     float *source = 0;
     CMPLX *sinkFrame = 0;
     CMPLX *sourceFrame = 0;
+    int32_t newLastframe = lastframe;
+    bool mergedNonSliding = false;
     // Loop over the source connections...
     for (size_t sourceI = 0, sourceN = sourceOutlets->size(); sourceI < sourceN;
          sourceI++) {
@@ -832,6 +834,8 @@ struct Inletf : public OpcodeBase<Inletf> {
           source = (float *)sourceOutlet->fsignal->frame.auxp;
           // Compare against the source frame counter; using the sink's
           // framecount here stopped updates after the first merge.
+          // Defer updating shared lastframe until all sources are checked so
+          // fan-in from multiple outlets with the same framecount still merges.
           if (lastframe < int(sourceOutlet->fsignal->framecount)) {
             for (size_t binI = 0, binN = fsignal->N + 2; binI < binN;
                  binI += 2) {
@@ -841,10 +845,16 @@ struct Inletf : public OpcodeBase<Inletf> {
                 sink[binI + 1] = source[binI + 1];
               }
             }
-            fsignal->framecount = lastframe = sourceOutlet->fsignal->framecount;
+            if (int(sourceOutlet->fsignal->framecount) > newLastframe) {
+              newLastframe = int(sourceOutlet->fsignal->framecount);
+            }
+            mergedNonSliding = true;
           }
         }
       }
+    }
+    if (mergedNonSliding) {
+      fsignal->framecount = lastframe = newLastframe;
     }
     return result;
   }

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -91,7 +91,9 @@
  *
  * Optional igain is an i-rate linear amplitude applied to that connection
  * when the sink inlet accumulates sources. It defaults to 1 (unity), so
- * omitted gain and explicit unity match historical behavior.
+ * omitted gain and explicit unity match historical behavior. If the same
+ * source outlet is connected more than once to the same sink inlet, the
+ * gains are summed.
  *
  * alwayson Tinstrument [p4, ..., pn]
  *
@@ -263,6 +265,13 @@ struct SignalFlowGraphState {
   std::vector<std::vector<std::vector<Outletf *> *> *> foutletVectors;
   std::vector<std::vector<std::vector<Outletv *> *> *> voutletVectors;
   std::vector<std::vector<std::vector<Outletkid *> *> *> kidoutletVectors;
+  // Gain vectors are heap-pooled like sourceOutlets: opcode structs are
+  // zeroed raw memory and must not own std::vector by value.
+  std::vector<std::vector<MYFLT> *> againVectors;
+  std::vector<std::vector<MYFLT> *> kgainVectors;
+  std::vector<std::vector<MYFLT> *> fgainVectors;
+  std::vector<std::vector<MYFLT> *> vgainVectors;
+  std::vector<std::vector<MYFLT> *> kidgainVectors;
   SignalFlowGraphState(CSOUND *csound_) {
     csound = csound_;
     signal_flow_ports_lock = csound->Create_Mutex(0);
@@ -282,13 +291,25 @@ struct SignalFlowGraphState {
       delete *it;
     for (std::vector<std::vector<std::vector<Outletkid *> *> *>::iterator it = kidoutletVectors.begin(), end = kidoutletVectors.end(); it != end; it++)
       delete *it;
+    for (std::vector<std::vector<MYFLT> *>::iterator it = againVectors.begin(), end = againVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<MYFLT> *>::iterator it = kgainVectors.begin(), end = kgainVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<MYFLT> *>::iterator it = fgainVectors.begin(), end = fgainVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<MYFLT> *>::iterator it = vgainVectors.begin(), end = vgainVectors.end(); it != end; it++)
+      delete *it;
+    for (std::vector<std::vector<MYFLT> *>::iterator it = kidgainVectors.begin(), end = kidgainVectors.end(); it != end; it++)
+      delete *it;
 
     aoutletsForSourceOutletIds.clear();
     ainletsForSinkInletIds.clear();
     aoutletVectors.clear();
+    againVectors.clear();
     koutletsForSourceOutletIds.clear();
     kinletsForSinkInletIds.clear();
     koutletVectors.clear();
+    kgainVectors.clear();
     foutletsForSourceOutletIds.clear();
     voutletsForSourceOutletIds.clear();
     kidoutletsForSourceOutletIds.clear();
@@ -296,8 +317,11 @@ struct SignalFlowGraphState {
     kidinletsForSinkInletIds.clear();
     finletsForSinkInletIds.clear();
     foutletVectors.clear();
+    fgainVectors.clear();
     voutletVectors.clear();
+    vgainVectors.clear();
     kidoutletVectors.clear();
+    kidgainVectors.clear();
     connections.clear();
   }
 };
@@ -369,7 +393,7 @@ struct Inleta : public OpcodeBase<Inleta> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outleta *> *> *sourceOutlets;
-  std::vector<MYFLT> sourceGains;
+  std::vector<MYFLT> *sourceGains;
   int32_t sampleN;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -384,11 +408,13 @@ struct Inleta : public OpcodeBase<Inleta> {
                   sfg_globals->aoutletVectors.end(),
                   sourceOutlets) == sfg_globals->aoutletVectors.end()) {
       sourceOutlets = new std::vector<std::vector<Outleta *> *>;
+      sourceGains = new std::vector<MYFLT>;
       sfg_globals->aoutletVectors.push_back(sourceOutlets);
+      sfg_globals->againVectors.push_back(sourceGains);
     } else {
       sourceOutlets->clear();
+      sourceGains->clear();
     }
-    sourceGains.clear();
     warn(csound, "sourceOutlets: 0x%x\n", sourceOutlets);
     sinkInletId[0] = 0;
     const char *insname =
@@ -414,13 +440,16 @@ struct Inleta : public OpcodeBase<Inleta> {
       const Connection &connection = sourceConnections[i];
       std::vector<Outleta *> &aoutlets =
           sfg_globals->aoutletsForSourceOutletIds[connection.sourceOutletId];
-      if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &aoutlets) ==
-          sourceOutlets->end()) {
+      std::vector<std::vector<Outleta *> *>::iterator existing =
+          std::find(sourceOutlets->begin(), sourceOutlets->end(), &aoutlets);
+      if (existing == sourceOutlets->end()) {
         sourceOutlets->push_back(&aoutlets);
-        sourceGains.push_back(connection.gain);
+        sourceGains->push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
              connection.sourceOutletId.c_str(), this, sinkInletId);
+      } else {
+        (*sourceGains)[existing - sourceOutlets->begin()] += connection.gain;
       }
     }
     warn(csound, "ENDED Inleta::init().\n");
@@ -441,7 +470,7 @@ struct Inleta : public OpcodeBase<Inleta> {
          sourceI++) {
       // Loop over the source connection instances...
       std::vector<Outleta *> *instances = sourceOutlets->at(sourceI);
-      MYFLT gain = sourceGains[sourceI];
+      MYFLT gain = sourceGains->at(sourceI);
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         Outleta *sourceOutlet = instances->at(instanceI);
@@ -519,7 +548,7 @@ struct Inletk : public OpcodeBase<Inletk> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletk *> *> *sourceOutlets;
-  std::vector<MYFLT> sourceGains;
+  std::vector<MYFLT> *sourceGains;
   int32_t ksmps;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -530,11 +559,13 @@ struct Inletk : public OpcodeBase<Inletk> {
                   sfg_globals->koutletVectors.end(),
                   sourceOutlets) == sfg_globals->koutletVectors.end()) {
       sourceOutlets = new std::vector<std::vector<Outletk *> *>;
+      sourceGains = new std::vector<MYFLT>;
       sfg_globals->koutletVectors.push_back(sourceOutlets);
+      sfg_globals->kgainVectors.push_back(sourceGains);
     } else {
       sourceOutlets->clear();
+      sourceGains->clear();
     }
-    sourceGains.clear();
     sinkInletId[0] = 0;
     const char *insname =
         csound->GetInstrumentList(csound)[opds.insdshead->insno]->insname;
@@ -559,13 +590,16 @@ struct Inletk : public OpcodeBase<Inletk> {
       const Connection &connection = sourceConnections[i];
       std::vector<Outletk *> &koutlets =
           sfg_globals->koutletsForSourceOutletIds[connection.sourceOutletId];
-      if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets) ==
-          sourceOutlets->end()) {
+      std::vector<std::vector<Outletk *> *>::iterator existing =
+          std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets);
+      if (existing == sourceOutlets->end()) {
         sourceOutlets->push_back(&koutlets);
-        sourceGains.push_back(connection.gain);
+        sourceGains->push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x"
                          "of inlet %s.\n"),
              connection.sourceOutletId.c_str(), this, sinkInletId);
+      } else {
+        (*sourceGains)[existing - sourceOutlets->begin()] += connection.gain;
       }
     }
     return OK;
@@ -582,7 +616,7 @@ struct Inletk : public OpcodeBase<Inletk> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletk *> *instances = sourceOutlets->at(sourceI);
-      MYFLT gain = sourceGains[sourceI];
+      MYFLT gain = sourceGains->at(sourceI);
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletk *sourceOutlet = instances->at(instanceI);
@@ -656,7 +690,7 @@ struct Inletf : public OpcodeBase<Inletf> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletf *> *> *sourceOutlets;
-  std::vector<MYFLT> sourceGains;
+  std::vector<MYFLT> *sourceGains;
   int32_t ksmps;
   int32_t lastframe;
   bool fsignalInitialized;
@@ -671,11 +705,13 @@ struct Inletf : public OpcodeBase<Inletf> {
                   sfg_globals->foutletVectors.end(),
                   sourceOutlets) == sfg_globals->foutletVectors.end()) {
       sourceOutlets = new std::vector<std::vector<Outletf *> *>;
+      sourceGains = new std::vector<MYFLT>;
       sfg_globals->foutletVectors.push_back(sourceOutlets);
+      sfg_globals->fgainVectors.push_back(sourceGains);
     } else {
       sourceOutlets->clear();
+      sourceGains->clear();
     }
-    sourceGains.clear();
     sinkInletId[0] = 0;
     const char *insname =
         csound->GetInstrumentList(csound)[opds.insdshead->insno]->insname;
@@ -700,19 +736,24 @@ struct Inletf : public OpcodeBase<Inletf> {
       const Connection &connection = sourceConnections[i];
       std::vector<Outletf *> &foutlets =
           sfg_globals->foutletsForSourceOutletIds[connection.sourceOutletId];
-      if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &foutlets) ==
-          sourceOutlets->end()) {
+      std::vector<std::vector<Outletf *> *>::iterator existing =
+          std::find(sourceOutlets->begin(), sourceOutlets->end(), &foutlets);
+      if (existing == sourceOutlets->end()) {
         sourceOutlets->push_back(&foutlets);
-        sourceGains.push_back(connection.gain);
+        sourceGains->push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
              connection.sourceOutletId.c_str(), this, sinkInletId);
+      } else {
+        (*sourceGains)[existing - sourceOutlets->begin()] += connection.gain;
       }
     }
     return OK;
   }
   /**
    * Mix fsig values from active outlets feeding this inlet.
+   * Non-sliding frames max-merge source into sink (older code wrote the
+   * wrong direction and only ran for inactive sources).
    */
   int32_t audio(CSOUND *csound) {
     LockGuard guard(csound, sfg_globals->signal_flow_ports_lock);
@@ -726,65 +767,72 @@ struct Inletf : public OpcodeBase<Inletf> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletf *> *instances = sourceOutlets->at(sourceI);
-      const float gain = (float)sourceGains[sourceI];
+      const float gain = (float)sourceGains->at(sourceI);
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletf *sourceOutlet = instances->at(instanceI);
         // Skip inactive instances.
-        if (sourceOutlet->opds.insdshead->actflg) {
-          if (!fsignalInitialized) {
-            int32 N = sourceOutlet->fsignal->N;
-            if (UNLIKELY(sourceOutlet->fsignal == fsignal)) {
-              csound->Warning(csound,
-                              "%s", Str("Unsafe to have same fsig as in and out"));
-            }
-            fsignal->sliding = 0;
-            if (sourceOutlet->fsignal->sliding) {
-              if (fsignal->frame.auxp == 0 ||
-                  fsignal->frame.size <
-                      sizeof(MYFLT) * opds.insdshead->ksmps * (N + 2))
-                csound->AuxAlloc(
-                    csound, (N + 2) * sizeof(MYFLT) * opds.insdshead->ksmps,
-                    &fsignal->frame);
-              fsignal->NB = sourceOutlet->fsignal->NB;
-              fsignal->sliding = 1;
-            } else if (fsignal->frame.auxp == 0 ||
-                       fsignal->frame.size < sizeof(float) * (N + 2)) {
-              csound->AuxAlloc(csound, (N + 2) * sizeof(float),
-                               &fsignal->frame);
-            }
-            fsignal->N = N;
-            fsignal->overlap = sourceOutlet->fsignal->overlap;
-            fsignal->winsize = sourceOutlet->fsignal->winsize;
-            fsignal->wintype = sourceOutlet->fsignal->wintype;
-            fsignal->format = sourceOutlet->fsignal->format;
-            fsignal->framecount = 1;
-            lastframe = 0;
-            if (UNLIKELY(!((fsignal->format == PVS_AMP_FREQ) ||
-                           (fsignal->format == PVS_AMP_PHASE))))
-              result = csound->InitError(csound,
-                                         "%s", Str("inletf: signal format "
-                                             "must be amp-phase or amp-freq."));
-            fsignalInitialized = true;
+        if (!sourceOutlet->opds.insdshead->actflg) {
+          continue;
+        }
+        if (!fsignalInitialized) {
+          int32 N = sourceOutlet->fsignal->N;
+          if (UNLIKELY(sourceOutlet->fsignal == fsignal)) {
+            csound->Warning(csound,
+                            "%s", Str("Unsafe to have same fsig as in and out"));
           }
-          if (fsignal->sliding) {
-            for (int32_t frameI = 0; frameI < ksmps; frameI++) {
-              sinkFrame = (CMPLX *)fsignal->frame.auxp + (fsignal->NB * frameI);
-              sourceFrame = (CMPLX *)sourceOutlet->fsignal->frame.auxp +
-                            (fsignal->NB * frameI);
-              for (size_t binI = 0, binN = fsignal->NB; binI < binN; binI++) {
-                float amp = sourceFrame[binI].re * gain;
-                if (amp > sinkFrame[binI].re) {
-                  sinkFrame[binI].re = amp;
-                  sinkFrame[binI].im = sourceFrame[binI].im;
-                }
+          fsignal->sliding = 0;
+          if (sourceOutlet->fsignal->sliding) {
+            if (fsignal->frame.auxp == 0 ||
+                fsignal->frame.size <
+                    sizeof(MYFLT) * opds.insdshead->ksmps * (N + 2))
+              csound->AuxAlloc(
+                  csound, (N + 2) * sizeof(MYFLT) * opds.insdshead->ksmps,
+                  &fsignal->frame);
+            fsignal->NB = sourceOutlet->fsignal->NB;
+            fsignal->sliding = 1;
+          } else if (fsignal->frame.auxp == 0 ||
+                     fsignal->frame.size < sizeof(float) * (N + 2)) {
+            csound->AuxAlloc(csound, (N + 2) * sizeof(float),
+                             &fsignal->frame);
+          }
+          fsignal->N = N;
+          fsignal->NB = sourceOutlet->fsignal->NB;
+          fsignal->overlap = sourceOutlet->fsignal->overlap;
+          fsignal->winsize = sourceOutlet->fsignal->winsize;
+          fsignal->wintype = sourceOutlet->fsignal->wintype;
+          fsignal->format = sourceOutlet->fsignal->format;
+          fsignal->framecount = 1;
+          lastframe = 0;
+          if (fsignal->frame.auxp != 0) {
+            memset(fsignal->frame.auxp, 0, fsignal->frame.size);
+          }
+          if (UNLIKELY(!((fsignal->format == PVS_AMP_FREQ) ||
+                         (fsignal->format == PVS_AMP_PHASE))))
+            result = csound->InitError(csound,
+                                       "%s", Str("inletf: signal format "
+                                           "must be amp-phase or amp-freq."));
+          fsignalInitialized = true;
+        }
+        if (fsignal->sliding) {
+          for (int32_t frameI = 0; frameI < ksmps; frameI++) {
+            sinkFrame = (CMPLX *)fsignal->frame.auxp + (fsignal->NB * frameI);
+            sourceFrame = (CMPLX *)sourceOutlet->fsignal->frame.auxp +
+                          (fsignal->NB * frameI);
+            for (size_t binI = 0, binN = fsignal->NB; binI < binN; binI++) {
+              float amp = sourceFrame[binI].re * gain;
+              if (amp > sinkFrame[binI].re) {
+                sinkFrame[binI].re = amp;
+                sinkFrame[binI].im = sourceFrame[binI].im;
               }
             }
           }
         } else {
           sink = (float *)fsignal->frame.auxp;
           source = (float *)sourceOutlet->fsignal->frame.auxp;
-          if (lastframe < int(fsignal->framecount)) {
+          // Compare against the source frame counter; using the sink's
+          // framecount here stopped updates after the first merge.
+          if (lastframe < int(sourceOutlet->fsignal->framecount)) {
             for (size_t binI = 0, binN = fsignal->N + 2; binI < binN;
                  binI += 2) {
               float amp = source[binI] * gain;
@@ -869,7 +917,7 @@ struct Inletv : public OpcodeBase<Inletv> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletv *> *> *sourceOutlets;
-  std::vector<MYFLT> sourceGains;
+  std::vector<MYFLT> *sourceGains;
   size_t arraySize;
   size_t myFltsPerArrayElement;
   int32_t sampleN;
@@ -893,11 +941,13 @@ struct Inletv : public OpcodeBase<Inletv> {
                   sfg_globals->voutletVectors.end(),
                   sourceOutlets) == sfg_globals->voutletVectors.end()) {
       sourceOutlets = new std::vector<std::vector<Outletv *> *>;
+      sourceGains = new std::vector<MYFLT>;
       sfg_globals->voutletVectors.push_back(sourceOutlets);
+      sfg_globals->vgainVectors.push_back(sourceGains);
     } else {
       sourceOutlets->clear();
+      sourceGains->clear();
     }
-    sourceGains.clear();
     warn(csound, "sourceOutlets: 0x%x\n", sourceOutlets);
     sinkInletId[0] = 0;
     const char *insname =
@@ -925,13 +975,16 @@ struct Inletv : public OpcodeBase<Inletv> {
       const Connection &connection = sourceConnections[i];
       std::vector<Outletv *> &voutlets =
           sfg_globals->voutletsForSourceOutletIds[connection.sourceOutletId];
-      if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &voutlets) ==
-          sourceOutlets->end()) {
+      std::vector<std::vector<Outletv *> *>::iterator existing =
+          std::find(sourceOutlets->begin(), sourceOutlets->end(), &voutlets);
+      if (existing == sourceOutlets->end()) {
         sourceOutlets->push_back(&voutlets);
-        sourceGains.push_back(connection.gain);
+        sourceGains->push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s\n"),
              connection.sourceOutletId.c_str(), this, sinkInletId);
+      } else {
+        (*sourceGains)[existing - sourceOutlets->begin()] += connection.gain;
       }
     }
     warn(csound, "ENDED Inletv::init().\n");
@@ -951,7 +1004,7 @@ struct Inletv : public OpcodeBase<Inletv> {
          sourceI++) {
       // Loop over the source connection instances...
       std::vector<Outletv *> *instances = sourceOutlets->at(sourceI);
-      MYFLT gain = sourceGains[sourceI];
+      MYFLT gain = sourceGains->at(sourceI);
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         Outletv *sourceOutlet = instances->at(instanceI);
@@ -1045,7 +1098,7 @@ struct Inletkid : public OpcodeBase<Inletkid> {
   char sinkInletId[MAX_STRING];
   char *instanceId;
   std::vector<std::vector<Outletkid *> *> *sourceOutlets;
-  std::vector<MYFLT> sourceGains;
+  std::vector<MYFLT> *sourceGains;
   int32_t ksmps;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -1056,11 +1109,13 @@ struct Inletkid : public OpcodeBase<Inletkid> {
                   sfg_globals->kidoutletVectors.end(),
                   sourceOutlets) == sfg_globals->kidoutletVectors.end()) {
       sourceOutlets = new std::vector<std::vector<Outletkid *> *>;
+      sourceGains = new std::vector<MYFLT>;
       sfg_globals->kidoutletVectors.push_back(sourceOutlets);
+      sfg_globals->kidgainVectors.push_back(sourceGains);
     } else {
       sourceOutlets->clear();
+      sourceGains->clear();
     }
-    sourceGains.clear();
     sinkInletId[0] = 0;
     instanceId = csound->StringArg2Name(csound, (char *)0, SinstanceId->data,
                                      (char *)"", 1);
@@ -1087,13 +1142,16 @@ struct Inletkid : public OpcodeBase<Inletkid> {
       const Connection &connection = sourceConnections[i];
       std::vector<Outletkid *> &koutlets =
           sfg_globals->kidoutletsForSourceOutletIds[connection.sourceOutletId];
-      if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets) ==
-          sourceOutlets->end()) {
+      std::vector<std::vector<Outletkid *> *>::iterator existing =
+          std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets);
+      if (existing == sourceOutlets->end()) {
         sourceOutlets->push_back(&koutlets);
-        sourceGains.push_back(connection.gain);
+        sourceGains->push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
              connection.sourceOutletId.c_str(), this, sinkInletId);
+      } else {
+        (*sourceGains)[existing - sourceOutlets->begin()] += connection.gain;
       }
     }
     return OK;
@@ -1110,7 +1168,7 @@ struct Inletkid : public OpcodeBase<Inletkid> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletkid *> *instances = sourceOutlets->at(sourceI);
-      MYFLT gain = sourceGains[sourceI];
+      MYFLT gain = sourceGains->at(sourceI);
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletkid *sourceOutlet = instances->at(instanceI);

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -79,7 +79,7 @@
  * or number, so it is valid to use the same inlet name in more than one
  * instrument (but not to use the same inlet name twice in one instrument).
  *
- * connect Tsource1, Soutlet1, Tsink1, Sinlet1
+ * connect Tsource1, Soutlet1, Tsink1, Sinlet1 [, igain]
  *
  * The connect opcode, valid only in orchestra headers, sends the signals
  * from the indicated outlet in all instances of the indicated source
@@ -88,6 +88,10 @@
  * outlet instances. Thus multiple instances of an outlet may fan in to one
  * instance of an inlet, or one instance of an outlet may fan out to
  * multiple instances of an inlet.
+ *
+ * Optional igain is an i-rate linear amplitude applied to that connection
+ * when the sink inlet accumulates sources. It defaults to 1 (unity), so
+ * omitted gain and explicit unity match historical behavior.
  *
  * alwayson Tinstrument [p4, ..., pn]
  *
@@ -233,6 +237,11 @@ bool operator<(const EventBlock &a, const EventBlock &b) {
 // Identifiers are always "sourcename:outletname" and "sinkname:inletname",
 // or "sourcename:idname:outletname" and "sinkname:inletname."
 
+struct Connection {
+  std::string sourceOutletId;
+  MYFLT gain; // i-rate linear amplitude; default 1
+};
+
 struct SignalFlowGraphState {
   CSOUND *csound;
   void *signal_flow_ports_lock;
@@ -247,7 +256,7 @@ struct SignalFlowGraphState {
   std::map<std::string, std::vector<Inletf *>> finletsForSinkInletIds;
   std::map<std::string, std::vector<Inletv *>> vinletsForSinkInletIds;
   std::map<std::string, std::vector<Inletkid *>> kidinletsForSinkInletIds;
-  std::map<std::string, std::vector<std::string>> connections;
+  std::map<std::string, std::vector<Connection>> connections;
   std::map<EventBlock, int> functionTablesForEvtblks;
   std::vector<std::vector<std::vector<Outleta *> *> *> aoutletVectors;
   std::vector<std::vector<std::vector<Outletk *> *> *> koutletVectors;
@@ -360,6 +369,7 @@ struct Inleta : public OpcodeBase<Inleta> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outleta *> *> *sourceOutlets;
+  std::vector<MYFLT> sourceGains;
   int32_t sampleN;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -378,6 +388,7 @@ struct Inleta : public OpcodeBase<Inleta> {
     } else {
       sourceOutlets->clear();
     }
+    sourceGains.clear();
     warn(csound, "sourceOutlets: 0x%x\n", sourceOutlets);
     sinkInletId[0] = 0;
     const char *insname =
@@ -397,18 +408,19 @@ struct Inleta : public OpcodeBase<Inleta> {
     }
     // Find source outlets connecting to this.
     // Any number of sources may connect to any number of sinks.
-    std::vector<std::string> &sourceOutletIds =
+    std::vector<Connection> &sourceConnections =
         sfg_globals->connections[sinkInletId];
-    for (size_t i = 0, n = sourceOutletIds.size(); i < n; i++) {
-      const std::string &sourceOutletId = sourceOutletIds[i];
+    for (size_t i = 0, n = sourceConnections.size(); i < n; i++) {
+      const Connection &connection = sourceConnections[i];
       std::vector<Outleta *> &aoutlets =
-          sfg_globals->aoutletsForSourceOutletIds[sourceOutletId];
+          sfg_globals->aoutletsForSourceOutletIds[connection.sourceOutletId];
       if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &aoutlets) ==
           sourceOutlets->end()) {
         sourceOutlets->push_back(&aoutlets);
+        sourceGains.push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
-             sourceOutletId.c_str(), this, sinkInletId);
+             connection.sourceOutletId.c_str(), this, sinkInletId);
       }
     }
     warn(csound, "ENDED Inleta::init().\n");
@@ -429,6 +441,7 @@ struct Inleta : public OpcodeBase<Inleta> {
          sourceI++) {
       // Loop over the source connection instances...
       std::vector<Outleta *> *instances = sourceOutlets->at(sourceI);
+      MYFLT gain = sourceGains[sourceI];
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         Outleta *sourceOutlet = instances->at(instanceI);
@@ -436,7 +449,7 @@ struct Inleta : public OpcodeBase<Inleta> {
         if (sourceOutlet->opds.insdshead->actflg) {
           for (int32_t sampleI = 0, sampleN = ksmps(); sampleI < sampleN;
                ++sampleI) {
-            asignal[sampleI] += sourceOutlet->asignal[sampleI];
+            asignal[sampleI] += sourceOutlet->asignal[sampleI] * gain;
           }
         }
       }
@@ -506,6 +519,7 @@ struct Inletk : public OpcodeBase<Inletk> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletk *> *> *sourceOutlets;
+  std::vector<MYFLT> sourceGains;
   int32_t ksmps;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -520,6 +534,7 @@ struct Inletk : public OpcodeBase<Inletk> {
     } else {
       sourceOutlets->clear();
     }
+    sourceGains.clear();
     sinkInletId[0] = 0;
     const char *insname =
         csound->GetInstrumentList(csound)[opds.insdshead->insno]->insname;
@@ -538,18 +553,19 @@ struct Inletk : public OpcodeBase<Inletk> {
     }
     // Find source outlets connecting to this.
     // Any number of sources may connect to any number of sinks.
-    std::vector<std::string> &sourceOutletIds =
+    std::vector<Connection> &sourceConnections =
         sfg_globals->connections[sinkInletId];
-    for (size_t i = 0, n = sourceOutletIds.size(); i < n; i++) {
-      const std::string &sourceOutletId = sourceOutletIds[i];
+    for (size_t i = 0, n = sourceConnections.size(); i < n; i++) {
+      const Connection &connection = sourceConnections[i];
       std::vector<Outletk *> &koutlets =
-          sfg_globals->koutletsForSourceOutletIds[sourceOutletId];
+          sfg_globals->koutletsForSourceOutletIds[connection.sourceOutletId];
       if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets) ==
           sourceOutlets->end()) {
         sourceOutlets->push_back(&koutlets);
+        sourceGains.push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x"
                          "of inlet %s.\n"),
-             sourceOutletId.c_str(), this, sinkInletId);
+             connection.sourceOutletId.c_str(), this, sinkInletId);
       }
     }
     return OK;
@@ -566,12 +582,13 @@ struct Inletk : public OpcodeBase<Inletk> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletk *> *instances = sourceOutlets->at(sourceI);
+      MYFLT gain = sourceGains[sourceI];
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletk *sourceOutlet = instances->at(instanceI);
         // Skip inactive instances.
         if (sourceOutlet->opds.insdshead->actflg) {
-          *ksignal += *sourceOutlet->ksignal;
+          *ksignal += *sourceOutlet->ksignal * gain;
         }
       }
     }
@@ -639,6 +656,7 @@ struct Inletf : public OpcodeBase<Inletf> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletf *> *> *sourceOutlets;
+  std::vector<MYFLT> sourceGains;
   int32_t ksmps;
   int32_t lastframe;
   bool fsignalInitialized;
@@ -657,6 +675,7 @@ struct Inletf : public OpcodeBase<Inletf> {
     } else {
       sourceOutlets->clear();
     }
+    sourceGains.clear();
     sinkInletId[0] = 0;
     const char *insname =
         csound->GetInstrumentList(csound)[opds.insdshead->insno]->insname;
@@ -675,18 +694,19 @@ struct Inletf : public OpcodeBase<Inletf> {
     }
     // Find source outlets connecting to this.
     // Any number of sources may connect to any number of sinks.
-    std::vector<std::string> &sourceOutletIds =
+    std::vector<Connection> &sourceConnections =
         sfg_globals->connections[sinkInletId];
-    for (size_t i = 0, n = sourceOutletIds.size(); i < n; i++) {
-      const std::string &sourceOutletId = sourceOutletIds[i];
+    for (size_t i = 0, n = sourceConnections.size(); i < n; i++) {
+      const Connection &connection = sourceConnections[i];
       std::vector<Outletf *> &foutlets =
-          sfg_globals->foutletsForSourceOutletIds[sourceOutletId];
+          sfg_globals->foutletsForSourceOutletIds[connection.sourceOutletId];
       if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &foutlets) ==
           sourceOutlets->end()) {
         sourceOutlets->push_back(&foutlets);
+        sourceGains.push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
-             sourceOutletId.c_str(), this, sinkInletId);
+             connection.sourceOutletId.c_str(), this, sinkInletId);
       }
     }
     return OK;
@@ -706,6 +726,7 @@ struct Inletf : public OpcodeBase<Inletf> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletf *> *instances = sourceOutlets->at(sourceI);
+      const float gain = (float)sourceGains[sourceI];
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletf *sourceOutlet = instances->at(instanceI);
@@ -752,8 +773,10 @@ struct Inletf : public OpcodeBase<Inletf> {
               sourceFrame = (CMPLX *)sourceOutlet->fsignal->frame.auxp +
                             (fsignal->NB * frameI);
               for (size_t binI = 0, binN = fsignal->NB; binI < binN; binI++) {
-                if (sourceFrame[binI].re > sinkFrame[binI].re) {
-                  sinkFrame[binI] = sourceFrame[binI];
+                float amp = sourceFrame[binI].re * gain;
+                if (amp > sinkFrame[binI].re) {
+                  sinkFrame[binI].re = amp;
+                  sinkFrame[binI].im = sourceFrame[binI].im;
                 }
               }
             }
@@ -764,9 +787,10 @@ struct Inletf : public OpcodeBase<Inletf> {
           if (lastframe < int(fsignal->framecount)) {
             for (size_t binI = 0, binN = fsignal->N + 2; binI < binN;
                  binI += 2) {
-              if (source[binI] > sink[binI]) {
-                source[binI] = sink[binI];
-                source[binI + 1] = sink[binI + 1];
+              float amp = source[binI] * gain;
+              if (amp > sink[binI]) {
+                sink[binI] = amp;
+                sink[binI + 1] = source[binI + 1];
               }
             }
             fsignal->framecount = lastframe = sourceOutlet->fsignal->framecount;
@@ -845,6 +869,7 @@ struct Inletv : public OpcodeBase<Inletv> {
    */
   char sinkInletId[MAX_STRING];
   std::vector<std::vector<Outletv *> *> *sourceOutlets;
+  std::vector<MYFLT> sourceGains;
   size_t arraySize;
   size_t myFltsPerArrayElement;
   int32_t sampleN;
@@ -872,6 +897,7 @@ struct Inletv : public OpcodeBase<Inletv> {
     } else {
       sourceOutlets->clear();
     }
+    sourceGains.clear();
     warn(csound, "sourceOutlets: 0x%x\n", sourceOutlets);
     sinkInletId[0] = 0;
     const char *insname =
@@ -893,18 +919,19 @@ struct Inletv : public OpcodeBase<Inletv> {
     }
     // Find source outlets connecting to this.
     // Any number of sources may connect to any number of sinks.
-    std::vector<std::string> &sourceOutletIds =
+    std::vector<Connection> &sourceConnections =
         sfg_globals->connections[sinkInletId];
-    for (size_t i = 0, n = sourceOutletIds.size(); i < n; i++) {
-      const std::string &sourceOutletId = sourceOutletIds[i];
+    for (size_t i = 0, n = sourceConnections.size(); i < n; i++) {
+      const Connection &connection = sourceConnections[i];
       std::vector<Outletv *> &voutlets =
-          sfg_globals->voutletsForSourceOutletIds[sourceOutletId];
+          sfg_globals->voutletsForSourceOutletIds[connection.sourceOutletId];
       if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &voutlets) ==
           sourceOutlets->end()) {
         sourceOutlets->push_back(&voutlets);
+        sourceGains.push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s\n"),
-             sourceOutletId.c_str(), this, sinkInletId);
+             connection.sourceOutletId.c_str(), this, sinkInletId);
       }
     }
     warn(csound, "ENDED Inletv::init().\n");
@@ -924,6 +951,7 @@ struct Inletv : public OpcodeBase<Inletv> {
          sourceI++) {
       // Loop over the source connection instances...
       std::vector<Outletv *> *instances = sourceOutlets->at(sourceI);
+      MYFLT gain = sourceGains[sourceI];
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         Outletv *sourceOutlet = instances->at(instanceI);
@@ -935,7 +963,7 @@ struct Inletv : public OpcodeBase<Inletv> {
             // warn(csound, "Inletv::audio: sourceOutlet: 0%x in arraydat: 0x%x
             // data: 0x%x (0x%x)\n", sourceOutlet, insignal, indata,
             // &insignal->data);
-            vsignal->data[signalI] += indata[signalI];
+            vsignal->data[signalI] += indata[signalI] * gain;
           }
         }
       }
@@ -1017,6 +1045,7 @@ struct Inletkid : public OpcodeBase<Inletkid> {
   char sinkInletId[MAX_STRING];
   char *instanceId;
   std::vector<std::vector<Outletkid *> *> *sourceOutlets;
+  std::vector<MYFLT> sourceGains;
   int32_t ksmps;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -1031,6 +1060,7 @@ struct Inletkid : public OpcodeBase<Inletkid> {
     } else {
       sourceOutlets->clear();
     }
+    sourceGains.clear();
     sinkInletId[0] = 0;
     instanceId = csound->StringArg2Name(csound, (char *)0, SinstanceId->data,
                                      (char *)"", 1);
@@ -1051,18 +1081,19 @@ struct Inletkid : public OpcodeBase<Inletkid> {
     }
     // Find source outlets connecting to this.
     // Any number of sources may connect to any number of sinks.
-    std::vector<std::string> &sourceOutletIds =
+    std::vector<Connection> &sourceConnections =
         sfg_globals->connections[sinkInletId];
-    for (size_t i = 0, n = sourceOutletIds.size(); i < n; i++) {
-      const std::string &sourceOutletId = sourceOutletIds[i];
+    for (size_t i = 0, n = sourceConnections.size(); i < n; i++) {
+      const Connection &connection = sourceConnections[i];
       std::vector<Outletkid *> &koutlets =
-          sfg_globals->kidoutletsForSourceOutletIds[sourceOutletId];
+          sfg_globals->kidoutletsForSourceOutletIds[connection.sourceOutletId];
       if (std::find(sourceOutlets->begin(), sourceOutlets->end(), &koutlets) ==
           sourceOutlets->end()) {
         sourceOutlets->push_back(&koutlets);
+        sourceGains.push_back(connection.gain);
         warn(csound, Str("Connected instances of outlet %s to instance 0x%x of "
                          "inlet %s.\n"),
-             sourceOutletId.c_str(), this, sinkInletId);
+             connection.sourceOutletId.c_str(), this, sinkInletId);
       }
     }
     return OK;
@@ -1079,13 +1110,14 @@ struct Inletkid : public OpcodeBase<Inletkid> {
          sourceI++) {
       // Loop over the source connection instances...
       const std::vector<Outletkid *> *instances = sourceOutlets->at(sourceI);
+      MYFLT gain = sourceGains[sourceI];
       for (size_t instanceI = 0, instanceN = instances->size();
            instanceI < instanceN; instanceI++) {
         const Outletkid *sourceOutlet = instances->at(instanceI);
         // Skip inactive instances and also all non-matching instances.
         if (sourceOutlet->opds.insdshead->actflg) {
           if (std::strcmp(sourceOutlet->instanceId, instanceId) == 0) {
-            *ksignal += *sourceOutlet->ksignal;
+            *ksignal += *sourceOutlet->ksignal * gain;
           }
         }
       }
@@ -1123,9 +1155,12 @@ struct Connect : public OpcodeBase<Connect> {
     sinkInletId += ":";
     sinkInletId +=
         csound->StringArg2Name(csound, (char *)0, Sinlet->data, (char *)"", 1);
-    warn(csound, Str("Connected outlet %s to inlet %s.\n"),
-         sourceOutletId.c_str(), sinkInletId.c_str());
-    sfg_globals->connections[sinkInletId].push_back(sourceOutletId);
+    warn(csound, Str("Connected outlet %s to inlet %s (gain %f).\n"),
+         sourceOutletId.c_str(), sinkInletId.c_str(), *gain);
+    Connection connection;
+    connection.sourceOutletId = sourceOutletId;
+    connection.gain = *gain;
+    sfg_globals->connections[sinkInletId].push_back(connection);
     return OK;
   }
 };
@@ -1156,9 +1191,12 @@ struct Connecti : public OpcodeBase<Connecti> {
     sinkInletId += ":";
     sinkInletId +=
         csound->StringArg2Name(csound, (char *)0, Sinlet->data, (char *)"", 1);
-    warn(csound, Str("Connected outlet %s to inlet %s.\n"),
-         sourceOutletId.c_str(), sinkInletId.c_str());
-    sfg_globals->connections[sinkInletId].push_back(sourceOutletId);
+    warn(csound, Str("Connected outlet %s to inlet %s (gain %f).\n"),
+         sourceOutletId.c_str(), sinkInletId.c_str(), *gain);
+    Connection connection;
+    connection.sourceOutletId = sourceOutletId;
+    connection.gain = *gain;
+    sfg_globals->connections[sinkInletId].push_back(connection);
     return OK;
   }
 };
@@ -1189,9 +1227,12 @@ struct Connectii : public OpcodeBase<Connectii> {
     sinkInletId += ":";
     sinkInletId +=
         csound->StringArg2Name(csound, (char *)0, Sinlet->data, (char *)"", 1);
-    warn(csound, Str("Connected outlet %s to inlet %s.\n"),
-         sourceOutletId.c_str(), sinkInletId.c_str());
-    sfg_globals->connections[sinkInletId].push_back(sourceOutletId);
+    warn(csound, Str("Connected outlet %s to inlet %s (gain %f).\n"),
+         sourceOutletId.c_str(), sinkInletId.c_str(), *gain);
+    Connection connection;
+    connection.sourceOutletId = sourceOutletId;
+    connection.gain = *gain;
+    sfg_globals->connections[sinkInletId].push_back(connection);
     return OK;
   }
 };
@@ -1219,9 +1260,12 @@ struct ConnectS : public OpcodeBase<ConnectS> {
     sinkInletId += ":";
     sinkInletId +=
         csound->StringArg2Name(csound, (char *)0, Sinlet->data, (char *)"", 1);
-    warn(csound, Str("Connected outlet %s to inlet %s.\n"),
-         sourceOutletId.c_str(), sinkInletId.c_str());
-    sfg_globals->connections[sinkInletId].push_back(sourceOutletId);
+    warn(csound, Str("Connected outlet %s to inlet %s (gain %f).\n"),
+         sourceOutletId.c_str(), sinkInletId.c_str(), *gain);
+    Connection connection;
+    connection.sourceOutletId = sourceOutletId;
+    connection.gain = *gain;
+    sfg_globals->connections[sinkInletId].push_back(connection);
     return OK;
   }
 };

--- a/Opcodes/signalflowgraph.cpp
+++ b/Opcodes/signalflowgraph.cpp
@@ -244,10 +244,17 @@ struct Connection {
   MYFLT gain; // i-rate linear amplitude; default 1
 };
 
+struct FsigSourceFrameState {
+  uint64_t generation;
+  uint32_t framecount;
+  bool seen;
+};
+
 struct SignalFlowGraphState {
   CSOUND *csound;
   void *signal_flow_ports_lock;
   void *signal_flow_ftables_lock;
+  uint64_t nextFoutletGeneration;
   std::map<std::string, std::vector<Outleta *>> aoutletsForSourceOutletIds;
   std::map<std::string, std::vector<Outletk *>> koutletsForSourceOutletIds;
   std::map<std::string, std::vector<Outletf *>> foutletsForSourceOutletIds;
@@ -259,6 +266,8 @@ struct SignalFlowGraphState {
   std::map<std::string, std::vector<Inletv *>> vinletsForSinkInletIds;
   std::map<std::string, std::vector<Inletkid *>> kidinletsForSinkInletIds;
   std::map<std::string, std::vector<Connection>> connections;
+  std::map<const Inletf *, std::map<const Outletf *, FsigSourceFrameState>>
+      fframesForInlets;
   std::map<EventBlock, int> functionTablesForEvtblks;
   std::vector<std::vector<std::vector<Outleta *> *> *> aoutletVectors;
   std::vector<std::vector<std::vector<Outletk *> *> *> koutletVectors;
@@ -274,6 +283,7 @@ struct SignalFlowGraphState {
   std::vector<std::vector<MYFLT> *> kidgainVectors;
   SignalFlowGraphState(CSOUND *csound_) {
     csound = csound_;
+    nextFoutletGeneration = 0;
     signal_flow_ports_lock = csound->Create_Mutex(0);
     signal_flow_ftables_lock = csound->Create_Mutex(0);
   }
@@ -322,6 +332,7 @@ struct SignalFlowGraphState {
     vgainVectors.clear();
     kidoutletVectors.clear();
     kidgainVectors.clear();
+    fframesForInlets.clear();
     connections.clear();
   }
 };
@@ -641,9 +652,11 @@ struct Outletf : public OpcodeNoteoffBase<Outletf> {
    */
   char sourceOutletId[MAX_STRING];
   SignalFlowGraphState *sfg_globals;
+  uint64_t generation;
   int32_t init(CSOUND *csound) {
     QueryGlobalPointer(csound, "sfg_globals", sfg_globals);
     LockGuard guard(csound, sfg_globals->signal_flow_ports_lock);
+    generation = ++sfg_globals->nextFoutletGeneration;
     const char *insname =
         csound->GetInstrumentList(csound)[opds.insdshead->insno]->insname;
     if (insname) {
@@ -692,7 +705,7 @@ struct Inletf : public OpcodeBase<Inletf> {
   std::vector<std::vector<Outletf *> *> *sourceOutlets;
   std::vector<MYFLT> *sourceGains;
   int32_t ksmps;
-  int32_t lastframe;
+  uint32_t lastframe;
   bool fsignalInitialized;
   SignalFlowGraphState *sfg_globals;
   int32_t init(CSOUND *csound) {
@@ -701,6 +714,7 @@ struct Inletf : public OpcodeBase<Inletf> {
     ksmps = opds.insdshead->ksmps;
     lastframe = 0;
     fsignalInitialized = false;
+    sfg_globals->fframesForInlets[this].clear();
     if (std::find(sfg_globals->foutletVectors.begin(),
                   sfg_globals->foutletVectors.end(),
                   sourceOutlets) == sfg_globals->foutletVectors.end()) {
@@ -752,8 +766,8 @@ struct Inletf : public OpcodeBase<Inletf> {
   }
   /**
    * Mix fsig values from active outlets feeding this inlet.
-   * Non-sliding frames max-merge source into sink (older code wrote the
-   * wrong direction and only ran for inactive sources).
+   * Non-sliding frames rebuild when any source advances. Sliding frames
+   * rebuild every k-cycle.
    */
   int32_t audio(CSOUND *csound) {
     LockGuard guard(csound, sfg_globals->signal_flow_ports_lock);
@@ -762,8 +776,43 @@ struct Inletf : public OpcodeBase<Inletf> {
     float *source = 0;
     CMPLX *sinkFrame = 0;
     CMPLX *sourceFrame = 0;
-    int32_t newLastframe = lastframe;
-    bool mergedNonSliding = false;
+    std::map<const Outletf *, FsigSourceFrameState> &sourceFrames =
+        sfg_globals->fframesForInlets[this];
+    for (auto &sourceFrameState : sourceFrames) {
+      sourceFrameState.second.seen = false;
+    }
+    bool sourceFrameChanged = false;
+    for (size_t sourceI = 0, sourceN = sourceOutlets->size(); sourceI < sourceN;
+         sourceI++) {
+      const std::vector<Outletf *> *instances = sourceOutlets->at(sourceI);
+      for (size_t instanceI = 0, instanceN = instances->size();
+           instanceI < instanceN; instanceI++) {
+        const Outletf *sourceOutlet = instances->at(instanceI);
+        if (!sourceOutlet->opds.insdshead->actflg) {
+          continue;
+        }
+        const FsigSourceFrameState state = {
+            sourceOutlet->generation, sourceOutlet->fsignal->framecount, true};
+        auto frame = sourceFrames.insert(std::make_pair(sourceOutlet, state));
+        if (frame.second || frame.first->second.generation != state.generation ||
+            frame.first->second.framecount != state.framecount) {
+          sourceFrameChanged = true;
+        }
+        frame.first->second = state;
+      }
+    }
+    for (auto frame = sourceFrames.begin(); frame != sourceFrames.end();) {
+      if (!frame->second.seen) {
+        frame = sourceFrames.erase(frame);
+        sourceFrameChanged = true;
+      } else {
+        ++frame;
+      }
+    }
+    if (fsignalInitialized && fsignal->frame.auxp != 0 &&
+        (fsignal->sliding || sourceFrameChanged)) {
+      memset(fsignal->frame.auxp, 0, fsignal->frame.size);
+    }
     // Loop over the source connections...
     for (size_t sourceI = 0, sourceN = sourceOutlets->size(); sourceI < sourceN;
          sourceI++) {
@@ -832,11 +881,7 @@ struct Inletf : public OpcodeBase<Inletf> {
         } else {
           sink = (float *)fsignal->frame.auxp;
           source = (float *)sourceOutlet->fsignal->frame.auxp;
-          // Compare against the source frame counter; using the sink's
-          // framecount here stopped updates after the first merge.
-          // Defer updating shared lastframe until all sources are checked so
-          // fan-in from multiple outlets with the same framecount still merges.
-          if (lastframe < int(sourceOutlet->fsignal->framecount)) {
+          if (sourceFrameChanged) {
             for (size_t binI = 0, binN = fsignal->N + 2; binI < binN;
                  binI += 2) {
               float amp = source[binI] * gain;
@@ -845,16 +890,12 @@ struct Inletf : public OpcodeBase<Inletf> {
                 sink[binI + 1] = source[binI + 1];
               }
             }
-            if (int(sourceOutlet->fsignal->framecount) > newLastframe) {
-              newLastframe = int(sourceOutlet->fsignal->framecount);
-            }
-            mergedNonSliding = true;
           }
         }
       }
     }
-    if (mergedNonSliding) {
-      fsignal->framecount = lastframe = newLastframe;
+    if (sourceFrameChanged && fsignalInitialized && !fsignal->sliding) {
+      fsignal->framecount = ++lastframe;
     }
     return result;
   }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -836,7 +836,11 @@ def runTest():
         ],
         [
             "test_connect_gain.csd",
-            "test connect i-rate gain (omit, unity, non-unity, fan-in)",
+            "test connect i-rate gain (omit, unity, non-unity, fan-in, duplicate)",
+        ],
+        [
+            "test_connect_gain_fsig.csd",
+            "test connect i-rate gain on active non-sliding fsig inlets",
         ],
     ]
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -834,6 +834,10 @@ def runTest():
             "test_signalflowgraph_lifetime.csd",
             "test signal-flow graph cleanup and ftgenonce",
         ],
+        [
+            "test_connect_gain.csd",
+            "test connect i-rate gain (omit, unity, non-unity, fan-in)",
+        ],
     ]
 
     arrayTests = [

--- a/tests/commandline/test_connect_gain.csd
+++ b/tests/commandline/test_connect_gain.csd
@@ -1,0 +1,94 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+; Omitted gain (defaults to 1) vs explicit unity must match.
+connect "SourceA", "out", "SinkOmit", "in"
+connect "SourceA", "out", "SinkUnity", "in", 1
+
+; Non-unity gain scales the connection.
+connect "SourceA", "out", "SinkHalf", "in", 0.5
+
+; Fan-in with per-edge gains: 1 + 0.5 = 1.5
+connect "SourceA", "out", "SinkFan", "in", 1
+connect "SourceB", "out", "SinkFan", "in", 0.5
+
+; String-instrument overload with gain (connect.S).
+connect "SourceA", "out", "SinkString", "in", 0.25
+
+alwayson "SourceA"
+alwayson "SourceB"
+alwayson "SinkOmit"
+alwayson "SinkUnity"
+alwayson "SinkHalf"
+alwayson "SinkFan"
+alwayson "SinkString"
+
+instr SourceA
+  outletk "out", 1
+endin
+
+instr SourceB
+  outletk "out", 1
+endin
+
+instr SinkOmit
+  kin inletk "in"
+  if timeinstk() > 1 then
+    if abs(kin - 1) > 1e-6 then
+      printks "connect gain omit failed: expected=1 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+
+instr SinkUnity
+  kin inletk "in"
+  if timeinstk() > 1 then
+    if abs(kin - 1) > 1e-6 then
+      printks "connect gain unity failed: expected=1 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+
+instr SinkHalf
+  kin inletk "in"
+  if timeinstk() > 1 then
+    if abs(kin - 0.5) > 1e-6 then
+      printks "connect gain 0.5 failed: expected=0.5 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+
+instr SinkFan
+  kin inletk "in"
+  if timeinstk() > 1 then
+    if abs(kin - 1.5) > 1e-6 then
+      printks "connect gain fan-in failed: expected=1.5 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+
+instr SinkString
+  kin inletk "in"
+  if timeinstk() > 1 then
+    if abs(kin - 0.25) > 1e-6 then
+      printks "connect.S gain failed: expected=0.25 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+</CsInstruments>
+<CsScore>
+e 0.05
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_connect_gain.csd
+++ b/tests/commandline/test_connect_gain.csd
@@ -22,6 +22,10 @@ connect "SourceB", "out", "SinkFan", "in", 0.5
 ; Explicit string-instrument overload with gain.
 connect.S "SourceA", "out", "SinkString", "in", 0.25
 
+; Duplicate edges to the same inlet sum their gains: 0.5 + 0.25 = 0.75
+connect "SourceA", "out", "SinkDup", "in", 0.5
+connect "SourceA", "out", "SinkDup", "in", 0.25
+
 alwayson "SourceA"
 alwayson "SourceB"
 alwayson "SinkOmit"
@@ -29,6 +33,7 @@ alwayson "SinkUnity"
 alwayson "SinkHalf"
 alwayson "SinkFan"
 alwayson "SinkString"
+alwayson "SinkDup"
 
 ; timeinstk() counts k-cycles (not seconds). With sr/ksmps above,
 ; e 0.05 is many cycles, so checks after the first cycle do run.
@@ -85,6 +90,16 @@ instr SinkString
   if timeinstk() >= 2 then
     if abs(kin - 0.25) > 1e-6 then
       printks "connect.S gain failed: expected=0.25 got=%f\n", 0, kin
+      exitnowk(1)
+    endif
+  endif
+endin
+
+instr SinkDup
+  kin inletk "in"
+  if timeinstk() >= 2 then
+    if abs(kin - 0.75) > 1e-6 then
+      printks "connect gain duplicate failed: expected=0.75 got=%f\n", 0, kin
       exitnowk(1)
     endif
   endif

--- a/tests/commandline/test_connect_gain.csd
+++ b/tests/commandline/test_connect_gain.csd
@@ -19,8 +19,8 @@ connect "SourceA", "out", "SinkHalf", "in", 0.5
 connect "SourceA", "out", "SinkFan", "in", 1
 connect "SourceB", "out", "SinkFan", "in", 0.5
 
-; String-instrument overload with gain (connect.S).
-connect "SourceA", "out", "SinkString", "in", 0.25
+; Explicit string-instrument overload with gain.
+connect.S "SourceA", "out", "SinkString", "in", 0.25
 
 alwayson "SourceA"
 alwayson "SourceB"
@@ -30,6 +30,8 @@ alwayson "SinkHalf"
 alwayson "SinkFan"
 alwayson "SinkString"
 
+; timeinstk() counts k-cycles (not seconds). With sr/ksmps above,
+; e 0.05 is many cycles, so checks after the first cycle do run.
 instr SourceA
   outletk "out", 1
 endin
@@ -40,7 +42,7 @@ endin
 
 instr SinkOmit
   kin inletk "in"
-  if timeinstk() > 1 then
+  if timeinstk() >= 2 then
     if abs(kin - 1) > 1e-6 then
       printks "connect gain omit failed: expected=1 got=%f\n", 0, kin
       exitnowk(1)
@@ -50,7 +52,7 @@ endin
 
 instr SinkUnity
   kin inletk "in"
-  if timeinstk() > 1 then
+  if timeinstk() >= 2 then
     if abs(kin - 1) > 1e-6 then
       printks "connect gain unity failed: expected=1 got=%f\n", 0, kin
       exitnowk(1)
@@ -60,7 +62,7 @@ endin
 
 instr SinkHalf
   kin inletk "in"
-  if timeinstk() > 1 then
+  if timeinstk() >= 2 then
     if abs(kin - 0.5) > 1e-6 then
       printks "connect gain 0.5 failed: expected=0.5 got=%f\n", 0, kin
       exitnowk(1)
@@ -70,7 +72,7 @@ endin
 
 instr SinkFan
   kin inletk "in"
-  if timeinstk() > 1 then
+  if timeinstk() >= 2 then
     if abs(kin - 1.5) > 1e-6 then
       printks "connect gain fan-in failed: expected=1.5 got=%f\n", 0, kin
       exitnowk(1)
@@ -80,7 +82,7 @@ endin
 
 instr SinkString
   kin inletk "in"
-  if timeinstk() > 1 then
+  if timeinstk() >= 2 then
     if abs(kin - 0.25) > 1e-6 then
       printks "connect.S gain failed: expected=0.25 got=%f\n", 0, kin
       exitnowk(1)

--- a/tests/commandline/test_connect_gain_fsig.csd
+++ b/tests/commandline/test_connect_gain_fsig.csd
@@ -12,6 +12,11 @@ nchnls = 1
 connect "FSrc", "fout", "FSink1", "fin", 1
 connect "FSrc", "fout", "FSinkHalf", "fin", 0.5
 
+; Fan-in: a silent first source must not block a later source with the same
+; framecount (shared lastframe is updated only after all sources merge).
+connect "SilentFirst", "fout", "FanSink", "fin", 1
+connect "ToneSecond", "fout", "FanSink", "fin", 1
+
 gkamp1 init 0
 gkampHalf init 0
 
@@ -43,11 +48,37 @@ instr FSinkHalf
     endif
   endif
 endin
+
+instr SilentFirst
+  azero = 0
+  fsig pvsanal azero, 256, 64, 256, 1
+  outletf "fout", fsig
+endin
+
+instr ToneSecond
+  atone oscili 0.5, 1875
+  fsig pvsanal atone, 256, 64, 256, 1
+  outletf "fout", fsig
+endin
+
+instr FanSink
+  fsig inletf "fin"
+  kamp, kfreq pvsbin fsig, 10
+  if timeinstk() == 80 then
+    if kamp < 0.01 then
+      printks "connect fsig fan-in failed: bin10 amp=%f freq=%f\n", 0, kamp, kfreq
+      exitnowk(1)
+    endif
+  endif
+endin
 </CsInstruments>
 <CsScore>
 i "FSrc" 0 0.15
 i "FSink1" 0 0.15
 i "FSinkHalf" 0 0.15
+i "SilentFirst" 0 0.2
+i "ToneSecond" 0 0.2
+i "FanSink" 0 0.2
 e
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_connect_gain_fsig.csd
+++ b/tests/commandline/test_connect_gain_fsig.csd
@@ -1,0 +1,53 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+
+; Active non-sliding fsig connections must apply per-edge gain.
+connect "FSrc", "fout", "FSink1", "fin", 1
+connect "FSrc", "fout", "FSinkHalf", "fin", 0.5
+
+gkamp1 init 0
+gkampHalf init 0
+
+instr FSrc
+  a1 oscili 0.5, 440
+  fsig pvsanal a1, 256, 64, 256, 1
+  outletf "fout", fsig
+endin
+
+instr FSink1
+  fsig inletf "fin"
+  kamp, kfr pvsbin fsig, 2
+  gkamp1 = kamp
+endin
+
+instr FSinkHalf
+  fsig inletf "fin"
+  kamp, kfr pvsbin fsig, 2
+  gkampHalf = kamp
+  if timeinstk() == 40 then
+    if gkamp1 < 1e-6 then
+      printks "connect fsig gain failed: unity amp zero\n", 0
+      exitnowk(1)
+    endif
+    kratio = gkampHalf / gkamp1
+    if abs(kratio - 0.5) > 0.15 then
+      printks "connect fsig gain failed: expected ratio~0.5 got=%f (full=%f half=%f)\n", 0, kratio, gkamp1, gkampHalf
+      exitnowk(1)
+    endif
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i "FSrc" 0 0.15
+i "FSink1" 0 0.15
+i "FSinkHalf" 0 0.15
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_connect_gain_fsig.csd
+++ b/tests/commandline/test_connect_gain_fsig.csd
@@ -12,17 +12,24 @@ nchnls = 1
 connect "FSrc", "fout", "FSink1", "fin", 1
 connect "FSrc", "fout", "FSinkHalf", "fin", 0.5
 
-; Fan-in: a silent first source must not block a later source with the same
-; framecount (shared lastframe is updated only after all sources merge).
+; Fan-in: an early source must not block a later source with a lower framecount.
 connect "SilentFirst", "fout", "FanSink", "fin", 1
 connect "ToneSecond", "fout", "FanSink", "fin", 1
 
+; Sliding fsig inlets must not keep peaks from earlier k-cycles.
+connect "SlidingSource", "fout", "SlidingSink", "fin", 1
+
 gkamp1 init 0
 gkampHalf init 0
+gkampDirect init 0
+gkampSlidingDirect init 0
 
 instr FSrc
-  a1 oscili 0.5, 440
+  aenv linseg 0.5, 0.08, 0.5, 0.001, 0, 0.119, 0
+  a1 oscili aenv, 440
   fsig pvsanal a1, 256, 64, 256, 1
+  kdirect, kfrdirect pvsbin fsig, 2
+  gkampDirect = kdirect
   outletf "fout", fsig
 endin
 
@@ -44,6 +51,16 @@ instr FSinkHalf
     kratio = gkampHalf / gkamp1
     if abs(kratio - 0.5) > 0.15 then
       printks "connect fsig gain failed: expected ratio~0.5 got=%f (full=%f half=%f)\n", 0, kratio, gkamp1, gkampHalf
+      exitnowk(1)
+    endif
+  endif
+  if timeinstk() == 100 then
+    if gkampDirect > 0.001 then
+      printks "connect fsig decay setup failed: direct amp=%f\n", 0, gkampDirect
+      exitnowk(1)
+    endif
+    if gkamp1 > 0.01 then
+      printks "connect fsig retained stale peak: inlet amp=%f\n", 0, gkamp1
       exitnowk(1)
     endif
   endif
@@ -71,14 +88,42 @@ instr FanSink
     endif
   endif
 endin
+
+instr SlidingSource
+  aenv linseg 1, 0.05, 1, 0.001, 0, 0.499, 0
+  atone oscili aenv, 1875
+  fsig pvsanal atone, 256, 1, 256, 1
+  adirect, afreq pvsbin fsig, 10
+  kdirect rms adirect
+  gkampSlidingDirect = kdirect
+  outletf "fout", fsig
+endin
+
+instr SlidingSink
+  fsig inletf "fin"
+  ainlet, afreq pvsbin fsig, 10
+  kinlet rms ainlet
+  if timeinstk() == 300 then
+    if gkampSlidingDirect > 0.001 then
+      printks "connect sliding fsig decay setup failed: direct amp=%f\n", 0, gkampSlidingDirect
+      exitnowk(1)
+    endif
+    if kinlet > 0.01 then
+      printks "connect sliding fsig retained stale peak: inlet amp=%f\n", 0, kinlet
+      exitnowk(1)
+    endif
+  endif
+endin
 </CsInstruments>
 <CsScore>
-i "FSrc" 0 0.15
-i "FSink1" 0 0.15
-i "FSinkHalf" 0 0.15
-i "SilentFirst" 0 0.2
-i "ToneSecond" 0 0.2
-i "FanSink" 0 0.2
+i "FSrc" 0 0.2
+i "FSink1" 0 0.2
+i "FSinkHalf" 0 0.2
+i "SilentFirst" 0 0.25
+i "ToneSecond" 0.05 0.2
+i "FanSink" 0.05 0.2
+i "SlidingSource" 0 0.55
+i "SlidingSink" 0 0.55
 e
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/soak/connect.csd
+++ b/tests/soak/connect.csd
@@ -16,17 +16,17 @@ nchnls = 2
 
 ; Connect up the instruments to create a signal flow graph.
 
-connect "SimpleSine",   "leftout",     "Reverberator",     	"leftin"
-connect "SimpleSine",   "rightout",    "Reverberator",     	"rightin"
+connect "SimpleSine",   "leftout",     "Reverberator",     	"leftin", 1
+connect "SimpleSine",   "rightout",    "Reverberator",     	"rightin", 1
 
-connect "Moogy",        "leftout",     "Reverberator",     	"leftin"
-connect "Moogy",        "rightout",    "Reverberator",     	"rightin"
+connect "Moogy",        "leftout",     "Reverberator",     	"leftin", 1
+connect "Moogy",        "rightout",    "Reverberator",     	"rightin", 1
 
-connect "Reverberator", "leftout",     "Compressor",       	"leftin"
-connect "Reverberator", "rightout",    "Compressor",       	"rightin"
+connect "Reverberator", "leftout",     "Compressor",       	"leftin", 1
+connect "Reverberator", "rightout",    "Compressor",       	"rightin", 1
 
-connect "Compressor",   "leftout",     "Soundfile",       	"leftin"
-connect "Compressor",   "rightout",    "Soundfile",       	"rightin"
+connect "Compressor",   "leftout",     "Soundfile",       	"leftin", 1
+connect "Compressor",   "rightout",    "Soundfile",       	"rightin", 1
 
 ; Turn on the "effect" units in the signal flow graph.
 

--- a/tests/soak/connect.csd
+++ b/tests/soak/connect.csd
@@ -16,17 +16,17 @@ nchnls = 2
 
 ; Connect up the instruments to create a signal flow graph.
 
-connect "SimpleSine",   "leftout",     "Reverberator",     	"leftin", 1
-connect "SimpleSine",   "rightout",    "Reverberator",     	"rightin", 1
+connect "SimpleSine",   "leftout",     "Reverberator",     	"leftin"
+connect "SimpleSine",   "rightout",    "Reverberator",     	"rightin"
 
-connect "Moogy",        "leftout",     "Reverberator",     	"leftin", 1
-connect "Moogy",        "rightout",    "Reverberator",     	"rightin", 1
+connect "Moogy",        "leftout",     "Reverberator",     	"leftin"
+connect "Moogy",        "rightout",    "Reverberator",     	"rightin"
 
-connect "Reverberator", "leftout",     "Compressor",       	"leftin", 1
-connect "Reverberator", "rightout",    "Compressor",       	"rightin", 1
+connect "Reverberator", "leftout",     "Compressor",       	"leftin"
+connect "Reverberator", "rightout",    "Compressor",       	"rightin"
 
-connect "Compressor",   "leftout",     "Soundfile",       	"leftin", 1
-connect "Compressor",   "rightout",    "Soundfile",       	"rightin", 1
+connect "Compressor",   "leftout",     "Soundfile",       	"leftin"
+connect "Compressor",   "rightout",    "Soundfile",       	"rightin"
 
 ; Turn on the "effect" units in the signal flow graph.
 


### PR DESCRIPTION
Apply Connection.gain when inlets accumulate outlets (default 1), and add a regression test covering omit, unity, scale, and fan-in. At this time, no k-rate or a-rate gain exists; only i-rate. Review shows no prior use of the gain parameter in available Csound orchestras.