### PR TITLE
Fix pvsadsyn bin selection bounds

### DIFF
--- a/OOps/pstream.c
+++ b/OOps/pstream.c
@@ -118,8 +118,10 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
     int32_t i;
     PVSDAT  *fs = p->fsig;
     int32_t N = fs->N;
-    int32_t noscs,n_oscs;
-    int32_t startbin,binoffset;
+    int32_t numbins,n_oscs;
+    int32_t startbin,binincr;
+    int64_t lastbin;
+    double value;
     MYFLT *p_x;
 
     if (UNLIKELY(fs->sliding))
@@ -130,10 +132,11 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
     p->winsize = fs->winsize;
     p->wintype = fs->wintype;
     p->fftsize = N;
-    noscs   = N/2 + 1;                     /* max possible */
-    n_oscs = (int32_t) *p->n_oscs;    /* user param*/
-    if (UNLIKELY(n_oscs <=0))
-      csound->InitError(csound, Str("pvadsyn: bad value for inoscs\n"));
+    numbins = N/2 + 1;                     /* max possible */
+    value = (double)*p->n_oscs;
+    if (UNLIKELY(!(value >= 1.0 && value < (double)numbins + 1.0)))
+      return csound->InitError(csound, Str("pvsadsyn: bad value for inoscs\n"));
+    n_oscs = (int32_t)value;             /* user param */
     /* remove this when I know how to do it... */
     if (UNLIKELY(fs->format != PVS_AMP_FREQ))
       return csound->InitError(csound,
@@ -144,19 +147,26 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
                as have to set/reset each osc when started and stopped */
 
     /* check bin params */
-    startbin = (int32_t) *p->ibin;            /* default 0 */
-    binoffset = (int32_t) *p->ibinoffset; /* default 1 */
-    if (UNLIKELY(startbin < 0 || startbin > noscs))
+    value = (double)*p->ibinoffset;
+    if (UNLIKELY(!(value > -1.0 && value < (double)numbins)))
       return csound->InitError(csound,
-                               Str("pvsadsyn: ibin parameter out of range.\n"));
-    if (UNLIKELY(startbin + n_oscs > noscs))
+                               Str("pvsadsyn: ibinoffset out of range.\n"));
+    startbin = (int32_t)value;                 /* default 0 */
+    value = (double)*p->ibinincr;
+    if (UNLIKELY(!(value >= 1.0 && value < (double)numbins + 1.0)))
       return csound->InitError(csound,
-                               Str("pvsadsyn: ibin + inoscs too large.\n"));
-    /* calc final max bin target */
-    p->maxosc = startbin + (n_oscs * binoffset);
-    if (UNLIKELY(p->maxosc > noscs))
+                               Str("pvsadsyn: ibinincr must be positive and "
+                                   "no larger than the number of bins.\n"));
+    binincr = (int32_t)value;                  /* default 1 */
+    lastbin = (int64_t)startbin +
+              (int64_t)(n_oscs - 1) * (int64_t)binincr;
+    if (UNLIKELY(lastbin >= numbins))
       return csound->InitError(csound, Str("pvsadsyn: "
-                              "ibin + (inoscs * ibinoffset) too large."));
+                              "ibinoffset + ((inoscs - 1) * ibinincr) "
+                              "too large."));
+    p->startbin = startbin;
+    p->binincr = binincr;
+    p->lastbin = (int32_t)lastbin;
 
     p->outptr = 0;
     p->lastframe = 0;
@@ -165,16 +175,16 @@ int32_t pvadsynset(CSOUND *csound, PVADS *p)
     p->one_over_overlap = (float)(FL(1.0) / p->overlap);
     /* alloc for all oscs;
        in case we can do something with them dynamically, one day */
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->a);
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->x);
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->y);
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->amps);
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->lastamps);
-    csound->AuxAlloc(csound, noscs * sizeof(MYFLT),&p->freqs);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->a);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->x);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->y);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->amps);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->lastamps);
+    csound->AuxAlloc(csound, numbins * sizeof(MYFLT),&p->freqs);
     csound->AuxAlloc(csound, p->overlap * sizeof(MYFLT),&p->outbuf);
     /* initialize oscbank */
     p_x = (MYFLT *) p->x.auxp;
