### PR TITLE
Add stable chebyshevpoly2 evaluator

### DIFF
--- a/Opcodes/shape.c
+++ b/Opcodes/shape.c
@@ -159,6 +159,12 @@ static int32_t ChebyshevPolyInit(CSOUND* csound, CHEBPOLY* p)
    Coefficients (k0, k1, k2, ... ) are k-rate multipliers of each Chebyshev
    polynomial starting with the zero-order polynomial T0(x) = 1, then
    T1(x) = x, T2(x) = 2x^2 - 1, etc. */
+/*
+ * Known limitation: expanding high-order Chebyshev terms can overflow even
+ * when the final series is finite. Keep this implementation unchanged for
+ * its established behavior and faster low-order sample loop. Use
+ * chebyshevpoly2 for direct evaluation; do not apply that fix here.
+ */
 static int32_t ChebyshevPolynomial(CSOUND* csound, CHEBPOLY* p)
 {
     int32_t     i, j;
@@ -223,6 +229,133 @@ static int32_t ChebyshevPolynomial(CSOUND* csound, CHEBPOLY* p)
       out[n] = sum;
     }
 
+    return OK;
+}
+
+typedef struct {
+    OPDS    h;
+    MYFLT   *aout, *ain, *kcoefficients[VARGMAX-1];
+    AUXCH   coeff;
+    int32_t count;
+} CHEBPOLY2;
+
+static int32_t ChebyshevPoly2Init(CSOUND* csound, CHEBPOLY2* p)
+{
+    p->count = GetInputArgCnt((OPDS *)p) - 1;
+    if (UNLIKELY(p->count < 1))
+      return csound->InitError(csound, "%s",
+                               Str("chebyshevpoly2: no coefficients"));
+    csound->AuxAlloc(csound, (size_t)p->count * sizeof(double), &p->coeff);
+    return OK;
+}
+
+static int32_t ChebyshevPolynomial2(CSOUND* csound, CHEBPOLY2* p)
+{
+    int32_t i, count = p->count;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
+    uint32_t n, nsmps = CS_KSMPS;
+    MYFLT *out = p->aout;
+    MYFLT *in = p->ain;
+    double *coeff = (double*)p->coeff.auxp;
+    IGN(csound);
+
+    for (i = 0; i < count; ++i)
+      coeff[i] = (double)*p->kcoefficients[i];
+    if (UNLIKELY(offset)) memset(out, 0, offset * sizeof(MYFLT));
+    if (UNLIKELY(early)) {
+      nsmps -= early;
+      memset(&out[nsmps], 0, early * sizeof(MYFLT));
+    }
+    if (count == 1) {
+      MYFLT value = (MYFLT)coeff[0];
+      for (n = offset; n < nsmps; ++n) out[n] = value;
+    }
+    else if (count == 2) {
+      double c0 = coeff[0], c1 = coeff[1];
+      for (n = offset; n < nsmps; ++n)
+        out[n] = (MYFLT)(c0 + (double)in[n] * c1);
+    }
+    else {
+      int32_t last = count - 1;
+      /* Keep the recurrence here: this loop runs once per audio sample. */
+      for (n = offset; n < nsmps; ++n) {
+        double x = (double)in[n];
+        double b0, b1 = 0.0, b2 = 0.0;
+        for (i = last; i >= 1; --i) {
+          b0 = 2.0 * x * b1 - b2 + coeff[i];
+          b2 = b1;
+          b1 = b0;
+        }
+        out[n] = (MYFLT)(x * b1 - b2 + coeff[0]);
+      }
+    }
+    return OK;
+}
+
+typedef struct {
+    OPDS     h;
+    MYFLT    *aout, *ain;
+    ARRAYDAT *coefficients;
+} CHEBPOLY2ARRAY;
+
+static int32_t ChebyshevPoly2ArrayInit(CSOUND* csound, CHEBPOLY2ARRAY* p)
+{
+    ARRAYDAT *coeff = p->coefficients;
+    if (UNLIKELY(coeff->data == NULL || coeff->sizes == NULL ||
+                 coeff->dimensions != 1 || coeff->sizes[0] < 1))
+      return csound->InitError(csound, "%s",
+                               Str("chebyshevpoly2: coefficients must be "
+                                   "a non-empty one-dimensional array"));
+    return OK;
+}
+
+static int32_t ChebyshevPolynomial2Array(CSOUND* csound, CHEBPOLY2ARRAY* p)
+{
+    ARRAYDAT *coefficients = p->coefficients;
+    int32_t i, count;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
+    uint32_t n, nsmps = CS_KSMPS;
+    MYFLT *out = p->aout;
+    MYFLT *in = p->ain;
+    MYFLT *coeff;
+
+    if (UNLIKELY(coefficients->data == NULL || coefficients->sizes == NULL ||
+                 coefficients->dimensions != 1 || coefficients->sizes[0] < 1))
+      return csound->PerfError(csound, &p->h,
+                               Str("chebyshevpoly2: coefficients must be "
+                                   "a non-empty one-dimensional array"));
+    count = coefficients->sizes[0];
+    coeff = (MYFLT*)coefficients->data;
+    if (UNLIKELY(offset)) memset(out, 0, offset * sizeof(MYFLT));
+    if (UNLIKELY(early)) {
+      nsmps -= early;
+      memset(&out[nsmps], 0, early * sizeof(MYFLT));
+    }
+    if (count == 1) {
+      MYFLT value = coeff[0];
+      for (n = offset; n < nsmps; ++n) out[n] = value;
+    }
+    else if (count == 2) {
+      double c0 = (double)coeff[0], c1 = (double)coeff[1];
+      for (n = offset; n < nsmps; ++n)
+        out[n] = (MYFLT)(c0 + (double)in[n] * c1);
+    }
+    else {
+      int32_t last = count - 1;
+      /* Keep the recurrence here: this loop runs once per audio sample. */
+      for (n = offset; n < nsmps; ++n) {
+        double x = (double)in[n];
+        double b0, b1 = 0.0, b2 = 0.0;
+        for (i = last; i >= 1; --i) {
+          b0 = 2.0 * x * b1 - b2 + (double)coeff[i];
+          b2 = b1;
+          b1 = b0;
+        }
+        out[n] = (MYFLT)(x * b1 - b2 + (double)coeff[0]);
+      }
+    }
     return OK;
 }
 
