### PR TITLE
Fix randomi and randomh rate handling

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -1298,6 +1298,21 @@ static int32_t aRangeRand(CSOUND *csound, RANGERAND *p)
     return OK;
 }
 
+/* Higher rates can emit only one new value per output sample.  Keep their
+   phase remainder while forcing that update. */
+#define RANDOM_PHASE_INCREMENT(inc_, rate_, scale_)                        \
+    do {                                                                  \
+      MYFLT scaled_ = (rate_) * (scale_);                                 \
+      if (LIKELY(scaled_ > FL(0.0) && scaled_ < FMAXLEN))                 \
+        (inc_) = (uint32_t)scaled_;                                       \
+      else if (UNLIKELY(!(scaled_ > FL(0.0))))                            \
+        (inc_) = 0U;                                                      \
+      else if (scaled_ < (MYFLT)UINT64_MAX)                              \
+        (inc_) = MAXLEN + (uint32_t)((uint64_t)scaled_ & PHMASK);         \
+      else                                                                \
+        (inc_) = MAXLEN;                                                  \
+    } while (0)
+
 /* mode and fstval arguments added */
 /* by Francois Pinot, jan. 2011    */
 static int32_t randomi_set(CSOUND *csound, RANDOMI *p)
@@ -1331,8 +1346,11 @@ static int32_t randomi_set(CSOUND *csound, RANDOMI *p)
 
 static int32_t krandomi(CSOUND *csound, RANDOMI *p)
 {
+    uint32_t inc;
+
     *p->ar = (p->num1 + (MYFLT)p->phs * p->dfdmax) * (*p->max - *p->min) + *p->min;
-    p->phs += (int32)(*p->xcps * CS_KICVT);
+    RANDOM_PHASE_INCREMENT(inc, *p->xcps, CS_KICVT);
+    p->phs += inc;
     if (p->phs >= MAXLEN) {
       p->phs   &= PHMASK;
       p->num1   = p->num2;
@@ -1344,7 +1362,7 @@ static int32_t krandomi(CSOUND *csound, RANDOMI *p)
 
 static int32_t randomi(CSOUND *csound, RANDOMI *p)
 {
-    int32       phs = p->phs, inc;
+    uint32_t    phs = p->phs, inc = 0U;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -1355,17 +1373,20 @@ static int32_t randomi(CSOUND *csound, RANDOMI *p)
     min = *p->min;
     amp =  (*p->max - min);
     ar = p->ar;
-    inc = (int32)(*cpsp++ * CS_SICVT);
+    if (p->cpscod)
+      cpsp += offset;
+    else
+      RANDOM_PHASE_INCREMENT(inc, *cpsp, CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps; n++) {
+      if (p->cpscod)
+        RANDOM_PHASE_INCREMENT(inc, *cpsp++, CS_SICVT);
       ar[n] = (p->num1 + (MYFLT)phs * p->dfdmax) * amp + min;
       phs += inc;
-      if (p->cpscod)
-        inc = (int32)(*cpsp++ * CS_SICVT);
       if (phs >= MAXLEN) {
         phs &= PHMASK;
         p->num1 = p->num2;
@@ -1400,8 +1421,11 @@ static int32_t randomh_set(CSOUND *csound, RANDOMH *p)
 
 static int32_t krandomh(CSOUND *csound, RANDOMH *p)
 {
+    uint32_t inc;
+
     *p->ar = p->num1 * (*p->max - *p->min) + *p->min;
-    p->phs += (int32)(*p->xcps * CS_KICVT);
+    RANDOM_PHASE_INCREMENT(inc, *p->xcps, CS_KICVT);
+    p->phs += inc;
     if (p->phs >= MAXLEN) {
       p->phs &= PHMASK;
       p->num1 = randGab(csound);
@@ -1411,7 +1435,7 @@ static int32_t krandomh(CSOUND *csound, RANDOMH *p)
 
 static int32_t randomh(CSOUND *csound, RANDOMH *p)
 {
-    int32       phs = p->phs, inc;
+    uint32_t    phs = p->phs, inc = 0U;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
@@ -1422,17 +1446,20 @@ static int32_t randomh(CSOUND *csound, RANDOMH *p)
     min  = *p->min;
     amp  = (*p->max - min);
     ar   = p->ar;
-    inc  = (int32)(*cpsp++ * CS_SICVT);
+    if (p->cpscod)
+      cpsp += offset;
+    else
+      RANDOM_PHASE_INCREMENT(inc, *cpsp, CS_SICVT);
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps; n++) {
+      if (p->cpscod)
+        RANDOM_PHASE_INCREMENT(inc, *cpsp++, CS_SICVT);
       ar[n]     = p->num1 * amp + min;
       phs      += inc;
-      if (p->cpscod)
-        inc     = (int32)(*cpsp++ * CS_SICVT);
       if (phs >= MAXLEN) {
         phs    &= PHMASK;
         p->num1 = randGab(csound);
@@ -1441,6 +1468,8 @@ static int32_t randomh(CSOUND *csound, RANDOMH *p)
     p->phs = phs;
     return OK;
 }
+
+#undef RANDOM_PHASE_INCREMENT
 
 static int32_t random3_set(CSOUND *csound, RANDOM3 *p)
 {

--- a/Opcodes/uggab.h
+++ b/Opcodes/uggab.h
@@ -199,7 +199,7 @@ typedef struct {
         OPDS    h;
         MYFLT   *ar, *min, *max, *xcps, *mode, *fstval;
         int16   cpscod;
-        int32   phs;
+        uint32_t phs;
         MYFLT   num1, num2, dfdmax;
 } RANDOMI;
 
@@ -209,7 +209,7 @@ typedef struct {
         OPDS    h;
         MYFLT   *ar, *min, *max, *xcps, *mode, *fstval;
         int16   cpscod;
-        int32   phs;
+        uint32_t phs;
         MYFLT   num1;
 } RANDOMH;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -873,6 +873,7 @@ def runTest():
         ["test_vdelay_reinit.csd", "test variable delay state across reinit"],
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
+        ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],

--- a/tests/commandline/test_random_rate_correctness.csd
+++ b/tests/commandline/test_random_rate_correctness.csd
@@ -1,0 +1,156 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1, 2
+  seed 1
+  acps = sr
+  if p1 == 1 then
+    arandom randomi 0, 1, acps, 2, .25
+  else
+    arandom randomh 0, 1, acps, 2, .25
+  endif
+
+  ksample downsamp arandom
+  kcount init 0
+  if kcount == 1 then
+    if abs(ksample - .25) < .000001 then
+      printks "random opcode used an inactive rate sample: type=%g\n", 0, p1
+      exitnowk(-1)
+    endif
+    gkchecks += 1
+  endif
+  kcount += 1
+endin
+
+instr 3, 4, 5, 6
+  iNaN strtod "nan"
+  iHuge strtod "1e100"
+  if p4 == 1 then
+    iRate = iNaN
+  elseif p4 == 2 then
+    iRate = -1
+  elseif p4 == 3 then
+    iRate = iHuge
+  elseif p4 == 4 then
+    iRate = 0
+  else
+    iRate = (p1 <= 4 ? sr : kr) * 2.5
+  endif
+
+  if p1 == 3 then
+    acps = iRate
+    arandom randomi 0, 1, acps, 2, .25
+    kdeviation max_k arandom - .5, 1, 1
+    kvalue downsamp arandom
+  elseif p1 == 4 then
+    acps = iRate
+    arandom randomh 0, 1, acps, 2, .25
+    kdeviation max_k arandom - .5, 1, 1
+    kvalue downsamp arandom
+  elseif p1 == 5 then
+    kcps = iRate
+    krandom randomi 0, 1, kcps, 2, .25
+    kdeviation = abs(krandom - .5)
+    kvalue = krandom
+  else
+    kcps = iRate
+    krandom randomh 0, 1, kcps, 2, .25
+    kdeviation = abs(krandom - .5)
+    kvalue = krandom
+  endif
+
+  kfirst init 1
+  if qnan(kvalue) != 0 || qnan(kdeviation) != 0 || \
+     kdeviation > .500001 then
+    printks "random opcode produced an invalid value: type=%g rate=%g\n", \
+             0, p1, p4
+    exitnowk(-1)
+  endif
+  if (p4 < 3 || p4 == 4) && abs(kvalue - .25) > .000001 then
+    printks "random opcode advanced for an invalid rate: type=%g rate=%g\n", \
+             0, p1, p4
+    exitnowk(-1)
+  endif
+  if kfirst == 0 && (p4 == 3 || p4 == 5) && abs(kvalue - .25) < .000001 then
+    printks "random opcode did not advance at a high rate: type=%g\n", 0, p1
+    exitnowk(-1)
+  endif
+  if kfirst == 1 then
+    gkchecks += 1
+    kfirst = 0
+  endif
+endin
+
+; Whole extra cycles must not change the fractional phase remainder.
+instr 7, 8
+  seed 1
+  ifirst random 0, 1
+  isecond random 0, 1
+  seed 1
+  if p1 == 7 then
+    kresult randomi 0, 1, p4 * kr, 2, .25
+    iexpected = (ifirst + isecond) / 2
+  else
+    kresult randomh 0, 1, p4 * kr, 2, .25
+    iexpected = ifirst
+  endif
+  kcount init 0
+  if kcount == 1 && abs(kresult - iexpected) > .000001 then
+    printks "random opcode lost the phase remainder: type=%g value=%g\n", 0, p1, kresult
+    exitnowk(-1)
+  endif
+  if kcount == 2 then
+    if abs(kresult - isecond) > .000001 then
+      printks "random opcode advanced the wrong number of times: type=%g\n", 0, p1
+      exitnowk(-1)
+    endif
+    gkchecks += 1
+  endif
+  kcount += 1
+endin
+
+instr 99
+  if i(gkchecks) != 26 then
+    prints "not all random rate checks ran\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 .001875 .01
+i 2 .021875 .01
+i 3 .05 .004 1
+i 3 .06 .004 2
+i 3 .07 .004 3
+i 4 .08 .004 1
+i 4 .09 .004 2
+i 4 .10 .004 3
+i 5 .11 .004 1
+i 5 .12 .004 2
+i 5 .13 .004 3
+i 6 .14 .004 1
+i 6 .15 .004 2
+i 6 .16 .004 3
+i 3 .18 .004 4
+i 4 .19 .004 4
+i 5 .20 .004 4
+i 6 .21 .004 4
+i 3 .22 .004 5
+i 4 .23 .004 5
+i 5 .24 .004 5
+i 6 .25 .004 5
+i 7 .27 .008 1.5
+i 8 .29 .008 1.5
+i 7 .31 .008 2.5
+i 8 .33 .008 2.5
+i 99 .35 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix rate handling in `randomi` and `randomh`.

- Read audio-rate frequency inputs at the active sample offset, once per sample. Previously, partial blocks used skipped input samples, and full blocks read one value past the input buffer.
- Bound the phase increment before integer conversion and use unsigned phase state. This avoids out-of-range conversions and signed overflow. Zero, negative, and NaN rates hold the current value; positive high rates advance once per output step, retaining the phase remainder while it fits the conversion range.
- Use a shared macro with integer masking for the high-rate remainder. It adds no helper function calls or `isnan`/`isfinite` checks. Scalar rates for audio outputs are converted once per control cycle.
