### PR TITLE
fix: preserve oscbnk float phase between blocks

### DIFF
--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -396,7 +396,8 @@ static int32_t oscbnkset(CSOUND *csound, OSCBNK *p)
     csound->AuxAlloc(csound, i, &(p->auxdata));
   p->osc = (OSCBNK_OSC *) p->auxdata.auxp;
 
-  memset(p->outft, 0, p->outft_len*sizeof(MYFLT));
+  if (p->outft != NULL)
+    memset(p->outft, 0, p->outft_len*sizeof(MYFLT));
 
   p->floatph = (!IS_POW_TWO(p->flen1)) | (!IS_POW_TWO(p->flen2));
   /* initialise oscillators */

--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -623,6 +623,7 @@ static int32_t oscbnk(CSOUND *csound, OSCBNK *p)
     /* save amplitude and phase */
     o->osc_amp = a;
     o->osc_phs = ph;
+    o->osc_phsf = phf;
   }
   p->init_k = 0;
   return OK;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -583,6 +583,7 @@ def runTest():
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
+        ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],

--- a/tests/commandline/test_oscbnk_float_phase_state.csd
+++ b/tests/commandline/test_oscbnk_float_phase_state.csd
@@ -1,0 +1,46 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 1000
+kr = 125
+ksmps = 8
+nchnls = 1
+; A non-power-of-two table selects oscbnk's float-phase path.
+giTable ftgen 1, 0, 100, -7, 0, 100, 1
+
+gkBlock init 0
+gkPrevious init 0
+gkBad init 0
+
+instr 1
+  a1 oscbnk 100, 0, 0, 0, 1, 1234, 0.1, 0.2, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 1, 1, 0, 0, 0, 0, 0, 0
+  kFirst downsamp a1
+  if gkBlock > 0 then
+    if kFirst != 0 then
+      if abs(kFirst - gkPrevious) < 0.001 then
+        gkBad = 1
+      endif
+    endif
+  endif
+  gkPrevious = kFirst
+  gkBlock += 1
+  if gkBlock >= 6 then
+    turnoff
+  endif
+endin
+
+instr 2
+  if gkBad != 0 then
+    printks "oscbnk float phase did not advance between blocks\n", 0
+    exitnowk(1)
+  endif
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 0.08
+i 2 0.06 0.01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
When `oscbnk` uses a non-power-of-two oscillator table, the float-phase path advances a local phase value for each sample but only stores the integer phase at the end of the performance block. The next block starts from the old float phase, repeating the same waveform segment.

Store the updated float phase with the other oscillator state so non-power-of-two tables continue across blocks. Add a command-line regression case for this path.
