### PR TITLE
fix: correct oscil1i interpolation and scan endpoints

### DIFF
--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -192,22 +192,40 @@ int32_t ko1set(CSOUND *csound, OSCIL1 *p)
 
   if (UNLIKELY((ftp = csound->FTFind(csound, p->ifn)) == NULL))
     return NOTOK;
-  if(IS_POW_TWO(ftp->flen)) {
-  if (UNLIKELY(*p->idur <= FL(0.0))) {
-    p->phs = MAXLEN-1;
-  }
-  else p->phs = 0;
-  p->kinc = (int32_t) (CS_KICVT / *p->idur);
-  if (p->kinc==0) p->kinc = 1;
-  } else {
-    if (UNLIKELY(*p->idur <= FL(0.0)))
-      p->fphs = 1. - 1./ftp->flen;
-    else p->fphs = FL(0.0);
-    p->kinc = 0;
-    p->inc = 1./(*p->idur*CS_EKR);
-  }
+  if (UNLIKELY(!isfinite(*p->idur)))
+    return csound->InitError(csound, "%s",
+                            Str("oscil1: duration must be finite"));
+
   p->ftp = ftp;
   p->dcnt = (int32_t)(*p->idel * CS_EKR);
+  if (IS_POW_TWO(ftp->flen)) {
+    if (*p->idur == FL(0.0)) {
+      p->phs = MAXLEN;
+      p->kinc = 1; /* Select the fixed-point table path. */
+      p->dcnt = -1;
+    }
+    else {
+      double increment = CS_KICVT / *p->idur;
+      p->phs = *p->idur < FL(0.0) ? MAXLEN - 1 : 0;
+      /* A scan shorter than one control period reaches the end in one step. */
+      if (increment >= MAXLEN) p->kinc = MAXLEN;
+      else if (increment <= -MAXLEN) p->kinc = -MAXLEN;
+      else p->kinc = (int32_t) increment;
+      if (p->kinc == 0) p->kinc = *p->idur < FL(0.0) ? -1 : 1;
+    }
+  }
+  else {
+    p->kinc = 0;
+    if (*p->idur == FL(0.0)) {
+      p->fphs = 1.;
+      p->inc = 0.;
+      p->dcnt = -1;
+    }
+    else {
+      p->fphs = *p->idur < FL(0.0) ? 1. - 1./ftp->flen : 0.;
+      p->inc = 1./(*p->idur*CS_EKR);
+    }
+  }
 
   return OK;
 }
