### PR TITLE
fix: scale gbuzz non-power-of-two table index

### DIFF
--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -222,7 +222,7 @@ int32_t gbuzz(CSOUND *csound, GBUZZ *p)
       num = ftbl[(int32_t)(PHMOD1(fphs*k)*flen)]
         - r * ftbl[(int32_t)(PHMOD1(fphs*km1)*flen)]
         - p->rtn * ftbl[(int32_t)(PHMOD1(fphs*kpn)*flen)]
-        + p->rtnp1 * ftbl[(int32_t)(PHMOD1(fphs*kpnm1))]*flen;
+        + p->rtnp1 * ftbl[(int32_t)(PHMOD1(fphs*kpnm1)*flen)];
       if (LIKELY(denom > FL(0.0002) || denom < -FL(0.0002))) {
         ar[n] = last = num / denom * scal;
       }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -578,6 +578,7 @@ def runTest():
         ["test_voice_init.csd", "voice initializes its SingWave helper"],
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
+        ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],
         ["test_string.csd", "test string assignment and printing"],

--- a/tests/commandline/test_gbuzz_nonpower_phase.csd
+++ b/tests/commandline/test_gbuzz_nonpower_phase.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -m0 -n
+</CsOptions>
+<CsInstruments>
+sr=48000
+ksmps=1
+nchnls=1
+0dbfs=1
+
+instr 1
+  asig gbuzz .01, 480, 3, 1, 0.5, 1
+  kval downsamp asig
+  kcount init 0
+  if kcount == 0 then
+    if abs(kval - 0.01) > 0.0001 then
+      printks "gbuzz first sample mismatch: expected .01, got %f\\n", 1, kval
+      exitnowk(-1)
+    endif
+  endif
+  kcount += 1
+endin
+</CsInstruments>
+<CsScore>
+f 1 0 100 11 1
+i 1 0 0.01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`gbuzz` produced incorrect output whenever its function table had a non-power-of-two length. In the float-phase path, the final partial converted the normalized phase to an integer before multiplying by the table length. That always selected table entry zero and then scaled the sample by the table length.

This changes the lookup to match the other partial terms and adds a command-line regression case using a 100-point table.
