### PR TITLE
Fix strcat copying unused buffer capacity

### DIFF
--- a/OOps/str_ops.c
+++ b/OOps/str_ops.c
@@ -297,7 +297,8 @@ int32_t str_changed_k(CSOUND *csound, STRCHGD *p)
 int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
 {
   int64_t kcnt = p->h.insdshead->kcounter;
-  size_t size = (int32_t) strlen(p->str1->data) + strlen(p->str2->data);
+  size_t firstLength = strlen(p->str1->data);
+  size_t size = firstLength + strlen(p->str2->data);
   if(size >= MAX_STRINGDAT_SIZE) {
      if(is_perf_thread(&p->h))
      return csound->PerfError(csound, &p->h,
@@ -332,7 +333,7 @@ int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
       p->r->data = temp;
       p->r->size = alloc_size;
     }
-    memcpy(p->r->data, p->str1->data, p->str1->size);
+    memcpy(p->r->data, p->str1->data, firstLength + 1);
     strcat(p->r->data, p->str2->data);
     return OK;
   }
@@ -385,7 +386,7 @@ int32_t strcat_opcode(CSOUND *csound, STRCAT_OP *p)
        p->r->data = temp;
        p->r->size = alloc_size;
     }
-     memcpy(p->r->data, p->str1->data, p->r->size - 1);
+     memcpy(p->r->data, p->str1->data, firstLength + 1);
      strcat(p->r->data,ostr);
      csound->Free(csound, ostr);
      return OK;

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -12,6 +12,10 @@
 #include <stdlib.h>
 #include "csoundCore.h"
 #include "gtest/gtest.h"
+#include <cstring>
+extern "C" {
+#include "str_ops.h"
+}
 
 #define csoundCompileOrc(a,b) csoundCompileOrc(a,b,0)
 #define csoundReadScore(a,b) csoundEventString(a,b,0)
@@ -888,4 +892,35 @@ TEST_F (OrcCompileTests, testAssert)
     // Perform one k-cycle to execute the instrument
     csoundPerformKsmps(csound);
     ASSERT_EQ (6, csoundErrCnt(csound));
+}
+
+TEST_F (OrcCompileTests, StrcatDoesNotCopyUnusedInputCapacity)
+{
+    char firstData[128]{};
+    char outputData[128];
+    char suffixData[] = "[]";
+    std::strcpy(firstData, "i");
+    std::memset(outputData, 'x', sizeof(outputData));
+    outputData[0] = '\0';
+    STRINGDAT first{};
+    STRINGDAT suffix{};
+    STRINGDAT output{};
+    first.data = firstData;
+    first.size = sizeof(firstData);
+    suffix.data = suffixData;
+    suffix.size = sizeof(suffixData);
+    output.data = outputData;
+    output.size = 8;
+    STRCAT_OP op{};
+    INSDS context{};
+    op.h.insdshead = &context;
+    op.r = &output;
+    op.str1 = &first;
+    op.str2 = &suffix;
+
+    ASSERT_EQ(OK, strcat_opcode(csound, &op));
+    EXPECT_STREQ("i[]", output.data);
+    for (size_t i = output.size; i < sizeof(outputData); i++) {
+        EXPECT_EQ('x', outputData[i]) << "write beyond output capacity at " << i;
+    }
 }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -581,6 +581,7 @@ def runTest():
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],
         ["test_string.csd", "test string assignment and printing"],
+        ["test_strcat_buffer_capacity.csd", "strcat copies text rather than buffer capacity"],
         [
             "test_strstrip_reallocation.csd",
             "test strstrip reallocation and termination",

--- a/tests/commandline/test_strcat_buffer_capacity.csd
+++ b/tests/commandline/test_strcat_buffer_capacity.csd
@@ -1,0 +1,37 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m128
+</CsOptions>
+<CsInstruments>
+ksmps = 1
+instr 1
+  Stext init "A long string reserves more storage than its next value needs. Shortening it must not make strcat copy that spare capacity."
+  Stext = "i"
+  Sresult strcat Stext, "[]"
+  if strcmp(Sresult, "i[]") != 0 then
+    exitnow 1
+  endif
+  Sright init "Another long string reserves more storage than the first input has. Prepending must read only the input text."
+  Sright = "b"
+  Sleft = "a"
+  Sright strcat Sleft, Sright
+  if strcmp(Sright, "ab") != 0 then
+    exitnow 1
+  endif
+  Sleft strcat Sleft, "b"
+  Sleft strcat Sleft, Sleft
+  if strcmp(Sleft, "abab") != 0 then
+    exitnow 1
+  endif
+  Sempty = ""
+  Sempty strcat Sempty, Sempty
+  if strlen(Sempty) != 0 then
+    exitnow 1
+  endif
+  prints "strcat buffer capacity passed\n"
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`strcat` copied the first input's buffer capacity rather than its text length. After a string became shorter, copying that unused capacity could write beyond a smaller destination buffer. When the output reused the second input, the copy could also read beyond the first input.

Use the first input's text length plus its terminator for both copies. Keep the existing handling for outputs that reuse either input.

Includes a unit test that checks writes against the destination capacity and an orchestra regression covering separate output storage, aliased inputs and outputs, and empty strings.

No tests were rerun on this branch. The unit test and orchestra regression previously passed under AddressSanitizer on the combined integration branch.
