### PR TITLE
Bound mirror folding for extreme values

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -80,24 +80,44 @@ static int32_t kwrap(CSOUND *csound, WRAP *p)
 
 /*---------------------------------------------------------------------*/
 
+static MYFLT mirror_value(MYFLT input, MYFLT lower, MYFLT upper)
+{
+    double value = input, low = lower, high = upper;
+    double width, remainder, lowrem;
+    int quotient, lowquot, odd;
+
+    if (low >= high) {
+      double sum = low + high;
+      return (MYFLT)(isfinite(sum) ? sum * 0.5 : low * 0.5 + high * 0.5);
+    }
+    if (value >= low && value <= high) return input;
+    if (!isfinite(value) || !isfinite(low) || !isfinite(high))
+      return (MYFLT)NAN;
+
+    width = high - low;
+    if (!isfinite(width)) {
+      /* Such a wide finite interval needs at most one reflection. */
+      return (MYFLT)(value > high ? high - (value - high)
+                                  : low + (low - value));
+    }
+
+    /* Reduce separately: value - low can overflow or lose the low offset. */
+    remainder = remquo(value, width, &quotient);
+    lowrem = remquo(low, width, &lowquot);
+    remainder -= lowrem;
+    odd = (quotient % 2 != 0) != (lowquot % 2 != 0);
+    if (remainder < 0.0) {
+      remainder += width;
+      odd = !odd;
+    }
+    /* Quotient parity selects the direction without doubling the width. */
+    return (MYFLT)(odd ? high - remainder : low + remainder);
+}
+
 static int32_t kmirror(CSOUND *csound, WRAP *p)
 {
     IGN(csound);
-    MYFLT  xsig, xlow, xhigh;
-    xsig = *p->xsig;
-    xhigh= *p->xhigh;
-    xlow = *p->xlow;
-
-    if (xlow >= xhigh) *p->xdest = (xlow + xhigh)*FL(0.5);
-    else {
-      while ((xsig > xhigh) || (xsig < xlow)) {
-        if (xsig > xhigh)
-          xsig = xhigh + xhigh - xsig;
-        else
-          xsig = xlow + xlow - xsig;
-      }
-      *p->xdest = xsig;
-    }
+    *p->xdest = mirror_value(*p->xsig, *p->xlow, *p->xhigh);
     return OK;
 }
 
