### PR TITLE
Size UDP string replies for exact-length strings

### DIFF
--- a/Top/server.c
+++ b/Top/server.c
@@ -307,7 +307,7 @@ static uintptr_t udp_recv(void *pdata){
           if (csoundGetChannelPtr(csound, (void **) &stringdat, chn,
                                   CSOUND_STRING_CHANNEL | CSOUND_OUTPUT_CHANNEL)
               == CSOUND_SUCCESS) {
-            size_t size = stringdat->size + strlen(chn) + 1;
+            size_t size = stringdat->size + strlen(chn) + 2;
             spin_lock_t *lock =
               (spin_lock_t *) get_channel_lock(csound, (char*) chn);
             msg = (char *) csound->Calloc(csound, size);


### PR DESCRIPTION
Allocates room for the channel name, separators, payload, and terminator so exact-size string replies are not truncated.