### PR TITLE
fix: reject unmatched score parentheses

### DIFF
--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -1121,7 +1121,20 @@ static MYFLT read_expression(CSOUND *csound)
           *++op = c; c = getscochar(csound, 1); break;
         case ')':
           if (UNLIKELY(!type)) {
-            scorerr(csound, Str("missing operand before ')' in [] expression"));
+            csound->inerrcnt++;
+            csound->ErrorMsg(csound,
+                             Str("score error: missing operand before ')' in [] expression"));
+            print_input_backtrace(csound, 1, csoundErrorMsg);
+            flushlin(csound);
+            return FL(0.0);
+          }
+          if (UNLIKELY(*op != '(')) {
+            csound->inerrcnt++;
+            csound->ErrorMsg(csound,
+                             Str("score error: unmatched ')' in [] expression"));
+            print_input_backtrace(csound, 1, csoundErrorMsg);
+            flushlin(csound);
+            return *pv;
           }
           while (*op != '(') {
             MYFLT v = operate(csound, *(pv-1), *pv, *op);

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -864,6 +864,27 @@ i 1 0 -1
   result = csoundPerformKsmps(csound);
 }
 
+TEST (ScoreCompileTests, testUnmatchedScoreParenthesis)
+{
+  CSOUND *csound = csoundCreate(NULL, NULL);
+  const char* csd = R"(
+<CsoundSynthesizer>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+instr 1
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1 [1)
+</CsScore>
+</CsoundSynthesizer>
+  )";
+  EXPECT_EQ(CSOUND_ERROR, csoundCompileCSD(csound, csd, 1, 0));
+  csoundDestroy(csound);
+}
+
 TEST_F (OrcCompileTests, testAssert)
 {
     int32_t result;


### PR DESCRIPTION
An unmatched `)` in a score expression can empty the operator stack, then the parser dereferences the missing stack entry while reducing the expression. This change reports malformed closing parentheses as a score compile error, flushes the rest of the malformed score line, and returns safely.

The regression test compiles a score containing `[1)` and verifies that `csoundCompileCSD` returns `CSOUND_ERROR` without crashing.
