### PR TITLE
fix: stop diskgrain and syncloop grains at envelope end

### DIFF
--- a/Opcodes/syncgrain.c
+++ b/Opcodes/syncgrain.c
@@ -338,7 +338,7 @@ static int32_t syncgrainloop_process(CSOUND *csound, syncgrainloop *p)
         /* if the envelope is finished */
         /* the grain is also finished */
 
-        if (UNLIKELY(envindex[j] > envtablesize))
+        if (UNLIKELY(envindex[j] >= envtablesize))
           streamon[j] = 0;
       }
 

--- a/Opcodes/syncgrain.c
+++ b/Opcodes/syncgrain.c
@@ -668,6 +668,11 @@ static int32_t filegrain_process(CSOUND *csound, filegrain *p)
         if (index[j]  < 0)
           index[j] += dataframes;
 
+        if (UNLIKELY(envindex[j] >= envtablesize)) {
+          streamon[j] = 0;
+          continue;
+        }
+
         /* sum all the grain streams */
         tndx = (int32_t)index[j]*chans;
         endx = (int32_t) envindex[j];
@@ -692,7 +697,7 @@ static int32_t filegrain_process(CSOUND *csound, filegrain *p)
 
         /* if the envelope is finished */
         /* the grain is also finished */
-        if (envindex[j] > envtablesize)
+        if (envindex[j] >= envtablesize)
           streamon[j] = 0;
       }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -584,6 +584,7 @@ def runTest():
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],
         ["test_grain2_float_window_wrap.csd", "grain2 wraps non-power-of-two window phase"],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
+        ["test_diskgrain_envelope_bounds.csd", "diskgrain stops at envelope table bounds"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -585,6 +585,7 @@ def runTest():
         ["test_grain2_float_window_wrap.csd", "grain2 wraps non-power-of-two window phase"],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
         ["test_diskgrain_envelope_bounds.csd", "diskgrain stops at envelope table bounds"],
+        ["test_syncloop_envelope_end.csd", "syncloop retires grains at the envelope end"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],

--- a/tests/commandline/test_diskgrain_envelope_bounds.csd
+++ b/tests/commandline/test_diskgrain_envelope_bounds.csd
@@ -1,0 +1,43 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  kcount init 0
+  kgrsize = 8/sr
+  ; Start a grain every two samples, then finish all three active grains at
+  ; once. The next sample must skip the two that remain behind the first one.
+  if kcount >= 4 then
+    kgrsize = 1/sr
+  endif
+
+  aexact diskgrain "beats.wav", 1, 1, 1, 4/sr, 0, 1, 1
+  aoverlap diskgrain "beats.wav", 1, sr/2, 0, kgrsize, 0, 1, 4
+  kexact downsamp aexact
+  koverlap downsamp aoverlap
+  kcount = kcount + 1
+
+  if kcount == 5 then
+    if abs(kexact) > 0.001 then
+      printks "diskgrain read past the exact envelope end\n", 0
+      exitnowk(-1)
+    endif
+  elseif kcount == 6 then
+    if abs(koverlap) > 0.001 then
+      printks "diskgrain read a finished overlapping grain\n", 0
+      exitnowk(-1)
+    endif
+  endif
+endin
+</CsInstruments>
+<CsScore>
+f1 0 4 -2 1 1 1 1
+i1 0 0.001
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_syncloop_envelope_end.csd
+++ b/tests/commandline/test_syncloop_envelope_end.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  ; Four-sample grains start every four samples. Each old grain must retire
+  ; before its overlap slot is reused, keeping the output at one.
+  aout syncloop 1, 2000, 1, 0.0005, 0, 0, 0.001, 1, 2, 1
+  kout downsamp aout
+  if !(abs(kout - 1) <= 0.001) then
+    printks "syncloop envelope-end mismatch: actual=%.9f expected=1\n", 0, kout
+    exitnowk(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+f1 0 8 -2 1 1 1 1 1 1 1 1
+f2 0 4 -2 1 1 1 1
+i1 0 0.003
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Stop diskgrain grains when the envelope index reaches the table length. The previous `>` check allowed interpolation to read past the table's guard sample at the exact endpoint.

Also check the envelope index before interpolation: several overlapping grains can finish together, while cleanup removes only one per sample. Skip the finished grains still awaiting cleanup to prevent further out-of-bounds reads.

Apply the `>=` completion check to syncloop too. Its interpolation already checks the bounds, but grains at the exact endpoint stayed marked active, causing duplicate output when overlap slots were reused.
