### PR TITLE
Fix crossfm sample offsets and phase lookup bounds

### DIFF
--- a/Opcodes/crossfm.c
+++ b/Opcodes/crossfm.c
@@ -29,12 +29,32 @@
 #include "crossfm.h"
 #include <math.h>
 
+#define XFM_ADVANCE_INPUTS(offset_)                   \
+  do {                                                \
+    xfrq1 += (offset_) * p->frq1adv;                  \
+    xfrq2 += (offset_) * p->frq2adv;                  \
+    xndx1 += (offset_) * p->ndx1adv;                  \
+    xndx2 += (offset_) * p->ndx2adv;                  \
+  } while (0)
+
+/* A tiny negative phase can round to 1 after wrapping. The ordered
+   bound check also keeps NaN out of the table index conversion. */
+#define XFM_WRAP_PHASE(phase_)                        \
+  do {                                                \
+    (phase_) -= FLOOR(phase_);                        \
+    if (UNLIKELY(!((phase_) < FL(1.0))))              \
+      (phase_) = FL(0.0);                             \
+  } while (0)
+
 int32_t xfmset(CSOUND *csound, CROSSFM *p)
 {
     FUNC *ftp1 = csound->FTFind(csound, p->ifn1);
     FUNC *ftp2 = csound->FTFind(csound, p->ifn2);
     if (UNLIKELY(ftp1 == NULL  ||  ftp2 == NULL)) {
       return csound->InitError(csound, "%s", Str("crossfm: ftable not found"));
+    }
+    if (UNLIKELY(ftp1->flen < 1 || ftp2->flen < 1)) {
+      return csound->InitError(csound, "%s", Str("crossfm: ftable is empty"));
     }
     p->siz1 = (MYFLT)ftp1->flen;
     p->siz2 = (MYFLT)ftp2->flen;
@@ -91,6 +111,7 @@ int32_t xfm(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -105,9 +126,9 @@ int32_t xfm(CSOUND *csound, CROSSFM *p)
       out1[i] = sig1;
       out2[i] = sig2;
       phase1 += si1;
-      phase1 -= FLOOR(phase1);
+      XFM_WRAP_PHASE(phase1);
       phase2 += si2;
-      phase2 -= FLOOR(phase2);
+      XFM_WRAP_PHASE(phase2);
       n1 = (int32_t)(phase1 * siz1);
       n2 = (int32_t)(phase2 * siz2);
       sig1 = tbl1[n1];
@@ -162,6 +183,7 @@ int32_t xfmi(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -176,17 +198,17 @@ int32_t xfmi(CSOUND *csound, CROSSFM *p)
       out1[i] = sig1;
       out2[i] = sig2;
       phase1 += si1;
-      phase1 -= FLOOR(phase1);
+      XFM_WRAP_PHASE(phase1);
       phase2 += si2;
-      phase2 -= FLOOR(phase2);
+      XFM_WRAP_PHASE(phase2);
       x = phase1 * siz1;
       n1 = (int32_t)x;
       y1 = tbl1[n1];
-      sig1 = (tbl1[n1+1]-y1) * (x - FLOOR(x)) + y1;
+      sig1 = (tbl1[n1+1]-y1) * (x - n1) + y1;
       x = phase2 * siz2;
       n2 = (int32_t)x;
       y2 = tbl2[n2];
-      sig2 = (tbl2[n2+1]-y2) * (x - FLOOR(x)) + y2;
+      sig2 = (tbl2[n2+1]-y2) * (x - n2) + y2;
       xfrq1 += p->frq1adv;
       xfrq2 += p->frq2adv;
       xndx1 += p->ndx1adv;
@@ -236,6 +258,7 @@ int32_t xpm(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -249,10 +272,10 @@ int32_t xpm(CSOUND *csound, CROSSFM *p)
       out2[i] = sig2;
       phase1 += (frq1 * k);
       si1 = phase1 + *xndx2 * sig2 / TWOPI_F;
-      si1 -= FLOOR(si1);
+      XFM_WRAP_PHASE(si1);
       phase2 += (frq2 * k);
       si2 = phase2 + *xndx1 * sig1 / TWOPI_F;
-      si2 -= FLOOR(si2);
+      XFM_WRAP_PHASE(si2);
       n1 = (int32_t)(si1 * siz1);
       n2 = (int32_t)(si2 * siz2);
       sig1 = tbl1[n1];
@@ -263,8 +286,10 @@ int32_t xpm(CSOUND *csound, CROSSFM *p)
       xndx2 += p->ndx2adv;
     }
 
-    p->phase1 = phase1 - FLOOR(phase1);
-    p->phase2 = phase2 - FLOOR(phase2);
+    XFM_WRAP_PHASE(phase1);
+    XFM_WRAP_PHASE(phase2);
+    p->phase1 = phase1;
+    p->phase2 = phase2;
     p->sig1 = sig1;
     p->sig2 = sig2;
     return OK;
@@ -307,6 +332,7 @@ int32_t xpmi(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -320,26 +346,28 @@ int32_t xpmi(CSOUND *csound, CROSSFM *p)
       out2[i] = sig2;
       phase1 += (frq1 * k);
       si1 = phase1 + *xndx2 * sig2 / TWOPI_F;
-      si1 -= FLOOR(si1);
+      XFM_WRAP_PHASE(si1);
       phase2 += (frq2 * k);
       si2 = phase2 + *xndx1 * sig1 / TWOPI_F;
-      si2 -= FLOOR(si2);
+      XFM_WRAP_PHASE(si2);
       x = si1 * siz1;
       n1 = (int32_t)x;
       y1 = tbl1[n1];
-      sig1 = (tbl1[n1+1]-y1) * (x - FLOOR(x)) + y1;
+      sig1 = (tbl1[n1+1]-y1) * (x - n1) + y1;
       x = si2 * siz2;
       n2 = (int32_t)x;
       y2 = tbl2[n2];
-      sig2 = (tbl2[n2+1]-y2) * (x - FLOOR(x)) + y2;
+      sig2 = (tbl2[n2+1]-y2) * (x - n2) + y2;
       xfrq1 += p->frq1adv;
       xfrq2 += p->frq2adv;
       xndx1 += p->ndx1adv;
       xndx2 += p->ndx2adv;
   }
 
-    p->phase1 = phase1 - FLOOR(phase1);
-    p->phase2 = phase2 - FLOOR(phase2);
+    XFM_WRAP_PHASE(phase1);
+    XFM_WRAP_PHASE(phase2);
+    p->phase1 = phase1;
+    p->phase2 = phase2;
     p->sig1 = sig1;
     p->sig2 = sig2;
     return OK;
@@ -381,6 +409,7 @@ int32_t xfmpm(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -394,10 +423,10 @@ int32_t xfmpm(CSOUND *csound, CROSSFM *p)
       out2[i] = sig2;
       si1 = (frq1 + *xndx2 * frq2 * sig2) * k;
       phase1 += si1;
-      phase1 -= FLOOR(phase1);
+      XFM_WRAP_PHASE(phase1);
       phase2 += (frq2 * k);
       si2 = phase2 + *xndx1 * sig1 / TWOPI_F;
-      si2 -= FLOOR(si2);
+      XFM_WRAP_PHASE(si2);
       n1 = (int32_t)(phase1 * siz1);
       n2 = (int32_t)(si2 * siz2);
       sig1 = tbl1[n1];
@@ -409,7 +438,8 @@ int32_t xfmpm(CSOUND *csound, CROSSFM *p)
     }
 
     p->phase1 = phase1;
-    p->phase2 = phase2 - FLOOR(phase2);
+    XFM_WRAP_PHASE(phase2);
+    p->phase2 = phase2;
     p->sig1 = sig1;
     p->sig2 = sig2;
     return OK;
@@ -452,6 +482,7 @@ int32_t xfmpmi(CSOUND *csound, CROSSFM *p)
     if (UNLIKELY(offset)) {
       memset(out1, '\0', offset*sizeof(MYFLT));
       memset(out2, '\0', offset*sizeof(MYFLT));
+      XFM_ADVANCE_INPUTS(offset);
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -465,19 +496,19 @@ int32_t xfmpmi(CSOUND *csound, CROSSFM *p)
       out2[i] = sig2;
       si1 = (frq1 + *xndx2 * frq2 * sig2) * k;
       phase1 += si1;
-      phase1 -= FLOOR(phase1);
+      XFM_WRAP_PHASE(phase1);
       phase2 += (frq2 * k);
       si2 = phase2 + *xndx1 * sig1 / TWOPI_F;
-      si2 -= FLOOR(si2);
+      XFM_WRAP_PHASE(si2);
       x = phase1 * siz1;
       n1 = (int32_t)x;
       y1 = tbl1[n1];
-      sig1 = (tbl1[n1+1]-y1) * (x - FLOOR(x)) + y1;
+      sig1 = (tbl1[n1+1]-y1) * (x - n1) + y1;
       x = si2 * siz2;
       n2 = (int32_t
             )x;
       y2 = tbl2[n2];
-      sig2 = (tbl2[n2+1]-y2) * (x - FLOOR(x)) + y2;
+      sig2 = (tbl2[n2+1]-y2) * (x - n2) + y2;
       xfrq1 += p->frq1adv;
       xfrq2 += p->frq2adv;
       xndx1 += p->ndx1adv;
@@ -485,7 +516,8 @@ int32_t xfmpmi(CSOUND *csound, CROSSFM *p)
     }
 
     p->phase1 = phase1;
-    p->phase2 = phase2 - FLOOR(phase2);
+    XFM_WRAP_PHASE(phase2);
+    p->phase2 = phase2;
     p->sig1 = sig1;
     p->sig2 = sig2;
     return OK;
@@ -503,5 +535,3 @@ static OENTRY crossfm_localops[] = {
 };
 
 LINKAGE_BUILTIN(crossfm_localops)
-
-

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -631,6 +631,7 @@ def runTest():
         ["test_diskgrain_envelope_bounds.csd", "diskgrain stops at envelope table bounds"],
         ["test_syncloop_envelope_end.csd", "syncloop retires grains at the envelope end"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
+        ["test_crossfm_correctness.csd", "test crossed FM and PM correctness"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],

--- a/tests/commandline/test_crossfm_correctness.csd
+++ b/tests/commandline/test_crossfm_correctness.csd
@@ -1,0 +1,128 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+giSine ftgen 1, 0, 1024, 10, 1
+
+instr 1, 2, 3, 4, 5, 6
+  afrq1 = 1
+  afrq2 = 1.5
+  andx1 = .7
+  andx2 = .9
+  kfrq1 init 1
+  kfrq2 init 1.5
+  kndx1 init .7
+  kndx2 init .9
+
+  if p1 == 1 then
+    aa1, aa2 crossfm afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crossfm kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crossfm afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crossfm kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  elseif p1 == 2 then
+    aa1, aa2 crossfmi afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crossfmi kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crossfmi afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crossfmi kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  elseif p1 == 3 then
+    aa1, aa2 crosspm afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crosspm kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crosspm afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crosspm kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  elseif p1 == 4 then
+    aa1, aa2 crosspmi afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crosspmi kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crosspmi afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crosspmi kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  elseif p1 == 5 then
+    aa1, aa2 crossfmpm afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crossfmpm kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crossfmpm afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crossfmpm kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  else
+    aa1, aa2 crossfmpmi afrq1, afrq2, andx1, andx2, 400, giSine, giSine
+    ak1, ak2 crossfmpmi kfrq1, kfrq2, kndx1, kndx2, 400, giSine, giSine
+    am1, am2 crossfmpmi afrq1, kfrq2, andx1, kndx2, 400, giSine, giSine
+    an1, an2 crossfmpmi kfrq1, afrq2, kndx1, andx2, 400, giSine, giSine
+  endif
+
+  kerr1 max_k abs(aa1 - ak1), 1, 1
+  kerr2 max_k abs(aa2 - ak2), 1, 1
+  kerr3 max_k abs(am1 - ak1) + abs(am2 - ak2), 1, 1
+  kerr4 max_k abs(an1 - ak1) + abs(an2 - ak2), 1, 1
+  if kerr1 > .000001 || kerr2 > .000001 || kerr3 > .000001 || kerr4 > .000001 then
+    printks "crossfm%d rate mismatch: errors=%g,%g,%g,%g\n", \
+             0, p1, kerr1, kerr2, kerr3, kerr4
+    exitnowk(-1)
+  endif
+  kfirst init 1
+  if kfirst == 1 then
+    koffset offsetsmps
+    if koffset != 5 then
+      printks "crossfm%d offset mismatch: offset=%d errors=%g,%g\n", \
+               0, p1, koffset, kerr1, kerr2
+      exitnowk(-1)
+    endif
+    gkchecks += 1
+    kfirst = 0
+  endif
+endin
+
+instr 11, 12, 13, 14, 15, 16
+  aneg init -1
+  if p4 == 0 then
+    abad sqrt aneg
+  else
+    abad = p4
+  endif
+  if p1 == 11 then
+    a1, a2 crossfm abad, abad, abad, abad, 400, giSine, giSine
+  elseif p1 == 12 then
+    a1, a2 crossfmi abad, abad, abad, abad, 400, giSine, giSine
+  elseif p1 == 13 then
+    a1, a2 crosspm abad, abad, abad, abad, 400, giSine, giSine
+  elseif p1 == 14 then
+    a1, a2 crosspmi abad, abad, abad, abad, 400, giSine, giSine
+  elseif p1 == 15 then
+    a1, a2 crossfmpm abad, abad, abad, abad, 400, giSine, giSine
+  else
+    a1, a2 crossfmpmi abad, abad, abad, abad, 400, giSine, giSine
+  endif
+endin
+
+instr 99
+  if i(gkchecks) != 6 then
+    prints "not all crossfm checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 .000625 .01
+i 2 .020625 .01
+i 3 .040625 .01
+i 4 .060625 .01
+i 5 .080625 .01
+i 6 .100625 .01
+i 11 .12 .004
+i 12 .13 .004
+i 13 .14 .004
+i 14 .15 .004
+i 15 .16 .004
+i 16 .17 .004
+; Tiny negative increments round to a wrapped phase of 1 without correction.
+i 11 .18 .004 -1e-20
+i 12 .19 .004 -1e-20
+i 13 .20 .004 -1e-20
+i 14 .21 .004 -1e-20
+i 15 .22 .004 -1e-20
+i 16 .23 .004 -1e-20
+i 99 .24 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix input alignment and table lookup bounds across `crossfm`, `crosspm`, `crossfmpm`, and their interpolating variants.

- When a note starts partway through a block, advance audio-rate frequency and modulation inputs to its first active sample. Control-rate inputs stay in place. Previously, the oscillators read the skipped prefix and produced the wrong onset.
- Keep wrapped phases below 1 before converting them to table indexes. Tiny negative phases can round to 1 after wrapping, causing interpolation to read past the guard point. The same comparison keeps NaN out of the integer conversion; empty tables are rejected at init.
- Reuse the integer table index to compute the interpolation fraction, removing redundant `floor` operations. Shared macros add no helper function calls to the sample loops.
