### PR TITLE
Use the local table pointer in ictrl14

### DIFF
--- a/OOps/midiops2.c
+++ b/OOps/midiops2.c
@@ -370,7 +370,6 @@
 
       if (*p->ifn > 0) {
         /* linear interpolation routine */
-        /* linear interpolation routine */
         FUNC *ftp = csound->FTFind(csound, p->ifn); /* gab-A1 */
         MYFLT phase, tmp, *tab;
          if (UNLIKELY(ftp == NULL))
@@ -380,7 +379,7 @@
       /* clamp it */
       value = value >= FL(0.0) ? (value <= 1.0 ? value : FL(1.0)) : FL(0.0);
       phase = value * (ftp->flen - 1); /* gab-A1 */
-      /* but here it also does use the guard point */
+      /* interpolate between adjacent samples */
       tmp = tab[(int32)phase];
       value = tmp + (tab[(int32)phase+1] - tmp) * (phase - (int32) phase);
       }

--- a/OOps/midiops2.c
+++ b/OOps/midiops2.c
@@ -379,7 +379,7 @@
          tab = ftp->ftable;
       /* clamp it */
       value = value >= FL(0.0) ? (value <= 1.0 ? value : FL(1.0)) : FL(0.0);
-      phase = value * (p->ftp->flen - 1); /* gab-A1 */
+      phase = value * (ftp->flen - 1); /* gab-A1 */
       /* but here it also does use the guard point */
       tmp = tab[(int32)phase];
       value = tmp + (tab[(int32)phase+1] - tmp) * (phase - (int32) phase);
@@ -606,5 +606,4 @@
     }
     return OK;
 }
-
 

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -623,6 +623,23 @@ TEST_F (IOTests, testAudioHostBased)
     csoundReset(csound);
 }
 
+TEST_F (IOTests, testCtrl14InitWithTable)
+{
+    ASSERT_EQ(CSOUND_SUCCESS, csoundSetOption(csound, "-n"));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, R"ORC(
+        giTable ftgen 0, 0, 8, -2, 0, 0.25, 0.5, 0.75, 1, 0.75, 0.5, 0.25
+        initc14 1, 1, 33, 1/3
+        iresult ctrl14 1, 1, 33, 2, 10, giTable
+        chnset iresult, "ctrl14-result"
+    )ORC", 0));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+
+    // The table maps 1/3 to 7/12; scaling to [2, 10] gives 20/3.
+    EXPECT_NEAR(20.0 / 3.0,
+                csoundGetControlChannel(csound, "ctrl14-result", nullptr),
+                1e-5);
+}
+
 TEST_F (IOTests, testMidiModules)
 {
     char *name, *type;


### PR DESCRIPTION
Uses the table pointer already resolved by FTFind, which avoids the null p->ftp access on the i-rate path.