### PR TITLE
Fix dcblock2 order changes and delay state

### DIFF
--- a/Opcodes/dcblockr.c
+++ b/Opcodes/dcblockr.c
@@ -85,52 +85,66 @@ typedef struct _dcblk2 {
   AUXCH   delay1;
   AUXCH   iirdelay1, iirdelay2, iirdelay3, iirdelay4;
   double  ydels[4];
-  int32_t dp1,dp2;
+  size_t  dp1, dp2;
+  size_t  del1size, iirdelsize;
   double  scaler;
 } DCBlock2;
 
 
 static int32_t dcblock2set(CSOUND *csound, DCBlock2* p)
 {
-    int32_t order = (int32_t) *p->order;
+    double order_value = (double)*p->order;
+    size_t del1size, iirdelsize, del1bytes, iirdelbytes;
+    int32_t clear_state, order;
+
+    if (UNLIKELY(!(order_value >= (double)INT32_MIN &&
+                   order_value <= (double)INT32_MAX)))
+      return csound->InitError(csound, Str("dcblock2: invalid order %f"),
+                               *p->order);
+    order = (int32_t)order_value;
     if (order == 0) order = 128;
     else if (order < 4) order = 4;
 
+    iirdelsize = (size_t)order;
+    if (UNLIKELY(iirdelsize - 1 > SIZE_MAX / (2 * sizeof(double))))
+      return csound->InitError(csound, "%s",
+                               Str("dcblock2: order is too large"));
+    del1size = (iirdelsize - 1) * 2;
+    del1bytes = del1size * sizeof(double);
+    iirdelbytes = iirdelsize * sizeof(double);
+    /* State can be reused only when the effective order is unchanged. */
+    clear_state = !*p->iskip || p->iirdelsize != iirdelsize;
+
     if (p->delay1.auxp == NULL ||
-        p->delay1.size < (order-1)*2*sizeof(double))
-      csound->AuxAlloc(csound, (order-1)*2*sizeof(double),
-                       &p->delay1);
+        p->delay1.size < del1bytes)
+      csound->AuxAlloc(csound, del1bytes, &p->delay1);
 
     if (p->iirdelay1.auxp == NULL ||
-        p->iirdelay1.size < (order)*sizeof(double))
-      csound->AuxAlloc(csound,
-                       (order)*sizeof(double), &p->iirdelay1);
+        p->iirdelay1.size < iirdelbytes)
+      csound->AuxAlloc(csound, iirdelbytes, &p->iirdelay1);
 
     if (p->iirdelay2.auxp == NULL ||
-        p->iirdelay2.size < (order)*sizeof(double))
-      csound->AuxAlloc(csound,
-                       (order)*sizeof(double), &p->iirdelay2);
+        p->iirdelay2.size < iirdelbytes)
+      csound->AuxAlloc(csound, iirdelbytes, &p->iirdelay2);
 
     if (p->iirdelay3.auxp == NULL ||
-        p->iirdelay3.size < (order)*sizeof(double))
-      csound->AuxAlloc(csound,
-                       (order)*sizeof(double), &p->iirdelay3);
+        p->iirdelay3.size < iirdelbytes)
+      csound->AuxAlloc(csound, iirdelbytes, &p->iirdelay3);
 
     if (p->iirdelay4.auxp == NULL ||
-        p->iirdelay4.size < (order)*sizeof(double))
-      csound->AuxAlloc(csound,
-                       (order)*sizeof(double), &p->iirdelay4);
+        p->iirdelay4.size < iirdelbytes)
+      csound->AuxAlloc(csound, iirdelbytes, &p->iirdelay4);
 
-    p->scaler = 1.0/order;
-    if (!*p->iskip) {
-      memset(p->ydels, 0, 4*sizeof(double));
-      /* p->ydels[0] = 0.0;   p->ydels[1] = 0.0; */
-      /* p->ydels[2] = 0.0;   p->ydels[3] = 0.0; */
-      memset(p->delay1.auxp, 0, sizeof(double)*(order-1)*2);
-      memset(p->iirdelay1.auxp, 0, sizeof(double)*(order));
-      memset(p->iirdelay2.auxp, 0, sizeof(double)*(order));
-      memset(p->iirdelay3.auxp, 0, sizeof(double)*(order));
-      memset(p->iirdelay4.auxp, 0, sizeof(double)*(order));
+    p->del1size = del1size;
+    p->iirdelsize = iirdelsize;
+    p->scaler = 1.0 / (double)order;
+    if (clear_state) {
+      memset(p->ydels, 0, sizeof(p->ydels));
+      memset(p->delay1.auxp, 0, del1bytes);
+      memset(p->iirdelay1.auxp, 0, iirdelbytes);
+      memset(p->iirdelay2.auxp, 0, iirdelbytes);
+      memset(p->iirdelay3.auxp, 0, iirdelbytes);
+      memset(p->iirdelay4.auxp, 0, iirdelbytes);
       p->dp1 = 0; p->dp2 = 0;
     }
     return OK;
@@ -148,18 +162,16 @@ static int32_t dcblock2(CSOUND *csound, DCBlock2* p)
     double   *iirdel[4],x1,x2,y,del;
     double   *ydels = p->ydels;
     double   scale = p->scaler;
-    int32_t      p1 = p->dp1;
-    int32_t      p2 = p->dp2;
+    size_t       p1 = p->dp1;
+    size_t       p2 = p->dp2;
     int32_t      j;
-    uint64_t del1size, iirdelsize;
+    size_t       del1size = p->del1size;
+    size_t       iirdelsize = p->iirdelsize;
 
     iirdel[0] = (double *) p->iirdelay1.auxp;
     iirdel[1] = (double *) p->iirdelay2.auxp;
     iirdel[2] = (double *) p->iirdelay3.auxp;
     iirdel[3] = (double *) p->iirdelay4.auxp;
-
-    del1size = p->delay1.size/sizeof(double);
-    iirdelsize = p->iirdelay1.size/sizeof(double);
 
     if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -182,8 +194,8 @@ static int32_t dcblock2(CSOUND *csound, DCBlock2* p)
       }
       out[i] = (MYFLT)(del - x1);
 
