### PR TITLE
Fix C WASM plugin relocation and message bounds

### DIFF
--- a/wasm/browser/src/module.js
+++ b/wasm/browser/src/module.js
@@ -594,8 +594,8 @@ export default async function loadWasm({ wasmDataURI, withPlugins = [], messageP
        * @type {WasmInst} */
       const pluginInstance = new WebAssembly.Instance(plugin, pluginOptions);
 
-      if (typeof pluginInstance.exports.__wasm_apply_data_relocs === "function") {
-        pluginInstance.exports.__wasm_apply_data_relocs();
+      if (typeof pluginInstance.exports["__wasm_apply_data_relocs"] === "function") {
+        pluginInstance.exports["__wasm_apply_data_relocs"]();
       }
       pluginInstance.exports.__wasm_call_ctors();
       pluginMemoryAllocation = 0;

--- a/wasm/browser/tests/tests.js
+++ b/wasm/browser/tests/tests.js
@@ -1369,6 +1369,60 @@ e
       assert.property(cs, "getMemory");
     });
 
+    it("bounds formatted WASM messages to the message buffer", function () {
+      const csound = cs.csoundCreate();
+      const wasm = cs.wasm.exports;
+      const message = "x".repeat(8192);
+      const text = new TextEncoder().encode(message + "\0");
+      const pointer = wasm.allocStringMem(text.length);
+      const newline = wasm.allocStringMem(2);
+      const log = sinon.stub(console, "log");
+
+      try {
+        new Uint8Array(cs.getMemory().buffer, pointer, text.length).set(text);
+        new Uint8Array(cs.getMemory().buffer, newline, 2).set([10, 0]);
+        wasm.csoundMessageS(csound, 0, pointer, 0);
+        wasm.csoundMessageS(csound, 0, newline, 0);
+        assert.deepEqual(log.args, [["x".repeat(4095)]]);
+      } finally {
+        log.restore();
+        wasm.freeStringMem(newline);
+        wasm.freeStringMem(pointer);
+        cs.csoundDestroy(csound);
+      }
+    });
+
+    it("handles a WASM message encoding error without throwing", function () {
+      const csound = cs.csoundCreate();
+      const wasm = cs.wasm.exports;
+      const format = wasm.allocStringMem(4);
+      const wideString = wasm.allocStringMem(8);
+      const args = wasm.allocStringMem(8);
+      const followingMessage = wasm.allocStringMem(4);
+      const log = sinon.stub(console, "log");
+
+      try {
+        const memory = cs.getMemory().buffer;
+        new Uint8Array(memory, format, 4).set([37, 108, 115, 0]); // %ls
+        const data = new DataView(memory);
+        // A lone surrogate cannot be encoded as a multibyte character.
+        data.setUint32(wideString, 0xd800, true);
+        data.setUint32(wideString + 4, 0, true);
+        data.setUint32(args, wideString, true);
+        new Uint8Array(memory, followingMessage, 4).set([111, 107, 10, 0]);
+        assert.doesNotThrow(() => wasm.csoundMessageS(csound, 0, format, args));
+        wasm.csoundMessageS(csound, 0, followingMessage, 0);
+        assert.deepEqual(log.args, [["ok"]]);
+      } finally {
+        log.restore();
+        wasm.freeStringMem(followingMessage);
+        wasm.freeStringMem(args);
+        wasm.freeStringMem(wideString);
+        wasm.freeStringMem(format);
+        cs.csoundDestroy(csound);
+      }
+    });
+
     it("reuses resources after failed plugin loads", async function () {
       const { libcsound } = await import(url);
       const badPlugin = Uint8Array.from(

--- a/wasm/src/csound_wasm.c
+++ b/wasm/src/csound_wasm.c
@@ -110,6 +110,13 @@ void csoundWasiJsMessageCallback(
 void csoundWasiCMessageCallback(CSOUND *csound, int attr, const char *format, va_list args) {
   char buffer[MAX_MESSAGE_STR];
   int len = vsnprintf(buffer, MAX_MESSAGE_STR, format, args);
+  if (len < 0) {
+    return;
+  }
+  /* vsnprintf returns the length before truncation. Only pass stored bytes. */
+  if (len >= MAX_MESSAGE_STR) {
+    len = MAX_MESSAGE_STR - 1;
+  }
   (* csoundWasiJsMessageCallback)(csound, attr, len, buffer);
 }
 

--- a/wasm/src/plugin_example.nix
+++ b/wasm/src/plugin_example.nix
@@ -37,12 +37,17 @@ in stdenvWasm.mkDerivation {
 
     echo "Link together plugin_example.wasm"
     $CC \
-      -Wl,-z,stack-size=131072 \
+      -shared \
+      -nostdlib \
+      -nostartfiles \
+      -Wl,--experimental-pic \
+      -Wl,--no-entry \
       -Wl,--import-table \
       -Wl,--import-memory \
-      -Wl,--export-all \
-      -Wl,--no-entry \
-      -lwasi-emulated-signal -lwasi-emulated-mman \
+      -Wl,--import-undefined \
+      -Wl,--export=__wasm_call_ctors \
+      -Wl,--export=csound_opcode_init \
+      -Wl,--export=csoundModuleInfo \
       plugin_example.o -o plugin_example.wasm
   '';
 


### PR DESCRIPTION
Loading the C example plugin overwrote engine memory because its linker used fixed addresses. Startup then failed while printing engine settings with `Invalid typed array length: -1`.

Build the C example as a relocatable module that uses the host's memory and function table, following the C++ example. Preserve the `__wasm_apply_data_relocs` export name through Closure compilation so production bundles apply plugin addresses before use.

The WASM message callback also passed formatting errors and unbounded lengths to JavaScript. It now skips failed formatting and limits truncated messages to the bytes stored in its buffer, preventing negative typed-array lengths and reads beyond the buffer.

This targets `develop` so #2629 can pick up the WASM fixes after merge.