-    for (i=0;i < noscs;i++)
+    for (i=0;i < numbins;i++)
       p_x[i] = FL(1.0);
 
     return OK;
@@ -193,7 +203,7 @@ static inline MYFLT fastoscil(MYFLT *a, MYFLT *x, MYFLT *y)
 static void adsyn_frame(CSOUND *csound, PVADS *p)
 {
     int32_t i,j;
-    int32_t startbin,lastbin,binoffset;
+    int32_t startbin,lastbin,binincr;
     MYFLT *outbuf = (MYFLT *) (p->outbuf.auxp);
 
     float *frame;        /* RWD MUST be 32bit */
@@ -211,12 +221,12 @@ static void adsyn_frame(CSOUND *csound, PVADS *p)
     amps      = (MYFLT *) p->amps.auxp;
     freqs     = (MYFLT *) p->freqs.auxp;
     lastamps  = (MYFLT *) p->lastamps.auxp;
-    startbin  = (int32_t) *p->ibin;
-    binoffset = (int32_t) *p->ibinoffset;
-    lastbin   = p->maxosc;
+    startbin  = p->startbin;
+    binincr   = p->binincr;
+    lastbin   = p->lastbin;
 
     /*update amps, freqs*/
-    for (i=startbin;i < lastbin;i+= binoffset) {
+    for (i=startbin;i <= lastbin;i+=binincr) {
       amps[i] = frame[i*2];
       /* lazy: force all freqs positive! */
       freqs[i] = ffac * FABS(frame[(i*2)+1]);
@@ -232,7 +242,7 @@ static void adsyn_frame(CSOUND *csound, PVADS *p)
        If compiler cannot inline fastoscil,
        would be worth doing so by hand here ?
      */
-    for (i=startbin;i < lastbin;i+=binoffset) {
+    for (i=startbin;i <= lastbin;i+=binincr) {
       MYFLT thisamp = lastamps[i];
       MYFLT delta_amp = (amps[i] - thisamp) * p->one_over_overlap;
 

--- a/include/pstream.h
+++ b/include/pstream.h
@@ -43,10 +43,10 @@
 
   asig      pvsynth fsig[,iinit]
 
-  asig      pvsadsyn fsig,inoscs,kfmod[,ibin,ibinoffset,iinit]
+  asig      pvsadsyn fsig,inoscs,kfmod[,ibinoffset,ibinincr,iinit]
 
-    ibin:       starting bin (defualt 0)
-    ibinoffset: distance between successive bins (default 1)
+    ibinoffset: starting bin (default 0)
+    ibinincr:   distance between successive bins (default 1)
     kfmod:      multiplier; 1 = no change, 2 = up one octave.
 
   fsig      pvscross fsrc,fdest,kamp1,kamp2
@@ -158,15 +158,15 @@ typedef struct {
         PVSDAT  *fsig;
         MYFLT   *n_oscs;
         MYFLT   *kfmod;
-        MYFLT   *ibin;          /* default  0 */
-        MYFLT   *ibinoffset;    /* default 1  */
+        MYFLT   *ibinoffset;    /* default 0 */
+        MYFLT   *ibinincr;      /* default 1 */
         MYFLT   *init;          /* not yet implemented  */
         /* internal */
         int32    outptr;
         uint32   lastframe;
         /* check these against fsig vals */
-        int32    overlap,winsize,fftsize,wintype,format,noscs;
-        int32    maxosc;
+        int32    overlap,winsize,fftsize,wintype,format,startbin;
+        int32    binincr,lastbin;
         float   one_over_overlap,pi_over_sr, one_over_sr;
         float   fmod;
         AUXCH   a;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -579,6 +579,20 @@ def runTest():
         ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
         ["test_oversample.csd", "test oversampling in new-style UDO"],
         ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
+        [
+            "test_pvsadsyn_last_bin.csd",
+            "pvsadsyn accepts a stepped selection ending at the last bin",
+        ],
+        [
+            "test_pvsadsyn_invalid_count.csd",
+            "pvsadsyn rejects an out-of-range oscillator count",
+            1,
+        ],
+        [
+            "test_pvsadsyn_invalid_increment.csd",
+            "pvsadsyn rejects invalid bin increments",
+            1,
+        ],
         ["test_voice_init.csd", "voice initializes its SingWave helper"],
         ["test_grain3_overlap_regression.csd", "grain3 should not fail with false overlap error"],
         ["test_grain3_float_interpolation.csd", "grain3 float-path interpolation should stay positive"],

--- a/tests/commandline/test_pvsadsyn_invalid_count.csd
+++ b/tests/commandline/test_pvsadsyn_invalid_count.csd
@@ -1,0 +1,26 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  ain oscili 0.1, 440
+  fsig pvsanal ain, 128, 32, 128, 1
+  icount = (p4 == -2 ? sqrt:i(-1) : p4)
+  aout pvsadsyn fsig, icount, 1
+  out aout
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0
+i 1 0 .01 -1
+i 1 0 .01 66
+i 1 0 .01 1e30
+i 1 0 .01 -2
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsadsyn_invalid_increment.csd
+++ b/tests/commandline/test_pvsadsyn_invalid_increment.csd
@@ -1,0 +1,31 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+instr 1
+  ain oscili 0.1, 440
+  fsig pvsanal ain, 128, 32, 128, 1
+  ioffset = (p5 == -2 ? sqrt:i(-1) : p5)
+  iincr = (p4 == -2 ? sqrt:i(-1) : p4)
+  aout pvsadsyn fsig, 2, 1, ioffset, iincr
+  out aout
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0 0
+i 1 0 .01 2147483647 0
+i 1 0 .01 -1 0
+i 1 0 .01 -2 0
+i 1 0 .01 1 -1
+i 1 0 .01 1 -2
+i 1 0 .01 1 65
+; The individual arguments fit, but the last selected bin does not.
+i 1 0 .01 2 63
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsadsyn_last_bin.csd
+++ b/tests/commandline/test_pvsadsyn_last_bin.csd
@@ -1,0 +1,57 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkchecks init 0
+
+instr 1
+  ; Put one audible partial in a known bin, including the last bin.
+  kframe[] init 130
+  kframe[p4 * 2] = .1
+  kframe[p4 * 2 + 1] = 440
+  fsig pvsfromarray kframe, 32
+  aout pvsadsyn fsig, p5, 1, p6, p7
+  aref pvsadsyn fsig, 1, 1, p4
+  kerror max_k abs(aout - aref * p8), 1, 1
+  ksample downsamp aout
+  if !(kerror <= .000001 && abs(ksample) <= .2) then
+    printks "pvsadsyn selected the wrong bins\n", 0
+    exitnowk(-1)
+  endif
+  kpeak peak aout
+  kcycle init 0
+  if kcycle == 14 then
+    if p8 == 1 && !(kpeak > .00001) then
+      printks "pvsadsyn omitted the selected bin\n", 0
+      exitnowk(-1)
+    endif
+    gkchecks += 1
+  endif
+  kcycle += 1
+endin
+
+instr 99
+  if i(gkchecks) != 8 then
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Bin, count, offset, increment, whether the bin is selected.
+i 1 0 .01 64 33 0 2 1
+i 1 0 .01 63 33 0 2 0
+i 1 0 .01 64 1 64 1 1
+i 1 0 .01 64 2 63 1 1
+i 1 0 .01 64 22 1 3 1
+; Preserve integer truncation of fractional selection arguments.
+i 1 0 .01 64 65.75 0 1 1
+i 1 0 .01 64 33.75 -.5 2.75 1
+i 1 0 .01 64 1 64.75 65.75 1
+i 99 .02 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `pvsadsyn` rejecting valid stepped selections that reach the final bin. For a 128-point FFT, 33 oscillators selecting bins `0, 2, …, 64` should fit.

- Calculate the last selected bin as `offset + (count - 1) * increment`, using 64-bit arithmetic to avoid overflow.
- Validate count, offset, and increment before integer conversion, and return immediately on invalid counts. This prevents undefined conversions and zero-increment loops while preserving fractional truncation.
- Cache the validated selection for synthesis and align internal argument names with `ibinoffset` and `ibinincr`.

All validation runs at initialization; the synthesis loop adds no function calls.
