### PR TITLE
fix: validate olabuffer overlap before integer arithmetic

### DIFF
--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -201,10 +201,10 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
 {
     MYFLT overlapCount = *self->overlapArgument;
 
-    if (UNLIKELY(floor(overlapCount) != overlapCount)) {
+    if (UNLIKELY(overlapCount <= FL(0.0) || floor(overlapCount) != overlapCount)) {
 
-      csound->Die(csound,
-                  "%s", Str("olabuffer: Error, overlap factor must be an integer"));
+      csound->Die(csound, "%s",
+                  Str("olabuffer: Error, overlap factor must be a positive integer"));
     }
 
     ARRAYDAT *array = (ARRAYDAT *) self->inputArgument;
@@ -217,7 +217,8 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
 
     int32_t frameSampleCount = array->sizes[0];
 
-    if (UNLIKELY(frameSampleCount <= (int32_t)overlapCount)) {
+    /* Check the bound before converting the overlap factor to int32_t. */
+    if (UNLIKELY((double)frameSampleCount <= (double)overlapCount)) {
 
       csound->Die(csound,
                   "%s", Str("olabuffer: Error, k-rate array size must be "

--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -89,11 +89,13 @@
 ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument);
 void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self);
 
-void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self);
+int32_t OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self);
 
 int32_t OLABuffer_initialise(CSOUND *csound, OLABuffer *self)
 {
-    OLABuffer_checkArgumentSanity(csound, self);
+    int32_t result = OLABuffer_checkArgumentSanity(csound, self);
+    if (UNLIKELY(result != OK))
+      return result;
     self->inputArray = (ARRAYDAT *)self->inputArgument;
     self->frameSamplesCount = self->inputArray->sizes[0];
     self->framesCount = *self->overlapArgument;
@@ -197,13 +199,13 @@ int32_t OLABuffer_process(CSOUND *csound, OLABuffer *self)
     return OK;
 }
 
-void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
+int32_t OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
 {
     MYFLT overlapCount = *self->overlapArgument;
 
     if (UNLIKELY(overlapCount <= FL(0.0) || floor(overlapCount) != overlapCount)) {
 
-      csound->Die(csound, "%s",
+      return csound->InitError(csound, "%s",
                   Str("olabuffer: Error, overlap factor must be a positive integer"));
     }
 
@@ -211,7 +213,7 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
 
     if (UNLIKELY(array->dimensions != 1)) {
 
-      csound->Die(csound, "%s",
+      return csound->InitError(csound, "%s",
                   Str("olabuffer: Error, k-rate array must be one dimensional"));
     }
 
@@ -220,24 +222,25 @@ void OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
     /* Check the bound before converting the overlap factor to int32_t. */
     if (UNLIKELY((double)frameSampleCount <= (double)overlapCount)) {
 
-      csound->Die(csound,
+      return csound->InitError(csound,
                   "%s", Str("olabuffer: Error, k-rate array size must be "
                       "larger than ovelap factor"));
     }
 
     if (UNLIKELY(frameSampleCount % (int32_t)overlapCount != 0)) {
 
-      csound->Die(csound, "%s", Str("olabuffer: Error, overlap factor must be "
+      return csound->InitError(csound, "%s", Str("olabuffer: Error, overlap factor must be "
                               "an integer multiple of k-rate array size"));
     }
 
     if (UNLIKELY(frameSampleCount / (int32_t)overlapCount <
                  (int32_t) self->h.insdshead->ksmps)) {
 
-      csound->Die(csound, "%s", Str("olabuffer: Error, k-rate array size divided "
+      return csound->InitError(csound, "%s", Str("olabuffer: Error, k-rate array size divided "
                               "by overlap factor must be larger than or equal "
                               "to ksmps"));
     }
+    return OK;
 }
 
 int32_t Framebuffer_initialise(CSOUND *csound, Framebuffer *self)

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -157,7 +157,13 @@ instr 1
   aOut olabuffer kFrame, iOverlap
   out aOut
 endin
+instr 2
+  kCount init 0
+  kCount += 1
+  chnset kCount, "alive"
+endin
 schedule(1, 0, 0.001)
+schedule(2, 0, 0.001)
 )";
 
     ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
@@ -175,8 +181,13 @@ schedule(1, 0, 0.001)
         }
     }
     else {
-        // A crash cannot satisfy this assertion, unlike an expected CLI failure.
-        EXPECT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        // Reject this instrument while the other one keeps performing.
+        for (int sample = 0; sample < 24; ++sample)
+            ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        EXPECT_EQ(csoundErrCnt(csound), 1);
+        int error = 0;
+        EXPECT_EQ(csoundGetControlChannel(csound, "alive", &error), FL(24.0));
+        EXPECT_EQ(error, 0);
         bool reportedOverlapError = false;
         while (csoundGetMessageCnt(csound)) {
             const char *message = csoundGetFirstMessage(csound);

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -139,6 +139,63 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(::testing::Values("space", "spdist"),
                        ::testing::Values(0, 1, 2)));
 
+class OLABufferTests : public OrcCompileTests,
+                      public ::testing::WithParamInterface<MYFLT> {};
+
+TEST_P(OLABufferTests, ValidatesOverlapBeforeIntegerArithmetic)
+{
+    const MYFLT overlap = GetParam();
+    const bool valid = overlap == 1 || overlap == 2 || overlap == 4;
+    const char *instrument = R"(
+sr = 48000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+instr 1
+  kFrame[] fillarray 1, 1, 1, 1, 1, 1, 1, 1
+  iOverlap chnget "overlap"
+  aOut olabuffer kFrame, iOverlap
+  out aOut
+endin
+schedule(1, 0, 0.001)
+)";
+
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    csoundCreateMessageBuffer(csound, 0);
+    ASSERT_EQ(csoundCompileOrc(csound, instrument), CSOUND_SUCCESS);
+    csoundSetControlChannel(csound, "overlap", overlap);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    if (valid) {
+        // Once all frames contain ones, overlap-add must sum to the factor.
+        for (int sample = 0; sample < 24; ++sample) {
+            ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+            if (sample >= 8)
+                EXPECT_EQ(csoundGetSpout(csound)[0], overlap);
+        }
+    }
+    else {
+        // A crash cannot satisfy this assertion, unlike an expected CLI failure.
+        EXPECT_NE(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+        bool reportedOverlapError = false;
+        while (csoundGetMessageCnt(csound)) {
+            const char *message = csoundGetFirstMessage(csound);
+            if (message && strstr(message, "olabuffer: Error,"))
+                reportedOverlapError = true;
+            csoundPopFirstMessage(csound);
+        }
+        EXPECT_TRUE(reportedOverlapError);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OverlapFactors, OLABufferTests,
+    ::testing::Values(FL(0.0), FL(-1.0), FL(0.5), FL(3.0), FL(8.0),
+                      FL(2147483648.0), std::numeric_limits<MYFLT>::infinity(),
+                      -std::numeric_limits<MYFLT>::infinity(),
+                      std::numeric_limits<MYFLT>::quiet_NaN(),
+                      FL(1.0), FL(2.0), FL(4.0)));
+
 TEST_F (OrcCompileTests, testArgsRequired)
 {
     ASSERT_EQ (1, args_required("a"));


### PR DESCRIPTION
Reject zero and negative olabuffer overlap factors before integer division or buffer allocation. Zero previously passed the integer check and caused division by zero.

Compare the overlap factor with the array size before converting it to `int32_t`. This rejects excessively large values and positive infinity without an out-of-range conversion, while preserving valid overlap factors.
