### PR TITLE
Fix local ksmps sample offsets

### DIFF
--- a/Engine/cs_new_dispatch.c
+++ b/Engine/cs_new_dispatch.c
@@ -37,6 +37,7 @@
 #include "csoundCore.h"
 #include "cs_par_base.h"
 #include "cs_par_orc_semantics.h"
+#include "interlocks.h"
 #include <stdbool.h>
 
 #if defined(_MSC_VER)
@@ -182,6 +183,17 @@ static int32_t dag_intersect(CSOUND *csound, struct set_t *current,
     return res;
 }
 
+static int32_t instr_has_direct_monitor(INSTRTXT *instr)
+{
+    OPTXT *opcode;
+    for (opcode = instr->nxtop; opcode != NULL; opcode = opcode->nxtop) {
+      OENTRY *entry = opcode->t.oentry;
+      if (entry != NULL && (entry->flags & IW) != 0)
+        return 1;
+    }
+    return 0;
+}
+
 void dag_build(CSOUND *csound, INSDS *chain)
 {
     INSDS *save = chain;
@@ -222,6 +234,7 @@ void dag_build(CSOUND *csound, INSDS *chain)
     i = 0; chain = save;
     while (chain != NULL) {     /* for each instance check against later */
       int32_t j = i+1;              /* count of instance */
+      int32_t current_monitor = instr_has_direct_monitor(chain->instr);
       if (UNLIKELY(csound->oparms->odebug))
         printf("\nWho depends on %d (instr %d)?\n", i, chain->insno);
       INSDS *next = chain->nxtact;
@@ -231,11 +244,13 @@ void dag_build(CSOUND *csound, INSDS *chain)
       while (next) {
         INSTR_SEMANTICS *later_instr = dag_get_info(csound, next->insno);
         int32_t cnt = 0;
+        int32_t later_monitor = instr_has_direct_monitor(next->instr);
         if (UNLIKELY(csound->oparms->odebug)) printf("%d ", j);
         //csp_set_print(csound, later_instr->read);
         //csp_set_print(csound, later_instr->write);
         //csp_set_print(csound, later_instr->read_write);
-        if (dag_intersect(csound, current_instr->write,
+        if (current_monitor || later_monitor ||
+            dag_intersect(csound, current_instr->write,
                           later_instr->read, cnt++)       ||
             dag_intersect(csound, current_instr->read_write,
                           later_instr->read, cnt++)       ||
@@ -504,6 +519,4 @@ taskID dag_end_task(CSOUND *csound, taskID i)
     //dag_print_state(csound);
     return next_task;
 }
-
-
 

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -2013,6 +2013,8 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
     */
     this_instr->ksmps_offset = 0;
     this_instr->ksmps_no_end = 0;
+    this_instr->spin += csound->inchnls * ofs;
+    this_instr->spout += ofs;
     do {
       this_instr->kcounter++; /*kcounter needs to be incremented BEFORE perf */
       /* copy inputs */
@@ -2116,7 +2118,9 @@ int32_t useropcd_local_ksmps(CSOUND *csound, UOPCODE *p)
     int32_t lksmps = this_instr->ksmps;
     while (ofs >= lksmps) {
       ofs -= lksmps;
-      start++;
+      start += lksmps;
+      this_instr->spin += csound->inchnls * lksmps;
+      this_instr->spout += lksmps;
     }
     this_instr->ksmps_offset = ofs;
     ofs = start;
@@ -2957,7 +2961,9 @@ int32_t subinstr(CSOUND *csound, SUBINST *p)
     */
     while (offset >= lksmps) {
       offset -= lksmps;
-      start += csound->nchnls;
+      start += incr;
+      ip->spin += csound->inchnls*lksmps;
+      ip->spout += lksmps;
     }
     ip->ksmps_offset = offset;
     if (early) {

--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -2338,19 +2338,41 @@ int32_t error_fn(CSOUND *csound, ERRFN *p)
 
 /* ------------------------------------------------------------------------ */
 
+static inline MYFLT monitor_spout_sample(CSOUND *csound, INSDS *instance,
+                                         uint32_t channel, uint32_t frame)
+{
+  MYFLT *spout = instance->spout;
+  uintptr_t base = (uintptr_t)csound->spout_tmp;
+  uintptr_t current = (uintptr_t)spout;
+  size_t samples = (size_t)csound->nspout * csound->oparms->numThreads;
+
+  if (current < base || current - base >= samples * sizeof(MYFLT))
+    return spout[channel * csound->ksmps + frame];
+
+  size_t offset = ((current - base) / sizeof(MYFLT)) % csound->nspout;
+  size_t index = offset + (size_t)channel * csound->ksmps + frame;
+  MYFLT value = csound->spout_tmp[index];
+
+  if (csound->multiThreadedThreadInfo != NULL) {
+    int32_t thread;
+    for (thread = 1; thread < csound->oparms->numThreads; thread++)
+      value += csound->spout_tmp[thread * (size_t)csound->nspout + index];
+  }
+  return value;
+}
+
 int32_t monitor_opcode_perf(CSOUND *csound, MONITOR_OPCODE *p)
 {
   uint32_t offset = p->h.insdshead->ksmps_offset;
-  uint32_t early  = p->h.insdshead->ksmps_no_end;
+  uint32_t end = CS_KSMPS - p->h.insdshead->ksmps_no_end;
   uint32_t i, j, nsmps = CS_KSMPS, nchnls = csound->GetNchnls(csound);
-  MYFLT *spout = csound->spout_tmp;
 
   for (j = 0; j<nchnls; j++) {
     for (i = 0; i<nsmps; i++) {
-      if (i<offset||i>nsmps-early)
+      if (i < offset || i >= end)
         p->ar[j][i] = FL(0.0);
       else
-        p->ar[j][i] = spout[i+j*nsmps];
+        p->ar[j][i] = monitor_spout_sample(csound, p->h.insdshead, j, i);
     }
   }
   return OK;
@@ -2654,25 +2676,17 @@ int32_t monitora_perf(CSOUND *csound, MONITOR_A *p)
 {
   ARRAYDAT *aa = p->tabin;
   uint32_t offset = p->h.insdshead->ksmps_offset;
-  uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t i, j, l, nsmps = CS_KSMPS;
-  MYFLT       *data = aa->data;
-  MYFLT       *sp= CS_SPOUT;
+  uint32_t nsmps = CS_KSMPS;
+  uint32_t end = nsmps - p->h.insdshead->ksmps_no_end;
+  uint32_t i, j;
+  MYFLT *data = aa->data;
   uint32_t len = (uint32_t)p->len;
 
-  for (l=0; l<len; l++) {
-    sp = CS_SPOUT;
-    memset(data, '\0', nsmps*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-    }
-    for (i = 0; i<nsmps; i++) {
-      for (j = 0; j<csound->GetNchnls(csound); j++) {
-        if (i<offset)
-          data[i+j*nsmps] = FL(0.0);
-        else
-          data[i+j*nsmps] = sp[i+j*nsmps];
-      }
+  memset(data, '\0', len * nsmps * sizeof(MYFLT));
+  for (j = 0; j < len; j++) {
+    for (i = offset; i < end; i++) {
+      data[i+j*nsmps] = monitor_spout_sample(csound, p->h.insdshead,
+                                             j, i);
     }
   }
   return OK;

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -912,7 +912,8 @@ int32_t kperf_debug(CSOUND *csound) {
       csound->spinrecv(csound); /*      fill the spin buf  */
     /* clear spout */
     memset(csound->spout, 0, csound->nspout * sizeof(MYFLT));
-    memset(csound->spout_tmp, 0, csound->nspout * sizeof(MYFLT));
+    memset(csound->spout_tmp, 0,
+           csound->nspout * csound->oparms->numThreads * sizeof(MYFLT));
   }
 
   ip = csound->actanchor.nxtact;

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -1049,7 +1049,9 @@ int32_t kperf_debug(CSOUND *csound) {
             */
             while (offset >= lksmps) {
               offset -= lksmps;
-              start += csound->nchnls;
+              start += incr;
+              ip->spin += csound->inchnls * lksmps;
+              ip->spout += lksmps;
             }
             ip->ksmps_offset = offset;
             if (UNLIKELY(early)) {

--- a/Top/csound_perf.c
+++ b/Top/csound_perf.c
@@ -139,7 +139,9 @@ inline static int32_t node_perf(CSOUND *csound, int32_t index,
         */
         while (offset >= lksmps) {
           offset -= lksmps;
-          start += csound->nchnls;
+          start += incr;
+          insds->spin += csound->inchnls * lksmps;
+          insds->spout += lksmps;
         }
         insds->ksmps_offset = offset;
         if (UNLIKELY(early)) {
@@ -351,7 +353,9 @@ int32_t kperf(CSOUND *csound) {
             */
             while (offset >= lksmps) {
               offset -= lksmps;
-              start += csound->nchnls;
+              start += incr;
+              ip->spin += csound->inchnls * lksmps;
+              ip->spout += lksmps;
             }
             ip->ksmps_offset = offset;
             if (UNLIKELY(early)) {

--- a/Top/main.c
+++ b/Top/main.c
@@ -669,6 +669,10 @@ extern int32_t DummyMidiWrite(CSOUND *csound, void *userData,
   O->sndfileSampleSize = sndfileSampleSize(FORMAT2SF(O->outformat));
   O->informat = O->outformat; /* informat default */
 
+#if defined(__wasi__)
+  O->numThreads = 1;
+#endif
+
 #ifdef PARCS
   if (O->numThreads > 1) {
     int32_t i;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -766,6 +766,16 @@ def runTest():
             1,
         ],
         ["test_sa.csd", "test sample accurate mode"],
+        [
+            "test_local_ksmps_sample_accurate.csd",
+            "test sample-accurate local ksmps offsets",
+        ],
+        [
+            "test_local_ksmps_sample_accurate.csd",
+            "test sample-accurate local ksmps offsets with PARCS",
+            None,
+            ["-nd", "--num-threads=2"],
+        ],
         ["test_overload_selection.csd", "test wrong annotation case"],
         ["test_unschedule.csd", "test unscheduling events"],
         ["diskin_excess_channels.csd", "test sample accurate mode"],

--- a/tests/commandline/test_local_ksmps_sample_accurate.csd
+++ b/tests/commandline/test_local_ksmps_sample_accurate.csd
@@ -1,0 +1,125 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 32
+ksmps = 16
+nchnls = 2
+0dbfs = 4
+
+gkDirectPasses init 0
+gkUdoPasses init 0
+gkSubPasses init 0
+gkUdoLeft init 0
+gkUdoRight init 0
+gkSubLeft init 0
+gkSubRight init 0
+
+opcode LocalUdo, aa, aa
+  setksmps 4
+  gkUdoPasses += 1
+  aInLeft, aInRight xin
+  xout aInLeft, aInRight
+endop
+
+opcode LocalOne, 0, 0
+  setksmps 1
+  aLeft = 1
+  aRight = 2
+  out aLeft, aRight
+endop
+
+opcode LocalOut, 0, 0
+  setksmps 4
+  aLeft = 1
+  aRight = 2
+  out aLeft, aRight
+endop
+
+instr 1
+  setksmps 4
+  gkDirectPasses += 1
+  aLeft = 1
+  aRight = 2
+  out aLeft, aRight
+endin
+
+instr 2
+  setksmps 4
+  gkSubPasses += 1
+  aLeft = 1
+  aRight = 2
+  out aLeft, aRight
+endin
+
+instr 10
+  aInLeft = 1
+  aInRight = 2
+  aLeft, aRight LocalUdo aInLeft, aInRight
+  gkUdoLeft downsamp aLeft, 16
+  gkUdoRight downsamp aRight, 16
+endin
+
+instr 20
+  aLeft, aRight subinstr 2
+  gkSubLeft downsamp aLeft, 16
+  gkSubRight downsamp aRight, 16
+endin
+
+instr 30
+  LocalOne
+endin
+
+instr 31
+  LocalOut
+endin
+
+instr 98
+  aLeft, aRight monitor
+  aPhase phasor sr / ksmps
+  kLeft downsamp aLeft * aPhase, 16
+  kRight downsamp aRight * aPhase, 16
+
+  if timeinstk() == 1 then
+    printf "udo ksmps=%d (%.6f, %.6f)\n", 1, p6, kLeft, kRight
+
+    if kLeft != p4 || kRight != p5 then
+      exitnowk 1
+    endif
+  endif
+endin
+
+instr 99
+  aLeft, aRight monitor
+  kDirectLeft downsamp aLeft, 16
+  kDirectRight downsamp aRight, 16
+
+  if timeinstk() == 1 then
+    printf "direct=%d (%.3f, %.3f), udo=%d (%.3f, %.3f), subinstr=%d (%.3f, %.3f)\n", 1, \
+           gkDirectPasses, kDirectLeft, kDirectRight, \
+           gkUdoPasses, gkUdoLeft, gkUdoRight, \
+           gkSubPasses, gkSubLeft, gkSubRight
+
+    if gkDirectPasses != 1 || gkUdoPasses != 1 || gkSubPasses != 1 || \
+       kDirectLeft != 0.25 || kDirectRight != 0.5 || \
+       gkUdoLeft != 0.25 || gkUdoRight != 0.5 || \
+       gkSubLeft != 0.25 || gkSubRight != 0.5 then
+      exitnowk 1
+    endif
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0.375 0.125
+i 10 0.375 0.125
+i 20 0.375 0.125
+i 99 0 0.5
+s
+i 31 0.375 0.125
+i 98 0 0.5 0.2109375 0.421875 4
+s
+i 30 0.375 0.03125
+i 98 0 0.5 0.046875 0.09375 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_local_ksmps_sample_accurate.csd
+++ b/tests/commandline/test_local_ksmps_sample_accurate.csd
@@ -75,6 +75,20 @@ instr 31
   LocalOut
 endin
 
+instr 97
+  setksmps 4
+  aLeft, aRight monitor
+  aMix[] monitor
+  kLeft downsamp aLeft
+  kRight downsamp aRight
+  kArrayLeft downsamp aMix[0]
+  kArrayRight downsamp aMix[1]
+  if kLeft != 2 || kRight != 4 || \
+     kArrayLeft != 2 || kArrayRight != 4 then
+    exitnowk 1
+  endif
+endin
+
 instr 98
   aLeft, aRight monitor
   aPhase phasor sr / ksmps
@@ -121,5 +135,9 @@ i 98 0 0.5 0.2109375 0.421875 4
 s
 i 30 0.375 0.03125
 i 98 0 0.5 0.046875 0.09375 1
+s
+i 31 0 0.5
+i 31 0 0.5
+i 97 0 0.5
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
Sample-accurate notes can start several local blocks into a global block. The old skip loop counted them in channel units. It ran work before the note began and left audio buffers at the cycle start.

This moves the normal, PARCS, debugger, UDO, and subinstrument paths to the first active local block. UDOs now keep their start in samples and handle a local ksmps of one.

The per-pass stride fix stays in #2739.

Closes #2741.