### PR TITLE
fix: keep logbtwo audio output indexing in range

### DIFF
--- a/OOps/aops.c
+++ b/OOps/aops.c
@@ -1538,10 +1538,10 @@ int32_t logbasetwoa(CSOUND *csound, EVAL *p)
   }
   for (n = offset; n < nsmps; n++) {
     MYFLT aa = a[n];
-    int32_t n = (int32_t)((aa -(FL(1.0)/INTERVAL)) / (INTERVAL-FL(1.0)/INTERVAL)
-                          *  STEPS + FL(0.5));
-    if (n<0 || n>STEPS) r[n] = LOG(aa)*ONEdLOG2;
-    else                r[n] = csound->logbase2[n];
+    int32_t indx = (int32_t)((aa -(FL(1.0)/INTERVAL)) / (INTERVAL-FL(1.0)/INTERVAL)
+                             *  STEPS + FL(0.5));
+    if (indx<0 || indx>STEPS) r[n] = LOG(aa)*ONEdLOG2;
+    else                     r[n] = csound->logbase2[indx];
   }
   return OK;
 }


### PR DESCRIPTION
`logbtwo` reused `n` for the lookup-table index inside the audio loop. That lookup index could then be used as the output buffer index, which can write far past the current audio block.

This keeps the sample index for `r[n]` and uses a separate index for `logbase2`.