### PR TITLE
Fix recorder thread shutdown deadlock

### DIFF
--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -212,7 +212,7 @@ extern "C" {
     MYFLT buf[bufsize];
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
     csoundLockMutex(recordData->mutex);
-    while (ATOMIC_GET8(recordData->running)) {
+    while (ATOMIC_GET_BOOL(recordData->running)) {
         csoundCondWait(recordData->condvar, recordData->mutex);
         int sampsread;
         do {
@@ -236,9 +236,9 @@ static bool stopRecordThread(recordData_t *recordData)
 {
     bool wasRunning;
     csoundLockMutex(recordData->mutex);
-    wasRunning = ATOMIC_GET8(recordData->running);
+    wasRunning = ATOMIC_GET_BOOL(recordData->running);
     if (wasRunning) {
-        ATOMIC_SET8(recordData->running, false);
+        ATOMIC_SET_BOOL(recordData->running, false);
         csoundCondSignal(recordData->condvar);
     }
     csoundUnlockMutex(recordData->mutex);
@@ -258,7 +258,7 @@ public:
         this->filename = filename;
         CsoundPerformanceThreadMessage::lockRecord();
         recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
-        if (ATOMIC_GET8(recordData->running)) {
+        if (ATOMIC_GET_BOOL(recordData->running)) {
             CsoundPerformanceThreadMessage::unlockRecord();
             return;
         }
@@ -308,7 +308,7 @@ public:
                    NULL, SFLIB_TRUE);
         recordData->sfname = csound->Strdup(csound, filename.c_str());
         csoundLockMutex(recordData->mutex);
-        ATOMIC_SET8(recordData->running, true);
+        ATOMIC_SET_BOOL(recordData->running, true);
         recordData->thread = csoundCreateThread(recordThread_, (void*) recordData);
         csoundUnlockMutex(recordData->mutex);
 
@@ -645,7 +645,7 @@ int32_t CsoundPerformanceThread::Perform()
       if(processcallback != NULL)
            processcallback(cdata);
       retval = csoundPerformKsmps(csound);
-      if (ATOMIC_GET8(recordData.running)) {
+      if (ATOMIC_GET_BOOL(recordData.running)) {
           const MYFLT *spout = csoundGetSpout(csound);
           int len = csoundGetKsmps(csound) * csoundGetChannels(csound,0);
           int written = csoundWriteCircularBuffer(NULL, recordData.cbuf,
@@ -751,7 +751,7 @@ void CsoundPerformanceThread::csPerfThread_constructor(CSOUND *csound_)
     recordData.cbuf = NULL;
     recordData.sfile = NULL;
     recordData.thread = NULL;
-    ATOMIC_SET8(recordData.running, false);
+    ATOMIC_SET_BOOL(recordData.running, false);
 
         recordData.mutex = csoundCreateMutex (0);
         recordData.condvar = csoundCreateCondVar();
@@ -913,7 +913,7 @@ int32_t CsoundPerformanceThread::Join()
     int32_t retval;
     retval = status;
 
-    if (ATOMIC_GET8(recordData.running))
+    if (ATOMIC_GET_BOOL(recordData.running))
       stopRecordThread(&recordData);
     if (perfThread) {
       retval = (int32_t) csoundJoinThread(perfThread);

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -308,12 +308,24 @@ public:
           CsoundPerformanceThreadMessage::unlockRecord();
           return;
         }
-        csoundSndfileCommand(csound, (SNDFILE *) recordData->sfile, SFC_SET_CLIPPING,
+        csound->SndfileCommand(csound, (SNDFILE *) recordData->sfile, SFC_SET_CLIPPING,
                    NULL, SFLIB_TRUE);
         recordData->sfname = csound->Strdup(csound, filename.c_str());
         csoundLockMutex(recordData->mutex);
-        ATOMIC_SET_BOOL(recordData->running, true);
         recordData->thread = csoundCreateThread(recordThread_, (void*) recordData);
+        if (recordData->thread) {
+          ATOMIC_SET_BOOL(recordData->running, true);
+        }
+        else {
+          csoundMessage(csound, "Could not create recording thread.");
+          ATOMIC_SET_BOOL(recordData->running, false);
+          csound->SndfileClose(csound, (SNDFILE *) recordData->sfile);
+          recordData->sfile = NULL;
+          csound->Free(csound, recordData->sfname);
+          recordData->sfname = NULL;
+          csoundDestroyCircularBuffer(csound, recordData->cbuf);
+          recordData->cbuf = NULL;
+        }
         csoundUnlockMutex(recordData->mutex);
 
 

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -264,6 +264,7 @@ public:
         }
         CSOUND * csound = pt_->GetCsound();
         if (!csound) {
+            CsoundPerformanceThreadMessage::unlockRecord();
             return;
         }
         recordData->csound = csound;
@@ -275,6 +276,7 @@ public:
 
         if (!recordData->cbuf) {
           csoundMessage(csound, "Could create recording buffer.");
+          CsoundPerformanceThreadMessage::unlockRecord();
           return;
         }
 
@@ -302,6 +304,8 @@ public:
         if (!recordData->sfile) {
           csoundMessage(csound, "Could not open file for recording.");
           csoundDestroyCircularBuffer(csound, recordData->cbuf);
+          recordData->cbuf = NULL;
+          CsoundPerformanceThreadMessage::unlockRecord();
           return;
         }
         csoundSndfileCommand(csound, (SNDFILE *) recordData->sfile, SFC_SET_CLIPPING,

--- a/Top/csPerfThread.cpp
+++ b/Top/csPerfThread.cpp
@@ -211,8 +211,8 @@ extern "C" {
     const int bufsize = 4096;
     MYFLT buf[bufsize];
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
-    while (recordData->running) {
-                csoundLockMutex (recordData->mutex);
+    csoundLockMutex(recordData->mutex);
+    while (ATOMIC_GET8(recordData->running)) {
         csoundCondWait(recordData->condvar, recordData->mutex);
         int sampsread;
         do {
@@ -221,8 +221,8 @@ extern "C" {
             csound->SndfileWriteSamples(csound, (SNDFILE *) recordData->sfile,
                             buf, sampsread);
         } while(sampsread != 0);
-                csoundUnlockMutex (recordData->mutex);
     }
+    csoundUnlockMutex(recordData->mutex);
     csound->Message(csound, "Perf thread: stopped recording,\n"
                     "closing file %s\n", recordData->sfname);
     csound->SndfileClose(csound,(SNDFILE *) recordData->sfile);
@@ -230,6 +230,21 @@ extern "C" {
     csound->Free(csound, recordData->sfname);
     return (uintptr_t) ((unsigned int) retval);
   }
+}
+
+static bool stopRecordThread(recordData_t *recordData)
+{
+    bool wasRunning;
+    csoundLockMutex(recordData->mutex);
+    wasRunning = ATOMIC_GET8(recordData->running);
+    if (wasRunning) {
+        ATOMIC_SET8(recordData->running, false);
+        csoundCondSignal(recordData->condvar);
+    }
+    csoundUnlockMutex(recordData->mutex);
+    if (wasRunning)
+      csoundJoinThread(recordData->thread);
+    return wasRunning;
 }
 
 class CsPerfThreadMsg_Record: public CsoundPerformanceThreadMessage {
@@ -243,7 +258,7 @@ public:
         this->filename = filename;
         CsoundPerformanceThreadMessage::lockRecord();
         recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
-        if (recordData->running) {
+        if (ATOMIC_GET8(recordData->running)) {
             CsoundPerformanceThreadMessage::unlockRecord();
             return;
         }
@@ -292,8 +307,10 @@ public:
         csoundSndfileCommand(csound, (SNDFILE *) recordData->sfile, SFC_SET_CLIPPING,
                    NULL, SFLIB_TRUE);
         recordData->sfname = csound->Strdup(csound, filename.c_str());
-        recordData->running = true;
+        csoundLockMutex(recordData->mutex);
+        ATOMIC_SET8(recordData->running, true);
         recordData->thread = csoundCreateThread(recordThread_, (void*) recordData);
+        csoundUnlockMutex(recordData->mutex);
 
 
         CsoundPerformanceThreadMessage::unlockRecord();
@@ -320,9 +337,7 @@ public:
       recordData_t *recordData = CsoundPerformanceThreadMessage::getRecordData();
       CSOUND *csound = recordData->csound;
 
-      if (recordData->running) {
-          recordData->running = false;
-          csoundJoinThread(recordData->thread);
+      if (stopRecordThread(recordData)) {
           if (recordData->sfile) { // if for some reason the file wasn't closed
             csound->SndfileClose(csound,(SNDFILE *) recordData->sfile);
             recordData->sfile = NULL;
@@ -630,7 +645,7 @@ int32_t CsoundPerformanceThread::Perform()
       if(processcallback != NULL)
            processcallback(cdata);
       retval = csoundPerformKsmps(csound);
-      if (recordData.running) {
+      if (ATOMIC_GET8(recordData.running)) {
           const MYFLT *spout = csoundGetSpout(csound);
           int len = csoundGetKsmps(csound) * csoundGetChannels(csound,0);
           int written = csoundWriteCircularBuffer(NULL, recordData.cbuf,
@@ -736,7 +751,7 @@ void CsoundPerformanceThread::csPerfThread_constructor(CSOUND *csound_)
     recordData.cbuf = NULL;
     recordData.sfile = NULL;
     recordData.thread = NULL;
-    recordData.running = false;
+    ATOMIC_SET8(recordData.running, false);
 
         recordData.mutex = csoundCreateMutex (0);
         recordData.condvar = csoundCreateCondVar();
@@ -898,11 +913,8 @@ int32_t CsoundPerformanceThread::Join()
     int32_t retval;
     retval = status;
 
-    if (recordData.running) {
-        recordData.running = false;
-        csoundCondSignal(recordData.condvar);
-        csoundJoinThread(recordData.thread);
-    }
+    if (ATOMIC_GET8(recordData.running))
+      stopRecordThread(&recordData);
     if (perfThread) {
       retval = (int32_t) csoundJoinThread(perfThread);
       perfThread = (void*) 0;

--- a/include/csPerfThread.hpp
+++ b/include/csPerfThread.hpp
@@ -102,7 +102,7 @@ typedef struct {
     void *cbuf;
     void *sfile;
     void *thread;
-    char running;
+    bool running;
     void* condvar;
     void* mutex;
     char *sfname;

--- a/include/csPerfThread.hpp
+++ b/include/csPerfThread.hpp
@@ -102,7 +102,7 @@ typedef struct {
     void *cbuf;
     void *sfile;
     void *thread;
-    bool running;
+    char running;
     void* condvar;
     void* mutex;
     char *sfname;

--- a/include/sysdep.h
+++ b/include/sysdep.h
@@ -510,6 +510,17 @@ char *strNcpy(char *dst, const char *src, size_t siz);
 #endif
 
 #ifdef MSVC
+#define ATOMIC_SET_BOOL(var, val) \
+  ((void) InterlockedExchange8((volatile char *) &(var), (char) !!(val)))
+#define ATOMIC_GET_BOOL(var) \
+  (InterlockedExchangeAdd8((volatile char *) &(var), 0) != 0)
+#else
+#define ATOMIC_SET_BOOL(var, val) \
+  do { ATOMIC_SET8(var, !!(val)); } while (0)
+#define ATOMIC_GET_BOOL ATOMIC_GET8
+#endif
+
+#ifdef MSVC
 #define ATOMIC_DECR(var) InterlockedExchangeAdd(&var, -1)
 #elif defined(HAVE_ATOMIC_BUILTIN)
 #define ATOMIC_DECR(var) __atomic_sub_fetch(&var, 1, __ATOMIC_SEQ_CST)

--- a/tests/c/perfthread_test.cpp
+++ b/tests/c/perfthread_test.cpp
@@ -58,7 +58,7 @@ TEST(PerfThreadsTests, Record) {
 
     CsoundPerformanceThread performanceThread1(csound.GetCsound());
     performanceThread1.Play();
-    performanceThread1.Record("missing-record-dir/testrec.wav");
+    performanceThread1.Record("");
     performanceThread1.StopRecord();
     performanceThread1.FlushMessageQueue();
     performanceThread1.Record("testrec.wav");

--- a/tests/c/perfthread_test.cpp
+++ b/tests/c/perfthread_test.cpp
@@ -58,6 +58,9 @@ TEST(PerfThreadsTests, Record) {
 
     CsoundPerformanceThread performanceThread1(csound.GetCsound());
     performanceThread1.Play();
+    performanceThread1.Record("missing-record-dir/testrec.wav");
+    performanceThread1.StopRecord();
+    performanceThread1.FlushMessageQueue();
     performanceThread1.Record("testrec.wav");
     csoundSleep(2000);
     performanceThread1.StopRecord();


### PR DESCRIPTION
Fixes #2751

The recorder checked `running` before taking its condition mutex. A stop could clear the flag and signal before the recorder started waiting. `StopRecord()` would then get stuck in `join()`.

The `running` flag stays a `bool` and now uses Csound's boolean atomic helpers. The recorder checks it while holding the condition mutex. Both shutdown paths clear the flag and signal under that mutex, then release it before joining.
