### PR TITLE
Fix gain processing at sample-accurate note ends

### DIFF
--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -1299,8 +1299,15 @@ int32_t gain(CSOUND *csound, GAIN *p)
 
     q = p->prvq;
     asig = p->asig;
-    if (UNLIKELY(early)) nsmps -= early;
-    for (n = offset; n < nsmps-early; n++) {
+    ar = p->ar;
+    if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
+    if (UNLIKELY(early)) {
+      nsmps -= early;
+      memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
+    }
+    if (UNLIKELY(offset >= nsmps))
+      return OK;
+    for (n = offset; n < nsmps; n++) {
       double as = (double)asig[n];
       q = c1 * as * as + c2 * q;
     }
@@ -1309,12 +1316,6 @@ int32_t gain(CSOUND *csound, GAIN *p)
       a = *p->krms / sqrt(q);
     else
       a = *p->krms;
-    ar = p->ar;
-    if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
-    }
     if ((diff = a - p->prva) != 0.0) {
       m = p->prva;
       inc = diff / (double)(nsmps-offset);
@@ -1352,6 +1353,8 @@ int32_t balance(CSOUND *csound, BALANCE *p)
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
+    if (UNLIKELY(offset >= nsmps))
+      return OK;
     for (n = offset; n < nsmps; n++) {
       double as = (double)asig[n];
       double cs = (double)csig[n];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -930,6 +930,7 @@ def runTest():
         ["test_follow_period.csd", "test follow period handling"],
         ["test_follow_invalid_period.csd", "reject invalid follow period", 1],
         ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
+        ["test_gain_sample_end.csd", "test gain sample-accurate note end"],
         ["test_distort_sample_offset.csd", "test distort sample-accurate onset"],
         ["test_distort_istor_first_init.csd", "test distort state-preserving first init"],
         ["test_distort_invalid_kdist.csd", "reject non-finite distort amount", 1],

--- a/tests/commandline/test_gain_sample_end.csd
+++ b/tests/commandline/test_gain_sample_end.csd
@@ -1,0 +1,32 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+
+gicapture ftgen 0, 0, 64, -2, 0
+
+instr 1
+  asignal = 1
+  aresult gain asignal, 1, 100
+  aindex line 0, p3, p3 * sr
+  tablew aresult, aindex, gicapture
+endin
+
+instr 99
+  ilast table 53, gicapture
+  if !(ilast > 0) then
+    prints "gain cleared an active sample at note end\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .00675
+i 99 .02 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`gain` subtracted `ksmps_no_end` twice. On a sample-accurate final block, it measured too few input samples, cleared part of the active output, and left the true inactive tail untouched.

This change computes the active endpoint once and uses it for level tracking, output, and tail clearing. It also makes `gain` and `balance` return without changing smoothing state when a block contains no active samples, avoiding division by zero.
