### PR TITLE
fix: align waveguide frequency reads with sample offsets

### DIFF
--- a/Opcodes/flanger.c
+++ b/Opcodes/flanger.c
@@ -133,6 +133,7 @@ static int32_t wguide1(CSOUND *csound, WGUIDE1 *p)
       memset(&out[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (p->xdelcod) { /* delay changes at audio-rate */
+      freq_del += offset;
       for (n                 = offset; n<nsmps; n++) {
         /*---------------- delay -----------------------*/
         MYFLT fd             = *freq_del++;
@@ -265,6 +266,8 @@ static int32_t wguide2(CSOUND *csound, WGUIDE2 *p)
       memset(&out[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (p->xdel1cod) { /* delays change at audio-rate */
+      freq_del1 += offset;
+      freq_del2 += offset;
       for (n=offset;n<nsmps;n++) {
         MYFLT fd1 = *freq_del1++;
         MYFLT fd2 = *freq_del2++;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -792,6 +792,7 @@ def runTest():
             1,
         ],
         ["test_sa.csd", "test sample accurate mode"],
+        ["test_wguide_sample_offset.csd", "waveguides align audio-rate frequencies with note starts"],
         [
             "test_local_ksmps_sample_accurate.csd",
             "test sample-accurate local ksmps offsets",

--- a/tests/commandline/test_wguide_sample_offset.csd
+++ b/tests/commandline/test_wguide_sample_offset.csd
@@ -1,0 +1,63 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1, 2
+  asig = .1
+  afreq1 = 4000
+  afreq2 = 2000
+  kfreq1 init 4000
+  kfreq2 init 2000
+  if p1 == 1 then
+    aAudio wguide1 asig, afreq1, 1000, 0
+    aControl wguide1 asig, kfreq1, 1000, 0
+  else
+    aAudio wguide2 asig, afreq1, afreq2, 1000, 1000, 0, 0
+    aControl wguide2 asig, kfreq1, kfreq2, 1000, 1000, 0, 0
+  endif
+
+  kfirst init 1
+  koffset offsetsmps
+  if kfirst == 1 then
+    if koffset != p4 then
+      printks "wguide%d: expected start offset %d, got %d\n", 0, p1, p4, koffset
+      exitnowk(-1)
+    endif
+    gkchecks += 1
+    kfirst = 0
+  endif
+  ; Equal constant frequencies must give equal output at either rate.
+  kerror max_k aAudio - aControl, 1, 1
+  if !(kerror < .000001) then
+    printks "wguide%d: audio/control-rate mismatch at start offset %d: %g\n", 0, p1, p4, kerror
+    exitnowk(-1)
+  endif
+endin
+
+instr 99
+  if i(gkchecks) != 8 then
+    prints "not all waveguide offset checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Check aligned starts and offsets near the start, middle, and end of a block.
+i 1 0        .008 0
+i 2 0        .008 0
+i 1 .020125  .008 1
+i 2 .020125  .008 1
+i 1 .040625  .008 5
+i 2 .040625  .008 5
+i 1 .061875  .008 15
+i 2 .061875  .008 15
+i 99 .08 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
With `--sample-accurate`, `wguide1` and `wguide2` start processing at the note's sample offset but read audio-rate frequencies from the beginning of the block. This uses frequency values from before the note starts and produces different output from identical control-rate frequencies.

Advance each audio-rate frequency pointer by the start offset before processing, keeping frequency values aligned with the input samples.
