### PR TITLE
Fix tabsum range bounds while preserving guard-point access

### DIFF
--- a/Opcodes/tabsum.c
+++ b/Opcodes/tabsum.c
@@ -51,6 +51,8 @@ static int32_t tabsuminit(CSOUND *csound, TABSUM *p)
 static int32_t tabsum(CSOUND *csound, TABSUM *p)
 {
     int32_t i, min, max;
+    double min_value = (double)*p->kmin;
+    double max_value = (double)*p->kmax;
     MYFLT ans = FL(0.0);
     FUNC  *ftp = p->ftp;
     MYFLT *t;
@@ -60,8 +62,16 @@ static int32_t tabsum(CSOUND *csound, TABSUM *p)
       return csound->PerfError(csound, &(p->h),
                                "%s", Str("tabsum: Not initialised"));
     t = p->ftp->ftable;
-    min = MYFLT2LRND(*p->kmin);
-    max = MYFLT2LRND(*p->kmax);
+    /* Allow rounding to index zero or the allocated guard point. */
+    if (UNLIKELY(!(min_value > -1.0 && min_value < (double)ftp->flen + 1.0 &&
+                   max_value > -1.0 && max_value < (double)ftp->flen + 1.0)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("tabsum: range is outside table bounds"));
+    min = MYFLT2LRND(min_value);
+    max = MYFLT2LRND(max_value);
+    if (UNLIKELY((uint32_t)min > ftp->flen || (uint32_t)max > ftp->flen))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("tabsum: range is outside table bounds"));
     if (UNLIKELY(min == 0 && max == 0)) max = ftp->flen-1;
     else if (UNLIKELY(min > max)) {
       int32_t k = min; min = max; max = k;
@@ -80,6 +90,5 @@ static OENTRY tabsum_localops[] = {
 };
 
 LINKAGE_BUILTIN(tabsum_localops)
-
 
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -691,6 +691,8 @@ def runTest():
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
+        ["test_tabsum_ranges.csd", "tabsum handles valid table ranges"],
+        ["test_tabsum_invalid_range.csd", "tabsum rejects out-of-range indexes", 1],
         ["test_newstyle_passbycopy.csd", "test newstyle udo with setksmps"],
         ["test_polymorphic_udo.csd", "test polymorphic udo"],
         ["test_udo_a_array.csd", "test udo with a-array"],

--- a/tests/commandline/test_tabsum_invalid_range.csd
+++ b/tests/commandline/test_tabsum_invalid_range.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giTable ftgen 1, 0, -4, -2, 1, 2, 3, 4
+
+instr 1
+  kmin = (p4 == 99 ? sqrt(-1) : p4)
+  kmax = (p5 == 99 ? sqrt(-1) : p5)
+  ksum tabsum 1, kmin, kmax
+endin
+</CsInstruments>
+<CsScore>
+i 1 0    0.01 -1 0
+i 1 0.02 0.01  0 5
+i 1 0.04 0.01  0 1e100
+; Values inside the conversion bounds may round outside the table.
+i 1 0 .01 -.75 0
+i 1 0 .01 0 4.75
+i 1 0 .01 99 0
+i 1 0 .01 0 99
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_tabsum_ranges.csd
+++ b/tests/commandline/test_tabsum_ranges.csd
@@ -1,0 +1,64 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+
+giTable ftgen 1, 0, -4, -2, 1, 2, 3, 4, 7
+gkchecks init 0
+
+instr 1
+  ksum tabsum 1, p4, p5
+  if !(abs(ksum - p6) <= 0.000001) then
+    printks "tabsum range %g to %g: expected %g, got %g\n", 0, p4, p5, p6, ksum
+    exitnowk(-1)
+  endif
+  kfirst init 1
+  if kfirst == 1 then
+    gkchecks += 1
+    kfirst = 0
+  endif
+endin
+instr 2
+  kcycle init 0
+  kmax = 1 + kcycle % 4
+  ksum tabsum 1, 1, kmax
+  kexpected[] fillarray 2, 5, 9, 16
+  if !(abs(ksum - kexpected[kcycle % 4]) <= .000001) then
+    printks "tabsum did not follow the changing range\n", 0
+    exitnowk(-1)
+  endif
+  if kcycle == 7 then
+    gkchecks += 1
+  endif
+  kcycle += 1
+endin
+
+instr 99
+  if i(gkchecks) != 12 then
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0    0.01 0 0 10
+i 1 0.02 0.01 0 3 10
+i 1 0.04 0.01 3 1 9
+i 1 0.06 0.01 1 2 5
+; Explicit endpoints may include the guard point; the default excludes it.
+i 1 0 .01 0 4 17
+i 1 0 .01 4 4 7
+i 1 0 .01 4 2 14
+; Round fractional endpoints as before, including either table boundary.
+i 1 0 .01 0 3.6 17
+i 1 0 .01 0 4.25 17
+i 1 0 .01 -.25 3 10
+i 1 0 .01 -.25 .25 10
+i 2 0 .01
+i 99 .08 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Check `tabsum` range arguments before integer conversion, then check the rounded indices before reading the table. This rejects NaN, infinity, and out-of-range values without invalid conversions or out-of-bounds reads.

Preserve nearest-integer rounding, reversed ranges, and the default whole-table sum. Explicit ranges can still include the allocated guard point at `ftlen`; rejecting that endpoint would break existing uses.

The checks run once per control cycle. The sum loop adds no function calls.
