### PR TITLE
fix: wrap grain2 float window phase

### DIFF
--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -876,7 +876,7 @@ static int32_t grain2(CSOUND *csound, GRAIN2 *p)
         if (w_interp) a += (pos - n)*(w_ft[n+1] - a);
         o->window_phsf += wf;
         if (o->window_phsf >= FL(1.0)) {
-          o->window_phs = PHMOD1(o->window_phs);       /* new grain    */
+          o->window_phsf = PHMOD1(o->window_phsf);     /* new grain    */
           grain2_init_grain(p, o);
           /* grain frequency */
           if (f_nolock) {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -582,6 +582,7 @@ def runTest():
         ["test_voice_init.csd", "voice initializes its SingWave helper"],
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
+        ["test_grain2_float_window_wrap.csd", "grain2 wraps non-power-of-two window phase"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],

--- a/tests/commandline/test_grain2_float_window_wrap.csd
+++ b/tests/commandline/test_grain2_float_window_wrap.csd
@@ -1,0 +1,32 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+; A non-power-of-two window table selects grain2's float-phase path.
+giwave ftgen 1, 0, 16, 7, 1, 16, 1
+giwindow ftgen 2, 0, 18, 7, 0, 18, 1
+gkcount init 0
+
+instr 1
+  aout grain2 1, 0, 0.0001, 1, 1, 2, 1, 1, 8
+  ksample downsamp aout
+  if gkcount == 5 then
+    ; After the first window, phase 1.041666... wraps to .041666...
+    if abs(ksample - (1.0 / 24.0)) > 0.02 then
+      printks "grain2 float window phase did not wrap: %.9f\n", 0, ksample
+      exitnowk(-1)
+    endif
+  endif
+  gkcount += 1
+endin
+</CsInstruments>
+<CsScore>
+i1 0 0.001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`grain2` leaves its floating-point window phase above 1.0 when a non-power-of-two window wraps, then uses that value to index the window table. This can read past the table and corrupt output.

Wrap `window_phsf` in the float-phase path before starting the next grain.