@@ -576,6 +709,12 @@ static OENTRY shape_localops[] =
    { "polynomial", S(POLYNOMIAL), 0,  "a", "az", NULL, (SUBR)Polynomial },
    { "chebyshevpoly", S(CHEBPOLY), 0, "a", "az",
      (SUBR)ChebyshevPolyInit, (SUBR)ChebyshevPolynomial },
+   { "chebyshevpoly2", S(CHEBPOLY2), 0, "a", "az",
+     (SUBR)ChebyshevPoly2Init, (SUBR)ChebyshevPolynomial2 },
+   { "chebyshevpoly2", S(CHEBPOLY2ARRAY), 0, "a", "ak[]",
+     (SUBR)ChebyshevPoly2ArrayInit, (SUBR)ChebyshevPolynomial2Array },
+   { "chebyshevpoly2", S(CHEBPOLY2ARRAY), 0, "a", "ai[]",
+     (SUBR)ChebyshevPoly2ArrayInit, (SUBR)ChebyshevPolynomial2Array },
    { "pdclip", S(PD_CLIP), 0,  "a", "akkop", NULL, (SUBR)PDClip },
    { "pdhalf", S(PD_HALF), 0,  "a", "akop", NULL, (SUBR)PDHalfX },
    { "pdhalfy", S(PD_HALF), 0,  "a", "akop", NULL, (SUBR)PDHalfY },

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -935,6 +935,8 @@ def runTest():
         ["test_distort_invalid_kdist.csd", "reject non-finite distort amount", 1],
         ["test_distort_invalid_ihp.csd", "reject non-finite distort filter frequency", 1],
         ["test_distort1_large_pregain.csd", "test distort1 with large pregain"],
+        ["test_chebyshevpoly_high_order.csd", "test high-order Chebyshev evaluation"],
+        ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],
         ["test_bus_channels.csd", "testing bus channels"],

