### PR TITLE
Minor fix

### DIFF
--- a/Python/ctcsound.py
+++ b/Python/ctcsound.py
@@ -2052,7 +2052,9 @@ class CsoundPerformanceThread:
         self.cpt = libcspt.csoundCreatePerformanceThread(csp)
 
     def __del__(self):
-        libcspt.csoundDestroyPerforma#
+        libcspt.csoundDestroyPerformanceThread(self.cpt)
+    
+    #
     # Realtime MIDI I/O
     #
     def set_host_midi_IO(self):


### PR DESCRIPTION
csoundPerformanceThread was not destroyed when finishing because de __del__ method of the class CsoundPerfomanceThread was corrupted.