### PR TITLE
Fix track frequency bounds and trfilter Nyquist lookup

### DIFF
--- a/Opcodes/psynth.c
+++ b/Opcodes/psynth.c
@@ -641,6 +641,8 @@ static int32_t trscale_process(CSOUND *csound, _PTRANS *p)
         else
           frameout[i] = framein[i];
         outfr = framein[i + 1] * scale;
+        if (UNLIKELY(!(outfr >= FL(0.0))))
+          outfr = FL(0.0);
         frameout[i + 1] = (float) (outfr < nyq ? outfr : nyq);
         frameout[i + 2] = framein[i + 2];
         id = (int32_t) framein[i + 3];
@@ -670,6 +672,8 @@ static int32_t trshift_process(CSOUND *csound, _PTRANS *p)
         else
           frameout[i] = framein[i];
         outfr = framein[i + 1] + shift;
+        if (UNLIKELY(!(outfr >= FL(0.0))))
+          outfr = FL(0.0);
         frameout[i + 1] = (float) (outfr < nyq ? outfr : nyq);
         frameout[i + 2] = framein[i + 2];
         id = (int32_t) framein[i + 3];
@@ -1023,9 +1027,11 @@ static int32_t trfil_process(CSOUND *csound, _PSFIL *p)
       if (UNLIKELY(amnt < 0))
         amnt = 0;
       do {
-        fr = FABS(framein[i + 1]);
-        if (UNLIKELY(!(fr <= nyq)))
-          fr = fr > nyq ? nyq : FL(0.0);
+        fr = framein[i + 1];
+        if (UNLIKELY(!(fr >= FL(0.0))))
+          fr = FL(0.0);
+        else if (UNLIKELY(fr > nyq))
+          fr = nyq;
         pos = fr * len / nyq;
         /* At Nyquist, use the guard point without reading beyond it. */
         if (UNLIKELY(pos >= len))

--- a/Opcodes/psynth.c
+++ b/Opcodes/psynth.c
@@ -1011,7 +1011,8 @@ static int32_t trfil_process(CSOUND *csound, _PSFIL *p)
     MYFLT   *fil = p->tab->ftable;
     float   *framein = (float *) p->fin->frame.auxp;
     float   *frameout = (float *) p->fout->frame.auxp;
-    int32_t i = 0, id /* = (int32_t) framein[3]*/, len = p->len, end = p->numbins * 4;
+    int32_t i = 0, id /* = (int32_t) framein[3]*/, len = p->len,
+            end = p->numbins * 4;
 
     if (p->lastframe < p->fin->framecount) {
       MYFLT   fr, pos = FL(0.0), frac = FL(0.0);
@@ -1022,15 +1023,18 @@ static int32_t trfil_process(CSOUND *csound, _PSFIL *p)
       if (UNLIKELY(amnt < 0))
         amnt = 0;
       do {
-        fr = framein[i + 1];
-        if (UNLIKELY(fr > nyq))
-          fr = nyq;
-        //if (fr < 0)
-        fr = FABS(fr);
+        fr = FABS(framein[i + 1]);
+        if (UNLIKELY(!(fr <= nyq)))
+          fr = fr > nyq ? nyq : FL(0.0);
         pos = fr * len / nyq;
-        posi = (int32_t) pos;
-        frac = pos - posi;
-        gain = fil[posi] + frac * (fil[posi + 1] - fil[posi]);
+        /* At Nyquist, use the guard point without reading beyond it. */
+        if (UNLIKELY(pos >= len))
+          gain = fil[len];
+        else {
+          posi = (int32_t) pos;
+          frac = pos - posi;
+          gain = fil[posi] + frac * (fil[posi + 1] - fil[posi]);
+        }
         frameout[i] = (float) (framein[i] * (FL(1.0) - amnt + gain * amnt));
         frameout[i + 1] = fr;
         frameout[i + 2] = framein[i + 2];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -582,6 +582,7 @@ def runTest():
         ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
         ["test_oversample.csd", "test oversampling in new-style UDO"],
         ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
+        ["test_trfilter_frequency_bounds.csd", "test trfilter frequency bounds"],
         [
             "test_pvsadsyn_last_bin.csd",
             "pvsadsyn accepts a stepped selection ending at the last bin",

--- a/tests/commandline/test_trfilter_frequency_bounds.csd
+++ b/tests/commandline/test_trfilter_frequency_bounds.csd
@@ -1,0 +1,59 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+giSine ftgen 1, 0, 8192, 10, 1
+giFilter ftgen 2, 0, -16, -7, 1, 16, 2
+
+instr 1
+  kchecks init 0
+  kcycle timeinstk
+  asig oscili .5, 1000, giSine
+  ffreq, fphase pvsifd asig, 64, 16, 1
+  ftracks partials ffreq, fphase, .001, 1, 3, 10
+  fscaled trscale ftracks, p4
+  ffiltered trfilter fscaled, p5, giFilter
+  flow1, kfreq1, kamp1 trlowest ftracks, 1
+  if p4 == 0 then
+    flow2, kfreq2, kamp2 trlowest ffiltered, 1
+  else
+    fhigh2, kfreq2, kamp2 trhighest ffiltered, 1
+  endif
+
+  if kamp1 > 0 then
+    kratio = kamp2 / kamp1
+    kexpected = min(abs(kfreq1 * p4), sr / 2)
+    kgain = 1 + kexpected / (sr / 2) * p5
+    if kamp2 <= 0 || abs(kfreq2 - kexpected) > .001 || abs(kratio - kgain) > .000001 then
+      printks "trfilter bounds failed: frequency=%f ratio=%f\n", 0, kfreq2, kratio
+      exitnowk(-1)
+    endif
+    kchecks += 1
+  endif
+  if kcycle == 90 && kchecks == 0 then
+    printks "trfilter produced no track to check\n", 0
+    exitnowk(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Beyond Nyquist, at the endpoint, at DC, and inside the table.
+i 1 0 .1 10 1
+i 1 .1 .1 -10 1
+i 1 .2 .1 4 1
+i 1 .3 .1 -4 1
+i 1 .4 .1 0 1
+i 1 .5 .1 1 1
+i 1 .6 .1 -1 1
+i 1 .7 .1 .713 1
+; Partial filtering and bypass keep their existing gain.
+i 1 .8 .1 .713 .5
+i 1 .9 .1 -10 0
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_trfilter_frequency_bounds.csd
+++ b/tests/commandline/test_trfilter_frequency_bounds.csd
@@ -17,18 +17,29 @@ instr 1
   asig oscili .5, 1000, giSine
   ffreq, fphase pvsifd asig, 64, 16, 1
   ftracks partials ffreq, fphase, .001, 1, 3, 10
-  fscaled trscale ftracks, p4
-  ffiltered trfilter fscaled, p5, giFilter
   flow1, kfreq1, kamp1 trlowest ftracks, 1
-  if p4 == 0 then
+  if p6 == 0 then
+    fprocessed trscale ftracks, p4
+    kexpected = min(max(kfreq1 * p4, 0), sr / 2)
+  else
+    fprocessed trshift ftracks, p4
+    kexpected = min(max(kfreq1 + p4, 0), sr / 2)
+  endif
+  ffiltered trfilter fprocessed, p5, giFilter
+  if kexpected == 0 then
+    flow0, kfreq0, kamp0 trlowest fprocessed, 1
     flow2, kfreq2, kamp2 trlowest ffiltered, 1
   else
+    fhigh0, kfreq0, kamp0 trhighest fprocessed, 1
     fhigh2, kfreq2, kamp2 trhighest ffiltered, 1
   endif
 
   if kamp1 > 0 then
+    if abs(kfreq0 - kexpected) > .001 || abs(kamp0 - kamp1) > .000001 then
+      printks "track frequency bounds failed: mode=%f frequency=%f expected=%f\n", 0, p6, kfreq0, kexpected
+      exitnowk(-1)
+    endif
     kratio = kamp2 / kamp1
-    kexpected = min(abs(kfreq1 * p4), sr / 2)
     kgain = 1 + kexpected / (sr / 2) * p5
     if kamp2 <= 0 || abs(kfreq2 - kexpected) > .001 || abs(kratio - kgain) > .000001 then
       printks "trfilter bounds failed: frequency=%f ratio=%f\n", 0, kfreq2, kratio
@@ -43,17 +54,26 @@ instr 1
 endin
 </CsInstruments>
 <CsScore>
-; Beyond Nyquist, at the endpoint, at DC, and inside the table.
-i 1 0 .1 10 1
-i 1 .1 .1 -10 1
-i 1 .2 .1 4 1
-i 1 .3 .1 -4 1
-i 1 .4 .1 0 1
-i 1 .5 .1 1 1
-i 1 .6 .1 -1 1
-i 1 .7 .1 .713 1
+; Scale beyond Nyquist, to the endpoint, below zero, to DC, and inside the table.
+i 1 0 .1 10 1 0
+i 1 .1 .1 -10 1 0
+i 1 .2 .1 4 1 0
+i 1 .3 .1 -4 1 0
+i 1 .4 .1 0 1 0
+i 1 .5 .1 1 1 0
+i 1 .6 .1 -1 1 0
+i 1 .7 .1 .713 1 0
 ; Partial filtering and bypass keep their existing gain.
-i 1 .8 .1 .713 .5
-i 1 .9 .1 -10 0
+i 1 .8 .1 .713 .5 0
+i 1 .9 .1 -10 0 0
+; Shift below zero, to DC, down within range, unchanged, to Nyquist, and beyond.
+i 1 1 .1 -10000 1 1
+i 1 1.1 .1 -1000 1 1
+i 1 1.2 .1 -500 1 1
+i 1 1.3 .1 0 1 1
+i 1 1.4 .1 3000 1 1
+i 1 1.5 .1 10000 1 1
+i 1 1.6 .1 -500 .5 1
+i 1 1.7 .1 -10000 0 1
 </CsScore>
 </CsoundSynthesizer>


### PR DESCRIPTION
`trscale` and `trshift` now clamp output frequencies to zero through Nyquist. Downward shifts still work; results below zero become zero. NaN results also become zero.

`trfilter` keeps its own frequency bounds before indexing the filter table. Negative frequencies now become zero instead of being reflected with an absolute value.

At Nyquist, `trfilter` uses the table's guard-point value directly, without reading beyond it. This endpoint fix also applies to valid, non-negative track frequencies. Filtering within the valid range stays unchanged.
