### PR TITLE
Fix audio sumarray output clearing at sample offsets

### DIFF
--- a/OOps/array_ops.c
+++ b/OOps/array_ops.c
@@ -3307,15 +3307,11 @@ int32_t tabsuma(CSOUND *csound, TABQUERY1 *p)
                              "%s", Str("array-variable not a vector"));
 
 
-  if (UNLIKELY(offset)) memset(ans, '\0', offset*sizeof(MYFLT));
-  if (UNLIKELY(early)) {
-    nsmps -= early;
-    memset(&ans[nsmps], '\0', early*sizeof(MYFLT));
-  }
+  nsmps -= early;
 
   for (i=1; i<t->dimensions; i++) numarrays *= t->sizes[i];
 
-  memset(&ans[offset], '\0', nsmps*sizeof(MYFLT));
+  memset(ans, '\0', CS_KSMPS*sizeof(MYFLT));
 
   int32_t numarrays4 = numarrays - (numarrays % 4);
 

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 if(BUILD_TESTS)
   add_executable(unittests
+        array_ops_test.cpp
         channel_tests.cpp
         csound_data_structures_test.cpp
         csound_debug_callback_test.cpp

--- a/tests/c/array_ops_test.cpp
+++ b/tests/c/array_ops_test.cpp
@@ -1,0 +1,63 @@
+#define __BUILDING_LIBCSOUND
+
+extern "C" {
+#include "array_ops.h"
+}
+#include "gtest/gtest.h"
+
+#include <array>
+
+TEST(ArrayOpsTests, SumAudioArrayStaysWithinOutputBlock)
+{
+  constexpr int32_t ksmps = 8;
+  constexpr int32_t guardSize = 8;
+  constexpr MYFLT guardValue = FL(1234.0);
+  const std::array<std::array<int32_t, 2>, 7> bounds{{
+    {0, 0}, {3, 0}, {0, 2}, {3, 2}, {3, 4}, {7, 0}, {3, 5}
+  }};
+
+  std::array<MYFLT, 5 * ksmps> input{};
+  for (int32_t channel = 0; channel < 5; ++channel) {
+    for (int32_t i = 0; i < ksmps; ++i)
+      input[channel * ksmps + i] = (MYFLT)(10 * channel + i);
+  }
+
+  for (int32_t channels : {1, 2, 4, 5}) {
+    for (auto [offset, early] : bounds) {
+      SCOPED_TRACE(::testing::Message() << "channels=" << channels
+                   << " offset=" << offset << " early=" << early);
+      std::array<MYFLT, ksmps + 2 * guardSize> output;
+      output.fill(guardValue);
+
+      int32_t sizes[] = {channels};
+      ARRAYDAT array{};
+      array.dimensions = 1;
+      array.sizes = sizes;
+      array.arrayMemberSize = ksmps * sizeof(MYFLT);
+      array.data = input.data();
+
+      INSDS instance{};
+      instance.ksmps = ksmps;
+      instance.ksmps_offset = offset;
+      instance.ksmps_no_end = early;
+
+      TABQUERY1 opcode{};
+      opcode.h.insdshead = &instance;
+      opcode.ans = output.data() + guardSize;
+      opcode.tab = &array;
+
+      ASSERT_EQ(tabsuma(nullptr, &opcode), OK);
+
+      for (int32_t i = 0; i < guardSize; ++i) {
+        EXPECT_EQ(output[i], guardValue);
+        EXPECT_EQ(output[guardSize + ksmps + i], guardValue);
+      }
+      for (int32_t i = 0; i < ksmps; ++i) {
+        MYFLT expected = FL(0.0);
+        if (i >= offset && i < ksmps - early)
+          expected = (MYFLT)(5 * channels * (channels - 1) + channels * i);
+        EXPECT_EQ(opcode.ans[i], expected) << "sample=" << i;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix audio `sumarray` clearing past its output block when a note starts at a nonzero sample offset. The clear starts at `ans + offset` but uses a length measured from the start of the block.

Clear exactly `ksmps` output samples once, then sum only the active samples. This keeps samples before the note starts and after it ends silent without writing beyond the output buffer.

The existing unrolled summation loops stay unchanged, with no added calls or checks inside them.
