### PR TITLE
Fix PARCS completion race between control cycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1461,7 +1461,7 @@ if(BUILD_MULTI_CORE)
 
    if(USE_LOCK_BARRIER)
      message(STATUS "Using thread-lock barrier.")
-     list(APPEND libcsound_CFLAGS -DPARCS_USE_THREAD_BARRIER)
+     list(APPEND libcsound_CFLAGS -DPARCS_USE_LOCK_BARRIER)
    else()
     message(STATUS "Using lock-free barrier.")
    endif()

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1878,9 +1878,11 @@ static void reset(CSOUND *csound) {
   int32_t n = 0;
 
   // stop multicore threads if still running
-  if (csound->oparms->numThreads > 1) {
+  if (csound->oparms->numThreads > 1 &&
+      csound->multiThreadedThreadInfo != NULL &&
+      ATOMIC_GET(csound->multiThreadedComplete) == 0) {
     ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
     csound->WaitBarrier(csound->barrier1);
 #else
     ATOMIC_SET(csound->parflag,!csound->parflag);

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1882,7 +1882,7 @@ static void reset(CSOUND *csound) {
       csound->multiThreadedThreadInfo != NULL &&
       ATOMIC_GET(csound->multiThreadedComplete) == 0) {
     ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
     csound->WaitBarrier(csound->barrier1);
 #else
     ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1885,7 +1885,7 @@ static void reset(CSOUND *csound) {
 #ifdef PARCS_USE_THREAD_BARRIER
     csound->WaitBarrier(csound->barrier1);
 #else
-    ATOMIC_SET(csound->parflag,!csound->parflag);
+    ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));
 #endif
   }
   csound_cleanup(csound);

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -953,7 +953,7 @@ int32_t kperf_debug(CSOUND *csound) {
         dag_reinit(csound); /* set to initial state */
 
       /* process this partition */
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
       csound->WaitBarrier(csound->barrier1);
 #else
       int32_t parflag = !ATOMIC_GET(csound->parflag);
@@ -961,7 +961,7 @@ int32_t kperf_debug(CSOUND *csound) {
 #endif
       csound_node_perf(csound, 0, n);
       /* wait until partition is complete */
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
       csound->WaitBarrier(csound->barrier2);
 #else
       {

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -953,22 +953,24 @@ int32_t kperf_debug(CSOUND *csound) {
         dag_reinit(csound); /* set to initial state */
 
       /* process this partition */
-#ifdef PARCS_USE_LOCK_BARRIER
-      csound->WaitBarrier(csound->barrier1)
+#ifdef PARCS_USE_THREAD_BARRIER
+      csound->WaitBarrier(csound->barrier1);
 #else
-      ATOMIC_SET(csound->parflag,!csound->parflag);
+      int32_t parflag = !ATOMIC_GET(csound->parflag);
+      ATOMIC_SET(csound->parflag, parflag);
 #endif
       csound_node_perf(csound, 0, n);
       /* wait until partition is complete */
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
       csound->WaitBarrier(csound->barrier2);
 #else
       {
-        int32_t i, sum;
+        int32_t i;
         do {
-          for(i = 1, sum = 1; i < n; i++)
-            sum += csound->taskflag[i];
-        } while(sum < n);
+          for(i = 1; i < n; i++)
+            if (ATOMIC_GET(csound->taskflag[i]) != parflag)
+              break;
+        } while(i < n);
       }
 #endif
       /* do the mixing of thread buffers */

--- a/Top/csound_perf.c
+++ b/Top/csound_perf.c
@@ -200,14 +200,14 @@ unsigned long kperf_thread(void *cs) {
     return ULONG_MAX;
   }
   index++;
-  int32_t parflag, last_parflag = 0;
+  int32_t parflag, taskflag = 0;
   while (1) {
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
     csound->WaitBarrier(csound->barrier1);
 #else
     do parflag = ATOMIC_GET(csound->parflag);
-    while(parflag == last_parflag);
-    last_parflag = parflag;
+    while(parflag == taskflag);
+    taskflag = parflag;
 #endif
     if (ATOMIC_GET(csound->multiThreadedComplete) == 1) {
       // exit thread on performance end
@@ -215,7 +215,7 @@ unsigned long kperf_thread(void *cs) {
       return 0UL;
     }
     node_perf(csound, index, numThreads);
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
     csound->WaitBarrier(csound->barrier2);
 #else
     ATOMIC_SET(csound->taskflag[index], parflag);
@@ -272,7 +272,7 @@ int32_t kperf(CSOUND *csound) {
         dag_reinit(csound); /* set to initial state */
 
       /* process this partition */
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
       csound->WaitBarrier(csound->barrier1);
 #else
       int32_t parflag = !ATOMIC_GET(csound->parflag);
@@ -280,7 +280,7 @@ int32_t kperf(CSOUND *csound) {
 #endif
       node_perf(csound, 0, n);
       /* wait until partition is complete */
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
       csound->WaitBarrier(csound->barrier2);
 #else
       {
@@ -418,7 +418,7 @@ int32_t kperf(CSOUND *csound) {
         csoundUnlockMutex(csound->API_lock);
       if (csound->oparms->numThreads > 1) {
         ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
         ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));
@@ -465,7 +465,7 @@ int32_t perform_buffer(CSOUND *csound) {
           csoundUnlockMutex(csound->API_lock);
         if (csound->oparms->numThreads > 1) {
         ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
         ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));

--- a/Top/csound_perf.c
+++ b/Top/csound_perf.c
@@ -200,25 +200,25 @@ unsigned long kperf_thread(void *cs) {
     return ULONG_MAX;
   }
   index++;
-  int32_t parflag, taskflag = 0;
+  int32_t parflag, last_parflag = 0;
   while (1) {
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
     csound->WaitBarrier(csound->barrier1);
 #else
     do parflag = ATOMIC_GET(csound->parflag);
-    while(parflag == taskflag);
-    taskflag = parflag;
+    while(parflag == last_parflag);
+    last_parflag = parflag;
 #endif
     if (ATOMIC_GET(csound->multiThreadedComplete) == 1) {
       // exit thread on performance end
       free(threadId);
       return 0UL;
     }
-    csound->taskflag[index] = 0;
     node_perf(csound, index, numThreads);
-    csound->taskflag[index] = 1;
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
     csound->WaitBarrier(csound->barrier2);
+#else
+    ATOMIC_SET(csound->taskflag[index], parflag);
 #endif
   }
 }
@@ -272,22 +272,24 @@ int32_t kperf(CSOUND *csound) {
         dag_reinit(csound); /* set to initial state */
 
       /* process this partition */
-#ifdef PARCS_USE_LOCK_BARRIER
-      csound->WaitBarrier(csound->barrier1)
+#ifdef PARCS_USE_THREAD_BARRIER
+      csound->WaitBarrier(csound->barrier1);
 #else
-      ATOMIC_SET(csound->parflag,!csound->parflag);
+      int32_t parflag = !ATOMIC_GET(csound->parflag);
+      ATOMIC_SET(csound->parflag, parflag);
 #endif
       node_perf(csound, 0, n);
       /* wait until partition is complete */
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
       csound->WaitBarrier(csound->barrier2);
 #else
       {
-        int32_t i, sum;
+        int32_t i;
         do {
-          for(i = 1, sum = 1; i < n; i++)
-            sum += csound->taskflag[i];
-        } while(sum < n);
+          for(i = 1; i < n; i++)
+            if (ATOMIC_GET(csound->taskflag[i]) != parflag)
+              break;
+        } while(i < n);
       }
 #endif
       /* do the mixing of thread buffers */
@@ -416,7 +418,7 @@ int32_t kperf(CSOUND *csound) {
         csoundUnlockMutex(csound->API_lock);
       if (csound->oparms->numThreads > 1) {
         ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
         ATOMIC_SET(csound->parflag,!csound->parflag);
@@ -463,7 +465,7 @@ int32_t perform_buffer(CSOUND *csound) {
           csoundUnlockMutex(csound->API_lock);
         if (csound->oparms->numThreads > 1) {
         ATOMIC_SET(csound->multiThreadedComplete, 1);
-#ifdef PARCS_USE_LOCK_BARRIER
+#ifdef PARCS_USE_THREAD_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
         ATOMIC_SET(csound->parflag,!csound->parflag);
@@ -479,5 +481,3 @@ int32_t perform_buffer(CSOUND *csound) {
   }
   return 0;
 }
-
-

--- a/Top/csound_perf.c
+++ b/Top/csound_perf.c
@@ -421,7 +421,7 @@ int32_t kperf(CSOUND *csound) {
 #ifdef PARCS_USE_THREAD_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
-        ATOMIC_SET(csound->parflag,!csound->parflag);
+        ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));
 #endif
       }
       csoundMessage(csound, Str("end of Performance\n"));
@@ -468,7 +468,7 @@ int32_t perform_buffer(CSOUND *csound) {
 #ifdef PARCS_USE_THREAD_BARRIER
         csound->WaitBarrier(csound->barrier1);
 #else
-        ATOMIC_SET(csound->parflag,!csound->parflag);
+        ATOMIC_SET(csound->parflag, !ATOMIC_GET(csound->parflag));
 #endif
         }
         return done;

--- a/Top/main.c
+++ b/Top/main.c
@@ -675,7 +675,7 @@ extern int32_t DummyMidiWrite(CSOUND *csound, void *userData,
     THREADINFO *current = NULL;
     csound->Message(csound, "multicore performance "
                     "with %d threads\n", O->numThreads); 
-#ifdef PARCS_USE_THREAD_BARRIER
+#ifdef PARCS_USE_LOCK_BARRIER
     csp_barrier_alloc(csound, &(csound->barrier1), O->numThreads);
 #else
     ATOMIC_SET(csound->parflag, 0);

--- a/Top/main.c
+++ b/Top/main.c
@@ -678,6 +678,7 @@ extern int32_t DummyMidiWrite(CSOUND *csound, void *userData,
 #ifdef PARCS_USE_THREAD_BARRIER
     csp_barrier_alloc(csound, &(csound->barrier1), O->numThreads);
 #else
+    ATOMIC_SET(csound->parflag, 0);
     csound->taskflag = (int32_t *) csound->Calloc(csound,
                                                  sizeof(int32_t)
                                                   *O->numThreads);

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -840,6 +840,16 @@ def runTest():
         ],
     ]
 
+    if not csoundExecutable.lower().endswith((".wasm", ".cwasm")):
+        tests.append(
+            [
+                "test_parcs_instance_overlap.csd",
+                "PARCS does not enter one instrument instance twice",
+                0,
+                ["-nd", "--num-threads=4"],
+            ]
+        )
+
     arrayTests = [
         ["arrays/arrays_i_local.csd", "local i[]"],
         ["arrays/arrays_i_global.csd", "global i[]"],

--- a/tests/commandline/test_parcs_instance_overlap.csd
+++ b/tests/commandline/test_parcs_instance_overlap.csd
@@ -1,0 +1,53 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+
+sr = 48000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+gkOverlap init 0
+
+instr Fast
+  kTick = 0
+endin
+
+instr Slow
+  kInside init 0
+  kCycle timeinstk
+
+  if kInside != 0 then
+    printf "PARCS_OVERLAP: Slow entered twice at control cycle %d\n", \
+        1, kCycle
+    gkOverlap = 1
+  endif
+
+  kInside = 1
+  kIndex = 0
+  kSum = 0
+  while kIndex < 5000 do
+    kSum += sqrt(kIndex + 1)
+    kIndex += 1
+  od
+  kInside = 0
+endin
+
+instr Check
+  if i(gkOverlap) != 0 then
+    prints "FAIL: PARCS entered one instrument instance twice\n"
+    exitnow 1
+  endif
+  prints "PASS: no overlap detected\n"
+endin
+
+</CsInstruments>
+<CsScore>
+i "Fast" 0 0.25
+i "Slow" 0 0.25
+i "Check" 0.30 0.01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
PARCS could reuse a worker's completion flag from the last control cycle. Workers now publish the cycle they finished, so the DAG waits for fresh work.

The lock-barrier path now uses the right guard and stops workers once.

Fixes #2742.