### PR TITLE
fix: reject unmatched score brackets

### DIFF
--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -1166,6 +1166,14 @@ static MYFLT read_expression(CSOUND *csound)
           if (UNLIKELY(!type)) {
             scorerr(csound, Str("missing operand before closing bracket in []"));
           }
+          if (UNLIKELY(*op != '[')) {
+            csound->inerrcnt++;
+            csound->ErrorMsg(csound,
+                             Str("score error: unmatched ']' in [] expression"));
+            print_input_backtrace(csound, 1, csoundErrorMsg);
+            flushlin(csound);
+            return *pv;
+          }
           while (*op != '[') {
             MYFLT v = operate(csound, *(pv-1), *pv, *op);
             op--; pv--;

--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -1128,6 +1128,11 @@ static MYFLT read_expression(CSOUND *csound)
             flushlin(csound);
             return FL(0.0);
           }
+          while (*op != '(' && *op != '[') {
+            MYFLT v = operate(csound, *(pv-1), *pv, *op);
+            op--; pv--;
+            *pv = v;
+          }
           if (UNLIKELY(*op != '(')) {
             csound->inerrcnt++;
             csound->ErrorMsg(csound,
@@ -1135,11 +1140,6 @@ static MYFLT read_expression(CSOUND *csound)
             print_input_backtrace(csound, 1, csoundErrorMsg);
             flushlin(csound);
             return *pv;
-          }
-          while (*op != '(') {
-            MYFLT v = operate(csound, *(pv-1), *pv, *op);
-            op--; pv--;
-            *pv = v;
           }
           type = 1;
           op--; c = getscochar(csound, 1); break;

--- a/Engine/sread.c
+++ b/Engine/sread.c
@@ -1166,6 +1166,11 @@ static MYFLT read_expression(CSOUND *csound)
           if (UNLIKELY(!type)) {
             scorerr(csound, Str("missing operand before closing bracket in []"));
           }
+          while (*op != '[' && *op != '(') {
+            MYFLT v = operate(csound, *(pv-1), *pv, *op);
+            op--; pv--;
+            *pv = v;
+          }
           if (UNLIKELY(*op != '[')) {
             csound->inerrcnt++;
             csound->ErrorMsg(csound,
@@ -1173,11 +1178,6 @@ static MYFLT read_expression(CSOUND *csound)
             print_input_backtrace(csound, 1, csoundErrorMsg);
             flushlin(csound);
             return *pv;
-          }
-          while (*op != '[') {
-            MYFLT v = operate(csound, *(pv-1), *pv, *op);
-            op--; pv--;
-            *pv = v;
           }
           //printf("done ]*** *op=%c v=%lg (%c)\n", *op, *pv, c);
           //getscochar(csound, 1);

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -889,6 +889,27 @@ i1 0 1 [1)
   csoundDestroy(csound);
 }
 
+TEST (ScoreCompileTests, testUnmatchedScoreBracket)
+{
+  CSOUND *csound = csoundCreate(NULL, NULL);
+  const char* csd = R"(
+<CsoundSynthesizer>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 1
+instr 1
+endin
+</CsInstruments>
+<CsScore>
+i1 0 1 [(1+2]
+</CsScore>
+</CsoundSynthesizer>
+  )";
+  EXPECT_EQ(CSOUND_ERROR, csoundCompileCSD(csound, csd, 1, 0));
+  csoundDestroy(csound);
+}
+
 TEST_F (OrcCompileTests, testAssert)
 {
     int32_t result;


### PR DESCRIPTION
Malformed score expressions with an unmatched closing bracket could underflow the score parser's operator and value stacks.

For example, `i1 0 1 [(1+2]` reached the `]` handler while `(` was still on the operator stack. The handler kept reducing until it found `[`, reading before the stack arrays and aborting during score compilation.

This change reports an unmatched `]` and stops parsing before the stack can underflow. It also adds a regression test for the malformed expression.
