### PR TITLE
Fixed csoundArrayDataType issue

### DIFF
--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -3079,7 +3079,9 @@ int32_t csoundArrayDataDimensions(const ARRAYDAT *adat) {
 }
 
 const char *csoundArrayDataType(const ARRAYDAT *adat) {
-  return adat->arrayType->varTypeName;
+  if(adat && adat->arrayType)
+   return adat->arrayType->varTypeName;
+  else return NULL;
 }
 
 const int32_t *csoundArrayDataSizes(const ARRAYDAT *adat){

--- a/tests/c/channel_tests.cpp
+++ b/tests/c/channel_tests.cpp
@@ -707,6 +707,19 @@ TEST_F (ChannelTests, ArrayChannel)
     ASSERT_EQ(val, data[0]);
 }
 
+TEST_F (ChannelTests, ArrayChannelDataType) {
+    ARRAYDAT *adat = NULL;
+    csoundCompileOrc(csound, "instr 1\nendin\n");
+    csoundStart(csound); 
+    csoundGetChannelPtr(csound, (void **) &adat, "never_initialized",
+                              CSOUND_ARRAY_CHANNEL |
+                              CSOUND_INPUT_CHANNEL |
+                              CSOUND_OUTPUT_CHANNEL);
+    const char *type = csoundArrayDataType(adat);  
+    ASSERT_TRUE(type == NULL);
+}
+
+
 TEST_F (ChannelTests, AudioChannel)
 {
     csoundCompileOrc(csound, R"ORC(


### PR DESCRIPTION
This fixes the segfault with csoundArrayDataType() and adds a test for it.
Closes #2756 