### PR TITLE
fix(debug): report live values for typed pass-by-ref UDO arguments

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -2162,7 +2162,7 @@ int32_t csound_compile_tree(CSOUND *csound, TREE *root, int32_t async)
           opinfo->oentry->perf = NULL;
         }
 
-        csoundBuildUserOpcodeRewirePlan(csound, opinfo);
+        build_user_opcode_rewire_plan(csound, opinfo);
       }
 
       break;

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -188,11 +188,6 @@ static inline void rewire_argpp(CSOUND *csound, OPDS *chain, int32_t index,
 static MYFLT *pbr_resolve_struct_target(CSOUND *csound, MYFLT *argPtr,
                                         const char *structPath);
 
-typedef struct pbr_alias_entry {
-  const char *name;
-  int32_t ar_index;
-} PBR_ALIAS_ENTRY;
-
 typedef struct pbr_plan_builder {
   PBR_ALIAS_ENTRY *aliases;
   int32_t alias_count;
@@ -451,7 +446,11 @@ static int32_t pbr_add_alias(CSOUND *csound,
     return NOTOK;
   }
 
-  builder->aliases[builder->alias_count].name = name;
+  builder->aliases[builder->alias_count].name =
+    cs_strndup(csound, name, strlen(name));
+  if (builder->aliases[builder->alias_count].name == NULL) {
+    return NOTOK;
+  }
   builder->aliases[builder->alias_count].ar_index = ar_index;
   builder->alias_count++;
 
@@ -834,6 +833,22 @@ static void pbr_free_seed_entries(CSOUND *csound,
   csound->Free(csound, entries);
 }
 
+static void pbr_free_aliases(CSOUND *csound,
+                             PBR_ALIAS_ENTRY *aliases,
+                             int32_t alias_count) {
+  int32_t i;
+
+  if (aliases == NULL) {
+    return;
+  }
+
+  for (i = 0; i < alias_count; i++) {
+    csound->Free(csound, aliases[i].name);
+  }
+
+  csound->Free(csound, aliases);
+}
+
 static void pbr_free_plan(CSOUND *csound, PBR_REWIRE_PLAN *plan) {
   if (plan == NULL) {
     return;
@@ -842,6 +857,7 @@ static void pbr_free_plan(CSOUND *csound, PBR_REWIRE_PLAN *plan) {
   pbr_free_entries(csound, plan->init_entries, plan->init_count);
   pbr_free_entries(csound, plan->perf_entries, plan->perf_count);
   pbr_free_seed_entries(csound, plan->seed_entries, plan->seed_count);
+  pbr_free_aliases(csound, plan->aliases, plan->alias_count);
   csound->Free(csound, plan);
 }
 
@@ -1245,8 +1261,10 @@ void csoundBuildUserOpcodeRewirePlan(CSOUND *csound, OPCODINFO *udoinfo) {
   plan->init_entries = builder.init_entries;
   plan->perf_entries = builder.perf_entries;
   plan->seed_entries = builder.seed_entries;
-
-  csound->Free(csound, builder.aliases);
+  /* Retained so callers (currently the debugger) can resolve a UDO-local
+     variable name to the caller storage its opcodes were rewired onto. */
+  plan->alias_count = builder.alias_count;
+  plan->aliases = builder.aliases;
 }
 
 void csoundFreeOpcodeInfoChain(CSOUND *csound) {
@@ -1405,6 +1423,70 @@ static int32_t handle_pass_by_ref(CSOUND* csound, UOPCODE* p,
      other immutable inputs stay protected because writes happen to the output
      scratch slot first; mutable inputs are written back after the chain. */
   return pbr_seed_pass_through_outputs(csound, p, lcurip, 1);
+}
+
+/* True when this invocation was set up with pass-by-ref, i.e. its internal
+   opcodes were rewired onto caller storage.  Shared with useropcdset() so
+   the debugger cannot drift from the engine.  Recomputed per call rather
+   than read from OPCODINFO.passByRef, which only records the most recent
+   init. */
+static int32_t udo_call_is_pass_by_ref(const UOPCODE *p,
+                                       const OPCODINFO *udoinfo) {
+  return udoinfo != NULL && udoinfo->newStyle && p->ip != NULL &&
+    p->parent_ip != NULL && p->parent_ip->ksmps == p->ip->ksmps &&
+    p->parent_ip->esr == p->ip->esr;
+}
+
+MYFLT *csoundUserOpcodeRefArgStorage(const UOPCODE *p, const char *varName) {
+  OPCODINFO *udoinfo;
+  PBR_REWIRE_PLAN *plan;
+  MYFLT *target;
+  int32_t ar_index;
+  int32_t outchns;
+  int32_t i;
+
+  if (p == NULL || p->buf == NULL || varName == NULL) {
+    return NULL;
+  }
+
+  udoinfo = p->buf->opcode_info;
+  if (!udo_call_is_pass_by_ref(p, udoinfo)) {
+    return NULL;
+  }
+
+  plan = udoinfo->pbr_plan;
+  if (plan == NULL || plan->aliases == NULL) {
+    return NULL;
+  }
+
+  /* Exact match only: base-name matching would map a plain variable onto a
+     slot that was aliased for one of its struct members. */
+  ar_index = pbr_alias_lookup_exact(plan->aliases, plan->alias_count, varName);
+  outchns = udoinfo->outchns;
+  if (ar_index < 0 || ar_index >= outchns + udoinfo->inchns) {
+    return NULL;
+  }
+
+  target = p->ar[ar_index];
+  if (target == NULL) {
+    return NULL;
+  }
+
+  /* An input sharing caller storage with an output is read through the xin
+     snapshot refreshed each k-cycle; p->ar[] already holds the output the body
+     wrote over it.  Mirrors pbr_apply_entries().  The xin lookup walks the init
+     chain, so only do it once a collision is confirmed. */
+  if (ar_index >= outchns) {
+    for (i = 0; i < outchns; i++) {
+      if (p->ar[i] == target) {
+        XIN *xin = pbr_find_xin(p->ip);
+
+        return xin != NULL ? xin->args[ar_index - outchns] : target;
+      }
+    }
+  }
+
+  return target;
 }
 
 /*
@@ -1639,9 +1721,9 @@ int32_t useropcdset(CSOUND *csound, UOPCODE *p)
   if (UNLIKELY(err != OK))
     goto finish_init;
 
-  inm->passByRef = buf->opcode_info->newStyle &&
-    parent_ip->ksmps == p->ip->ksmps &&
-    parent_ip->esr == p->ip->esr;
+  /* Per-definition flag for perf-routine selection.  The debugger must not
+     read this back: the next init of the same UDO overwrites it. */
+  inm->passByRef = udo_call_is_pass_by_ref(p, inm);
 
   if(inm->passByRef) {
     if (UNLIKELY(handle_pass_by_ref(csound, p, lcurip) != OK)) {

--- a/Engine/udo.c
+++ b/Engine/udo.c
@@ -1203,7 +1203,7 @@ static int32_t pbr_writeback_pass_through_inputs(CSOUND *csound,
   return OK;
 }
 
-void csoundBuildUserOpcodeRewirePlan(CSOUND *csound, OPCODINFO *udoinfo) {
+void build_user_opcode_rewire_plan(CSOUND *csound, OPCODINFO *udoinfo) {
   PBR_PLAN_BUILDER builder = {0};
   PBR_REWIRE_PLAN *plan;
   OPTXT *optxt;
@@ -1267,7 +1267,7 @@ void csoundBuildUserOpcodeRewirePlan(CSOUND *csound, OPCODINFO *udoinfo) {
   plan->aliases = builder.aliases;
 }
 
-void csoundFreeOpcodeInfoChain(CSOUND *csound) {
+void free_opcode_info_chain(CSOUND *csound) {
   OPCODINFO *current = csound->opcodeInfo;
 
   while (current != NULL) {
@@ -1437,7 +1437,7 @@ static int32_t udo_call_is_pass_by_ref(const UOPCODE *p,
     p->parent_ip->esr == p->ip->esr;
 }
 
-MYFLT *csoundUserOpcodeRefArgStorage(const UOPCODE *p, const char *varName) {
+MYFLT *user_opcode_ref_arg_storage(const UOPCODE *p, const char *varName) {
   OPCODINFO *udoinfo;
   PBR_REWIRE_PLAN *plan;
   MYFLT *target;

--- a/H/cs_internal.h
+++ b/H/cs_internal.h
@@ -186,13 +186,20 @@ extern "C" {
     char    *input_struct_path;
   } PBR_SEED_ENTRY;
 
+  typedef struct pbr_alias_entry {
+    char    *name;             /* owned copy of the UDO-local variable name */
+    int32_t ar_index;          /* slot in UOPCODE.ar holding caller storage */
+  } PBR_ALIAS_ENTRY;
+
   typedef struct pbr_rewire_plan {
     int32_t init_count;
     int32_t perf_count;
     int32_t seed_count;
+    int32_t alias_count;
     PBR_REWIRE_ENTRY *init_entries;
     PBR_REWIRE_ENTRY *perf_entries;
     PBR_SEED_ENTRY   *seed_entries;
+    PBR_ALIAS_ENTRY  *aliases;
   } PBR_REWIRE_PLAN;
 
   typedef struct opcodinfo {

--- a/H/udo.h
+++ b/H/udo.h
@@ -116,4 +116,10 @@ void recycle_init_only_udo_instances(CSOUND *, INSDS *);
 void csoundBuildUserOpcodeRewirePlan(CSOUND *, OPCODINFO *);
 void csoundFreeOpcodeInfoChain(CSOUND *);
 
+/* Caller storage a pass-by-ref UDO argument was rewired onto, or NULL when
+   varName is an ordinary local of the UDO instance (or the call does not use
+   pass-by-ref).  The returned pointer is borrowed and only valid while the
+   instance is active. */
+MYFLT *csoundUserOpcodeRefArgStorage(const UOPCODE *p, const char *varName);
+
 #endif

--- a/H/udo.h
+++ b/H/udo.h
@@ -113,13 +113,13 @@ int32_t useropcd_local_ksmps(CSOUND *, UOPCODE*);
 int32_t useropcd_pass_by_copy(CSOUND *, UOPCODE*);
 int32_t useropcd_pass_by_ref(CSOUND *, UOPCODE *);
 void recycle_init_only_udo_instances(CSOUND *, INSDS *);
-void csoundBuildUserOpcodeRewirePlan(CSOUND *, OPCODINFO *);
-void csoundFreeOpcodeInfoChain(CSOUND *);
+void build_user_opcode_rewire_plan(CSOUND *, OPCODINFO *);
+void free_opcode_info_chain(CSOUND *);
 
 /* Caller storage a pass-by-ref UDO argument was rewired onto, or NULL when
    varName is an ordinary local of the UDO instance (or the call does not use
    pass-by-ref).  The returned pointer is borrowed and only valid while the
    instance is active. */
-MYFLT *csoundUserOpcodeRefArgStorage(const UOPCODE *p, const char *varName);
+MYFLT *user_opcode_ref_arg_storage(const UOPCODE *p, const char *varName);
 
 #endif

--- a/Top/csound.c
+++ b/Top/csound.c
@@ -1910,7 +1910,7 @@ static void reset(CSOUND *csound) {
     csound->opcodes = NULL;
   }
   if (csound->opcodeInfo != NULL) {
-    csoundFreeOpcodeInfoChain(csound);
+    free_opcode_info_chain(csound);
   }
 
   csound->oparms_.odebug = 0;

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -350,9 +350,9 @@ void csoundDebugFreeOpcodeList(CSOUND *csound, debug_opcode_t *opcode_list)
  * (opcode name(a:k):a) run pass-by-ref: the xin/xout names are rewired
  * onto the caller's storage and the instance's own pool slots for them
  * stay untouched, so those names must be read through
- * csoundUserOpcodeRefArgStorage() instead of lclbas.
+ * user_opcode_ref_arg_storage() instead of lclbas.
  */
-static debug_variable_t *csoundDebugBuildVarList(
+static debug_variable_t *debug_build_var_list(
     CSOUND *csound, CS_VARIABLE *varPoolHead, MYFLT *lclbas, int32_t isGlobal,
     const UOPCODE *udo)
 {
@@ -368,7 +368,7 @@ static debug_variable_t *csoundDebugBuildVarList(
             }
         } else {
             base = udo != NULL ?
-                csoundUserOpcodeRefArgStorage(udo, var->varName) : NULL;
+                user_opcode_ref_arg_storage(udo, var->varName) : NULL;
             if (base == NULL) {
                 base = lclbas + var->memBlockIndex;
             }
@@ -409,7 +409,7 @@ static debug_variable_t *csoundDebugBuildVarList(
     return head;
 }
 
-static const UOPCODE *csoundDebugUdoInvocation(const debug_instr_t *instr)
+static const UOPCODE *debug_udo_invocation(const debug_instr_t *instr)
 {
     INSDS *ip;
     OPCOD_IOBUFS *buf;
@@ -429,9 +429,9 @@ static const UOPCODE *csoundDebugUdoInvocation(const debug_instr_t *instr)
  debug_variable_t *csoundDebugGetVariables(CSOUND *csound,
                                                  debug_instr_t *instr)
 {
-    return csoundDebugBuildVarList(csound, instr->varPoolHead,
+    return debug_build_var_list(csound, instr->varPoolHead,
                                    instr->lclbas, 0,
-                                   csoundDebugUdoInvocation(instr));
+                                   debug_udo_invocation(instr));
 }
 
 debug_variable_t *csoundDebugGetGlobalVariables(CSOUND *csound)
@@ -444,10 +444,10 @@ debug_variable_t *csoundDebugGetGlobalVariables(CSOUND *csound)
     if (pool == NULL) {
         return NULL;
     }
-    return csoundDebugBuildVarList(csound, pool->head, NULL, 1, NULL);
+    return debug_build_var_list(csound, pool->head, NULL, 1, NULL);
 }
 
-static UOPCODE *csoundDebugUdoFindSavedSibling(UOPCODE *nestedHead,
+static UOPCODE *debug_udo_find_saved_sibling(UOPCODE *nestedHead,
                                                INSDS *sibling_parent,
                                                int32_t *truncatedOut)
 {
@@ -481,7 +481,7 @@ static UOPCODE *csoundDebugUdoFindSavedSibling(UOPCODE *nestedHead,
     return NULL;
 }
 
-static UOPCODE *csoundDebugUdoChainNext(UOPCODE *p, INSDS *parent_ip,
+static UOPCODE *debug_udo_chain_next(UOPCODE *p, INSDS *parent_ip,
                                         int32_t *truncatedOut)
 {
     UOPCODE *next;
@@ -499,12 +499,12 @@ static UOPCODE *csoundDebugUdoChainNext(UOPCODE *p, INSDS *parent_ip,
         return next;
     }
     if (next->parent_ip == p->ip) {
-        return csoundDebugUdoFindSavedSibling(next, parent_ip, truncatedOut);
+        return debug_udo_find_saved_sibling(next, parent_ip, truncatedOut);
     }
     return NULL;
 }
 
-static int32_t csoundDebugVisitedEnsureCapacity(CSOUND *csound,
+static int32_t debug_visited_ensure_capacity(CSOUND *csound,
                                                 UOPCODE ***visited,
                                                 int32_t *visitedCapacity,
                                                 int32_t visitedCount,
@@ -535,7 +535,7 @@ static int32_t csoundDebugVisitedEnsureCapacity(CSOUND *csound,
     return 1;
 }
 
-static int csoundDebugUopcodeVisited(UOPCODE *p, UOPCODE **visited,
+static int debug_uopcode_visited(UOPCODE *p, UOPCODE **visited,
                                      int32_t visitedCount)
 {
     int32_t i;
@@ -547,7 +547,7 @@ static int csoundDebugUopcodeVisited(UOPCODE *p, UOPCODE **visited,
     return 0;
 }
 
-static const char *csoundDebugUdoName(UOPCODE *p)
+static const char *debug_udo_name(UOPCODE *p)
 {
     OPCOD_IOBUFS *buf = p->buf;
     if (buf != NULL && buf->opcode_info != NULL && buf->opcode_info->name != NULL) {
@@ -559,7 +559,7 @@ static const char *csoundDebugUdoName(UOPCODE *p)
     return "unknown";
 }
 
-static void csoundDebugAppendUdoFrame(
+static void debug_append_udo_frame(
     CSOUND *csound,
     debug_udo_frame_t **head,
     debug_udo_frame_t **tail,
@@ -570,12 +570,12 @@ static void csoundDebugAppendUdoFrame(
 {
     debug_udo_frame_t *frame =
         csound->Malloc(csound, sizeof(debug_udo_frame_t));
-    frame->udoName = csoundDebugUdoName(p);
+    frame->udoName = debug_udo_name(p);
     frame->callLine = (p->h.optext != NULL) ? p->h.optext->t.linenum : 0;
     frame->depth = depth;
     frame->frameIndex = frameIndex;
     if (udo_ip->instr != NULL && udo_ip->instr->varPool != NULL) {
-        frame->varList = csoundDebugBuildVarList(
+        frame->varList = debug_build_var_list(
             csound, udo_ip->instr->varPool->head, udo_ip->lclbas, 0, p);
     } else {
         frame->varList = NULL;
@@ -589,7 +589,7 @@ static void csoundDebugAppendUdoFrame(
     }
 }
 
-static void csoundDebugCollectUdoFrames(
+static void debug_collect_udo_frames(
     CSOUND *csound,
     INSDS *ip,
     int32_t depth,
@@ -604,7 +604,7 @@ static void csoundDebugCollectUdoFrames(
     int32_t siblingIndex = 0;
 
     for (p = (UOPCODE *)ip->opcod_deact; p != NULL;
-         p = csoundDebugUdoChainNext(p, ip, truncatedOut)) {
+         p = debug_udo_chain_next(p, ip, truncatedOut)) {
         INSDS *udo_ip = p->ip;
         if (udo_ip == NULL) {
             continue;
@@ -617,17 +617,17 @@ static void csoundDebugCollectUdoFrames(
         if (!ATOMIC_GET(udo_ip->init_done)) {
             continue;
         }
-        if (csoundDebugUopcodeVisited(p, *visited, *visitedCount)) {
+        if (debug_uopcode_visited(p, *visited, *visitedCount)) {
             continue;
         }
-        if (!csoundDebugVisitedEnsureCapacity(csound, visited, visitedCapacity,
+        if (!debug_visited_ensure_capacity(csound, visited, visitedCapacity,
                                               *visitedCount, truncatedOut)) {
             return;
         }
         (*visited)[(*visitedCount)++] = p;
-        csoundDebugAppendUdoFrame(csound, head, tail, p, udo_ip, depth,
+        debug_append_udo_frame(csound, head, tail, p, udo_ip, depth,
                                   siblingIndex++);
-        csoundDebugCollectUdoFrames(csound, udo_ip, depth + 1, head, tail,
+        debug_collect_udo_frames(csound, udo_ip, depth + 1, head, tail,
                                     visited, visitedCount, visitedCapacity,
                                     truncatedOut);
     }
@@ -651,7 +651,7 @@ debug_udo_frame_t *csoundDebugGetUdoFrames(CSOUND *csound,
         return NULL;
     }
     ip = (INSDS *)instr->instrptr;
-    csoundDebugCollectUdoFrames(csound, ip, 0, &head, &tail, &visited,
+    debug_collect_udo_frames(csound, ip, 0, &head, &tail, &visited,
                                 &visitedCount, &visitedCapacity, truncatedOut);
     if (visited != NULL) {
         csound->Free(csound, visited);

--- a/Top/csound_debug.c
+++ b/Top/csound_debug.c
@@ -344,9 +344,17 @@ void csoundDebugFreeOpcodeList(CSOUND *csound, debug_opcode_t *opcode_list)
  *   S       -> STRINGDAT, data points to the C string
  *   f       -> PVSDAT*,   decode with csoundDebugSerializeFsig()
  *   [       -> ARRAYDAT*, decode with csoundDebugSerializeArray()
+ *
+ * udo is the invocation a UDO instance belongs to, NULL for top-level
+ * instruments and the global pool. Csound 7 typed headers
+ * (opcode name(a:k):a) run pass-by-ref: the xin/xout names are rewired
+ * onto the caller's storage and the instance's own pool slots for them
+ * stay untouched, so those names must be read through
+ * csoundUserOpcodeRefArgStorage() instead of lclbas.
  */
 static debug_variable_t *csoundDebugBuildVarList(
-    CSOUND *csound, CS_VARIABLE *varPoolHead, MYFLT *lclbas, int32_t isGlobal)
+    CSOUND *csound, CS_VARIABLE *varPoolHead, MYFLT *lclbas, int32_t isGlobal,
+    const UOPCODE *udo)
 {
     debug_variable_t *head = NULL;
     debug_variable_t *debug_var = NULL;
@@ -359,7 +367,11 @@ static debug_variable_t *csoundDebugBuildVarList(
                 base = (MYFLT *) &var->memBlock->value;
             }
         } else {
-            base = lclbas + var->memBlockIndex;
+            base = udo != NULL ?
+                csoundUserOpcodeRefArgStorage(udo, var->varName) : NULL;
+            if (base == NULL) {
+                base = lclbas + var->memBlockIndex;
+            }
         }
         if (!head) {
             head = csound->Malloc(csound, sizeof(debug_variable_t));
@@ -397,11 +409,29 @@ static debug_variable_t *csoundDebugBuildVarList(
     return head;
 }
 
+static const UOPCODE *csoundDebugUdoInvocation(const debug_instr_t *instr)
+{
+    INSDS *ip;
+    OPCOD_IOBUFS *buf;
+
+    if (instr == NULL || instr->instrptr == NULL) {
+        return NULL;
+    }
+    /* Only UDO instances get opcod_iobufs (insno > maxinsno). */
+    ip = (INSDS *)instr->instrptr;
+    buf = (OPCOD_IOBUFS *)ip->opcod_iobufs;
+    if (buf == NULL) {
+        return NULL;
+    }
+    return (const UOPCODE *)buf->uopcode_struct;
+}
+
  debug_variable_t *csoundDebugGetVariables(CSOUND *csound,
                                                  debug_instr_t *instr)
 {
     return csoundDebugBuildVarList(csound, instr->varPoolHead,
-                                   instr->lclbas, 0);
+                                   instr->lclbas, 0,
+                                   csoundDebugUdoInvocation(instr));
 }
 
 debug_variable_t *csoundDebugGetGlobalVariables(CSOUND *csound)
@@ -414,7 +444,7 @@ debug_variable_t *csoundDebugGetGlobalVariables(CSOUND *csound)
     if (pool == NULL) {
         return NULL;
     }
-    return csoundDebugBuildVarList(csound, pool->head, NULL, 1);
+    return csoundDebugBuildVarList(csound, pool->head, NULL, 1, NULL);
 }
 
 static UOPCODE *csoundDebugUdoFindSavedSibling(UOPCODE *nestedHead,
@@ -546,7 +576,7 @@ static void csoundDebugAppendUdoFrame(
     frame->frameIndex = frameIndex;
     if (udo_ip->instr != NULL && udo_ip->instr->varPool != NULL) {
         frame->varList = csoundDebugBuildVarList(
-            csound, udo_ip->instr->varPool->head, udo_ip->lclbas, 0);
+            csound, udo_ip->instr->varPool->head, udo_ip->lclbas, 0, p);
     } else {
         frame->varList = NULL;
     }

--- a/include/csdebug.h
+++ b/include/csdebug.h
@@ -340,7 +340,14 @@ PUBLIC debug_instr_t *csoundDebugGetInstrInstances(CSOUND *csound);
  */
 PUBLIC void csoundDebugFreeInstrInstances(CSOUND *csound, debug_instr_t *instr);
 
-/** Get list of variables for instrument */
+/** Get list of variables for an instrument or UDO instance
+ *
+ * For a top-level instrument this reads the instance pool. For a UDO
+ * instance (breakpointInstr when paused inside a UDO body, or a
+ * debug_instr_t built from that INSDS) typed pass-by-ref arguments are
+ * resolved onto the caller's storage; other locals still come from the
+ * instance pool.
+ */
 PUBLIC debug_variable_t *csoundDebugGetVariables(CSOUND *csound,
                                                  debug_instr_t *instr);
 
@@ -353,7 +360,9 @@ PUBLIC void csoundDebugFreeVariables(CSOUND *csound,
  * Walks the UOPCODE chain hung off the instrument's opcod_deact list and
  * returns one entry per active UDO sub-instance (including nested/recursive
  * frames at greater depth values). Each frame includes a variable list for
- * that UDO body, read the same way as csoundDebugGetVariables().
+ * that UDO body. Typed pass-by-ref arguments are resolved onto the caller's
+ * storage; other locals are read from the instance pool, matching
+ * csoundDebugGetVariables() on a UDO instance.
  *
  * callLine is the source line of the UDO call (from the call-site opcode).
  * frameIndex orders sibling calls on the same parent (0 = head / most recent

--- a/tests/c/csound_debugger_test.cpp
+++ b/tests/c/csound_debugger_test.cpp
@@ -9,6 +9,7 @@
 
 #include "csoundCore.h"
 #include "csdebug.h"
+#include "udo.h"
 #include "gtest/gtest.h"
 
 
@@ -837,5 +838,349 @@ TEST_F (DebuggerTests, testUdoFramesRecursiveSelfCall)
     ASSERT_GE(maxDepth, 2);
 
     csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+static MYFLT readDebugAudioPeak(debug_variable_t *var, uint32_t ksmps)
+{
+    MYFLT peak = 0;
+    uint32_t n;
+
+    if (var == NULL || var->data == NULL) {
+        return 0;
+    }
+    for (n = 0; n < ksmps; n++) {
+        MYFLT sample = std::fabs(((MYFLT *)var->data)[n]);
+        if (sample > peak) {
+            peak = sample;
+        }
+    }
+    return peak;
+}
+
+/* Csound 7 typed headers (opcode name(arg:k):a) enable pass-by-ref, which
+   rewires the UDO's internal opcodes onto caller storage and leaves the
+   instance's own var-pool slots for those names untouched. The frame walker
+   must report the caller storage, otherwise every named argument reads 0. */
+TEST_F (DebuggerTests, testUdoFramesTypedHeaderArgsAreLive)
+{
+    const char *orc =
+        "opcode simpleGain(ain:a, kGain:k):a\n"
+        "  kInternal = kGain * 2\n"
+        "  aOut = ain * kInternal\n"
+        "  xout(aOut)\n"
+        "endop\n"
+        "instr 1\n"
+        "  kGain init 0.25\n"
+        "  aIn = oscili(0.3, 440)\n"
+        "  aOut = simpleGain(aIn, kGain)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+    uint32_t ksmps = csoundGetKsmps(csound);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    debug_udo_frame_t *frames = csoundDebugGetUdoFrames(csound, instrs, NULL);
+    ASSERT_NE(frames, nullptr);
+    ASSERT_STREQ(frames->udoName, "simpleGain");
+
+    /* Body local: already correct today, must not regress. */
+    debug_variable_t *kInternal = findDebugVar(frames->varList, "kInternal");
+    ASSERT_NE(kInternal, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kInternal), 0.5);
+
+    /* xin argument: storage is the caller's kGain. */
+    debug_variable_t *kGain = findDebugVar(frames->varList, "kGain");
+    ASSERT_NE(kGain, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kGain), 0.25);
+
+    /* xin audio argument and xout result: caller-side audio buffers. */
+    debug_variable_t *ain = findDebugVar(frames->varList, "ain");
+    ASSERT_NE(ain, nullptr);
+    ASSERT_GT(readDebugAudioPeak(ain, ksmps), 0.001);
+
+    debug_variable_t *aOut = findDebugVar(frames->varList, "aOut");
+    ASSERT_NE(aOut, nullptr);
+    ASSERT_GT(readDebugAudioPeak(aOut, ksmps), 0.001);
+
+    csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+/* Each recursive invocation owns its own caller-argument pointers, so the
+   per-frame values must differ instead of collapsing onto one slot. */
+TEST_F (DebuggerTests, testUdoFramesTypedRecursiveArgsPerFrame)
+{
+    const char *orc =
+        "opcode RecursiveUDO(kBaseFreq:k, iNumParts:i, iCurrentPart:i):a\n"
+        "  aOut = poscil:a(0.1, kBaseFreq * iCurrentPart)\n"
+        "  if (iCurrentPart < iNumParts) then\n"
+        "    aOut += RecursiveUDO(kBaseFreq, iNumParts, iCurrentPart + 1)\n"
+        "  endif\n"
+        "  xout(aOut)\n"
+        "endop\n"
+        "instr 1\n"
+        "  aOut = RecursiveUDO(400, 3, 1)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+    uint32_t ksmps = csoundGetKsmps(csound);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    debug_udo_frame_t *frames = csoundDebugGetUdoFrames(csound, instrs, NULL);
+    ASSERT_NE(frames, nullptr);
+
+    int32_t sawPart1 = 0;
+    int32_t sawPart2 = 0;
+    int32_t sawPart3 = 0;
+    for (debug_udo_frame_t *f = frames; f != NULL; f = f->next) {
+        ASSERT_STREQ(f->udoName, "RecursiveUDO");
+        debug_variable_t *partVar = findDebugVar(f->varList, "iCurrentPart");
+        debug_variable_t *freqVar = findDebugVar(f->varList, "kBaseFreq");
+        debug_variable_t *partsVar = findDebugVar(f->varList, "iNumParts");
+        debug_variable_t *aOut = findDebugVar(f->varList, "aOut");
+        ASSERT_NE(partVar, nullptr);
+        ASSERT_NE(freqVar, nullptr);
+        ASSERT_NE(partsVar, nullptr);
+        ASSERT_NE(aOut, nullptr);
+        ASSERT_DOUBLE_EQ(readDebugScalar(freqVar), 400);
+        ASSERT_DOUBLE_EQ(readDebugScalar(partsVar), 3);
+        ASSERT_GT(readDebugAudioPeak(aOut, ksmps), 0.001);
+        MYFLT part = readDebugScalar(partVar);
+        ASSERT_GE(part, 1);
+        ASSERT_LE(part, 3);
+        if (part == 1) {
+            sawPart1 = 1;
+        }
+        if (part == 2) {
+            sawPart2 = 1;
+        }
+        if (part == 3) {
+            sawPart3 = 1;
+        }
+    }
+    ASSERT_EQ(sawPart1, 1);
+    ASSERT_EQ(sawPart2, 1);
+    ASSERT_EQ(sawPart3, 1);
+
+    csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+/* When the caller passes one variable as both input and output, the body's
+   writes land on p->ar[input] as well, so reporting p->ar[] would show ain
+   already overwritten with aOut. Pass-by-ref reads such an input through a
+   per-k-cycle snapshot instead, and the frame walker has to follow the same
+   redirect. Asserting aOut == ain * kAmp is what distinguishes the two: without
+   the redirect ain and aOut are the same samples. */
+TEST_F (DebuggerTests, testUdoFramesTypedInPlaceArgUsesSnapshot)
+{
+    const char *orc =
+        "opcode scaleSig(ain:a, kAmp:k):a\n"
+        "  aOut = ain * kAmp\n"
+        "  xout(aOut)\n"
+        "endop\n"
+        "instr 1\n"
+        "  kAmp init 0.5\n"
+        "  aSig = oscili(0.4, 440)\n"
+        "  aSig = scaleSig(aSig, kAmp)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+    uint32_t ksmps = csoundGetKsmps(csound);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    debug_udo_frame_t *frames = csoundDebugGetUdoFrames(csound, instrs, NULL);
+    ASSERT_NE(frames, nullptr);
+    ASSERT_STREQ(frames->udoName, "scaleSig");
+
+    debug_variable_t *kAmp = findDebugVar(frames->varList, "kAmp");
+    ASSERT_NE(kAmp, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kAmp), 0.5);
+
+    debug_variable_t *ain = findDebugVar(frames->varList, "ain");
+    ASSERT_NE(ain, nullptr);
+    ASSERT_GT(readDebugAudioPeak(ain, ksmps), 0.001);
+
+    debug_variable_t *aOut = findDebugVar(frames->varList, "aOut");
+    ASSERT_NE(aOut, nullptr);
+    ASSERT_GT(readDebugAudioPeak(aOut, ksmps), 0.001);
+
+    /* ain must still be the pre-scale input, not the output written over it. */
+    for (uint32_t n = 0; n < ksmps; n++) {
+        ASSERT_NEAR(((MYFLT *)aOut->data)[n],
+                    ((MYFLT *)ain->data)[n] * 0.5, 1e-12);
+    }
+
+    csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+/* Pass-through xout(ain) redirects the ain alias onto the output slot, so
+   an in-place call must report ain as the scaled output, not a pre-write
+   snapshot. Equality with the caller's aSig is what distinguishes that from
+   the colliding-input snapshot used when xin and xout are different names. */
+TEST_F (DebuggerTests, testUdoFramesTypedPassThroughArgFollowsOutput)
+{
+    const char *orc =
+        "opcode scaleThru(ain:a, kAmp:k):a\n"
+        "  ain = ain * kAmp\n"
+        "  xout(ain)\n"
+        "endop\n"
+        "instr 1\n"
+        "  kAmp init 0.5\n"
+        "  aSig = oscili(0.4, 440)\n"
+        "  aSig = scaleThru(aSig, kAmp)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+    uint32_t ksmps = csoundGetKsmps(csound);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    debug_variable_t *instrVars = csoundDebugGetVariables(csound, instrs);
+    ASSERT_NE(instrVars, nullptr);
+    debug_udo_frame_t *frames = csoundDebugGetUdoFrames(csound, instrs, NULL);
+    ASSERT_NE(frames, nullptr);
+    ASSERT_STREQ(frames->udoName, "scaleThru");
+
+    debug_variable_t *kAmp = findDebugVar(frames->varList, "kAmp");
+    ASSERT_NE(kAmp, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kAmp), 0.5);
+
+    debug_variable_t *ain = findDebugVar(frames->varList, "ain");
+    ASSERT_NE(ain, nullptr);
+    ASSERT_GT(readDebugAudioPeak(ain, ksmps), 0.001);
+
+    debug_variable_t *aSig = findDebugVar(instrVars, "aSig");
+    ASSERT_NE(aSig, nullptr);
+    ASSERT_GT(readDebugAudioPeak(aSig, ksmps), 0.001);
+
+    for (uint32_t n = 0; n < ksmps; n++) {
+        ASSERT_NEAR(((MYFLT *)ain->data)[n],
+                    ((MYFLT *)aSig->data)[n], 1e-12);
+    }
+
+    csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeVariables(csound, instrVars);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+/* setksmps disables pass-by-ref; xin copies into the instance pool and the
+   frame walker must keep reading those slots rather than caller storage. */
+TEST_F (DebuggerTests, testUdoFramesTypedLocalKsmpsArgsAreLive)
+{
+    const char *orc =
+        "opcode localGain(kGain:k):k\n"
+        "  setksmps 1\n"
+        "  kInternal = kGain * 2\n"
+        "  kOut = kInternal\n"
+        "  xout(kOut)\n"
+        "endop\n"
+        "instr 1\n"
+        "  kGain init 0.25\n"
+        "  kOut = localGain(kGain)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    debug_udo_frame_t *frames = csoundDebugGetUdoFrames(csound, instrs, NULL);
+    ASSERT_NE(frames, nullptr);
+    ASSERT_STREQ(frames->udoName, "localGain");
+
+    debug_variable_t *kInternal = findDebugVar(frames->varList, "kInternal");
+    ASSERT_NE(kInternal, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kInternal), 0.5);
+
+    debug_variable_t *kGain = findDebugVar(frames->varList, "kGain");
+    ASSERT_NE(kGain, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kGain), 0.25);
+
+    debug_variable_t *kOut = findDebugVar(frames->varList, "kOut");
+    ASSERT_NE(kOut, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kOut), 0.5);
+
+    csoundDebugFreeUdoFrames(csound, frames);
+    csoundDebugFreeInstrInstances(csound, instrs);
+}
+
+/* Breakpoints inside a UDO body go through csoundDebugGetVariables() on that
+   instance, not GetUdoFrames. The same remapping must apply. */
+TEST_F (DebuggerTests, testGetVariablesTypedUdoInstanceArgsAreLive)
+{
+    const char *orc =
+        "opcode simpleGain(ain:a, kGain:k):a\n"
+        "  kInternal = kGain * 2\n"
+        "  aOut = ain * kInternal\n"
+        "  xout(aOut)\n"
+        "endop\n"
+        "instr 1\n"
+        "  kGain init 0.25\n"
+        "  aIn = oscili(0.3, 440)\n"
+        "  aOut = simpleGain(aIn, kGain)\n"
+        "endin\n";
+
+    int32_t compileErr = csoundCompileOrc(csound, orc, 0);
+    ASSERT_EQ(compileErr, 0);
+    csoundStart(csound);
+    csoundEventString(csound, "i 1 0 1", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), 0);
+    uint32_t ksmps = csoundGetKsmps(csound);
+
+    debug_instr_t *instrs = csoundDebugGetInstrInstances(csound);
+    ASSERT_NE(instrs, nullptr);
+    INSDS *parent = (INSDS *)instrs->instrptr;
+    ASSERT_NE(parent, nullptr);
+    UOPCODE *p = (UOPCODE *)parent->opcod_deact;
+    ASSERT_NE(p, nullptr);
+    ASSERT_NE(p->ip, nullptr);
+
+    debug_instr_t udoInstr;
+    memset(&udoInstr, 0, sizeof(udoInstr));
+    udoInstr.varPoolHead = p->ip->instr->varPool->head;
+    udoInstr.lclbas = p->ip->lclbas;
+    udoInstr.instrptr = p->ip;
+
+    debug_variable_t *vars = csoundDebugGetVariables(csound, &udoInstr);
+    ASSERT_NE(vars, nullptr);
+
+    debug_variable_t *kInternal = findDebugVar(vars, "kInternal");
+    ASSERT_NE(kInternal, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kInternal), 0.5);
+
+    debug_variable_t *kGain = findDebugVar(vars, "kGain");
+    ASSERT_NE(kGain, nullptr);
+    ASSERT_DOUBLE_EQ(readDebugScalar(kGain), 0.25);
+
+    debug_variable_t *ain = findDebugVar(vars, "ain");
+    ASSERT_NE(ain, nullptr);
+    ASSERT_GT(readDebugAudioPeak(ain, ksmps), 0.001);
+
+    csoundDebugFreeVariables(csound, vars);
     csoundDebugFreeInstrInstances(csound, instrs);
 }


### PR DESCRIPTION
## Summary

- `csoundDebugGetUdoFrames()` / `csoundDebugGetVariables()` reported 0 for every named argument of a Csound 7 typed-header UDO (`opcode name(ain:a, kGain:k):a`), while audio was correct. Classic `opcode name, a, ak` + `xin` UDOs were unaffected.
- Cause: when caller `ksmps`/`esr` match, `useropcdset()` enables pass-by-ref and rewires the body onto `UOPCODE.ar[]`. The instance pool slots for those names are allocated but never written; the debugger was reading `lclbas + memBlockIndex`.
- Fix: keep the compile-time name → `ar_index` table already built by `csoundBuildUserOpcodeRewirePlan()`, and resolve through `csoundUserOpcodeRefArgStorage()`. That table already encodes pass-through xout and in-place `aSig = udo(aSig)` collisions, which a hand-rolled xin/xout walk would get wrong.

Engine runtime behaviour is unchanged: the alias table is retained instead of freed, plus a read-only accessor. No hot-path change. `debug_variable_t` layout and WASM exports are unchanged.


Not in this PR: `csoundDebugGetUdoFrames()` still enumerates O(2^depth) frames for recursive UDOs; clients de-duplicate per call site.