### PR TITLE
fix: reject undersized ftest wave tables

### DIFF
--- a/Opcodes/ftest.c
+++ b/Opcodes/ftest.c
@@ -141,6 +141,9 @@ static int32_t wavetable(FGDATA *ff, FUNC *ftp)
   srcfil = csound->FTFind(csound, &ff->e.p[5]);
   if (srcfil==NULL)
     return csound->InitError(csound, "%s", Str("ftable number does not exist\n"));
+  if (UNLIKELY(ftp->flen < srcfil->flen))
+    return csound->FtError(ff, "%s",
+                           Str("wave table size is smaller than source table size"));
   if (UNLIKELY(nargs < 3))
     csound->Warning(csound, "%s", Str("insufficient arguments"));
   fp_filter = srcfil->ftable;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -553,6 +553,10 @@ def runTest():
             "expected failure: GEN42 probability total overflows",
             1,
         ],
+        [
+            "test_ftest_wave_short_destination.csd",
+            "reject an undersized wave table without crashing",
+        ],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],

--- a/tests/commandline/test_ftest_wave_short_destination.csd
+++ b/tests/commandline/test_ftest_wave_short_destination.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-d -m0 -n
+</CsOptions>
+<CsInstruments>
+sr=48000
+ksmps=32
+nchnls=1
+instr 1
+endin
+</CsInstruments>
+<CsScore>
+f 2 0 64 10 1
+f 1 0 32 "wave" 2 1 0
+i 1 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
The `wave` ftable generator computes its deconvolution step count from `ftp->flen / srcfil->flen` without checking the destination size first. When the destination is smaller than the source, integer division produces zero, `log2(0)` becomes negative infinity, and the invalid step count leads to memory errors.

Reject undersized destination tables before the calculation so malformed `wave` definitions report a Csound ftable error and valid source and destination sizes keep their current behavior. The change includes a command-line regression for the undersized case.
