### PR TITLE
fix: correct paulstretch FFT bins and window handling

### DIFF
--- a/Opcodes/paulstretch.c
+++ b/Opcodes/paulstretch.c
@@ -24,12 +24,10 @@
     Foundation, Inc., 31 Milk Street, #960789, Boston, MA, 02196, USA
 */
 #include <stdlib.h>
-#include <complex.h>
 
 #ifdef _MSC_VER
 #define _USE_MATH_DEFINES
 #endif
-#include <math.h>
 #include <math.h>
 #ifdef BUILD_PLUGINS
 #include "csdl.h"
@@ -38,15 +36,10 @@
 #endif
 #include "interlocks.h"
 
-#ifdef ANDROID
-float crealf(_Complex float);
-float cimagf(_Complex float);
-#endif
-
 typedef struct {
     OPDS h;
     MYFLT *out, *stretch, *winsize, *ifn;
-    MYFLT start_pos, displace_pos;
+    double start_pos, displace_pos;
     MYFLT *window;
     MYFLT *old_windowed_buf;
     MYFLT *hinv_buf;
@@ -66,7 +59,7 @@ typedef struct {
 
 static void compute_block(CSOUND *csound, PAULSTRETCH *p)
 {
-    uint32_t istart_pos = floor(p->start_pos);
+    uint32_t istart_pos = (uint32_t)p->start_pos;
     uint32_t pos;
     uint32_t i;
     uint32_t windowsize = p->windowsize;
@@ -85,25 +78,17 @@ static void compute_block(CSOUND *csound, PAULSTRETCH *p)
         tmp[i] = FL(0.0);
       }
     }
-    /* re-order bins and take FFT */
-    tmp[p->windowsize] = tmp[1];
-    tmp[p->windowsize + 1] = FL(0.0);
     csound->RealFFT(csound, p->setup, tmp);
+    /* Unpack Nyquist after the FFT; DC has no imaginary component. */
+    tmp[p->windowsize] = tmp[1];
+    tmp[1] = FL(0.0);
+    tmp[p->windowsize + 1] = FL(0.0);
     /* randomize phase */
     for (i = 0; i < windowsize + 2; i += 2) {
       MYFLT mag = HYPOT(tmp[i], tmp[i + 1]);
-      // Android 5.1 does not seem to have cexpf ...
-      // complex ph = cexpf(I * ((MYFLT)rand() / RAND_MAX) * 2 * PI);
-      // so ...
       MYFLT  x = (((MYFLT)rand() / RAND_MAX) * 2 * PI);
-#ifdef MSVC
-      // TODO - Double check this is equivalent to non-windows complex definition
-          _Fcomplex ph = { cos(x), sin(x) };
-#else
-      complex double ph =  cos(x) + I*sin(x);
-#endif
-      tmp[i] = mag * (MYFLT)crealf(ph);
-      tmp[i + 1] = mag * (MYFLT)cimagf(ph);
+      tmp[i] = mag * COS(x);
+      tmp[i + 1] = mag * SIN(x);
     }
 
     /* re-order bins and take inverse FFT */
@@ -118,25 +103,41 @@ static void compute_block(CSOUND *csound, PAULSTRETCH *p)
       }
       old_windowed_buf[i] = tmp[i];
     }