@@ -105,7 +125,7 @@ static int32_t mirror(CSOUND *csound, WRAP *p)
 {
     IGN(csound);
     MYFLT       *adest, *asig;
-    MYFLT       xlow, xhigh, xaverage, xsig;
+    MYFLT       xlow, xhigh, xaverage;
     uint32_t    offset = p->h.insdshead->ksmps_offset;
     uint32_t    early  = p->h.insdshead->ksmps_no_end;
     uint32_t    n, nsmps = CS_KSMPS;
@@ -121,7 +141,7 @@ static int32_t mirror(CSOUND *csound, WRAP *p)
       memset(&adest[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (xlow >= xhigh)  {
-      xaverage = (xlow + xhigh)*FL(0.5);
+      xaverage = mirror_value(FL(0.0), xlow, xhigh);
       for (n=offset;n<nsmps;n++) {
         adest[n] = xaverage;
       }
@@ -129,14 +149,7 @@ static int32_t mirror(CSOUND *csound, WRAP *p)
     }
 
     for (n=offset;n<nsmps;n++) {
-      xsig = asig[n];
-      while ((xsig > xhigh) || ( xsig < xlow )) {
-        if (xsig > xhigh)
-          xsig = xhigh + xhigh - xsig;
-        else
-          xsig = xlow + xlow - xsig;
-      }
-      adest[n] = xsig;
+      adest[n] = mirror_value(asig[n], xlow, xhigh);
     }
     return OK;
 }

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -80,44 +80,52 @@ static int32_t kwrap(CSOUND *csound, WRAP *p)
 
 /*---------------------------------------------------------------------*/
 
-static MYFLT mirror_value(MYFLT input, MYFLT lower, MYFLT upper)
-{
-    double value = input, low = lower, high = upper;
-    double width, remainder, lowrem;
-    int quotient, lowquot, odd;
-
-    if (low >= high) {
-      double sum = low + high;
-      return (MYFLT)(isfinite(sum) ? sum * 0.5 : low * 0.5 + high * 0.5);
-    }
-    if (value >= low && value <= high) return input;
-    if (!isfinite(value) || !isfinite(low) || !isfinite(high))
-      return (MYFLT)NAN;
-
-    width = high - low;
-    if (!isfinite(width)) {
-      /* Such a wide finite interval needs at most one reflection. */
-      return (MYFLT)(value > high ? high - (value - high)
-                                  : low + (low - value));
-    }
-
-    /* Reduce separately: value - low can overflow or lose the low offset. */
-    remainder = remquo(value, width, &quotient);
-    lowrem = remquo(low, width, &lowquot);
-    remainder -= lowrem;
-    odd = (quotient % 2 != 0) != (lowquot % 2 != 0);
-    if (remainder < 0.0) {
-      remainder += width;
-      odd = !odd;
-    }
-    /* Quotient parity selects the direction without doubling the width. */
-    return (MYFLT)(odd ? high - remainder : low + remainder);
-}
+#define MIRROR_VALUE(output, input, lower, upper) do {                         \
+    double mirror_input = (input), low = (lower), high = (upper);              \
+    double width, remainder, lowrem;                                           \
+    int quotient, lowquot, odd;                                                \
+                                                                               \
+    if (low >= high) {                                                         \
+      double sum = low + high;                                                 \
+      (output) = (MYFLT)(isfinite(sum) ? sum * 0.5                             \
+                                     : low * 0.5 + high * 0.5);                \
+      break;                                                                   \
+    }                                                                          \
+    if (mirror_input >= low && mirror_input <= high) {                         \
+      (output) = (MYFLT)mirror_input;                                          \
+      break;                                                                   \
+    }                                                                          \
+    if (!isfinite(mirror_input) || !isfinite(low) || !isfinite(high)) {        \
+      (output) = (MYFLT)NAN;                                                   \
+      break;                                                                   \
+    }                                                                          \
+                                                                               \
+    width = high - low;                                                        \
+    if (!isfinite(width)) {                                                    \
+      /* Such a wide finite interval needs at most one reflection. */          \
+      (output) = (MYFLT)(mirror_input > high                                   \
+                         ? high - (mirror_input - high)                        \
+                         : low + (low - mirror_input));                        \
+      break;                                                                   \
+    }                                                                          \
+                                                                               \
+    /* Reduce separately: input - low can overflow or lose the low offset. */  \
+    remainder = remquo(mirror_input, width, &quotient);                        \
+    lowrem = remquo(low, width, &lowquot);                                     \
+    remainder -= lowrem;                                                       \
+    odd = (quotient % 2 != 0) != (lowquot % 2 != 0);                           \
+    if (remainder < 0.0) {                                                     \
+      remainder += width;                                                      \
+      odd = !odd;                                                              \
+    }                                                                          \
+    /* Quotient parity selects the direction without doubling the width. */    \
+    (output) = (MYFLT)(odd ? high - remainder : low + remainder);              \
+} while (0)
 
 static int32_t kmirror(CSOUND *csound, WRAP *p)
 {
     IGN(csound);
-    *p->xdest = mirror_value(*p->xsig, *p->xlow, *p->xhigh);
+    MIRROR_VALUE(*p->xdest, *p->xsig, *p->xlow, *p->xhigh);
     return OK;
 }
 
@@ -141,7 +149,7 @@ static int32_t mirror(CSOUND *csound, WRAP *p)
       memset(&adest[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (xlow >= xhigh)  {
-      xaverage = mirror_value(FL(0.0), xlow, xhigh);
+      MIRROR_VALUE(xaverage, FL(0.0), xlow, xhigh);
       for (n=offset;n<nsmps;n++) {
         adest[n] = xaverage;
       }
@@ -149,7 +157,7 @@ static int32_t mirror(CSOUND *csound, WRAP *p)
     }
 
     for (n=offset;n<nsmps;n++) {
-      adest[n] = mirror_value(asig[n], xlow, xhigh);
+      MIRROR_VALUE(adest[n], asig[n], xlow, xhigh);
     }
     return OK;
 }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -921,6 +921,7 @@ def runTest():
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
+        ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],

--- a/tests/commandline/test_mirror_bounds.csd
+++ b/tests/commandline/test_mirror_bounds.csd
@@ -1,0 +1,78 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1
+  iscale = 2 ^ p8
+  ix = p4 * iscale
+  ilow = p5 * iscale
+  ihigh = p6 * iscale
+  ivalue mirror ix, ilow, ihigh
+  if !(abs(ivalue / iscale - p7) < .000001) then
+    prints "mirror i-rate mismatch: input=%g low=%g high=%g expected=%g got=%g\n", p4, p5, p6, p7, ivalue / iscale
+    exitnow(-1)
+  endif
+  kx = ix
+  ax = ix
+  kvalue mirror kx, ilow, ihigh
+  avalue mirror ax, ilow, ihigh
+  aexpected = p7
+  kerror max_k abs(avalue / iscale - aexpected), 1, 1
+  if !(abs(kvalue / iscale - p7) < .000001 && kerror < .000001) then
+    printks "mirror mismatch: input=%g low=%g high=%g expected=%g k=%g a-error=%g\n", 0, p4, p5, p6, p7, kvalue / iscale, kerror
+    exitnowk(-1)
+  endif
+  kfirst init 1
+  if kfirst == 1 then
+    gkchecks += 1
+    kfirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkchecks) != 27 then
+    prints "not all mirror checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Input, lower bound, upper bound, expected result, binary scale exponent.
+i 1 0 .004 -3.25 0 1 .75 0
+i 1 0 .004 -2 0 1 0 0
+i 1 0 .004 -1 0 1 1 0
+i 1 0 .004 -.5 0 1 .5 0
+i 1 0 .004 0 0 1 0 0
+i 1 0 .004 .25 0 1 .25 0
+i 1 0 .004 1 0 1 1 0
+i 1 0 .004 1.25 0 1 .75 0
+i 1 0 .004 2 0 1 0 0
+i 1 0 .004 3 0 1 1 0
+i 1 0 .004 1e20 0 1 0 0
+i 1 0 .004 -1e20 0 1 0 0
+i 1 0 .004 1e20 1 2 2 0
+i 1 0 .004 -1e20 1 2 2 0
+i 1 0 .004 -3 -2 3 -1 0
+i 1 0 .004 4 -2 3 2 0
+i 1 0 .004 9 -2 3 -1 0
+i 1 0 .004 0 3 3 3 126
+i 1 0 .004 0 3 2 2.5 126
+i 1 0 .004 3 -1 1 -1 126
+i 1 0 .004 3 -3 2 1 126
+i 1 0 .004 3 -3 -2 -3 126
+i 1 0 .004 2.5 -3 -2 -2.5 126
+i 1 0 .004 7 0 3 1 -120
+; Check notes that start and end within a control block.
+i 1 .000125 .003375 4 -2 3 2 0
+i 1 .000625 .003375 4 -2 3 2 0
+i 1 .001875 .003375 4 -2 3 2 0
+i 99 .01 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`mirror` reflected out-of-range values in a loop. Extreme finite inputs could require many iterations, doubled-bound arithmetic could overflow, and infinite inputs could keep the loop running forever. Computing the midpoint for reversed or equal bounds could also overflow even when both bounds were finite.

This change gives the audio-rate and control-rate forms one bounded reduction based on floating-point remainders. It avoids forming an overflowing doubled range, preserves values already inside the range, and computes the fallback midpoint without overflowing the sum.
