### PR TITLE
fix: preserve lag state and partial audio blocks

### DIFF
--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -25,7 +25,7 @@
 #include "emugens_common.h"
 
 #define LOG001 FL(-6.907755278982137)
-#define CALCSLOPE(next,prev,nsmps) ((next - prev)/nsmps)
+#define CALCSLOPE(next,prev,nsmps) (((next) - (prev))/(nsmps))
 
 #define SAMPLE_ACCURATE \
     uint32_t n, nsmps = CS_KSMPS;                                    \
@@ -155,7 +155,7 @@ static int32_t lag0k_next(CSOUND *csound, LAG0 *p) {
     } else {
         // faust uses tau2pole = exp(-1 / (lag*sr))
         b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
-        *p->out = y0 + b1 * (y1 - y0);
+        *p->out = y1 = y0 + b1 * (y1 - y0);
         p->lag = lag;
         p->y1 = y1;
         p->b1 = b1;
@@ -192,6 +192,9 @@ static int32_t laga_next(CSOUND *csound, LAG0 *p) {
 
     SAMPLE_ACCURATE
 
+    if (UNLIKELY(offset >= nsmps))
+        return OK;
+
     const MYFLT* restrict in = p->in;
     MYFLT lag = *p->lagtime;
     MYFLT y0, y1;
@@ -201,7 +204,7 @@ static int32_t laga_next(CSOUND *csound, LAG0 *p) {
         y1 = p->y1;
     else {
         p->started = 1;
-        y1 = in[0];
+        y1 = in[offset];
     }
 
     if (lag == p->lag) {
@@ -213,7 +216,7 @@ static int32_t laga_next(CSOUND *csound, LAG0 *p) {
     } else {
         // faust uses tau2pole = exp(-1 / (lag*sr))
         p->b1 = lag == FL(0.0) ? FL(0.0) : exp(LOG001 / (lag * p->sr));
-        MYFLT b1_slope = CALCSLOPE(p->b1, b1, nsmps);
+        MYFLT b1_slope = CALCSLOPE(p->b1, b1, nsmps - offset);
         p->lag = lag;
         for (n=offset; n<nsmps; n++) {
             b1 += b1_slope;
@@ -319,6 +322,9 @@ lagud_a(CSOUND *csound, LagUD *p) {
 
     SAMPLE_ACCURATE
 
+    if (UNLIKELY(offset >= nsmps))
+        return OK;
+
     const MYFLT* restrict in = p->in;
     MYFLT lagu = *p->lagtimeU;
     MYFLT lagd = *p->lagtimeD;
@@ -327,16 +333,11 @@ lagud_a(CSOUND *csound, LagUD *p) {
     MYFLT b1u  = p->b1u;
     MYFLT b1d  = p->b1d;
 
-    if (UNLIKELY(offset)) memset(p->out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early))  {
-      nsmps -= early;
-      memset(&p->out[nsmps], '\0', early*sizeof(MYFLT));
-    }
     if(LIKELY(p->started))
         y1 = p->y1;
     else {
         p->started = 1;
-        y1 = in[0];
+        y1 = in[offset];
     }
 
     if ((lagu == p->lagu) && (lagd == p->lagd)) {
@@ -356,10 +357,10 @@ lagud_a(CSOUND *csound, LagUD *p) {
         MYFLT sr = CS_ESR;
         // faust uses tau2pole = exp(-1 / (lag*sr))
         p->b1u = lagu == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagu * sr));
-        MYFLT b1u_slope = CALCSLOPE(p->b1u, b1u, nsmps);
+        MYFLT b1u_slope = CALCSLOPE(p->b1u, b1u, nsmps - offset);
         p->lagu = lagu;
         p->b1d  = lagd == FL(0.0) ? FL(0.0) : exp(LOG001 / (lagd * sr));
-        MYFLT b1d_slope = CALCSLOPE(p->b1d, b1d, nsmps);
+        MYFLT b1d_slope = CALCSLOPE(p->b1d, b1d, nsmps - offset);
         p->lagd = lagd;
         for (n=offset; n<nsmps; n++) {
             MYFLT y0 = in[n];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -929,6 +929,7 @@ def runTest():
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],
         ["test_follow_period.csd", "test follow period handling"],
         ["test_follow_invalid_period.csd", "reject invalid follow period", 1],
+        ["test_lag_state.csd", "lag state and partial audio blocks"],
         ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
         ["test_distort_sample_offset.csd", "test distort sample-accurate onset"],
         ["test_distort_istor_first_init.csd", "test distort state-preserving first init"],

--- a/tests/commandline/test_lag_state.csd
+++ b/tests/commandline/test_lag_state.csd
@@ -1,0 +1,106 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Independent recurrence for a unit step with explicit initial value zero.
+opcode LagReference, a, ii
+  setksmps 1
+  iTime, iFirstSamples xin
+  iTarget = exp(log(.001) / (iTime * sr))
+  kSample init 0
+  kSample += 1
+  kCoefficient = iTarget
+  if kSample <= iFirstSamples then
+    kCoefficient = 1 + (iTarget - 1) * kSample / iFirstSamples
+  endif
+  kValue init 0
+  kValue = 1 + kCoefficient * (kValue - 1)
+  aValue = kValue
+  xout aValue
+endop
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kTime = kCycle <= 2 ? .01 : (kCycle == 3 ? 0 : (kCycle % 2 == 0 ? .01 : .02))
+  kInput = kCycle <= 4 ? 1 : -.5
+  kLag lag kInput, kTime, 0
+  kAlias sclag kInput, kTime, 0
+  kLagUD lagud kInput, kTime, kTime, 0
+  kDefault lag kInput, kTime
+  kExpected init 0
+  kExpectedDefault init 1
+  kCoefficient = 0
+  if kTime > 0 then
+    kCoefficient = exp(log(.001) / (kTime * kr))
+  endif
+  kExpected = kInput + kCoefficient * (kExpected - kInput)
+  kExpectedDefault = kInput + kCoefficient * (kExpectedDefault - kInput)
+  if abs(kLag - kExpected) + abs(kAlias - kExpected) + \
+     abs(kLagUD - kExpected) + abs(kDefault - kExpectedDefault) > .00001 then
+    printks "lag state differs from recurrence on control cycle %d\n", 0, kCycle
+    exitnowk(-1)
+  endif
+  if kCycle == 8 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2, 3
+  aInput = p4
+  if p1 == 2 then
+    ; Omitting the initial value must use the first active input sample.
+    aLag lag aInput, .01
+    aLagUD lagud aInput, .01, .01
+    aReference = aInput
+  else
+    iOffset = round(p2 * sr) % ksmps
+    iFirstSamples = min(ksmps - iOffset, round(p3 * sr))
+    aLag lag aInput, .01, 0
+    aLagUD lagud aInput, .01, .01, 0
+    aReference LagReference .01, iFirstSamples
+    aReference *= p4
+  endif
+  aError = abs(aLag - aReference) + abs(aLagUD - aReference)
+  kError max_k aError, 1, 1
+  if !(kError <= .00001) then
+    printks "lag audio mismatch in instrument %d: %g\n", 0, p1, kError
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 11 then
+    prints "lag checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .016
+; Whole blocks and several partial-block layouts, with and without initial values.
+i 2 .02 .004 1
+i 3 .02 .004 1
+i 2 .030625 .003 1
+i 3 .030625 .003 1
+i 2 .04 .0035 1
+i 3 .04 .0035 1
+i 2 .050125 .0015 1
+i 3 .050125 .0015 1
+i 2 .060625 .003 -1
+i 3 .060625 .003 -1
+i 99 .07 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix state and sample handling in `lag` and `lagud`:

- Save the new control-rate `lag` output when lag time changes. Keeping the old state made repeated changes prevent convergence to the input.
- Initialize audio state from the first active sample when no initial value is supplied. Reading sample zero gave notes starting within a block the wrong initial state.
- Remove duplicate tail handling in audio `lagud`, which dropped active samples at note ends.
- Ramp coefficients across the active samples of a partial block and leave state untouched in empty blocks.

The aliases share these fixes. The sample loops gain no calls or checks, and full-block audio processing keeps its existing formulas.
