### PR TITLE
fix: preserve bformdec1 surround samples and input order

### DIFF
--- a/Opcodes/ambicode1.c
+++ b/Opcodes/ambicode1.c
@@ -92,7 +92,6 @@ typedef struct {
     /* Input arguments: */
     MYFLT *isetup;
     ARRAYDAT *tabin;
-    uint32_t dim;
 } AMBIDA;
 
 /* ------------------------------------------------------------------------- */
@@ -417,15 +416,17 @@ abformdec(CSOUND * csound, AMBID * p) {
         memset(p->aouts[1], '\0', offset*sizeof(MYFLT));
         memset(p->aouts[2], '\0', offset*sizeof(MYFLT));
         memset(p->aouts[3], '\0', offset*sizeof(MYFLT));
+        memset(p->aouts[4], '\0', offset*sizeof(MYFLT));
       }
-     if (UNLIKELY(early)) {
-      sampleCount -= early;
-      memset(&p->aouts[0][sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&p->aouts[1][sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&p->aouts[2][sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&p->aouts[3][sampleCount], '\0', early*sizeof(MYFLT));
-    }
-     /* This is a second order decoder provided by Bruce Wiggins. It is
+      if (UNLIKELY(early)) {
+        sampleCount -= early;
+        memset(&p->aouts[0][sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&p->aouts[1][sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&p->aouts[2][sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&p->aouts[3][sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&p->aouts[4][sampleCount], '\0', early*sizeof(MYFLT));
+      }
+      /* This is a second order decoder provided by Bruce Wiggins. It is
          optimised for high frequency use within a dual-band decoder,
          however it has good a low-frequency response. It is not quite
          'in-phase' but it is not far off. */
@@ -454,19 +455,6 @@ abformdec(CSOUND * csound, AMBID * p) {
       }
       else {
         /* This is the full matrix. */
-        if (UNLIKELY(offset)) {
-          memset(p->aouts[0], '\0', offset*sizeof(MYFLT));
-          memset(p->aouts[1], '\0', offset*sizeof(MYFLT));
-          memset(p->aouts[2], '\0', offset*sizeof(MYFLT));
-          memset(p->aouts[3], '\0', offset*sizeof(MYFLT));
-        }
-        if (UNLIKELY(early)) {
-          sampleCount -= early;
-          memset(&p->aouts[0][sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&p->aouts[1][sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&p->aouts[2][sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&p->aouts[3][sampleCount], '\0', early*sizeof(MYFLT));
-        }
         for (sampleIndex = offset; sampleIndex < sampleCount; sampleIndex++) {
           w = p->ains[0][sampleIndex];
           x = p->ains[1][sampleIndex];
@@ -690,6 +678,9 @@ ibformdec_a(CSOUND * csound, AMBIDA * p) {
     if (p->tabout->data==NULL || p->tabout->dimensions!=1)
       return csound->InitError(csound,
                                "%s", Str("bformdec1 output array not initialised"));
+    if (p->tabin->data==NULL || p->tabin->dimensions!=1)
+      return csound->InitError(csound,
+                               "%s", Str("bformdec1 input array not initialised"));
     dim = p->tabin->sizes[0];
     /* All we do in here is police our parameters. */
     if (UNLIKELY(dim != 4 &&
@@ -703,7 +694,7 @@ ibformdec_a(CSOUND * csound, AMBIDA * p) {
                                "%s", Str("The isetup value should be between 1 and 5."));
     }
     else {
-      p->dim = dim = p->tabout->sizes[0];
+      dim = p->tabout->sizes[0];
       /* Then we check the output arguments. */
       if (*(p->isetup) == 1 && dim == 2) {
         /* Stereo. */
@@ -751,7 +742,6 @@ abformdec_a(CSOUND * csound, AMBIDA * p) {
     uint32_t sampleCount = CS_KSMPS, sampleIndex;
     uint32_t ksmps = sampleCount;
     MYFLT p0, q, u, v, w, x, y, z;
-    uint32_t dim = p->dim;
     MYFLT *tabin = p->tabin->data, *tabout = p->tabout->data;
 
     switch ((int32_t
@@ -814,19 +804,21 @@ abformdec_a(CSOUND * csound, AMBIDA * p) {
         memset(&tabout[ksmps], '\0', offset*sizeof(MYFLT));
         memset(&tabout[2*ksmps], '\0', offset*sizeof(MYFLT));
         memset(&tabout[3*ksmps], '\0', offset*sizeof(MYFLT));
+        memset(&tabout[4*ksmps], '\0', offset*sizeof(MYFLT));
       }
-     if (UNLIKELY(early)) {
-      sampleCount -= early;
-      memset(&tabout[sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&tabout[ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&tabout[2*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-      memset(&tabout[3*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-    }
-     /* This is a second order decoder provided by Bruce Wiggins. It is
+      if (UNLIKELY(early)) {
+        sampleCount -= early;
+        memset(&tabout[sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&tabout[ksmps+sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&tabout[2*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&tabout[3*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
+        memset(&tabout[4*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
+      }
+      /* This is a second order decoder provided by Bruce Wiggins. It is
          optimised for high frequency use within a dual-band decoder,
          however it has good a low-frequency response. It is not quite
          'in-phase' but it is not far off. */
-      if (dim == 4) {
+      if (p->tabin->sizes[0] == 4) {
         /* Matrix truncated to first order (not ideal). */
         for (sampleIndex = offset; sampleIndex < sampleCount; sampleIndex++) {
           w = tabin[sampleIndex];
@@ -851,19 +843,6 @@ abformdec_a(CSOUND * csound, AMBIDA * p) {
       }
       else {
         /* This is the full matrix. */
-        if (UNLIKELY(offset)) {
-          memset(&tabout[0], '\0', offset*sizeof(MYFLT));
-          memset(&tabout[ksmps], '\0', offset*sizeof(MYFLT));
-          memset(&tabout[2*ksmps], '\0', offset*sizeof(MYFLT));
-          memset(&tabout[3*ksmps], '\0', offset*sizeof(MYFLT));
-        }
-        if (UNLIKELY(early)) {
-          sampleCount -= early;
-          memset(&tabout[0+sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&tabout[ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&tabout[2*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-          memset(&tabout[3*ksmps+sampleCount], '\0', early*sizeof(MYFLT));
-        }
         for (sampleIndex = offset; sampleIndex < sampleCount; sampleIndex++) {
           w = tabin[sampleIndex];
           x = tabin[ksmps+sampleIndex];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -632,6 +632,7 @@ def runTest():
         ["test_syncloop_envelope_end.csd", "syncloop retires grains at the envelope end"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
+        ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],

--- a/tests/commandline/test_bformdec1_surround.csd
+++ b/tests/commandline/test_bformdec1_surround.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  aW = 1
+  aZero = 0
+  aU = 1
+  aInput[] init p4
+  aInput[0] = aW
+  aArray[] init 5
+
+  if p4 == 4 then
+    aL, aR, aC, aSL, aSR bformdec1 3, aW, aZero, aZero, aZero
+  elseif p4 == 9 then
+    aInput[7] = aU
+    aL, aR, aC, aSL, aSR bformdec1 3, aW, aZero, aZero, aZero, \
+                                  aZero, aZero, aZero, aU, aZero
+  else
+    aInput[7] = aU
+    aL, aR, aC, aSL, aSR bformdec1 3, aW, aZero, aZero, aZero, \
+                                  aZero, aZero, aZero, aU, aZero, \
+                                  aZero, aZero, aZero, aZero, aZero, aZero, aZero
+  endif
+  aArray bformdec1 3, aInput
+
+  iHigherOrder = p4 > 4 ? 1 : 0
+  aFront = aW * (.405 + .085 * iHigherOrder)
+  aCentre = aW * (.085 + .045 * iHigherOrder)
+  aSurround = aW * (.635 - .08 * iHigherOrder)
+  aError = abs(aL - aFront) + abs(aR - aFront) + abs(aC - aCentre)
+  aError += abs(aSL - aSurround) + abs(aSR - aSurround)
+  aError += abs(aArray[0] - aFront) + abs(aArray[1] - aFront)
+  aError += abs(aArray[2] - aCentre)
+  aError += abs(aArray[3] - aSurround) + abs(aArray[4] - aSurround)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "bformdec1 with %d inputs lost or changed active samples: %g\n", 0, p4, kError
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 9 then
+    prints "bformdec1 checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Whole blocks, then a partial start and end, then a partial end alone.
+i 1 0 .004 4
+i 1 0 .004 9
+i 1 0 .004 16
+i 1 .010625 .003 4
+i 1 .010625 .003 9
+i 1 .010625 .003 16
+i 1 .02 .0035 4
+i 1 .02 .0035 9
+i 1 .02 .0035 16
+i 99 .03 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix three issues in `bformdec1`'s 5.0 surround decoder:

- Subtract the inactive tail once. The second- and third-order paths did it twice, dropping active samples from notes that end within a block.
- Clear inactive samples on all five outputs. The surround-right channel was omitted, leaving stale samples in its buffer.
- Select the array decoder's matrix from the input count, not the five output channels. Four-channel inputs now use the first-order matrix. Validate the input array at initialization before reading its shape.

The decode formulas stay unchanged, with no new calls or checks inside the sample loops.
