### PR TITLE
fix: check fof envelope table length

### DIFF
--- a/Opcodes/ugens7.c
+++ b/Opcodes/ugens7.c
@@ -38,7 +38,7 @@ static int32_t fofset0(CSOUND *csound, FOFS *p, int32_t flag)
     OVRLAP *ovp, *nxtovp;
     int32  olaps;
     // VL 22.03.24 check len to set float phase flag
-    if(IS_POW_TWO(p->ftp1->flen) && IS_POW_TWO(p->ftp1->flen))
+    if(IS_POW_TWO(p->ftp1->flen) && IS_POW_TWO(p->ftp2->flen))
       p->floatph = 0;
     else p->floatph = 1;
  


### PR DESCRIPTION
`fofset0` checked the waveform table twice before choosing integer phase mode.

This checks the envelope table too, so `fof` and `fof2` use float phase when either table length is not a power of two.