### PR TITLE
Fix Gendy segment processing and integer bounds

### DIFF
--- a/Opcodes/gendy.c
+++ b/Opcodes/gendy.c
@@ -63,20 +63,63 @@ typedef struct {
 #define dv2_31       (FL(4.656612873077392578125e-10))
 #define GENDYMAXCPS  8192          /* Max number of control points */
 
-static MYFLT gendy_distribution(CSOUND *csound, int32_t which, MYFLT a, int32 rnd)
+#define GENDY_BIPOLAR(rnd)                                                \
+  ((MYFLT)((int64_t)(uint32_t)(rnd) * 2 - BIPOLAR) * dv2_31)
+
+#define GENDY_POINTS(value)                                               \
+  ((value) >= FL(1.0)                                                     \
+   ? ((value) > GENDYMAXCPS ? GENDYMAXCPS : (int32_t)(value))            \
+   : 12)
+
+#define GENDY_KNUM(value, points)                                         \
+  ((value) >= FL(1.0) && (value) <= (MYFLT)(points)                       \
+   ? (int32_t)(value) : (points))
+
+#define GENDY_SET_CUBIC_PHASE(result, frequency, sample_rate)             \
+  do {                                                                    \
+    double frequency_ = (double)(frequency);                              \
+    double phase_;                                                        \
+    if (UNLIKELY(!(frequency_ > 0.001)))                                  \
+      frequency_ = 0.001;                                                 \
+    phase_ = (double)(sample_rate) / frequency_;                           \
+    if (UNLIKELY(!(phase_ < (double)INT32_MAX)))                           \
+      (result) = INT32_MAX;                                               \
+    else if (UNLIKELY(phase_ < 2.0))                                      \
+      (result) = 2;                                                       \
+    else                                                                  \
+      (result) = (int32_t)phase_;                                         \
+  } while (0)
+
+#define GENDY_SET_SPEED(result, minfreq, maxfreq, dur, onedsr, points)    \
+  do {                                                                    \
+    MYFLT speed_ = ((minfreq) + ((maxfreq) - (minfreq)) * (dur))          \
+      * (onedsr) * (points);                                              \
+    if (UNLIKELY(!(speed_ > FL(0.0))))                                    \
+      speed_ = FL(0.0);                                                   \
+    else if (UNLIKELY(speed_ > (MYFLT)(points)))                          \
+      speed_ = (MYFLT)(points);                                           \
+    (result) = speed_;                                                    \
+  } while (0)
+
+static MYFLT gendy_distribution(CSOUND *csound, MYFLT which, MYFLT a, int32 rnd)
 {
   IGN(csound);
+  int32_t selection;
   MYFLT   c, r;
+  if (which >= FL(0.0) && which < FL(7.0))
+    selection = (int32_t)which;
+  else
+    selection = 0;
   if (a > FL(1.0))
     a = FL(1.0);
   else if (a < FL(0.0001))
     a = FL(0.0001);
-  switch (which) {
+  switch (selection) {
   case 0: // linear
     break;
   case 1: // cauchy
     c = ATAN(FL(10.0)*a);
-    r = (MYFLT)((int32)((uint32_t)rnd<<1)-BIPOLAR) * dv2_31;
+    r = GENDY_BIPOLAR(rnd);
     r = (FL(1.0)/a) * TAN(c*r) * FL(0.1);
     return r;
   case 2: // logist
@@ -104,7 +147,7 @@ static MYFLT gendy_distribution(CSOUND *csound, int32_t which, MYFLT a, int32 rn
   default:
     break;
   }
-  r = (MYFLT)((int32)((uint32_t)rnd<<1)-BIPOLAR) * dv2_31;
+  r = GENDY_BIPOLAR(rnd);
   return r;
 }
 
@@ -117,12 +160,7 @@ static int32_t gendyset(CSOUND *csound, GENDY *p)
   p->phase   = FL(1.0);
   p->speed   = FL(100.0);
   p->index   = 0;
-  if (UNLIKELY(*p->initcps < FL(1.0)))
-    p->points = 12;
-  else if (UNLIKELY(*p->initcps > GENDYMAXCPS))
-    p->points = GENDYMAXCPS;
-  else
-    p->points = (int32)*p->initcps;
+  p->points = GENDY_POINTS(*p->initcps);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memamp);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memdur);
   memamp  = p->memamp.auxp;
@@ -130,7 +168,7 @@ static int32_t gendyset(CSOUND *csound, GENDY *p)
   p->rand = csound->Rand31(csound->RandSeed31(csound));
   for (i=0; i < p->points; i++) {
     p->rand = csound->Rand31(&p->rand);
-    memamp[i] = (MYFLT)((int32)((uint32_t)p->rand<<1)-BIPOLAR)*dv2_31;
+    memamp[i] = GENDY_BIPOLAR(p->rand);
     p->rand = csound->Rand31(&p->rand);
     memdur[i] = (MYFLT)p->rand * dv2_31;
   }
@@ -141,16 +179,14 @@ static int32_t kgendy(CSOUND *csound, GENDY *p)
 {
   int32_t     knum;
   MYFLT   *memamp, *memdur, minfreq, maxfreq, dist;
-  knum = (int32_t)*p->knum;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
   maxfreq = *p->maxfreq;
-  if (p->phase >= FL(1.0)) {
+  while (p->phase >= FL(1.0)) {
     int32_t index = p->index;
     p->phase -= FL(1.0);
-    if (knum > p->points || knum < 1)
-      knum = p->points;
     p->index = index = (index+1) % knum;
     p->amp = p->nextamp;
     p->rand = csound->Rand31(&p->rand);
@@ -176,8 +212,7 @@ static int32_t kgendy(CSOUND *csound, GENDY *p)
     else if (p->dur < FL(0.0))
       p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
     memdur[index] = p->dur;
-    p->speed =
-      (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
+    GENDY_SET_SPEED(p->speed, minfreq, maxfreq, p->dur, CS_ONEDSR, knum);
   }
   *p->out = *p->kamp * ((FL(1.0) - p->phase) * p->amp + p->phase * p->nextamp);
   p->phase += p->speed;
@@ -192,7 +227,7 @@ static int32_t agendy(CSOUND *csound, GENDY *p)
   uint32_t n, nsmps = CS_KSMPS;
   MYFLT   *out, *memamp, *memdur, minfreq, maxfreq, dist;
   out  = p->out;
-  knum = (int32_t)*p->knum;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
@@ -203,11 +238,9 @@ static int32_t agendy(CSOUND *csound, GENDY *p)
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
   for (n=offset; n<nsmps; n++) {
-    if (p->phase >= FL(1.0)) {
+    while (p->phase >= FL(1.0)) {
       int32_t index = p->index;
       p->phase -= FL(1.0);
-      if (knum > p->points || knum < 1)
-        knum = p->points;
       p->index = index = (index+1) % knum;
       p->amp = p->nextamp;
       p->rand = csound->Rand31(&p->rand);
@@ -231,8 +264,7 @@ static int32_t agendy(CSOUND *csound, GENDY *p)
       else if (p->dur < FL(0.0))
         p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
       memdur[index] = p->dur;
-      p->speed =
-        (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
+      GENDY_SET_SPEED(p->speed, minfreq, maxfreq, p->dur, CS_ONEDSR, knum);
     }
     out[n] = *p->kamp * ((FL(1.0) - p->phase) * p->amp + p->phase * p->nextamp);
     p->phase += p->speed;
@@ -249,12 +281,7 @@ static int32_t gendyxset(CSOUND *csound, GENDYX *p)
   p->phase   = FL(1.0);
   p->speed   = FL(100.0);
   p->index   = 0;
-  if (UNLIKELY(*p->initcps < FL(1.0)))
-    p->points = 12;
-  else if (UNLIKELY(*p->initcps > GENDYMAXCPS))
-    p->points = GENDYMAXCPS;
-  else
-    p->points = (int32)*p->initcps;
+  p->points = GENDY_POINTS(*p->initcps);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memamp);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memdur);
   memamp  = p->memamp.auxp;
@@ -263,7 +290,7 @@ static int32_t gendyxset(CSOUND *csound, GENDYX *p)
 
   for (i=0; i < p->points; i++) {
     p->rand   = (int32)csound->Rand31(&p->rand);
-    memamp[i] = (MYFLT)((int32)((uint32_t)p->rand<<1)-BIPOLAR)*dv2_31;
+    memamp[i] = GENDY_BIPOLAR(p->rand);
     p->rand   = csound->Rand31(&p->rand);
     memdur[i] = (MYFLT)p->rand * dv2_31;
   }
@@ -273,17 +300,18 @@ static int32_t gendyxset(CSOUND *csound, GENDYX *p)
 static int32_t kgendyx(CSOUND *csound, GENDYX *p)
 {
   int32_t     knum;
-  MYFLT   *memamp, *memdur, minfreq, maxfreq, dist, curve;
-  knum = (int32_t)*p->knum;
+  MYFLT   *memamp, *memdur, minfreq, maxfreq, dist;
+  MYFLT   curve, curveup, curvedown;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
   maxfreq = *p->maxfreq;
-  if (p->phase >= FL(1.0)) {
+  curveup = (*p->kcurveup > FL(0.0) ? *p->kcurveup : FL(0.0));
+  curvedown = (*p->kcurvedown > FL(0.0) ? *p->kcurvedown : FL(0.0));
+  while (p->phase >= FL(1.0)) {
     int32_t index = p->index;
     p->phase -= FL(1.0);
-    if (knum > p->points || knum < 1)
-      knum = p->points;
     p->index = index = (index+1) % knum;
     p->amp = p->nextamp;
     p->rand = csound->Rand31(&p->rand);
@@ -307,14 +335,9 @@ static int32_t kgendyx(CSOUND *csound, GENDYX *p)
     else if (p->dur < FL(0.0))
       p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
     memdur[index] = p->dur;
-    p->speed =
-      (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
+    GENDY_SET_SPEED(p->speed, minfreq, maxfreq, p->dur, CS_ONEDSR, knum);
   }
-  if (*p->kcurveup < FL(0.0))
-    *p->kcurveup = FL(0.0);
-  if (*p->kcurvedown < FL(0.0))
-    *p->kcurvedown = FL(0.0);
-  curve = ((p->nextamp - p->amp) > FL(0.0) ? *p->kcurveup : *p->kcurvedown);
+  curve = ((p->nextamp - p->amp) > FL(0.0) ? curveup : curvedown);
   *p->out = *p->kamp * (p->amp + POWER(p->phase, curve) * (p->nextamp - p->amp));
   p->phase += p->speed;
   return OK;
@@ -326,24 +349,25 @@ static int32_t agendyx(CSOUND *csound, GENDYX *p)
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  MYFLT   *out, *memamp, *memdur, minfreq, maxfreq, dist, curve;
+  MYFLT   *out, *memamp, *memdur, minfreq, maxfreq, dist;
+  MYFLT   curve, curveup, curvedown;
   out  = p->out;
-  knum = (int32_t)*p->knum;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
   maxfreq = *p->maxfreq;
+  curveup = (*p->kcurveup > FL(0.0) ? *p->kcurveup : FL(0.0));
+  curvedown = (*p->kcurvedown > FL(0.0) ? *p->kcurvedown : FL(0.0));
   if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
   if (UNLIKELY(early)) {
     nsmps -= early;
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
   for (n=offset; n<nsmps; n++) {
-    if (p->phase >= FL(1.0)) {
+    while (p->phase >= FL(1.0)) {
       int32_t index = p->index;
       p->phase -= FL(1.0);
-      if (knum > p->points || knum < 1)
-        knum = p->points;
       p->index = index = (index+1) % knum;
       p->amp = p->nextamp;
       p->rand = csound->Rand31(&p->rand);
@@ -367,14 +391,9 @@ static int32_t agendyx(CSOUND *csound, GENDYX *p)
       else if (p->dur < FL(0.0))
         p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
       memdur[index] = p->dur;
-      p->speed =
-        (minfreq + (maxfreq - minfreq) * p->dur) * CS_ONEDSR * knum;
+      GENDY_SET_SPEED(p->speed, minfreq, maxfreq, p->dur, CS_ONEDSR, knum);
     }
-    if (*p->kcurveup < FL(0.0))
-      *p->kcurveup = FL(0.0);
-    if (*p->kcurvedown < FL(0.0))
-      *p->kcurvedown = FL(0.0);
-    curve = ((p->nextamp - p->amp) > FL(0.0) ? *p->kcurveup : *p->kcurvedown);
+    curve = ((p->nextamp - p->amp) > FL(0.0) ? curveup : curvedown);
     out[n] = *p->kamp * (p->amp + POWER(p->phase, curve) * (p->nextamp - p->amp));
     p->phase += p->speed;
   }
@@ -393,12 +412,7 @@ static int32_t gendycset(CSOUND *csound, GENDYC *p)
   p->curve   = FL(0.0);
   p->phase   = 0;
   p->index   = 0;
-  if (UNLIKELY(*p->initcps < FL(1.0)))
-    p->points = 12;
-  else if (UNLIKELY(*p->initcps > GENDYMAXCPS))
-    p->points = GENDYMAXCPS;
-  else
-    p->points = (int32)*p->initcps;
+  p->points = GENDY_POINTS(*p->initcps);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memamp);
   csound->AuxAlloc(csound, p->points*sizeof(MYFLT), &p->memdur);
   memamp  = p->memamp.auxp;
@@ -406,7 +420,7 @@ static int32_t gendycset(CSOUND *csound, GENDYC *p)
   p->rand = csound->Rand31(csound->RandSeed31(csound));
   for (i=0; i < p->points; i++) {
     p->rand = csound->Rand31(&p->rand);
-    memamp[i] = (MYFLT)((int32)((uint32_t)p->rand<<1)-BIPOLAR)*dv2_31;
+    memamp[i] = GENDY_BIPOLAR(p->rand);
     p->rand = csound->Rand31(&p->rand);
     memdur[i] = (MYFLT)p->rand * dv2_31;
   }
@@ -417,7 +431,7 @@ static int32_t kgendyc(CSOUND *csound, GENDYC *p)
 {
   int32_t     knum;
   MYFLT   *memamp, *memdur, minfreq, maxfreq, dist;
-  knum = (int32_t)*p->knum;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
@@ -425,8 +439,6 @@ static int32_t kgendyc(CSOUND *csound, GENDYC *p)
   if (p->phase <= 0) {
     int32_t     index = p->index;
     MYFLT   fphase, next_midpnt;
-    if (knum > p->points || knum < 1)
-      knum = p->points;
     p->index = index = (index+1) % knum;
     p->amp = p->nextamp;
     p->rand = csound->Rand31(&p->rand);
@@ -452,11 +464,10 @@ static int32_t kgendyc(CSOUND *csound, GENDYC *p)
       p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
     memdur[index] = p->dur;
     fphase = (minfreq + (maxfreq - minfreq) * p->dur) * knum;
-    fphase = (fphase > FL(0.001) ? fphase : FL(0.001));
-    p->phase = (int32)(CS_ESR / fphase);
-    if (p->phase < 2) p->phase = 2;
+    GENDY_SET_CUBIC_PHASE(p->phase, fphase, CS_ESR);
     p->curve = FL(2.0) * (next_midpnt - p->midpnt - p->phase * p->slope);
-    p->curve = p->curve / (p->phase * p->phase + p->phase);
+    fphase = (MYFLT)p->phase;
+    p->curve = p->curve / (fphase * fphase + fphase);
   }
   p->phase--;
   *p->out = *p->kamp * p->midpnt;
@@ -471,10 +482,11 @@ static int32_t agendyc(CSOUND *csound, GENDYC *p)
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   int32_t     knum;
-  int32_t     remain = CS_KSMPS-offset-early;
+  uint32_t    n = offset;
+  uint32_t    remain = CS_KSMPS-offset-early;
   MYFLT   *out, *memamp, *memdur, minfreq, maxfreq, dist;
   out  = p->out;
-  knum = (int32_t)*p->knum;
+  knum = GENDY_KNUM(*p->knum, p->points);
   memamp  = p->memamp.auxp;
   memdur  = p->memdur.auxp;
   minfreq = *p->minfreq;
@@ -483,13 +495,11 @@ static int32_t agendyc(CSOUND *csound, GENDYC *p)
   if (UNLIKELY(early)) {
     memset(&out[remain+offset], '\0', early*sizeof(MYFLT));
   }
-  do {
-    uint32_t n, nsmps;
+  while (remain > 0) {
+    uint32_t end, nsmps;
     if (p->phase <= 0) {
       int32_t     index = p->index;
       MYFLT   fphase, next_midpnt;
-      if (knum > p->points || knum < 1)
-        knum = p->points;
       p->index = index = (index+1) % knum;
       p->amp = p->nextamp;
       p->rand = csound->Rand31(&p->rand);
@@ -515,22 +525,22 @@ static int32_t agendyc(CSOUND *csound, GENDYC *p)
         p->dur = FL(2.0) - FMOD(p->dur + FL(2.0), FL(2.0));
       memdur[index] = p->dur;
       fphase = (minfreq + (maxfreq - minfreq) * p->dur) * knum;
-      fphase = (fphase > FL(0.001) ? fphase : FL(0.001));
-      p->phase = (int32)(CS_ESR / fphase);
-      if (p->phase < 2) p->phase = 2;
+      GENDY_SET_CUBIC_PHASE(p->phase, fphase, CS_ESR);
       p->curve = FL(2.0) * (next_midpnt - p->midpnt - p->phase * p->slope);
-      p->curve = p->curve / (p->phase * p->phase + p->phase);
+      fphase = (MYFLT)p->phase;
+      p->curve = p->curve / (fphase * fphase + fphase);
     }
-    nsmps = (remain < p->phase ? remain : p->phase);
+    nsmps = (remain < (uint32_t)p->phase ? remain : (uint32_t)p->phase);
     remain   -= nsmps;
     p->phase -= nsmps;
-    for (n=offset; n<nsmps; n++) {
+    end = n + nsmps;
+    for (; n<end; n++) {
       out[n] = *p->kamp * p->midpnt; /* JPff-- was *out++ but that ignores
                                         sample accurate */
       p->slope  += p->curve;
       p->midpnt += p->slope;
     }
-  } while (remain);
+  }
   return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -586,6 +586,7 @@ def runTest():
         ["test_grain2_float_window_wrap.csd", "grain2 wraps non-power-of-two window phase"],
         ["test_partikkel_float_table_index.csd", "partikkel uses the scaled index for float table lookup"],
         ["test_grain4_correctness.csd", "grain4 handles envelopes, boundaries, and unused pitches"],
+        ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
         ["test_grain4_region_rounding.csd", "grain4 preserves sample rounding for source regions"],
         ["test_grain4_zero_length.csd", "reject zero grain4 source length", 1],
         ["test_grain4_subsample_length.csd", "reject sub-sample grain4 source length", 1],

--- a/tests/commandline/test_gendy_correctness.csd
+++ b/tests/commandline/test_gendy_correctness.csd
@@ -1,0 +1,94 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+
+giBlock ftgen 0, 0, 64, -2, 0
+giSingle ftgen 0, 0, 64, -2, 0
+
+instr 1
+  seed 1
+  aresult gendyc .5, 1, 1, 1, 1, 4000, 4000, .5, .5, 12, 12
+  aindex line 0, p3, p3 * sr
+  tablew aresult, aindex, giBlock
+endin
+
+instr 2
+  setksmps 1
+  seed 1
+  aresult gendyc .5, 1, 1, 1, 1, 4000, 4000, .5, .5, 12, 12
+  aindex line 0, p3, p3 * sr
+  tablew aresult, aindex, giSingle
+endin
+
+instr 3
+  iindex = 0
+  while iindex < 64 do
+    iblock table iindex, giBlock
+    isingle table iindex, giSingle
+    if abs(iblock - isingle) > .000000001 then
+      prints "gendyc differs at sample %d: block %.12g, single %.12g\n", \
+             iindex, iblock, isingle
+      exitnow -1
+    endif
+    iindex += 1
+  od
+endin
+
+instr 4
+  seed 1
+  aresult gendyc .5, 1, 1, 1, 1, .00001, .00001, .5, .5, 12, 12
+  out aresult
+endin
+
+instr 5
+  iNaN strtod "nan"
+  seed 1
+  aresult gendy .5, iNaN, iNaN, .5, .5, 100, 100, .5, .5, iNaN, iNaN
+  kresult downsamp aresult
+  if qnan(kresult) != 0 then
+    printks "gendy produced a non-finite value for defaulted selectors\n", 0
+    exitnowk -1
+  endif
+  out aresult
+endin
+
+instr 6
+  seed 1
+  agendy gendy .5, 1, 1, .5, .5, 8000, 8000, .5, .5, 12, 12
+  agendyx gendyx .5, 1, 1, .5, .5, 8000, 8000, .5, .5, 1, 1, 12, 12
+  kgendy max_k abs(agendy), 1, 1
+  kgendyx max_k abs(agendyx), 1, 1
+  if kgendy > .500000001 || kgendyx > .500000001 then
+    printks "high-frequency Gendy output exceeded its amplitude: %g, %g\n", \
+            0, kgendy, kgendyx
+    exitnowk -1
+  endif
+endin
+
+instr 7
+  kcurve init -1
+  aresult gendyx .5, 1, 1, .5, .5, 100, 100, .5, .5, \
+                 kcurve, kcurve, 12, 12
+  if kcurve != -1 then
+    printks "gendyx changed its curve input to %g\n", 0, kcurve
+    exitnowk -1
+  endif
+  out aresult
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .008
+i 2 .01 .008
+i 3 .02 .001
+i 4 .03 .001
+i 5 .04 .008
+i 6 .05 .008
+i 7 .06 .008
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`gendyc.a` restarted each segment at the block offset, so short segments overwrote the start of the block and left later samples stale. Advance one output cursor across all segments so block processing matches single-sample processing.

The Gendy family also used signed-overflow arithmetic for bipolar random values, overflowed `gendyc` segment-length squares, and cast unchecked control values to integers. Use wide or bounded conversions, consume every control-point segment crossed in a sample, and keep high-frequency interpolation within the amplitude range. `gendyx` now clamps curve values locally instead of changing its inputs.
