### PR TITLE
fix: validate tabslice increment before division

### DIFF
--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -3879,6 +3879,9 @@ int32_t tabslice(CSOUND *csound, TABSLICE *p) {
   int32_t end   = (int32_t) *p->end >= 0 ? *p->end :
     p->tabin->sizes[0] - 1;
   int32_t inc   = (int32_t) *p->inc;
+  if (UNLIKELY(inc<=0))
+    return csound->InitError(csound, "%s",
+                             Str("slice increment must be positive"));
   int32_t size = (end - start)/inc + 1;
 
   int32_t i, destIndex;
@@ -3892,9 +3895,6 @@ int32_t tabslice(CSOUND *csound, TABSLICE *p) {
     return csound->InitError(csound, "%s",
                              Str("slice larger than original size"));
   }
-  if (UNLIKELY(inc<=0))
-    return csound->InitError(csound, "%s",
-                             Str("slice increment must be positive"));
   if (UNLIKELY(tabinit(csound, p->tab, size, p->h.insdshead) != OK))
     return csound_array_init_resize_error(csound);
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -659,6 +659,7 @@ def runTest():
         ["test_karrays_udo.csd", "UDO with k[] arg"],
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
+        ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
         ["test_newstyle_passbycopy.csd", "test newstyle udo with setksmps"],
         ["test_polymorphic_udo.csd", "test polymorphic udo"],
         ["test_udo_a_array.csd", "test udo with a-array"],

--- a/tests/commandline/test_tabslice_increment.csd
+++ b/tests/commandline/test_tabslice_increment.csd
@@ -1,0 +1,35 @@
+<CsoundSynthesizer>
+<CsOptions>
+-ndm0
+</CsOptions>
+<CsInstruments>
+opcode assertK,0,kk
+  kActual, kExpected xin
+  if kActual != kExpected then
+    printks "tabslice returned %f, expected %f\n", 1, kActual, kExpected
+    exitnowk(-1)
+  endif
+endop
+
+instr 1
+  src:k[] init 4
+  src fillarray 1, 2, 3, 4
+  dst:k[] init 3
+  dst tabslice src, 1, 3, 1
+  assertK dst[0], 2
+  assertK dst[1], 3
+  assertK dst[2], 4
+  turnoff
+endin
+
+instr 2
+  src:k[] init 4
+  src fillarray 1, 2, 3, 4
+  dst:k[] tabslice src, 0, 3, 0
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.01
+i 2 0 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`tabslice` calculated its output length by dividing by the increment before validating that the increment was positive. A zero increment therefore triggered undefined division-by-zero behavior before the intended error path.

The increment check now runs first. The CSD regression test covers a valid slice with assertions and exercises zero increment as an expected failure.