-      p1 = ((uint64_t) p1 == del1size-1 ? 0 : p1 + 1);
-      p2 = ((uint64_t) p2 == iirdelsize-1 ? 0 : p2 + 1);
+      p1 = (p1 == del1size - 1 ? 0 : p1 + 1);
+      p2 = (p2 == iirdelsize - 1 ? 0 : p2 + 1);
     }
 
     p->dp1 = p1; p->dp2 = p2;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -876,6 +876,8 @@ def runTest():
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],
+        ["test_dcblock2_order_reinit.csd", "test dcblock2 order changes"],
+        ["test_dcblock2_invalid_order.csd", "reject invalid dcblock2 order", 1],
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],
         ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
         ["test_distort_sample_offset.csd", "test distort sample-accurate onset"],

--- a/tests/commandline/test_dcblock2_invalid_order.csd
+++ b/tests/commandline/test_dcblock2_invalid_order.csd
@@ -1,0 +1,23 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  iorder = (p4 == 0 ? sqrt:i(-1) : p4)
+  ain = 0
+  aout dcblock2 ain, iorder
+  out aout
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001 0
+i 1 0 .001 1e30
+i 1 0 .001 -1e30
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_dcblock2_order_reinit.csd
+++ b/tests/commandline/test_dcblock2_order_reinit.csd
@@ -1,0 +1,84 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1
+  kcount init 0
+  korder init p4
+  kinput = kcount == 0 || kcount == 14 ? 1 : 0
+  ain upsamp kinput
+  if kcount == 13 then
+    korder = p5
+    reinit FILTERS
+  endif
+
+FILTERS:
+  iorder = i(korder)
+  aref dcblock2 ain, p5, 0
+  atest dcblock2 ain, iorder, p6
+  rireturn
+
+  kref downsamp aref
+  ktest downsamp atest
+  if kcount >= 13 && !(abs(kref - ktest) <= 1e-12) then
+    printks "dcblock2 did not apply the new order\n", 0
+    exitnowk(-1)
+  endif
+  if kcount == 80 then
+    gkchecks += 1
+  endif
+  kcount += 1
+endin
+
+; Reinit with the same effective order must preserve the running filter.
+instr 2
+  kcount init 0
+  korder init p4
+  ain = (kcount == 0 ? 1 : 0)
+  aref dcblock2 ain, p5
+  if kcount == 13 then
+    korder = p5
+    reinit FILTER
+  endif
+
+FILTER:
+  atest dcblock2 ain, i(korder), 1
+  rireturn
+
+  kref downsamp aref
+  ktest downsamp atest
+  if !(abs(kref - ktest) <= 1e-12) then
+    printks "dcblock2 did not preserve state for the same order\n", 0
+    exitnowk(-1)
+  endif
+  if kcount == 600 then
+    gkchecks += 1
+  endif
+  kcount += 1
+endin
+
+instr 99
+  if i(gkchecks) != 8 then
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .012 8 4 1
+i 1 0 .012 4 8 1
+i 1 0 .012 8 4 0
+i 1 0 .012 4 8 0
+i 2 0 .08 8 8
+i 2 0 .08 8.9 8.1
+i 2 0 .08 0 128
+i 2 0 .08 3 -4
+i 99 .09 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `dcblock2` reinitialization when `iorder` changes. The filter currently uses allocated buffer sizes as delay lengths, so reducing the order leaves it running with the old delays and the new scale.

- Track active delay lengths separately from buffer capacity so order changes take effect in both directions.
- Clear buffers, sums, and indices when the effective order changes. Preserve state with `iskip` only when the order stays the same.
- Check the order before integer conversion and buffer-size arithmetic, and use `size_t` indices to avoid signed overflow on long delays.

Keep the existing default, minimum order, and fractional-order truncation. All validation stays at initialization; the sample loop adds no function calls.
