### PR TITLE
fix: refresh compressor gain when ratio or knees change

### DIFF
--- a/Opcodes/compress.c
+++ b/Opcodes/compress.c
@@ -120,6 +120,7 @@ static int32_t compress(CSOUND *csound, CMPRS *p)
       }
       else
         p->kneemul = FL(1.0);
+      p->newenv = 1;
     }
     if (*p->katt != p->curatt) {
       if ((p->curatt = *p->katt) < CS_ONEDSR)

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -850,6 +850,7 @@ def runTest():
             "test keyword spacing (if(, elseif(, etc.)",
         ],
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],
+        ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],
         ["test_bus_channels.csd", "testing bus channels"],

--- a/tests/commandline/test_compress_control_gain.csd
+++ b/tests/commandline/test_compress_control_gain.csd
@@ -1,0 +1,64 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1, 2
+  ; A steady sidechain keeps the detected envelope constant after startup.
+  asig = .5
+  kcount init 0
+  ibias = p1 == 1 ? 90 : 0
+  klow = (kcount < 4 ? p4 : p7) + ibias
+  khigh = (kcount < 4 ? p5 : p8) + ibias
+  kratio = kcount < 4 ? p6 : p9
+  if p1 == 1 then
+    aDynamic compress asig, asig, -90 + ibias, klow, khigh, kratio, 0, 0, 0
+    aReference compress asig, asig, -90 + ibias, p7 + ibias, p8 + ibias, p9, 0, 0, 0
+  else
+    aDynamic compress2 asig, asig, -90, klow, khigh, kratio, 0, 0, 0
+    aReference compress2 asig, asig, -90, p7, p8, p9, 0, 0, 0
+  endif
+  kerror max_k aDynamic - aReference, 1, 1
+  if kcount >= 4 then
+    if !(kerror < .000001) then
+      printks "compressor %d: gain mismatch after controls changed to %g, %g, %g: %g\n", 0, p1, p7, p8, p9, kerror
+      exitnowk(-1)
+    endif
+    if kcount == 4 then
+      gkchecks += 1
+    endif
+  endif
+  kcount += 1
+endin
+
+instr 99
+  if i(gkchecks) != 10 then
+    prints "not all compressor control checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+;             initial knee/ratio    final knee/ratio
+; Unchanged controls preserve the gain.
+i 1 0 .01     -20 -10 4              -20 -10 4
+i 2 0 .01     -20 -10 4              -20 -10 4
+; Increasing and decreasing the ratio must update the gain.
+i 1 0 .01     -20 -20 1              -20 -20 4
+i 2 0 .01     -20 -20 1              -20 -20 4
+i 1 0 .01     -20 -20 4              -20 -20 1
+i 2 0 .01     -20 -20 4              -20 -20 1
+; Each knee control must also update the gain.
+i 1 0 .01     -20 -10 4              -30 -10 4
+i 2 0 .01     -20 -10 4              -30 -10 4
+i 1 0 .01     -30 -20 4              -30 -10 4
+i 2 0 .01     -30 -20 4              -30 -10 4
+i 99 .02 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`compress` and `compress2` update their curve coefficients when the ratio or knee controls change, but reuse the cached gain until the detected input level changes. With a steady sidechain, the old gain can remain in effect indefinitely.

Mark the gain for recalculation when those coefficients change, so the new settings take effect even when the input envelope stays constant.
