### PR TITLE
fix: initialize grain3 float density phase

### DIFF
--- a/Opcodes/oscbnk.c
+++ b/Opcodes/oscbnk.c
@@ -912,6 +912,7 @@ static int32_t grain3set(CSOUND *csound, GRAIN3 *p)
   p->init_k = 1;
   p->mode = i & 0x7E;
   p->x_phs = OSCBNK_PHSMAX;
+  p->x_phsf = FL(1.0);
 
   p->ovrlap = (int32_t) MYFLT2LONG(*(p->imaxovr));        /* max. overlap */
   p->ovrlap = (p->ovrlap < 1 ? 1 : p->ovrlap) + 1;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -582,6 +582,7 @@ def runTest():
         ["test_voice_init.csd", "voice initializes its SingWave helper"],
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
+        ["test_grain3_float_density_start.csd", "grain3 float path should start its first grain immediately"],
         ["test_grain2_float_window_wrap.csd", "grain2 wraps non-power-of-two window phase"],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],

--- a/tests/commandline/test_grain3_float_density_start.csd
+++ b/tests/commandline/test_grain3_float_density_start.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+giw ftgen 1, 0, 18, 7, 1, 18, 1
+gis ftgen 2, 0, 16, 7, 1, 16, 1
+gkcount init 0
+
+instr 1
+  aout grain3 100, 0, 0, 0, 0.001, 100, 1, 2, 1, 0, 0, 1234, 0
+  ksample downsamp aout
+  if gkcount == 0 then
+    if ksample < 0.5 then
+      printks "grain3 float scheduler did not start a grain: %.9f\\n", 0, ksample
+      exitnowk(-1)
+    endif
+  endif
+  gkcount += 1
+endin
+</CsInstruments>
+<CsScore>
+i1 0 0.012
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`grain3` does not initialize its floating-point density phase, so non-power-of-two window tables delay the first grain until a full density cycle has elapsed.

Initialize the floating-point density phase alongside the integer phase so both render paths start at the same point.
