### PR TITLE
Fix downsamp window bounds and partial-block averaging

### DIFF
--- a/OOps/ugens6.c
+++ b/OOps/ugens6.c
@@ -29,8 +29,13 @@
 
 int32_t downset(CSOUND *csound, DOWNSAMP *p)
 {
-    if (UNLIKELY((p->len = (uint32_t)*p->ilen) > CS_KSMPS))
-      return csound->InitError(csound, "ilen > ksmps");
+    double length = (double)*p->ilen;
+
+    /* Check the truncated length before converting to an unsigned integer. */
+    if (UNLIKELY(!(length > -1.0 && length < (double)CS_KSMPS + 1.0)))
+      return csound->InitError(csound, "%s",
+                               Str("downsamp: window length out of range"));
+    p->len = (uint32_t)length;
     return OK;
 }
 
@@ -40,7 +45,7 @@ int32_t downsamp(CSOUND *csound, DOWNSAMP *p)
     MYFLT       *asig, sum;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    int32_t len, n;
+    uint32_t len, n;
 
     if (p->len <= 1)
       *p->kr = p->asig[offset];
@@ -48,7 +53,7 @@ int32_t downsamp(CSOUND *csound, DOWNSAMP *p)
       asig = p->asig;
       sum = FL(0.0);
       len = p->len;
-      if (len>(int32_t)(CS_KSMPS-early)) len = early;
+      if (len > CS_KSMPS - early) len = CS_KSMPS - early;
       for (n=offset; n<len; n++) {
         sum += asig[n];
       }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -807,6 +807,8 @@ def runTest():
             "test_audio_input_sample_bounds.csd",
             "audio input opcodes align partial-block input frames",
         ],
+        ["test_downsamp_sample_bounds.csd", "test downsamp partial blocks"],
+        ["test_downsamp_invalid_window.csd", "reject invalid downsamp window", 1],
         ["test_wguide_sample_offset.csd", "waveguides align audio-rate frequencies with note starts"],
         ["test_locsend_sample_offset.csd", "locsend aligns reverb sends with note starts"],
         [

--- a/tests/commandline/test_downsamp_invalid_window.csd
+++ b/tests/commandline/test_downsamp_invalid_window.csd
@@ -1,0 +1,23 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  iwindow = (p4 == 0 ? sqrt:i(-1) : p4)
+  ain = 0
+  kout downsamp ain, iwindow
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001 0
+i 1 0 .001 -1
+i 1 0 .001 9
+i 1 0 .001 1e30
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_downsamp_sample_bounds.csd
+++ b/tests/commandline/test_downsamp_sample_bounds.csd
@@ -1,0 +1,49 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1
+  ain = 1
+  kout downsamp ain, p5
+  if !(abs(kout - p4) <= 1e-12) then
+    printks "downsamp window %g: expected %g, got %g\n", 0, p5, p4, kout
+    exitnowk(-1)
+  endif
+  gkchecks += 1
+endin
+
+instr 99
+  if i(gkchecks) != 16 then
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Full blocks, including window truncation and the no-average cases.
+i 1 0 .001 1 8
+i 1 0 .001 1 4
+i 1 0 .001 1 0
+i 1 0 .001 1 1
+i 1 0 .001 1 8.75
+i 1 0 .001 1 .75
+i 1 0 .001 1 -.5
+; Early end, late start, and both in the same block.
+i 1 0 .000875 .875 8
+i 1 0 .000875 1 4
+i 1 0 .000125 .125 8
+i 1 .002375 .000625 .625 8
+i 1 .004375 .000375 .375 8
+i 1 .004375 .000375 .25 4
+i 1 .004375 .000375 0 2
+i 1 .004375 .000375 1 0
+i 1 .004375 .000375 1 1
+i 99 .006 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `downsamp` averaging when a note ends within a control block. The loop currently uses the number of inactive samples as its endpoint. In an eight-sample block with seven active samples, it sums just one sample. Use `ksmps - ksmps_no_end` as the limit instead.

Check window lengths before unsigned integer conversion, rejecting NaN, infinity, and values whose truncated length falls outside `0..ksmps`. Preserve fractional truncation, fixed-window averaging, and the `0`/`1` no-average cases.

Validation runs at initialization. The averaging loop adds no function calls.
