### PR TITLE
fix: update pitch conversion arrays every control cycle

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -358,7 +358,6 @@ typedef struct {
     MYFLT *irnd;
     MYFLT freqA4;
     int32_t rnd;
-    int32_t skip;
 } PITCHCONV_ARR;
 
 
@@ -366,20 +365,18 @@ static int32_t
 ftom_arr(CSOUND *csound, PITCHCONV_ARR *p) {
     MYFLT x, *indata, *outdata;
     int32_t i;
-    if(p->skip) {
-        p->skip = 0;
-        return OK;
-    }
     MYFLT a4 = p->freqA4;
-    IGN(csound);
+    int32_t numitems = p->inarr->sizes[0];
+    if (UNLIKELY(ARRAY_ENSURESIZE_PERF(csound, p->outarr, numitems) != OK))
+        return NOTOK;
     indata = p->inarr->data;
     outdata = p->outarr->data;
-    for(i=0; i < p->inarr->sizes[0]; i++) {
+    for(i=0; i < numitems; i++) {
         x = indata[i];
         outdata[i] = FL(12.0) * LOG2(x / a4) + FL(69.0);
     }
     if(UNLIKELY(p->rnd)) {
-        for(i=0; i < p->inarr->sizes[0]; i++) {
+        for(i=0; i < numitems; i++) {
             outdata[i] = (MYFLT)MYFLT2LRND(outdata[i]);
         }
     }
@@ -393,26 +390,19 @@ ftom_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     if (UNLIKELY(tabinit(csound, p->outarr, p->inarr->sizes[0],
                          p->h.insdshead) != OK))
       return csound_array_init_resize_error(csound);
-    p->skip = 0;
-    ftom_arr(csound, p);
-    p->skip = 1;
-    return OK;
+    return ftom_arr(csound, p);
 }
 
 static int32_t
 mtof_arr(CSOUND *csound, PITCHCONV_ARR *p) {
     MYFLT x, *indata, *outdata;
     int32_t i;
-    if(p->skip) {
-        p->skip = 0;
-        return OK;
-    }
     MYFLT a4 = p->freqA4;
-    IGN(csound);
+    int32_t numitems = p->inarr->sizes[0];
+    if (UNLIKELY(ARRAY_ENSURESIZE_PERF(csound, p->outarr, numitems) != OK))
+        return NOTOK;
     indata = p->inarr->data;
     outdata = p->outarr->data;
-    int32_t numitems = p->inarr->sizes[0];
-    ARRAY_ENSURESIZE_PERF(csound, p->outarr, numitems);
     for(i=0; i < numitems; i++) {
         x = indata[i];
         outdata[i] = POWER(FL(2.0), (x - FL(69.0)) / FL(12.0)) * a4;
@@ -426,10 +416,7 @@ mtof_arr_init(CSOUND *csound, PITCHCONV_ARR *p) {
     if (UNLIKELY(tabinit(csound, p->outarr, p->inarr->sizes[0],
                          p->h.insdshead) != OK))
       return csound_array_init_resize_error(csound);
-    p->skip = 0;
-    mtof_arr(csound, p);
-    p->skip = 1;
-    return OK;
+    return mtof_arr(csound, p);
 }
 
 /*

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -720,6 +720,7 @@ def runTest():
         ["test_vector_table_correctness.csd", "vector table indexing"],
         ["test_vector_table_invalid_index.csd", "reject invalid vector table index", 1],
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
+        ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
         ["test_tabsum_ranges.csd", "tabsum handles valid table ranges"],

--- a/tests/commandline/test_pitch_conversion_arrays.csd
+++ b/tests/commandline/test_pitch_conversion_arrays.csd
@@ -1,0 +1,98 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giFreqs ftgen 0, 0, -4, -2, 440, 880, 220, 110
+
+instr 1
+  iNotes[] fillarray 69, 81, 69.25
+  iHz[] mtof iNotes
+  iMidi[] ftom iHz
+  iRounded[] ftom iHz, 1
+  iIndex = 0
+  while iIndex < lenarray(iNotes) do
+    iExpectedHz mtof iNotes[iIndex]
+    iExpectedRounded = round(iNotes[iIndex])
+    if abs(iHz[iIndex] - iExpectedHz) > .0001 || \
+       abs(iMidi[iIndex] - iNotes[iIndex]) > .0001 || \
+       abs(iRounded[iIndex] - iExpectedRounded) > .0001 then
+      prints "pitch conversion failed at init time\n"
+      exitnow(-1)
+    endif
+    iIndex += 1
+  od
+
+  kNotes[] fillarray 69, 69
+  kFreqs[] fillarray 440, 440
+  kCycle init 0
+  kCycle += 1
+  kNotes[0] = 81 + kCycle - 1
+  kNotes[1] = 69.25 + kCycle - 1
+  kFreqs[0] = 880 * kCycle
+  kFreqs[1] = 445 * kCycle
+  kHz[] mtof kNotes
+  kMidi[] ftom kFreqs
+  kRounded[] ftom kFreqs, 1
+  kIndex = 0
+  while kIndex < lenarray(kNotes) do
+    kExpectedHz mtof kNotes[kIndex]
+    kExpectedMidi ftom kFreqs[kIndex]
+    kExpectedRounded ftom kFreqs[kIndex], 1
+    if abs(kHz[kIndex] - kExpectedHz) > .0001 || \
+       abs(kMidi[kIndex] - kExpectedMidi) > .0001 || \
+       abs(kRounded[kIndex] - kExpectedRounded) > .0001 then
+      printks "pitch conversion differs from scalar on cycle %d, element %d\n", 0, kCycle, kIndex
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+  gkChecks += 1
+endin
+
+instr 2
+  ; Vary the length within the capacity reserved at init time.
+  kSize init 4
+  kCycle init 0
+  kCycle += 1
+  kSize = kCycle + 1
+  kFreqs[] tab2array giFreqs, 0, kSize
+  kMidi[] ftom kFreqs
+  kHz[] mtof kMidi
+  kMidiSize lenarray kMidi
+  kHzSize lenarray kHz
+  if kMidiSize != kSize || kHzSize != kSize then
+    printks "pitch conversion output length did not follow input\n", 0
+    exitnowk(-1)
+  endif
+  kIndex = 0
+  while kIndex < kSize do
+    if abs(kHz[kIndex] - kFreqs[kIndex]) > .001 then
+      printks "pitch conversion failed after length change\n", 0
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+  gkChecks += 1
+endin
+
+instr 99
+  if i(gkChecks) != 12 then
+    prints "pitch conversion checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .003
+i 2 0 .003
+i 1 .01 .003
+i 2 .01 .003
+i 99 .02 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Array `mtof` and `ftom` skip their first control cycle, leaving init-time results after the inputs change. For example, changing MIDI 69 to 81 still gives 440 Hz for the first block instead of 880 Hz. Remove the skip so both match their scalar versions from the first cycle.

Also check output capacity before either conversion loop, update output lengths to match the inputs, and return on failure. `ftom` lacked this check; `mtof` ignored its result. This prevents writes beyond reserved storage without allocating during performance or adding checks inside the element loops.
