### PR TITLE
Keep buffer and include path diagnostics at debug level

### DIFF
--- a/Engine/csound_pre.lex
+++ b/Engine/csound_pre.lex
@@ -839,10 +839,10 @@ void do_include(CSOUND *csound, int term, yyscan_t yyscanner)
     PARM->alt_stack[PARM->macro_stack_ptr].line = csound_preget_lineno(yyscanner);
     if (strrchr(buffer,DIRSEP)) {
       PARM->alt_stack[PARM->macro_stack_ptr].path = PARM->path;
-      printf("setting path from %s to ", PARM->path);
       PARM->path = strdup(buffer); /* wasteful! */
       *(strrchr(PARM->path,DIRSEP)) = '\0';
-      printf("%s\n",PARM->path);
+      csound->DebugMsg(csound, "setting path from %s to %s",
+                       PARM->alt_stack[PARM->macro_stack_ptr].path, PARM->path);
     }
     else PARM->alt_stack[PARM->macro_stack_ptr].path = NULL;
     PARM->alt_stack[PARM->macro_stack_ptr].included = 1;

--- a/Engine/linevent.c
+++ b/Engine/linevent.c
@@ -235,7 +235,7 @@ void csoundInputMessage(CSOUND *csound, const char *message) {
     if (!size) return;
     if (UNLIKELY((STA(Linep) + size) >= STA(Linebufend))) {
       int32_t extralloc = (int32_t) (STA(Linep) + size - STA(Linebufend));
-      csound->Message(csound, "realloc %d\n", extralloc);
+      csound->DebugMsg(csound, "realloc %d", extralloc);
       // csound->Message(csound, "extralloc: %d %d %d\n",
       //                 extralloc, size, (int)(STA(Linebufend) - STA(Linep)));
       // FIXME -- Coverity points out that this test is always false


### PR DESCRIPTION
Long realtime score messages print `realloc N`, and orchestra includes print `setting path from ... to ...`, even with debug output disabled.

Route both messages through `DebugMsg` so normal runs stay quiet and verbose debugging still shows them. Emit the path change as one message through Csound's message callback.
