### PR TITLE
fix: validate string getcol column bounds

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -911,7 +911,7 @@ static int32_t cols_perf_S(CSOUND *csound, FFT *p) {
   STRINGDAT* dest = (STRINGDAT*)p->out->data;
   int32_t i;
   int32_t index = (int32_t)(*((MYFLT *)p->in2));
-  if (LIKELY(index < p->in->sizes[0])) {
+  if (LIKELY(index >= 0 && index < p->in->sizes[1])) {
     mem += index;
     for (i = 0; i<p->in->sizes[0]; i++) {
       dat->arrayType->copyValue(csound, dat->arrayType, (void*)dest, (void*)mem,

--- a/tests/commandline/arrays/test_getcol_string.csd
+++ b/tests/commandline/arrays/test_getcol_string.csd
@@ -1,0 +1,19 @@
+<CsoundSynthesizer>
+<CsOptions>
+-ndm0
+</CsOptions>
+<CsInstruments>
+instr 1
+  src:S[][] init 2, 3
+  src fillarray "a", "b", "c", "d", "e", "f"
+  col:S[] getcol src, 2
+  prints "column 2: %s %s\n", col[0], col[1]
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0
+</CsScore>
+</CsoundSynthesizer>
+
+Prints:
+column 2: c f

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -894,6 +894,7 @@ def runTest():
         ["arrays/test_redef_fail.csd", "fail on redefinition of variable by array", 1],
         ["arrays/array_copy.csd", "test for =.generic copy on k-rate only"],
         ["arrays/test_empty_array_init.csd", "test zero-length array initialization"],
+        ["arrays/test_getcol_string.csd", "getcol accepts the last string-array column"],
         [
             "arrays/test_struct_array_reshape_copy.csd",
             "reshaping a struct-array copy preserves its source",


### PR DESCRIPTION
`getcol` for string arrays checked the requested column against the row count. This rejected valid columns when a matrix had more columns than rows, and accepted invalid columns when it had more rows than columns, leading to out-of-bounds reads.

The check now uses the column dimension and rejects negative indexes. A command-line regression test covers the last valid column of a 2x3 string matrix.
