### PR TITLE
Keep chnparams defaults when control-channel hints are missing

### DIFF
--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -678,16 +678,10 @@ int32_t csoundSetControlChannelHints(CSOUND *csound, const char *name,
 }
 
 /**
- * Returns special parameters (assuming there are any) of a control channel,
- * previously set with csoundSetControlChannelHints().
- * If the channel exists, is a control channel, and has the special parameters
- * assigned, then the default, minimum, and maximum value is stored in *dflt,
- * *min, and *max, respectively, and a positive value that is one of
- * CSOUND_CONTROL_CHANNEL_INT, CSOUND_CONTROL_CHANNEL_LIN, and
- * CSOUND_CONTROL_CHANNEL_EXP is returned.
- * In any other case, *dflt, *min, and *max are not changed, and the return
- * value is zero if the channel exists, is a control channel, but has no
- * special parameters set; otherwise, a negative error code is returned.
+ * Copies a control channel's hints into *hints and returns CSOUND_SUCCESS.
+ * The caller must free hints->attributes if it is non-NULL.
+ * Returns CSOUND_ERROR and leaves *hints unchanged if the name is NULL,
+ * the channel does not exist, is not a control channel, or has no hints.
  */
 int32_t csoundGetControlChannelHints(CSOUND *csound, const char *name,
                                      controlChannelHints_t *hints){

--- a/OOps/bus.c
+++ b/OOps/bus.c
@@ -1701,12 +1701,14 @@ int32_t chnparams_opcode_init(CSOUND *csound, CHNPARAMS_OPCODE *p)
   if ((err & 15) == CSOUND_CONTROL_CHANNEL) {
     controlChannelHints_t hints;
     err = csoundGetControlChannelHints(csound, (char*) p->iname->data, &hints);
-    if (UNLIKELY(err > 0))
-      *(p->ictltype) = (MYFLT) err;
-    *(p->ictltype) = hints.behav;
-    *(p->idflt) = hints.dflt;
-    *(p->imin) = hints.min;
-    *(p->imax) = hints.max;
+    if (LIKELY(err == CSOUND_SUCCESS)) {
+      *(p->ictltype) = hints.behav;
+      *(p->idflt) = hints.dflt;
+      *(p->imin) = hints.min;
+      *(p->imax) = hints.max;
+      if (hints.attributes != NULL)
+        csound->Free(csound, hints.attributes);
+    }
   }
   return OK;
 }

--- a/include/csound.h
+++ b/include/csound.h
@@ -970,16 +970,14 @@ extern "C" {
                                           controlChannelHints_t hints);
 
   /**
-   * Returns special parameters (assuming there are any) of a control channel,
-   * previously set with csoundSetControlChannelHints() or the chnparams
-   * opcode.
-   * If the channel exists, is a control channel, the channel hints
-   * are stored in the preallocated controlChannelHints_t structure. The
-   * attributes member of the structure will be allocated inside this function
-   * so it is necessary to free it explicitly in the host.
+   * Copies a control channel's hints, previously set with
+   * csoundSetControlChannelHints() or the chn_k opcode, into *hints.
+   * The caller supplies the controlChannelHints_t structure and must free
+   * its attributes member if it is non-NULL.
    *
-   * The return value is zero if the channel exists and is a control
-   * channel, otherwise, an error code is returned.
+   * Returns CSOUND_SUCCESS on success. Returns CSOUND_ERROR and leaves
+   * *hints unchanged if the name is NULL, the channel does not exist,
+   * is not a control channel, or has no hints.
    */
   PUBLIC int32_t csoundGetControlChannelHints(CSOUND *, const char *name,
                                           controlChannelHints_t *hints);

--- a/tests/c/channel_tests.cpp
+++ b/tests/c/channel_tests.cpp
@@ -58,6 +58,29 @@ TEST_F (ChannelTests, ControlChannelParams)
     ASSERT_TRUE(hints2.max == 10);
 }
 
+TEST_F (ChannelTests, ChnparamsWithoutHints)
+{
+    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, R"ORC(
+        chn_k "plain", 3
+        itype, imode, ictltype, idflt, imin, imax chnparams "plain"
+        chnset itype, "type"
+        chnset imode, "mode"
+        chnset ictltype, "ctltype"
+        chnset idflt, "default"
+        chnset imin, "min"
+        chnset imax, "max"
+    )ORC"));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+
+    EXPECT_EQ(CSOUND_CONTROL_CHANNEL,
+              csoundGetControlChannel(csound, "type", nullptr));
+    EXPECT_EQ(3, csoundGetControlChannel(csound, "mode", nullptr));
+    EXPECT_EQ(0, csoundGetControlChannel(csound, "ctltype", nullptr));
+    EXPECT_EQ(0, csoundGetControlChannel(csound, "default", nullptr));
+    EXPECT_EQ(0, csoundGetControlChannel(csound, "min", nullptr));
+    EXPECT_EQ(0, csoundGetControlChannel(csound, "max", nullptr));
+}
+
 TEST_F (ChannelTests, ControlChannel)
 {
     csoundCompileOrc(csound, orc1);


### PR DESCRIPTION
Leaves the zero defaults in place unless csoundGetControlChannelHints succeeds, so plain control channels no longer copy garbage hint data.