### PR TITLE
global audio/audio-array vars make setting local ksmps fail

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2610,6 +2610,48 @@ static CS_VARIABLE *setup_arg_for_var_name(CSOUND* csound, ARG* arg,
   return arg->argPtr;
 }
 
+typedef struct audio_type_path {
+  const CS_TYPE *type;
+  const struct audio_type_path *parent;
+} AUDIO_TYPE_PATH;
+
+static int32_t type_contains_audio(const CS_TYPE *type,
+                                   const AUDIO_TYPE_PATH *path);
+
+static int32_t var_contains_audio(const CS_VARIABLE *var,
+                                  const AUDIO_TYPE_PATH *path) {
+  if (var == NULL || var->varType == NULL)
+    return 0;
+  return type_contains_audio(var->varType == &CS_VAR_TYPE_ARRAY
+                               ? var->subType : var->varType,
+                             path);
+}
+
+static int32_t type_contains_audio(const CS_TYPE *type,
+                                   const AUDIO_TYPE_PATH *path) {
+  const AUDIO_TYPE_PATH *current = path;
+  CONS_CELL *members;
+
+  if (type == &CS_VAR_TYPE_A)
+    return 1;
+  if (type == NULL || !type->userDefinedType)
+    return 0;
+  while (current != NULL) {
+    if (current->type == type)
+      return 0;
+    current = current->parent;
+  }
+
+  AUDIO_TYPE_PATH next = { type, path };
+  members = type->members;
+  while (members != NULL) {
+    if (var_contains_audio((CS_VARIABLE *) members->value, &next))
+      return 1;
+    members = members->next;
+  }
+  return 0;
+}
+
 static int32_t is_audio_var(CSOUND *csound, CS_VARIABLE *var,
                             const char *structPath) {
   if (structPath != NULL) {
@@ -2626,10 +2668,7 @@ static int32_t is_audio_var(CSOUND *csound, CS_VARIABLE *var,
     }
     csound->Free(csound, path);
   }
-  return var != NULL && var->varType != NULL &&
-    (var->varType == &CS_VAR_TYPE_A ||
-     (var->varType == &CS_VAR_TYPE_ARRAY &&
-      var->subType == &CS_VAR_TYPE_A));
+  return var_contains_audio(var, NULL);
 }
 
 

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2609,6 +2609,16 @@ static CS_VARIABLE *setup_arg_for_var_name(CSOUND* csound, ARG* arg,
   return arg->argPtr;
 }
 
+static int32_t is_audio_var(CSOUND *csound,
+                    CS_VARIABLE *var) {
+  if(var->varType == &CS_VAR_TYPE_A ||
+    (var->varType == &CS_VAR_TYPE_ARRAY &&
+     var->subType ==  &CS_VAR_TYPE_A))
+     return 1;
+   else return 0;
+}
+
+
 /* get storage ndx of const, pnum, lcl or gbl */
 /* argument const/gbl indexes are positiv+1, */
 /* pnum/lcl negativ-1 called only after      */
