### PR TITLE
fix: wrap non-power-of-two tablemix source

### DIFF
--- a/OOps/ugtabs.c
+++ b/OOps/ugtabs.c
@@ -717,7 +717,7 @@ int32_t table_mix(CSOUND *csound, TABLMIX *p) {
                       Str("table: could not find ftable %d"), (int32_t) *p->tab1);
       return NOTOK;
     }
-    np21 = isPowerOfTwo(ftp->flen) ? 0 : 1;
+    np21 = isPowerOfTwo(ftp1->flen) ? 0 : 1;
 
     if (UNLIKELY((ftp2 = csound->FTFind(csound, p->tab2)) == NULL)) {
       csound->Warning(csound,

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -695,6 +695,10 @@ def runTest():
             "test multiple operations on multiple array types",
         ],
         [
+            "test_tablemix_nonpower_source.csd",
+            "test tableimix wraps a non-power-of-two source table",
+        ],
+        [
             "prints_number_no_crash.csd",
             "test prints does not crash when given a number arguments"
         ],

--- a/tests/commandline/test_tablemix_nonpower_source.csd
+++ b/tests/commandline/test_tablemix_nonpower_source.csd
@@ -1,0 +1,34 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+#include "libassert.orc"
+
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giDest ftgen 1, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
+giSrc1 ftgen 2, 0, 6, -2, 10, 20, 30, 40, 50, 60
+giSrc2 ftgen 3, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
+
+instr 1
+  tableimix 1, 0, 8, 2, 0, 1, 3, 0, 0
+  assertEquals(table:i(0, 1), 10)
+  assertEquals(table:i(1, 1), 20)
+  assertEquals(table:i(2, 1), 30)
+  assertEquals(table:i(3, 1), 40)
+  assertEquals(table:i(4, 1), 50)
+  assertEquals(table:i(5, 1), 60)
+  assertEquals(table:i(6, 1), 10)
+  assertEquals(table:i(7, 1), 20)
+  prints "tableimix non-power source passed"
+  exitnow 0
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`table_mix()` derived the source-1 wrapping mode from the destination table length. When a power-of-two destination mixed a shorter non-power-of-two source, the source index used `0xFFFFFFFF` as a mask and read past the source table.

Derive the mode from source 1 so its index wraps at the source length. Add coverage for the mismatched table lengths that exposed the out-of-bounds read.
