### PR TITLE
fix: interpolate envlpx float phases correctly

### DIFF
--- a/OOps/ugens1.c
+++ b/OOps/ugens1.c
@@ -1455,7 +1455,7 @@ int32_t knvlpx(CSOUND *csound, ENVLPX *p)
       v1 = *ftab++;
       fact = (v1 + (*ftab - v1) * fract);
       phsf += p->kif;
-      if (phs >= FL(1.0)) {  
+      if (phsf >= FL(1.0)) {
         p->val = *(ftp->ftable + ftp->flen - 1); // unlikely to have ext gp
         if (UNLIKELY(!p->val)) {
           return csound->PerfError(csound, &(p->h),
@@ -1614,11 +1614,11 @@ int32_t envlpx(CSOUND *csound, ENVLPX *p)
         p->phs = phs;
       } else {
         MYFLT posf = phsf*flen;
-        fract = pos - (int32_t) posf;
+        fract = posf - (int32_t) posf;
         v1 = ftab[(int32_t) posf];
         fact = (v1 + (ftab[(int32_t)posf+1] - v1) * fract);
         phsf += p->kif;
-        if (phs >= FL(1.0)) {
+        if (phsf >= FL(1.0)) {
           p->val = ftab[flen - 1]; // unlikely to have ext gp
           p->val -= p->asym;
           phsf = FL(-1.0);
@@ -1809,7 +1809,7 @@ int32_t knvlpxr(CSOUND *csound, ENVLPR *p)
         MYFLT v1 = *ftab++;
         fact = (v1 + (*ftab - v1) * fract);
         phsf += p->kif;
-        if (phs  < FL(1.0) || p->rlsing)  
+        if (phsf < FL(1.0) || p->rlsing)
           p->val = fact;
         else {
           p->val = *(ftp->ftable + ftp->flen - 1);
@@ -1898,13 +1898,13 @@ int32_t envlpxr(CSOUND *csound, ENVLPR *p)
         } else {
           MYFLT fpos = phsf*flen;
           fract = fpos - (int32_t) fpos;
-          v1 = ftab[pos];
-          fact = (v1 + (ftab[pos+1] - v1) * fract);
+          v1 = ftab[(int32_t) fpos];
+          fact = (v1 + (ftab[(int32_t) fpos+1] - v1) * fract);
           phsf += p->kif;
-          if (phs >= 1.) {
+          if (phsf >= 1.) {
             val = ftab[p->ftp->flen];
             val -= p->asym;
-            phs = -1;
+            phsf = -1;
           }
           else val = fact;      
           p->phsf = phsf;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -579,6 +579,7 @@ def runTest():
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
+        ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],
         ["test_string.csd", "test string assignment and printing"],

--- a/tests/commandline/test_envlpx_float_interpolation.csd
+++ b/tests/commandline/test_envlpx_float_interpolation.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -m0 -n
+</CsOptions>
+<CsInstruments>
+sr=48000
+ksmps=1
+nchnls=1
+0dbfs=1
+instr 1
+  kenv envlpx 1, 1, 1, .1, 1, 1, .1
+  kcount init 0
+  if kcount == 1 then
+    if abs(kenv - 0.0000208333) > 0.00001 then
+      printks "envlpx second sample mismatch: expected about .000021, got %f\\n", 1, kenv
+      exitnowk(-1)
+    endif
+  endif
+  kcount += 1
+endin
+</CsInstruments>
+<CsScore>
+f 1 0 -100 -7 0 100 1
+i 1 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
On non-power-of-two function tables, envlpx's float-phase path computed the interpolation fraction from `pos`, an uninitialized integer phase index. It also used the integer `phs` for end-of-rise checks. This produced wrong envelope values and could leave the completion state incorrect.

The related float-phase branches in `knvlpx`, `knvlpxr`, and `envlpxr` had the same stale phase or index use. The patch uses `posf` for interpolation and `phsf` for phase checks, including float-path table indexing in `envlpxr`. A command-line regression covers a 100-point envelope table.