@@ -2697,11 +2707,14 @@ static ARG *create_arg(CSOUND *csound, INSTRTXT *ip, char *s,
   else if(engineState->varPool != NULL && (uintptr_t)engineState->varPool >= 0x1000 &&
           setup_arg_for_var_name(csound, arg, engineState->varPool, s) != NULL) {
        arg->type = ARG_GLOBAL;
+       if(is_audio_var(csound, arg->argPtr))
+          ip->glbvarcnt++;
     }
     else if(csound->engineState.varPool != NULL && (uintptr_t)csound->engineState.varPool >= 0x1000 &&
             setup_arg_for_var_name(csound, arg, csound->engineState.varPool, s) != NULL) {
     arg->type = ARG_GLOBAL;
-
+    if(is_audio_var(csound, arg->argPtr))
+          ip->glbvarcnt++;  
   }
   /* otherwise we have a local arg */
   else {

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2610,48 +2610,6 @@ static CS_VARIABLE *setup_arg_for_var_name(CSOUND* csound, ARG* arg,
   return arg->argPtr;
 }
 
-typedef struct audio_type_path {
-  const CS_TYPE *type;
-  const struct audio_type_path *parent;
-} AUDIO_TYPE_PATH;
-
-static int32_t type_contains_audio(const CS_TYPE *type,
-                                   const AUDIO_TYPE_PATH *path);
-
-static int32_t var_contains_audio(const CS_VARIABLE *var,
-                                  const AUDIO_TYPE_PATH *path) {
-  if (var == NULL || var->varType == NULL)
-    return 0;
-  return type_contains_audio(var->varType == &CS_VAR_TYPE_ARRAY
-                               ? var->subType : var->varType,
-                             path);
-}
-
-static int32_t type_contains_audio(const CS_TYPE *type,
-                                   const AUDIO_TYPE_PATH *path) {
-  const AUDIO_TYPE_PATH *current = path;
-  CONS_CELL *members;
-
-  if (type == &CS_VAR_TYPE_A)
-    return 1;
-  if (type == NULL || !type->userDefinedType)
-    return 0;
-  while (current != NULL) {
-    if (current->type == type)
-      return 0;
-    current = current->parent;
-  }
-
-  AUDIO_TYPE_PATH next = { type, path };
-  members = type->members;
-  while (members != NULL) {
-    if (var_contains_audio((CS_VARIABLE *) members->value, &next))
-      return 1;
-    members = members->next;
-  }
-  return 0;
-}
-
 static int32_t is_audio_var(CSOUND *csound, CS_VARIABLE *var,
                             const char *structPath) {
   if (structPath != NULL) {
@@ -2668,7 +2626,7 @@ static int32_t is_audio_var(CSOUND *csound, CS_VARIABLE *var,
     }
     csound->Free(csound, path);
   }
-  return var_contains_audio(var, NULL);
+  return csound_variable_contains_type(var, &CS_VAR_TYPE_A);
 }
 
 

--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -32,6 +32,7 @@
 #include "oload.h"
 #include "pstream.h"
 #include "csound_orc_semantics.h"
+#include "csound_orc_structs.h"
 #include "csound_standard_types.h"
 #include "csound_orc_compile.h"
 #include "namedins.h"
@@ -2609,13 +2610,26 @@ static CS_VARIABLE *setup_arg_for_var_name(CSOUND* csound, ARG* arg,
   return arg->argPtr;
 }
 
-static int32_t is_audio_var(CSOUND *csound,
-                    CS_VARIABLE *var) {
-  if(var->varType == &CS_VAR_TYPE_A ||
-    (var->varType == &CS_VAR_TYPE_ARRAY &&
-     var->subType ==  &CS_VAR_TYPE_A))
-     return 1;
-   else return 0;
+static int32_t is_audio_var(CSOUND *csound, CS_VARIABLE *var,
+                            const char *structPath) {
+  if (structPath != NULL) {
+    char *path = csoundStrdup(csound, structPath);
+    char *th;
+    char *memberName = cs_strtok_r(path, ".", &th);
+    while (memberName != NULL && var != NULL) {
+      if (var->varType == NULL || !var->varType->userDefinedType) {
+        var = NULL;
+        break;
+      }
+      var = getStructMember(var->varType->members, memberName);
+      memberName = cs_strtok_r(NULL, ".", &th);
+    }
+    csound->Free(csound, path);
+  }
+  return var != NULL && var->varType != NULL &&
+    (var->varType == &CS_VAR_TYPE_A ||
+     (var->varType == &CS_VAR_TYPE_ARRAY &&
+      var->subType == &CS_VAR_TYPE_A));
 }
 
 
@@ -2707,13 +2721,13 @@ static ARG *create_arg(CSOUND *csound, INSTRTXT *ip, char *s,
   else if(engineState->varPool != NULL && (uintptr_t)engineState->varPool >= 0x1000 &&
           setup_arg_for_var_name(csound, arg, engineState->varPool, s) != NULL) {
        arg->type = ARG_GLOBAL;
-       if(is_audio_var(csound, arg->argPtr))
+       if(is_audio_var(csound, arg->argPtr, arg->structPath))
           ip->glbvarcnt++;
     }
     else if(csound->engineState.varPool != NULL && (uintptr_t)csound->engineState.varPool >= 0x1000 &&
             setup_arg_for_var_name(csound, arg, csound->engineState.varPool, s) != NULL) {
     arg->type = ARG_GLOBAL;
-    if(is_audio_var(csound, arg->argPtr))
+    if(is_audio_var(csound, arg->argPtr, arg->structPath))
           ip->glbvarcnt++;  
   }
   /* otherwise we have a local arg */

--- a/Engine/csound_orc_structs.c
+++ b/Engine/csound_orc_structs.c
@@ -60,6 +60,61 @@ CS_VARIABLE* getStructMember(CONS_CELL* members, char* memberName) {
     return NULL;
 }
 
+typedef struct csound_type_path {
+  const CS_TYPE *type;
+  const struct csound_type_path *parent;
+} CSOUND_TYPE_PATH;
+
+static int32_t type_contains_type(const CS_TYPE *type,
+                                  const CS_TYPE *target,
+                                  const CSOUND_TYPE_PATH *path);
+
+static int32_t variable_contains_type(const CS_VARIABLE *var,
+                                      const CS_TYPE *target,
+                                      const CSOUND_TYPE_PATH *path) {
+  if (var == NULL || var->varType == NULL || target == NULL)
+    return 0;
+  if (var->varType == target)
+    return 1;
+  return type_contains_type(var->varType == &CS_VAR_TYPE_ARRAY
+                              ? var->subType : var->varType,
+                            target, path);
+}
+
+static int32_t type_contains_type(const CS_TYPE *type,
+                                  const CS_TYPE *target,
+                                  const CSOUND_TYPE_PATH *path) {
+  const CSOUND_TYPE_PATH *current = path;
+  const CONS_CELL *members;
+
+  if (type == NULL || target == NULL)
+    return 0;
+  if (type == target)
+    return 1;
+  if (!type->userDefinedType)
+    return 0;
+  while (current != NULL) {
+    if (current->type == type)
+      return 0;
+    current = current->parent;
+  }
+
+  CSOUND_TYPE_PATH next = { type, path };
+  members = type->members;
+  while (members != NULL) {
+    if (variable_contains_type((const CS_VARIABLE *) members->value,
+                               target, &next))
+      return 1;
+    members = members->next;
+  }
+  return 0;
+}
+
+int32_t csound_variable_contains_type(const CS_VARIABLE *var,
+                                      const CS_TYPE *target) {
+  return variable_contains_type(var, target, NULL);
+}
+
 /* Deep-free struct members if this instance owns them.
    Safe to call on aliases; does nothing if ownsMembers==0 or members==NULL. */
 void csound_free_struct_members(CSOUND *csound, CS_STRUCT_VAR *var) {

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1479,6 +1479,15 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
     return csound->InitError(csound, Str("Cannot find instr %d (UDO %s)\n"),
                              instno, inm->name);
 
+   if(tp->glbvarcnt > 0 &&
+      CS_KSMPS != csound->ksmps)
+    return csoundInitError(csound, "inherited local ksmps not permitted with global audio vars\n");
+
+  if(tp->glbvarcnt > 0 &&
+     CS_ESR != csound->esr)
+    return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
+  
+
   inm->recurse_depth++;
   if (csound->oparms->recursion_depth > 0 &&
       inm->recurse_depth > csound->oparms->recursion_depth) {
@@ -1550,14 +1559,6 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   lcurip->onedksmps = CS_ONEDKSMPS;
   lcurip->kicvt = CS_KICVT;
 
-  if(lcurip->instr->glbvarcnt > 0 &&
-     lcurip->ksmps != csound->ksmps)
-    return csoundInitError(csound, "inherited local ksmps not permitted with global audio vars\n");
-
-  if(lcurip->instr->glbvarcnt > 0 &&
-     lcurip->esr != csound->esr)
-    return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
-  
 
   /* VL 13-12-13 */
   /* this sets ksmps and kr local variables */
@@ -2483,6 +2484,7 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
 {
 
   if(p->h.insdshead->instr->glbvarcnt > 0 &&
+     *p->i_ksmps > 0 /* no-op */ &&
      csound->ksmps != *p->i_ksmps /* no-op */)
     return csoundInitError(csound, "local ksmps not permitted with global audio vars\n");
   
@@ -2694,7 +2696,7 @@ int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
 /*
  * subinstr opcode
  */
-int32_t subinstrset_(CSOUND *csound, SUBINST *p, int32_t instno)
+static int32_t subinstrset_(CSOUND *csound, SUBINST *p, int32_t instno, int32_t initop)
 {
   OPDS    *saved_ids = csound->ids;
   INSDS   *saved_curip = csound->curip;
@@ -2748,11 +2750,11 @@ int32_t subinstrset_(CSOUND *csound, SUBINST *p, int32_t instno)
   p->ip->kicvt = CS_KICVT;
 
 
-  if(p->ip->instr->glbvarcnt > 0 &&
+  if(!initop && p->ip->instr->glbvarcnt > 0 &&
      p->ip->ksmps != csound->ksmps)
     return csoundInitError(csound, "inherited local ksmps not permitted with global audio vars\n");
 
-  if(p->ip->instr->glbvarcnt > 0 &&
+  if(!initop && p->ip->instr->glbvarcnt > 0 &&
      p->ip->esr != csound->esr)
     return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
 
@@ -2882,7 +2884,7 @@ int32_t subinstrset_S(CSOUND *csound, SUBINST *p){
   inarg_ofs = (init_op ? 0 : SUBINSTNUMOUTS);
   instno = csoundStringArg2Insno(csound, ((STRINGDAT *)p->ar[inarg_ofs])->data, 1);
   if (UNLIKELY(instno==NOT_AN_INSTRUMENT)) instno = -1;
-  return subinstrset_(csound,p,instno);
+  return subinstrset_(csound,p,instno,init_op);
 }
 
 
@@ -2892,7 +2894,7 @@ int32_t subinstrset(CSOUND *csound, SUBINST *p){
   init_op = (p->h.perf == NULL ? 1 : 0);
   inarg_ofs = (init_op ? 0 : SUBINSTNUMOUTS);
   instno = (int32_t) *(p->ar[inarg_ofs]);
-  return subinstrset_(csound,p,instno);
+  return subinstrset_(csound,p,instno,init_op);
 }
 
 int32_t subinstr(CSOUND *csound, SUBINST *p)

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1636,6 +1636,9 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
     csound->ids = csound->ids->nxti;
   }
 
+  if (UNLIKELY(err != OK))
+    goto finish_init;
+
   inm->passByRef = buf->opcode_info->newStyle &&
     parent_ip->ksmps == p->ip->ksmps &&
     parent_ip->esr == p->ip->esr;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -2545,7 +2545,7 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
 */
 int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
   if(p->h.insdshead->instr->glbvarcnt > 0 &&
-     *p->os <= 1 /* no op */)
+     *p->os > 1 /* no op */)
     return csoundInitError(csound, "local sr not permitted with global audio vars\n");
 
   int32_t os;
@@ -2619,7 +2619,7 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
 */
 int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
   if(p->h.insdshead->instr->glbvarcnt > 0  &&
-     *p->os <= 1 /* no op */)
+     *p->os > 1 /* no op */)
     return csoundInitError(csound, "local sr not permitted with global audio vars\n");
   
   int32_t os, lksmps;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1550,6 +1550,15 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   lcurip->onedksmps = CS_ONEDKSMPS;
   lcurip->kicvt = CS_KICVT;
 
+  if(lcurip->instr->glbvarcnt > 0 &&
+     lcurip->ksmps != csound->ksmps)
+    return csoundInitError(csound, "inherited local ksmps not permitted with global audio vars\n");
+
+  if(lcurip->instr->glbvarcnt > 0 &&
+     lcurip->esr != csound->esr)
+    return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
+  
+
   /* VL 13-12-13 */
   /* this sets ksmps and kr local variables */
   /* create local ksmps variable and init with ksmps */
@@ -2473,7 +2482,8 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
 int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
 {
 
-  if(p->h.insdshead->instr->glbvarcnt > 0)
+  if(p->h.insdshead->instr->glbvarcnt > 0 &&
+     csound->ksmps != *p->i_ksmps /* no-op */)
     return csoundInitError(csound, "local ksmps not permitted with global audio vars\n");
   
   uint32_t  l_ksmps, n;
@@ -2532,7 +2542,8 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
    with audio/control array arguments.
 */
 int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
-  if(p->h.insdshead->instr->glbvarcnt > 0)
+  if(p->h.insdshead->instr->glbvarcnt > 0 &&
+     *p->os <= 1 /* no op */)
     return csoundInitError(csound, "local sr not permitted with global audio vars\n");
 
   int32_t os;
@@ -2551,10 +2562,10 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
                            "can't oversample if local ksmps != parent ksmps\n");
 
   os = MYFLT2LRND(*p->os);
-  onedos = FL(1.0)/os;
   if(os < 1)
     return csound->InitError(csound, "illegal oversampling ratio: %d\n", os);
   if(os == 1 || CS_ESR != parent_sr) return OK; /* no op if changed already */
+  onedos = FL(1.0)/os;
 
   l_sr = CS_ESR*os;
   CS_ESR = l_sr;
@@ -2605,7 +2616,8 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
    It modifies ksmps according to the resampling factor.
 */
 int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
-  if(p->h.insdshead->instr->glbvarcnt > 0)
+  if(p->h.insdshead->instr->glbvarcnt > 0  &&
+     *p->os <= 1 /* no op */)
     return csoundInitError(csound, "local sr not permitted with global audio vars\n");
   
   int32_t os, lksmps;
@@ -2624,10 +2636,10 @@ int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
                            "can't undersample if local ksmps != parent ksmps\n");
 
   os = MYFLT2LRND(*p->os);
-  onedos = FL(1.0)/os;
   if(os < 1)
     return csound->InitError(csound,
                              "illegal undersampling ratio: %d\n", os);
+  onedos = FL(1.0)/os;
 
   if(os == 1 || CS_ESR != parent_sr) return OK; /* no op if already changed */
 
@@ -2734,6 +2746,15 @@ int32_t subinstrset_(CSOUND *csound, SUBINST *p, int32_t instno)
   p->ip->onedkr = CS_ONEDKR;
   p->ip->onedksmps = CS_ONEDKSMPS;
   p->ip->kicvt = CS_KICVT;
+
+
+  if(p->ip->instr->glbvarcnt > 0 &&
+     p->ip->ksmps != csound->ksmps)
+    return csoundInitError(csound, "inherited local ksmps not permitted with global audio vars\n");
+
+  if(p->ip->instr->glbvarcnt > 0 &&
+     p->ip->esr != csound->esr)
+    return csoundInitError(csound, "inherited local sr not permitted with global audio vars\n");
 
   /* copy parameters from this instrument into our subinstrument */
   p->ip->xtratim  = saved_curip->xtratim;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -2473,6 +2473,9 @@ int32_t useropcd_pass_by_ref(CSOUND *csound, UOPCODE *p)
 int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
 {
 
+  if(p->h.insdshead->instr->glbvarcnt > 0)
+    return csoundInitError(csound, "local ksmps not permitted with global audio vars\n");
+  
   uint32_t  l_ksmps, n;
   OPCOD_IOBUFS *udo = (OPCOD_IOBUFS *) p->h.insdshead->opcod_iobufs;
   MYFLT parent_sr = udo ? udo->parent_ip->esr : csound->esr;
@@ -2529,6 +2532,9 @@ int32_t setksmpsset(CSOUND *csound, SETKSMPS *p)
    with audio/control array arguments.
 */
 int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
+  if(p->h.insdshead->instr->glbvarcnt > 0)
+    return csoundInitError(csound, "local sr not permitted with global audio vars\n");
+
   int32_t os;
   MYFLT l_sr, onedos;
   OPCOD_IOBUFS *udo = (OPCOD_IOBUFS *) p->h.insdshead->opcod_iobufs;
@@ -2599,6 +2605,9 @@ int32_t oversampleset(CSOUND *csound, OVSMPLE *p) {
    It modifies ksmps according to the resampling factor.
 */
 int32_t undersampleset(CSOUND *csound, OVSMPLE *p) {
+  if(p->h.insdshead->instr->glbvarcnt > 0)
+    return csoundInitError(csound, "local sr not permitted with global audio vars\n");
+  
   int32_t os, lksmps;
   MYFLT l_sr, onedos;
   OPCOD_IOBUFS *udo = (OPCOD_IOBUFS *) p->h.insdshead->opcod_iobufs;

--- a/H/csound_orc_structs.h
+++ b/H/csound_orc_structs.h
@@ -50,6 +50,9 @@ typedef struct {
 /* Returns a dynamically allocated string; caller must free using csound->Free() */
 int findStructMemberIndex(CONS_CELL* members, char* memberName);
 CS_VARIABLE* getStructMember(CONS_CELL* members, char* memberName);
+/* Checks the variable and nested struct or array members for target. */
+int32_t csound_variable_contains_type(const CS_VARIABLE *var,
+                                      const CS_TYPE *target);
 int32_t initStructVar(CSOUND* csound, void* p);
 void initializeStructVar(CSOUND* csound, CS_VARIABLE* var, MYFLT* mem);
 /* Note: signatures must match CS_TYPE callbacks in csound_type_system.h */

--- a/include/csoundCore.h
+++ b/include/csoundCore.h
@@ -155,6 +155,7 @@ typedef struct instr {
   int32_t instcnt;               /* Count number of instances ever */
   int32_t isNew;                 /* is this a new definition */
   int32_t nocheckpcnt;           /* Control checks on pcnt */
+  int32_t glbvarcnt;             /* global audio var count */
 } INSTRTXT;
 
 /**

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -497,6 +497,7 @@ def runTest():
         ["test_local_ksmps_global_fail.csd", "test failing use of global var with local ksmps",  1],
         ["test_local_ksmps_global_struct_k.csd", "allow global k-rate struct member with local ksmps"],
         ["test_local_ksmps_global_struct_a_fail.csd", "reject global a-rate struct member with local ksmps", 1],
+        ["test_local_ksmps_global_struct_copy_fail.csd", "reject global struct containing audio with local ksmps", 1],
         ["test_schedwhen.csd", "schedwhen opcode"],
         ["test_parse_error_unary.csd", "expected failure: unary parse error", 1],
         ["test_parse_error_unary_not.csd", "expected failure: unary ! parse error", 1],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -494,6 +494,7 @@ def runTest():
         ["test46.csd", "if-then with expression in boolean comparison"],
         ["test47.csd", "until loop and k[]"],
         ["test48.csd", "expected failure with variable used before defined", 1],
+        ["test_local_ksmps_global_fail.csd", "test failing use of global var with local ksmps",  1],
         ["test_schedwhen.csd", "schedwhen opcode"],
         ["test_parse_error_unary.csd", "expected failure: unary parse error", 1],
         ["test_parse_error_unary_not.csd", "expected failure: unary ! parse error", 1],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -495,6 +495,8 @@ def runTest():
         ["test47.csd", "until loop and k[]"],
         ["test48.csd", "expected failure with variable used before defined", 1],
         ["test_local_ksmps_global_fail.csd", "test failing use of global var with local ksmps",  1],
+        ["test_local_ksmps_global_struct_k.csd", "allow global k-rate struct member with local ksmps"],
+        ["test_local_ksmps_global_struct_a_fail.csd", "reject global a-rate struct member with local ksmps", 1],
         ["test_schedwhen.csd", "schedwhen opcode"],
         ["test_parse_error_unary.csd", "expected failure: unary parse error", 1],
         ["test_parse_error_unary_not.csd", "expected failure: unary ! parse error", 1],

--- a/tests/commandline/test_local_ksmps_global_fail.csd
+++ b/tests/commandline/test_local_ksmps_global_fail.csd
@@ -9,9 +9,15 @@ gatest init 0
 gaatest[] init 2
 gktest init 0
 
+opcode Test0,0,0
+  gatest = 1
+  prints "OK!"
+endop
+
 opcode Test1,0,0
   setksmps 1
   gktest = 1  // ok
+  prints "OK!"
 endop
 
 opcode Test2,0,0
@@ -24,16 +30,43 @@ opcode Test3,0,0
   gaatest[0] = 1 // fail
 endop
 
+opcode Test4,0,0
+ setksmps 1
+ Test0
+endop
+
+opcode Test00,0,0
+ setksmps 10 
+ gaatest[0] = 1 //ok
+ prints "OK!"
+endop
+
+
+
 
 instr 1
+Test0
+Test00
 Test1
 Test2
 Test3
+Test4
 endin
+
+instr 2
+gatest = 1
+endin
+
+instr 3
+setksmps 1
+subinstr 2
+endin
+
 
 
 </CsInstruments>
 <CsScore>
 i 1 0 1
+i 3 0 1
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_local_ksmps_global_fail.csd
+++ b/tests/commandline/test_local_ksmps_global_fail.csd
@@ -1,0 +1,39 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+
+
+gatest init 0
+gaatest[] init 2
+gktest init 0
+
+opcode Test1,0,0
+  setksmps 1
+  gktest = 1  // ok
+endop
+
+opcode Test2,0,0
+  setksmps 1
+  gatest = 1 // fail
+endop
+
+opcode Test3,0,0
+  setksmps 1
+  gaatest[0] = 1 // fail
+endop
+
+
+instr 1
+Test1
+Test2
+Test3
+endin
+
+
+</CsInstruments>
+<CsScore>
+i 1 0 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_local_ksmps_global_struct_a_fail.csd
+++ b/tests/commandline/test_local_ksmps_global_struct_a_fail.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+struct GlobalBus signal:a, level:k
+bus@global:GlobalBus = init()
+
+opcode WriteGlobalAudioMember, 0, 0
+  setksmps 1
+  value:a = 1
+  bus.signal = value
+endop
+
+instr 1
+  WriteGlobalAudioMember
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_local_ksmps_global_struct_copy_fail.csd
+++ b/tests/commandline/test_local_ksmps_global_struct_copy_fail.csd
@@ -1,0 +1,30 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+struct Bus signal:a
+bus@global:Bus = init()
+
+opcode ReadBus, a, 0
+  setksmps 4
+  local:Bus = bus
+  xout local.signal
+endop
+
+instr 1
+  result:a ReadBus
+  out result
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_local_ksmps_global_struct_k.csd
+++ b/tests/commandline/test_local_ksmps_global_struct_k.csd
@@ -1,0 +1,28 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+struct GlobalBus signal:a, level:k
+bus@global:GlobalBus = init()
+
+opcode WriteGlobalControlMember, 0, 0
+  setksmps 1
+  bus.level = 1
+endop
+
+instr 1
+  WriteGlobalControlMember
+endin
+
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
This PR introduces a check for the presence of global audio variables in a context where local ksmps or local sr are attempted. If these are detected, an init error is issued.
Closes #2737.