-    p->start_pos += p->displace_pos;
+    /* Keep emitting the overlap tail, then silence, after the source ends. */
+    if (p->displace_pos >= (double)p->ft->flen - p->start_pos)
+      p->start_pos = p->ft->flen;
+    else
+      p->start_pos += p->displace_pos;
 }
 
 static int32_t ps_init(CSOUND* csound, PAULSTRETCH *p)
 {
     FUNC *ftp = csound->FTFind(csound, p->ifn);
     uint32_t i = 0;
-    uint32_t size;
+    size_t size;
+    double samples = (double)CS_ESR * (double)*p->winsize;
+    double stretch = (double)*p->stretch;
 
     if (ftp == NULL)
       return csound->InitError(csound, "%s", Str("paulstretch: table not found"));
 
+    if (UNLIKELY(!(stretch > 0.0) || !isfinite(stretch)))
+      return csound->InitError(csound, "%s",
+                               Str("paulstretch: stretch must be finite and positive"));
+    /* RealFFT uses signed byte counts internally and needs two spare samples. */
+    if (UNLIKELY(!(samples >= 0.0 &&
+                   samples < (double)(INT32_MAX / sizeof(MYFLT) - 2))))
+      return csound->InitError(csound, "%s",
+                               Str("paulstretch: invalid window size"));
     p->ft = ftp;
-    p->windowsize = (uint32_t)FLOOR((CS_ESR * *p->winsize));
+    p->windowsize = (uint32_t)samples;
     if (p->windowsize < 16) {
       p->windowsize = 16;
     }
+    /* Real FFT bins and the two equal overlap halves require an even size. */
+    p->windowsize &= ~1u;
     p->half_windowsize = p->windowsize / 2;
-    p->displace_pos = (p->windowsize * FL(0.5)) / *p->stretch;
+    p->displace_pos = (double)p->half_windowsize / stretch;
 
     size = sizeof(MYFLT) * p->windowsize;
     csound->AuxAlloc(csound, size, &(p->m_window));
@@ -184,7 +185,6 @@ static int32_t paulstretch_perf(CSOUND* csound, PAULSTRETCH *p)
     MYFLT *out = p->out;
 
     if (UNLIKELY(offset)) {
-      memset(p->out, '\0', offset*sizeof(MYFLT));
       memset(p->out, '\0', offset*sizeof(MYFLT));
     }
     if (UNLIKELY(early)) {

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -26,6 +26,7 @@ if(BUILD_TESTS)
         engine_test.cpp
         io_test.cpp
         osc_blob_test.cpp
+        paulstretch_test.cpp
         server_test.cpp
         csound_plugin_opcode_test.cpp
         perfthread_test.cpp

--- a/tests/c/paulstretch_test.cpp
+++ b/tests/c/paulstretch_test.cpp
@@ -1,0 +1,127 @@
+#define __BUILDING_LIBCSOUND
+#include "csoundCore.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+namespace {
+
+struct FFTProbe {
+    int forwards = 0;
+    int inverses = 0;
+};
+
+void probeFFT(CSOUND *csound, void *setup, MYFLT *buffer)
+{
+    auto *probe = static_cast<FFTProbe *>(csoundGetHostData(csound));
+    auto *fft = static_cast<CSOUND_FFT_SETUP *>(setup);
+    if (fft->d == FFT_FWD) {
+        ++probe->forwards;
+        std::fill(buffer, buffer + fft->N, FL(0.0));
+        buffer[1] = FL(8.0);  // Nyquist, not DC's imaginary component.
+        buffer[2] = FL(3.0);
+        buffer[3] = FL(4.0);
+    }
+    else {
+        ++probe->inverses;
+        EXPECT_EQ(buffer[0], FL(0.0));
+        EXPECT_GT(std::abs(buffer[1]), FL(0.0));
+        EXPECT_LE(std::abs(buffer[1]), FL(8.0));
+        const double tolerance = sizeof(MYFLT) == sizeof(float) ? 1e-5 : 1e-12;
+        EXPECT_NEAR(std::hypot(buffer[2], buffer[3]), 5.0, tolerance);
+        std::fill(buffer, buffer + fft->N, FL(0.0));
+    }
+}
+
+class PaulstretchTests : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        csound = csoundCreate(&probe, nullptr);
+        ASSERT_NE(csound, nullptr);
+        csoundCreateMessageBuffer(csound, 0);
+        ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+        ASSERT_EQ(csoundSetOption(csound, "--fftlib=0"), CSOUND_SUCCESS);
+    }
+
+    void TearDown() override { csoundDestroy(csound); }
+
+    std::string messages()
+    {
+        std::string result;
+        while (csoundGetMessageCnt(csound)) {
+            result += csoundGetFirstMessage(csound);
+            csoundPopFirstMessage(csound);
+        }
+        return result;
+    }
+
+    void compile(const std::string &stretch, const std::string &window)
+    {
+        std::string orchestra =
+            "sr = 1024\nksmps = 8\nnchnls = 1\n0dbfs = 1\n"
+            "giSource ftgen 1, 0, 32, 10, 1\n"
+            "instr 1\naout paulstretch " + stretch + ", " + window +
+            ", giSource\nout aout\nendin\n";
+        ASSERT_EQ(csoundCompileOrc(csound, orchestra.c_str(), 0), CSOUND_SUCCESS)
+            << messages();
+        csoundEventString(csound, "i 1 0 0.1", 0);
+        ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS) << messages();
+    }
+
+    FFTProbe probe;
+    CSOUND *csound = nullptr;
+};
+
+TEST_F(PaulstretchTests, UnpacksRealFFTBeforeRandomizingPhase)
+{
+    ASSERT_NO_FATAL_FAILURE(compile("2", "16/1024"));
+    csound->RealFFT = probeFFT;
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS) << messages();
+    EXPECT_EQ(probe.forwards, 1);
+    EXPECT_EQ(probe.inverses, 1);
+}
+
+TEST_F(PaulstretchTests, RoundsOddWindowsToEvenSamples)
+{
+    ASSERT_NO_FATAL_FAILURE(compile("2", "17/1024"));
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS) << messages();
+}
+
+TEST_F(PaulstretchTests, TinyStretchReachesEndAndStaysSilent)
+{
+    ASSERT_NO_FATAL_FAILURE(compile("1e-30", "16/1024"));
+    bool heardSource = false;
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS) << messages();
+        const MYFLT *output = csoundGetSpout(csound);
+        for (uint32_t j = 0; j < csoundGetKsmps(csound); ++j) {
+            if (i < 2) {
+                EXPECT_TRUE(std::isfinite(output[j]));
+                heardSource |= output[j] != FL(0.0);
+            }
+            else
+                EXPECT_EQ(output[j], FL(0.0));
+        }
+    }
+    EXPECT_TRUE(heardSource);
+}
+
+TEST_F(PaulstretchTests, RejectsZeroStretch)
+{
+    ASSERT_NO_FATAL_FAILURE(compile("0", "16/1024"));
+    csoundPerformKsmps(csound);
+    EXPECT_NE(messages().find("stretch must be finite and positive"),
+              std::string::npos);
+}
+
+TEST_F(PaulstretchTests, RejectsOversizedWindow)
+{
+    ASSERT_NO_FATAL_FAILURE(compile("2", "1e20"));
+    csoundPerformKsmps(csound);
+    EXPECT_NE(messages().find("invalid window size"), std::string::npos);
+}
+
+} // namespace


### PR DESCRIPTION
`paulstretch` unpacked Nyquist before the forward FFT, mixing it into the DC magnitude and using a time-domain sample as the Nyquist bin. Unpack it after the FFT and clear DC's imaginary component before randomizing phase.

- Round windows down to an even sample count, with the existing minimum of 16, so FFT bins and overlap halves line up.
- Check stretch and window sizes before conversion and allocation to prevent invalid arithmetic; use `size_t` for buffer sizes.
- Keep source position in double precision and stop advancing it at the table end, preserving the overlap tail before silence without out-of-range integer conversions.
- Use the existing sine/cosine macros directly, removing the float-only complex conversion that lost precision in double builds.
