### PR TITLE
fix: wrap non-power-of-two tablemix indexes

### DIFF
--- a/OOps/ugtabs.c
+++ b/OOps/ugtabs.c
@@ -717,7 +717,7 @@ int32_t table_mix(CSOUND *csound, TABLMIX *p) {
                       Str("table: could not find ftable %d"), (int32_t) *p->tab1);
       return NOTOK;
     }
-    np21 = isPowerOfTwo(ftp->flen) ? 0 : 1;
+    np21 = isPowerOfTwo(ftp1->flen) ? 0 : 1;
 
     if (UNLIKELY((ftp2 = csound->FTFind(csound, p->tab2)) == NULL)) {
       csound->Warning(csound,

--- a/OOps/ugtabs.c
+++ b/OOps/ugtabs.c
@@ -747,7 +747,7 @@ int32_t table_mix(CSOUND *csound, TABLMIX *p) {
         p2 = i+off2;
         if (np2) {
           while(p0 < 0) p0 += flen;
-          while(p0 >= len1) p0 -= flen;
+          while(p0 >= flen) p0 -= flen;
         }
         else p0 &= ftp->lenmask;
         if (np21) {
@@ -770,7 +770,7 @@ int32_t table_mix(CSOUND *csound, TABLMIX *p) {
         p2 = i+off2;
         if (np2) {
           while(p0 < 0) p0 += flen;
-          while(p0 >= len1) p0 -= flen;
+          while(p0 >= flen) p0 -= flen;
         }
         else p0 &= ftp->lenmask;
         if (np21) {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -695,6 +695,10 @@ def runTest():
             "test multiple operations on multiple array types",
         ],
         [
+            "test_tablemix_nonpower_source.csd",
+            "test tableimix wraps a non-power-of-two source table",
+        ],
+        [
             "prints_number_no_crash.csd",
             "test prints does not crash when given a number arguments"
         ],

--- a/tests/commandline/test_tablemix_nonpower_source.csd
+++ b/tests/commandline/test_tablemix_nonpower_source.csd
@@ -1,0 +1,34 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -m0
+</CsOptions>
+<CsInstruments>
+#include "libassert.orc"
+
+sr = 44100
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giDest ftgen 1, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
+giSrc1 ftgen 2, 0, 6, -2, 10, 20, 30, 40, 50, 60
+giSrc2 ftgen 3, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
+
+instr 1
+  tableimix 1, 0, 8, 2, 0, 1, 3, 0, 0
+  assertEquals(table:i(0, 1), 10)
+  assertEquals(table:i(1, 1), 20)
+  assertEquals(table:i(2, 1), 30)
+  assertEquals(table:i(3, 1), 40)
+  assertEquals(table:i(4, 1), 50)
+  assertEquals(table:i(5, 1), 60)
+  assertEquals(table:i(6, 1), 10)
+  assertEquals(table:i(7, 1), 20)
+  prints "tableimix non-power source passed"
+  exitnow 0
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_tablemix_nonpower_source.csd
+++ b/tests/commandline/test_tablemix_nonpower_source.csd
@@ -13,6 +13,9 @@ nchnls = 1
 giDest ftgen 1, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
 giSrc1 ftgen 2, 0, 6, -2, 10, 20, 30, 40, 50, 60
 giSrc2 ftgen 3, 0, 8, -2, 0, 0, 0, 0, 0, 0, 0, 0
+giDestNonPower ftgen 4, 0, 500, 7, 0, 500, 0
+giSrcNonPower ftgen 5, 0, 300, 7, 10, 300, 20
+giSrcNonPower2 ftgen 6, 0, 500, 7, 0, 500, 0
 
 instr 1
   tableimix 1, 0, 8, 2, 0, 1, 3, 0, 0
@@ -25,10 +28,19 @@ instr 1
   assertEquals(table:i(6, 1), 10)
   assertEquals(table:i(7, 1), 20)
   prints "tableimix non-power source passed"
+  turnoff
+endin
+
+instr 2
+  tableimix 4, 0, 500, 5, 0, 1, 6, 0, 0
+  assert(abs(table:i(300, 4) - 0.5) < 1e-6,
+         "tableimix did not wrap the destination index\n")
+  prints "tableimix non-power destination passed"
   exitnow 0
 endin
 </CsInstruments>
 <CsScore>
 i1 0 1
+i2 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
`table_mix()` used the wrong table lengths for non-power-of-two wrapping. Source-1 wrapping could read past a short source table, while destination wrapping could turn a valid destination index negative when the destination was shorter than the source.

The source and destination paths now wrap against their own table lengths. One command-line CSD covers both mismatched-length cases and checks the wrapped values.