--- a/tests/commandline/test_chebyshevpoly2_empty_array.csd
+++ b/tests/commandline/test_chebyshevpoly2_empty_array.csd
@@ -1,0 +1,20 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  ain = .25
+  kcoeff[] init 0
+  aout chebyshevpoly2 ain, kcoeff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_chebyshevpoly_high_order.csd
+++ b/tests/commandline/test_chebyshevpoly_high_order.csd
@@ -1,0 +1,95 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+#define Z8 #0, 0, 0, 0, 0, 0, 0, 0#
+
+instr 1
+  kcycle init 0
+  ain = p4
+  kscale = kcycle < 2 ? 1 : -.25
+  ; T64 alone exposes the loss from converting to power coefficients.
+  aresult chebyshevpoly2 ain, $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, kscale
+  kcoeff[] fillarray $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, $Z8, kscale
+  aarray chebyshevpoly2 ain, kcoeff
+  aexpected = p5 * kscale
+  kerror max_k abs(aresult - aexpected) + abs(aarray - aexpected), 1, 1
+  if !(kerror < .0001) then
+    printks "T64 mismatch: input=%g expected=%g error=%g\n", 0, p4, p5 * kscale, kerror
+    exitnowk(-1)
+  endif
+  if kcycle == 5 then
+    gkchecks += 1
+  endif
+  kcycle += 1
+endin
+
+instr 2
+  kcycle init 0
+  ain = p4
+  kscale = kcycle < 2 ? 1 : -.25
+  aresult chebyshevpoly2 ain, .3 * kscale, -.2 * kscale,
+                               .7 * kscale, 0, -.5 * kscale,
+                               .1 * kscale, 0, 0, .4 * kscale
+  alegacy chebyshevpoly ain, .3 * kscale, -.2 * kscale,
+                             .7 * kscale, 0, -.5 * kscale,
+                             .1 * kscale, 0, 0, .4 * kscale
+  aexpected = p5 * kscale
+  kerror max_k abs(aresult - aexpected) + abs(alegacy - aexpected), 1, 1
+  if !(kerror < .0001) then
+    printks "mixed Chebyshev mismatch: input=%g expected=%g error=%g\n", 0, p4, p5 * kscale, kerror
+    exitnowk(-1)
+  endif
+  if kcycle == 5 then
+    gkchecks += 1
+  endif
+  kcycle += 1
+endin
+
+instr 3
+  ain = p4
+  aresult chebyshevpoly2 ain, p5
+  icoeff[] fillarray p5
+  aarray chebyshevpoly2 ain, icoeff
+  alinear chebyshevpoly2 ain, p5, .5
+  ilinear[] fillarray p5, .5
+  alinearArray chebyshevpoly2 ain, ilinear
+  aexpectedLinear = p5 + .5 * ain
+  kerror max_k abs(aresult - p5) + abs(aarray - p5) +
+               abs(alinear - aexpectedLinear) +
+               abs(alinearArray - aexpectedLinear), 1, 1
+  if !(kerror < .000001) then
+    printks "constant Chebyshev mismatch: expected=%g error=%g\n", 0, p5, kerror
+    exitnowk(-1)
+  endif
+  kfirst init 1
+  if kfirst == 1 then
+    gkchecks += 1
+    kfirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkchecks) != 6 then
+    prints "not all chebyshevpoly checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 .9 -.8301709349
+i 1 0 .01 1 1
+i 1 0 .01 -1 1
+i 2 0 .01 .75 .98359375
+i 2 0 .01 -.4 -.542259968
+i 3 0 .01 .9 .25
+i 99 .02 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`chebyshevpoly` expands Chebyshev terms into ordinary polynomial coefficients. This keeps its short Horner loop for common low orders, but high-order intermediate coefficients can overflow even when the final series is finite. This change keeps the existing opcode unchanged and documents that known tradeoff.

`chebyshevpoly2` evaluates the series directly with Clenshaw's recurrence and double-precision intermediate values. It accepts the existing variadic coefficient form plus one-dimensional `i[]` and `k[]` coefficient arrays, rejects empty arrays, and has direct constant and linear fast paths. Variadic coefficients are copied into contiguous storage once per control block, and the recurrence stays in each processing loop so no helper function runs per sample.
