### PR TITLE
fix: reject unavailable string array reads during initialization

### DIFF
--- a/Engine/csound_orc_compile.c
+++ b/Engine/csound_orc_compile.c
@@ -186,13 +186,15 @@ static void classify_udo_rates(CSOUND *csound, ENGINE_STATE *engineState) {
 }
 
 /* Expression lowering sees provisional UDO callbacks. Once their rates are
-   final, reject performance-only struct temporaries passed to init-only UDOs.
+   final, reject performance-only array reads passed to init-only consumers.
+   String reads need this check for built-ins too, including function calls
+   nested inside performance-time statements.
    UDOs take values, including wrappers around type-only built-ins.
    Follow member getters too, so selecting a nested struct keeps the phase of
    the array read. Only generated temporaries are tracked: user variables can
    have separate init and performance assignments. */
-static void verify_udo_struct_read_phases(CSOUND *csound,
-                                         ENGINE_STATE *engineState) {
+static void verify_array_read_phases(CSOUND *csound,
+                                      ENGINE_STATE *engineState) {
   INSTRTXT *instrument;
 
   for (instrument = engineState->instxtanchor.nxtinstxt;
@@ -207,12 +209,21 @@ static void verify_udo_struct_read_phases(CSOUND *csound,
       int32_t i;
 
       if (entry == NULL) continue;
-      if (udo_called_definition(entry) != NULL && entry->perf == NULL &&
+      if (opcode_is_init_only_value_consumer(entry) &&
           perfReads != NULL && text->inlist != NULL) {
         for (i = 0; i < text->inlist->count; i++) {
           source = cs_hash_table_get(csound, perfReads,
                                       text->inlist->arg[i]);
-          if (source != NULL) {
+          if (source == NULL) continue;
+          if (strcmp(source->oentry->opname, "##array_get.K") == 0) {
+            synterr(csound,
+                    Str("init-only opcode %s cannot take a performance-only "
+                        "string array read; use i(kIndex) for an init-time "
+                        "index or a performance-time consumer such as printf, "
+                        "line %d\n"),
+                    entry->opname, source->linenum);
+          }
+          else if (udo_called_definition(entry) != NULL) {
             synterr(csound,
                     Str("init-only UDO %s cannot take a performance-only "
                         "struct array read; "
@@ -226,6 +237,15 @@ static void verify_udo_struct_read_phases(CSOUND *csound,
       if (strcmp(entry->opname, "##array_get_struct") == 0 &&
           entry->init == NULL) {
         source = text;
+      }
+      else if (strcmp(entry->opname, "##array_get.K") == 0 &&
+               entry->init == NULL && text->outlist != NULL &&
+               text->outlist->count == 1) {
+        CS_VARIABLE *variable = csoundFindVariableWithName(
+          csound, instrument->varPool, text->outlist->arg[0]);
+        if (variable != NULL && variable->varType == &CS_VAR_TYPE_S) {
+          source = text;
+        }
       }
       else if (perfReads != NULL && text->inlist != NULL &&
                text->inlist->count > 0 &&
@@ -2402,7 +2422,7 @@ int32_t csound_compile_tree(CSOUND *csound, TREE *root, int32_t async)
   while (specialize_init_getters(csound, engineState)) {
     classify_udo_rates(csound, engineState);
   }
-  verify_udo_struct_read_phases(csound, engineState);
+  verify_array_read_phases(csound, engineState);
   for (ip = engineState->instxtanchor.nxtinstxt;
        ip != NULL; ip = ip->nxtinstxt) {
     if (ip->opcode_info != NULL) {

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -677,6 +677,109 @@ endin
     EXPECT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, orchestra));
 }
 
+class StringArrayInitConsumerTests
+    : public OrcCompileTests,
+      public ::testing::WithParamInterface<const char *> {};
+
+TEST_P (StringArrayInitConsumerTests, rejectsPerformanceRead)
+{
+    std::string orchestra =
+        "declare PrintWord(word:S):()\n"
+        "instr 1\n"
+        "  Swords[] fillarray \"first\", \"changed\"\n"
+        "  kIndex init 1\n"
+        "  ";
+    orchestra += GetParam();
+    orchestra += "\nendin\n"
+                 "opcode PrintWord(word:S):void\n"
+                 "  prints \"%s\", word\n"
+                 "endop\n";
+    csoundCreateMessageBuffer(csound, 0);
+    EXPECT_NE(CSOUND_SUCCESS, csoundCompileOrc(csound, orchestra.c_str()));
+    std::string messages;
+    while (csoundGetMessageCnt(csound) > 0) {
+        messages += csoundGetFirstMessage(csound);
+        csoundPopFirstMessage(csound);
+    }
+    EXPECT_NE(std::string::npos, messages.find("performance-only string array read"));
+    EXPECT_NE(std::string::npos, messages.find("i(kIndex)"));
+    EXPECT_NE(std::string::npos, messages.find("performance-time consumer"));
+    EXPECT_NE(std::string::npos, messages.find("line 5"));
+    csoundDestroyMessageBuffer(csound);
+}
+
+TEST_P (StringArrayInitConsumerTests, acceptsExplicitInitRead)
+{
+    std::string statement = GetParam();
+    size_t index = statement.find("[kIndex]");
+    ASSERT_NE(std::string::npos, index);
+    statement.replace(index, strlen("[kIndex]"), "[i(kIndex)]");
+    std::string orchestra =
+        "declare PrintWord(word:S):()\n"
+        "instr 1\n"
+        "  Swords[] fillarray \"first\", \"changed\"\n"
+        "  kIndex init 1\n" + statement + "\nendin\n"
+        "opcode PrintWord(word:S):void\n"
+        "  prints \"%s\", word\n"
+        "endop\n";
+    EXPECT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, orchestra.c_str()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    StringArrays, StringArrayInitConsumerTests,
+    ::testing::Values(
+        "prints \"INIT=[%s]\\n\", Swords[kIndex]",
+        "printfi \"INIT=[%s]\\n\", 1, Swords[kIndex]",
+        "Scopy strcpy Swords[kIndex]",
+        "Scopy = strcpy(Swords[kIndex])",
+        "Scopy init Swords[kIndex]",
+        "printf \"LENGTH=%d\\n\", 1, strlen(Swords[kIndex])",
+        "PrintWord Swords[kIndex]"));
+
+TEST_F (OrcCompileTests, testStringArrayInitAndPerformanceValues)
+{
+    const char *orchestra = R"(
+sr = 48000
+ksmps = 32
+nchnls = 1
+opcode PrintWord(word:S):void
+  printf "UDO=[%s]\n", 1, word
+endop
+instr 1
+  Swords[] fillarray "first", "changed"
+  kIndex init 1
+  prints "INIT=[%s]\n", Swords[i(kIndex)]
+  Scopy strcpy Swords[i(kIndex)]
+  prints "COPY=[%s]\n", Scopy
+  Svalue = Swords[kIndex]
+  printf "PERF=[%s]\n", kIndex + 1, Swords[kIndex]
+  printf "ASSIGN=[%s]\n", kIndex + 1, Svalue
+  PrintWord Swords[kIndex]
+  printtype Swords[kIndex]
+  kIndex = 0
+endin
+)";
+    csoundCreateMessageBuffer(csound, 0);
+    ASSERT_EQ(CSOUND_SUCCESS, csoundSetOption(csound, "-n -d -m0"));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, orchestra));
+    csoundReadScore(csound, "i 1 0 0.01\n");
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundPerformKsmps(csound));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundPerformKsmps(csound));
+    std::string messages;
+    while (csoundGetMessageCnt(csound) > 0) {
+        messages += csoundGetFirstMessage(csound);
+        csoundPopFirstMessage(csound);
+    }
+    for (const char *expected : {"INIT=[changed]", "COPY=[changed]",
+                                "PERF=[changed]", "PERF=[first]",
+                                "ASSIGN=[changed]", "ASSIGN=[first]",
+                                "UDO=[changed]"}) {
+        EXPECT_NE(std::string::npos, messages.find(expected)) << expected;
+    }
+    csoundDestroyMessageBuffer(csound);
+}
+
 TEST_F (OrcCompileTests, testReuse)
 {
     int32_t result;


### PR DESCRIPTION
Closes #2812.

An init-only consumer such as `prints` could silently read an empty string from `Swords[kIndex]`, even when that element contained text. The array getter produces its value only during performance, after the consumer has already run. The compiler now rejects this use, reports the source line, and suggests converting the index with `i()` or using a performance-time consumer such as `printf`.

Extend the existing array-read phase check to track compiler-generated string temporaries alongside struct temporaries. The check runs after UDO rates are final, so it covers init-only built-ins, nested function calls, and init-only UDOs, including forward declarations.

String and struct array reads now follow the same rule for init-only consumers: a value produced only during performance cannot supply an initialization-time input. Explicit init-index reads and performance reads keep working. Plain string `=` retains its existing init and performance behavior.
