### PR TITLE
fix: preserve mvmfilter decay with audio-rate frequency

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -1691,10 +1691,12 @@ static int32_t vco(CSOUND *csound, VCO *p)
       }
 
       for(n = offset; n < nsmps; n++) {
-        if (asigtau && tau[n] > FL(0.0)) {
-          r1 = exp(-1 / (tau[n]*fs));
-        } else {
-          r1 = 0;
+        if (asigtau) {
+          if (tau[n] > FL(0.0)) {
+            r1 = exp(-1 / (tau[n]*fs));
+          } else {
+            r1 = 0;
+          }
         }
 
         if (asigf0) {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -849,6 +849,7 @@ def runTest():
             "test_keyword_spacing.csd",
             "test keyword spacing (if(, elseif(, etc.)",
         ],
+        ["test_mvmfilter_mixed_rate.csd", "test mvmfilter with mixed input rates"],
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_mvmfilter_mixed_rate.csd
+++ b/tests/commandline/test_mvmfilter_mixed_rate.csd
@@ -1,0 +1,65 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1
+  kcount init 0
+  ain mpulse 1, 0
+  kfreq = kcount < 6 ? 1000 : 1500
+  ktau = kcount < 4 ? p4 : p5
+  afreq = kfreq
+  atau = ktau
+  akk mvmfilter ain, kfreq, ktau
+  aak mvmfilter ain, afreq, ktau
+  aka mvmfilter ain, kfreq, atau
+  aaa mvmfilter ain, afreq, atau
+  kakerror max_k aak - akk, 1, 1
+  kkaerror max_k aka - akk, 1, 1
+  kaaerror max_k aaa - akk, 1, 1
+  if !(kakerror < .00001 && kkaerror < .00001 && kaaerror < .00001) then
+    printks "mvmfilter rate mismatch: ak=%g ka=%g aa=%g\n", 0, kakerror, kkaerror, kaaerror
+    exitnowk(-1)
+  endif
+
+  ; Check the reference against the impulse response at sample 8.
+  ksample downsamp akk
+  if kcount == 1 then
+    kexpected = 0
+    if p4 > 0 then
+      kexpected = exp(-ksmps / (sr * p4)) * cos(2 * $M_PI * 1000 * ksmps / sr)
+    endif
+    if !(abs(ksample - kexpected) < .00001) then
+      printks "mvmfilter impulse mismatch: expected=%g actual=%g\n", 0, kexpected, ksample
+      exitnowk(-1)
+    endif
+  endif
+  if kcount == 10 then
+    gkchecks += 1
+  endif
+  kcount += 1
+endin
+
+instr 99
+  if i(gkchecks) != 5 then
+    prints "not all mvmfilter checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Constant and changing decay, including the non-positive decay path.
+i 1 0 .02 .01 .01
+i 1 0 .02 0 0
+i 1 0 .02 -.01 -.01
+i 1 0 .02 .01 .02
+i 1 0 .02 .01 0
+i 99 .03 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
With audio-rate frequency and control-rate decay, `mvmfilter` overwrites its decay factor with zero and copies the input instead of producing the expected resonance and decay.

Only update the decay factor inside the sample loop when decay is audio-rate. This preserves the control-rate value and makes all four input-rate combinations behave consistently.