@@ -261,27 +279,37 @@ int32_t kosc1(CSOUND *csound, OSCIL1 *p)
 int32_t kosc1i(CSOUND *csound, OSCIL1   *p)
 {
   FUNC        *ftp;
-  MYFLT       fract, v1, *ftab, fphs = p->fphs;
+  MYFLT       fract, v1, *ftab;
+  double      fphs = p->fphs;
   int32_t     phs = p->phs, dcnt;
 
   ftp = p->ftp;
   if (UNLIKELY(ftp==NULL)) goto err1;
   phs = p->phs;
-  if(p->kinc != 0) {
-  fract = PFRAC(phs);
-  ftab = ftp->ftable + (phs >> ftp->lobits);
-  v1 = *ftab++;
-  *p->rslt = (v1 + (*ftab - v1) * fract) * *p->kamp;
-  } else {
-    fphs = p->fphs;
-    fract = fphs - (int64_t) fphs;
-    ftab = ftp->ftable + (size_t) (fphs*ftp->flen);
-    v1 = *ftab++;
-    *p->rslt = (v1 + (*ftab - v1) * fract) * *p->kamp;
+  if (p->kinc != 0) {
+    if (phs >= MAXLEN)
+      *p->rslt = ftp->ftable[ftp->flen] * *p->kamp;
+    else {
+      fract = PFRAC(phs);
+      ftab = ftp->ftable + (phs >> ftp->lobits);
+      v1 = *ftab++;
+      *p->rslt = (v1 + (*ftab - v1) * fract) * *p->kamp;
+    }
+  }
+  else {
+    double position = fphs * ftp->flen;
+    if (position >= ftp->flen)
+      *p->rslt = ftp->ftable[ftp->flen] * *p->kamp;
+    else {
+      uint32_t index = (uint32_t) position;
+      fract = (MYFLT)(position - index);
+      ftab = ftp->ftable + index;
+      v1 = *ftab++;
+      *p->rslt = (v1 + (*ftab - v1) * fract) * *p->kamp;
+    }
   }
   if ((dcnt = p->dcnt) > 0) {
     dcnt--;
-    p->dcnt = dcnt;
   }
   else if (dcnt == 0) {
     if(p->kinc != 0) {
@@ -308,6 +336,7 @@ int32_t kosc1i(CSOUND *csound, OSCIL1   *p)
     p->fphs = fphs;
     }
   }
+  p->dcnt = dcnt;
   return OK;
  err1:
   return csound->PerfError(csound, &(p->h),

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -597,6 +597,7 @@ def runTest():
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
+        ["test_oscil1i.csd", "oscil1i interpolates scans and holds their endpoints"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],
         ["test_string.csd", "test string assignment and printing"],

--- a/tests/commandline/test_oscil1i.csd
+++ b/tests/commandline/test_oscil1i.csd
@@ -1,0 +1,73 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  ; p4: table, p5: duration, p6: delay, p7/p8: expected start/step.
+  iEnd = ftlen(p4)
+  iDelay = int(p6 * kr)
+  kCount init 0
+  kAmp = 1 + kCount / 8
+  kActual oscil1i p6, kAmp, p5, p4
+  kPosition limit p7 + max(kCount - iDelay, 0) * p8, 0, iEnd
+  kExpected = kPosition * kAmp
+  if !(abs(kActual - kExpected) <= 0.0001) then
+    printks "oscil1i mismatch: table=%d duration=%.9g sample=%d actual=%.9g expected=%.9g\n", 0, p4, p5, kCount, kActual, kExpected
+    exitnowk(-1)
+  endif
+  kCount += 1
+endin
+
+instr 2
+  ; oscil1 shares the initializer: zero duration must also hold its endpoint.
+  kCount init 0
+  kAmp = 1 + kCount / 8
+  kActual oscil1 p5, kAmp, 0, p4
+  kExpected = ftlen(p4) * kAmp
+  if !(abs(kActual - kExpected) <= 0.0001) then
+    printks "oscil1 zero-duration mismatch: actual=%.9g expected=%.9g\n", 0, kActual, kExpected
+    exitnowk(-1)
+  endif
+  kCount += 1
+endin
+</CsInstruments>
+<CsScore>
+; Linear tables with explicit guard values distinct from the last real sample.
+f1 0 9 -2 0 1 2 3 4 5 6 7 8
+f2 0 10 -2 0 1 2 3 4 5 6 7 8 9 10
+; Zero duration, with and without a delay.
+i1 0 .004 1 0 0 8 0
+i1 0 .004 2 0 0 10 0
+i1 0 .004 1 0 .000244140625 8 0
+i1 0 .004 2 0 .000244140625 10 0
+; Eight control periods, with and without a two-period delay.
+i1 0 .004 1 .0009765625 0 0 1
+i1 0 .004 2 .0009765625 0 0 1.25
+i1 0 .004 1 .0009765625 .000244140625 0 1
+i1 0 .004 2 .0009765625 .000244140625 0 1.25
+; Reverse scans retain their existing starting position.
+i1 0 .004 1 -.0009765625 0 8 -1
+i1 0 .004 2 -.0009765625 0 9 -1.25
+i1 0 .004 1 -.0009765625 .000244140625 8 -1
+i1 0 .004 2 -.0009765625 .000244140625 9 -1.25
+; Scans shorter than one control period finish on the next sample.
+i1 0 .004 1 .00006103515625 0 0 16
+i1 0 .004 2 .00006103515625 0 0 20
+i1 0 .004 1 -.00006103515625 0 8 -16
+i1 0 .004 2 -.00006103515625 0 9 -20
+i1 0 .004 1 1e-20 0 0 16
+i1 0 .004 2 1e-20 0 0 20
+i1 0 .004 1 -1e-20 0 8 -16
+i1 0 .004 2 -1e-20 0 9 -20
+i2 0 .004 1 0
+i2 0 .004 2 0
+i2 0 .004 1 .000244140625
+i2 0 .004 2 .000244140625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Read the table's endpoint directly when an oscil1i scan finishes, avoiding interpolation past the guard point. Save the completed state so the phase stops advancing, and use the fractional table index for non-power-of-two interpolation.

Handle zero duration without division in the initializer shared with oscil1. Bound fixed-point increments before integer conversion for very short scans, retain reverse scanning, and reject non-finite durations.
