### PR TITLE
fix: preserve trighold's first pulse after initialization

### DIFF
--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -459,10 +459,12 @@ trig_k(CSOUND *csound, Trig *p) {
 }
 
 static int32_t trig_init(CSOUND *csound, Trig *p) {
+    IGN(csound);
     p->counter = 0;
     p->prevtrig = FL(0.0);
     p->level = FL(0.0);
-    trig_k(csound, p);
+    /* Set the initial output without consuming the first performance trigger. */
+    *p->out = *p->in > FL(0.0) ? *p->in : FL(0.0);
     return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -570,6 +570,7 @@ def runTest():
         ["test_splitrig_sequences.csd", "splitrig sequence selection and changing tick counts"],
         ["test_splitrig_invalid_layout.csd", "splitrig rejects invalid maximum tick counts", 1],
         ["test_splitrig_invalid_sequence.csd", "splitrig rejects invalid indexes and tick counts", 1],
+        ["test_trighold_initial_trigger.csd", "trighold preserves its full duration after init and reinit"],
         ["test_udo_local_pool.csd", "test udos for separate local var pool"],
         ["test_ternary_expr.csd", "test ternary expr for backwards compatibility"],
         ["test_array_expr_opcall.csd", "test array expr in opcall"],

--- a/tests/commandline/test_trighold_initial_trigger.csd
+++ b/tests/commandline/test_trighold_initial_trigger.csd
@@ -1,0 +1,78 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  iDuration = p4 / kr
+  iTicks = max(1, round(p4))
+  kInput init p5
+  kPerfInput = p5
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 6 then
+    reinit HOLD
+  endif
+HOLD:
+  kFromInit trighold kInput, iDuration
+  kFromPerf trighold kPerfInput, iDuration
+  kAlias sctrig kInput, iDuration
+  ; Preserve the output available to init-time consumers.
+  if i(kFromInit) != p5 || i(kAlias) != p5 then
+    prints "trighold changed its initial output\n"
+    exitnow(-1)
+  endif
+  rireturn
+  kAge = (kCycle - 1) % 5
+  kExpected = kAge < iTicks ? p5 : 0
+  if kFromInit != kExpected || kFromPerf != kExpected || kAlias != kExpected then
+    printks "trighold duration %g cycles: wrong output on cycle %d\n", 0, p4, kCycle
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; Compare both rates at one sample per control cycle.
+  setksmps 1
+  kInput init .25
+  aInput init .25
+  kHold trighold kInput, 3 / sr
+  aHold trighold aInput, 3 / sr
+  kAudio downsamp aHold
+  kCycle init 0
+  kCycle += 1
+  kExpected = kCycle <= 3 ? .25 : 0
+  if kHold != kExpected || kAudio != kExpected then
+    printks "trighold audio/control duration differs on sample %d\n", 0, kCycle
+    exitnowk(-1)
+  endif
+  if kCycle == 8 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 5 then
+    prints "trighold checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 3 .25
+i 1 0 .01 1 1
+i 1 0 .01 .4 .5
+i 1 0 .01 0 .75
+i 2 .02 .001
+i 99 .03 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`trighold` called its control-rate performance routine during initialization. An already-positive input therefore started the hold before performance, shortening the first pulse by one control cycle and losing a one-cycle pulse entirely.

Set the initial output directly while leaving the counter and trigger state reset. This preserves the init-time output and gives the first pulse its full duration after initialization or reinitialization. The aliases share the fix; performance processing stays unchanged.
