### PR TITLE
fix(date): restore subsecond precision on macOS

### DIFF
--- a/Opcodes/date.c
+++ b/Opcodes/date.c
@@ -67,7 +67,7 @@ static int32_t datemyfltset(CSOUND *csound, DATEMYFLT *p)
     *p->time_ += (MYFLT)(tp.tv_nsec)*1.0e-9;
     if (p->OUTOCOUNT==2) *p->nano =(MYFLT)tp.tv_nsec;
 #else
-  #ifdef __MACH
+  #ifdef __MACH__
     // There may be more accurate methods.....
     struct timeval tp;
     int32_t rv = gettimeofday(&tp, NULL);


### PR DESCRIPTION
On macOS, `date` returned whole seconds and a zero nanosecond output because its platform guard checked `__MACH` instead of `__MACH__`.

Use the compiler-defined macro so `date` selects its existing `gettimeofday` implementation and preserves fractional seconds.
