### PR TITLE
fix: validate array row and column bounds

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -739,7 +739,7 @@ static int32_t rows_init(CSOUND *csound, FFT *p) {
 
 static int32_t rows_perf(CSOUND *csound, FFT *p) {
   int32_t start = *((MYFLT *)p->in2);
-  if (LIKELY(start < p->in->sizes[0])) {
+  if (LIKELY(start >= 0 && start < p->in->sizes[0])) {
     int32_t bytes =  p->in->sizes[1]*sizeof(MYFLT);
     start *= p->in->sizes[1];
     memcpy(p->out->data,p->in->data+start,bytes);
@@ -757,7 +757,7 @@ static int32_t rows_perf_S(CSOUND *csound, FFT *p)
   STRINGDAT* dest = (STRINGDAT*)p->out->data;
   int32_t i;
   int32_t index = (int32_t)(*((MYFLT *)p->in2));
-  if (LIKELY(index < p->in->sizes[0])) {
+  if (LIKELY(index >= 0 && index < p->in->sizes[0])) {
     index = (index * dat->sizes[1]);
     //printf("%d : %d\n", index, dat->sizes[1]);
     mem += index;
@@ -804,7 +804,7 @@ static int32_t set_rows_perf_S(CSOUND *csound, FFT *p)
 static int32_t rows_i(CSOUND *csound, FFT *p) {
   if (rows_init(csound,p) == OK) {
     int32_t start = *((MYFLT *)p->in2);
-    if (LIKELY(start < p->in->sizes[0])) {
+    if (LIKELY(start >= 0 && start < p->in->sizes[0])) {
       int32_t bytes =  p->in->sizes[1]*sizeof(MYFLT);
       start *= p->in->sizes[1];
       memcpy(p->out->data,p->in->data+start,bytes);
@@ -878,7 +878,7 @@ static int32_t cols_init(CSOUND *csound, FFT *p) {
 static int32_t cols_perf(CSOUND *csound, FFT *p) {
   int32_t start = *((MYFLT *)p->in2);
 
-  if (LIKELY(start < p->in->sizes[1])) {
+  if (LIKELY(start >= 0 && start < p->in->sizes[1])) {
     int32_t j,i,collen =  p->in->sizes[1], len = p->in->sizes[0];
     for (j=0,i=start; j < len; i+=collen, j++) {
       p->out->data[j] = p->in->data[i];
@@ -892,7 +892,7 @@ static int32_t cols_perf(CSOUND *csound, FFT *p) {
 static int32_t cols_i(CSOUND *csound, FFT *p) {
   if (cols_init(csound, p) == OK) {
     int32_t start = *((MYFLT *)p->in2);
-    if (LIKELY(start < p->in->sizes[1])) {
+    if (LIKELY(start >= 0 && start < p->in->sizes[1])) {
       int32_t j,i,collen =  p->in->sizes[1], len = p->in->sizes[0];
       for (j=0,i=start; j < len; i+=collen, j++) {
         p->out->data[j] = p->in->data[i];

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -911,7 +911,7 @@ static int32_t cols_perf_S(CSOUND *csound, FFT *p) {
   STRINGDAT* dest = (STRINGDAT*)p->out->data;
   int32_t i;
   int32_t index = (int32_t)(*((MYFLT *)p->in2));
-  if (LIKELY(index < p->in->sizes[0])) {
+  if (LIKELY(index >= 0 && index < p->in->sizes[1])) {
     mem += index;
     for (i = 0; i<p->in->sizes[0]; i++) {
       dat->arrayType->copyValue(csound, dat->arrayType, (void*)dest, (void*)mem,
@@ -992,22 +992,16 @@ static int32_t set_cols_i(CSOUND *csound, FFT *p) {
 }
 
 static int32_t set_cols_perf_S(CSOUND *csound, FFT *p) {
-  ARRAYDAT* dat = p->in;      /* The data in 2_D array */
-  STRINGDAT* mem = (STRINGDAT*)dat->data;
+  STRINGDAT* mem = (STRINGDAT*)p->in->data;
   STRINGDAT* dest = (STRINGDAT*)p->out->data;
   int32_t i;
   int32_t index = (int32_t)(*((MYFLT *)p->in2));
-  if (LIKELY(index < p->in->sizes[0])) {
-    index = (index * dat->sizes[1]);
-    //printf("%d : %d\n", index, dat->sizes[1]);
-    mem += index;
-    //incr = (index * (dat->arrayMemberSize / sizeof(MYFLT)));
-    //printf("*** mem = %p dst = %p\n", mem, dest);
+  if (LIKELY(index >= 0 && index < p->out->sizes[1])) {
+    dest += index;
     for (i = 0; i<p->in->sizes[0]; i++) {
-      dat->arrayType->copyValue(csound, dat->arrayType, (void*)mem, (void*)dest,
-                                p->h.insdshead);
-      //printf("*** copies i=%d: %s -> %s\n", i,(char*)(mem->data),(char*)(dest->data));
-      dest += p->in->sizes[1];
+      p->in->arrayType->copyValue(csound, p->in->arrayType,
+                                  (void*)dest, (void*)mem, p->h.insdshead);
+      dest += p->out->sizes[1];
       mem  += 1;
     }
     return OK;

--- a/tests/commandline/arrays/test_getcol_string.csd
+++ b/tests/commandline/arrays/test_getcol_string.csd
@@ -3,7 +3,7 @@
 -ndm0
 </CsOptions>
 <CsInstruments>
-#include "libassert.orc"
+#include "../libassert.orc"
 
 instr 1
   src:S[][] init 2, 3

--- a/tests/commandline/arrays/test_getcol_string.csd
+++ b/tests/commandline/arrays/test_getcol_string.csd
@@ -1,0 +1,30 @@
+<CsoundSynthesizer>
+<CsOptions>
+-ndm0
+</CsOptions>
+<CsInstruments>
+#include "libassert.orc"
+
+instr 1
+  src:S[][] init 2, 3
+  src fillarray "a", "b", "c", "d", "e", "f"
+  col:S[] getcol src, 2
+  assert(strcmp(col[0], "c") == 0, "getcol.S returned the wrong first value\n")
+  assert(strcmp(col[1], "f") == 0, "getcol.S returned the wrong second value\n")
+  turnoff
+endin
+
+instr 2
+  col:S[] init 2
+  col fillarray "X", "Y"
+  out:S[][] setcol col, 2
+  assert(strcmp(out[0][2], "X") == 0, "setcol.S wrote the wrong first value\n")
+  assert(strcmp(out[1][2], "Y") == 0, "setcol.S wrote the wrong second value\n")
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+i 2 0 0.01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/arrays/test_getrow_negative.csd
+++ b/tests/commandline/arrays/test_getrow_negative.csd
@@ -1,0 +1,22 @@
+<CsoundSynthesizer>
+<CsOptions>
+-ndm0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  kArr[][] init 2, 2
+  kArr fillarray 1, 2, 3, 4
+  kIndex init -1000
+  kRow[] getrow kArr, kIndex
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -895,6 +895,7 @@ def runTest():
         ["arrays/array_copy.csd", "test for =.generic copy on k-rate only"],
         ["arrays/test_empty_array_init.csd", "test zero-length array initialization"],
         ["arrays/test_getcol_string.csd", "getcol accepts the last string-array column"],
+        ["arrays/test_getrow_negative.csd", "reject negative getrow index", 1],
         [
             "arrays/test_struct_array_reshape_copy.csd",
             "reshaping a struct-array copy preserves its source",

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -894,6 +894,7 @@ def runTest():
         ["arrays/test_redef_fail.csd", "fail on redefinition of variable by array", 1],
         ["arrays/array_copy.csd", "test for =.generic copy on k-rate only"],
         ["arrays/test_empty_array_init.csd", "test zero-length array initialization"],
+        ["arrays/test_getcol_string.csd", "getcol accepts the last string-array column"],
         [
             "arrays/test_struct_array_reshape_copy.csd",
             "reshaping a struct-array copy preserves its source",


### PR DESCRIPTION
The array row and column operations accepted negative indices because their bounds checks only tested the upper limit. A negative `getrow` or `getcol` index could then read before the array; the string paths had the same gap.

The row and column getters now validate both bounds for numeric and string arrays. The existing string column fixes also use the correct dimensions and strides. Command-line coverage includes the last valid string column and a negative `getrow` index.
