### PR TITLE
fix: keep trigphasor starts and resets within range

### DIFF
--- a/Opcodes/emugens/scugens.c
+++ b/Opcodes/emugens/scugens.c
@@ -72,15 +72,17 @@ static inline MYFLT sc_wrap(MYFLT in, MYFLT lo, MYFLT hi) {
 }
 
 
-// Scalar branchless version
-static inline MYFLT sc_wrap_fast(MYFLT in, MYFLT lo, MYFLT hi, MYFLT range) {
-    in -= range * (in >= hi);   // subtract range if over
-    in += range * (in <  lo);   // add range if under
-    // fallback only if still out of range (multiple wraps)
-    if (UNLIKELY(in >= hi || in < lo))
-        in = in - range * FLOOR((in - lo) / range);
-    return in;
-}
+/* Arguments must be local values without side effects. */
+#define SC_WRAP_FAST(value, lo, hi, range) do {                             \
+    (value) -= (range) * ((value) >= (hi));                                \
+    (value) += (range) * ((value) < (lo));                                 \
+    if (UNLIKELY((value) >= (hi) || (value) < (lo))) {                      \
+        if ((range) == FL(0.0))                                          \
+            (value) = (lo);                                              \
+        else                                                            \
+            (value) -= (range) * FLOOR(((value) - (lo)) / (range));        \
+    }                                                                   \
+} while (0)
 
 
 
@@ -492,7 +494,7 @@ static int32_t trig_init(CSOUND *csound, Trig *p) {
    aindex phasor atrig, xrate, kstart, kend, kresetPos=kstart
    kindex phasor ktrig, krate, kstart, kend, kresetPos=kstart
 
-   trig:     When triggered, jump to resetPos (default: 0, equivalent to start).
+   trig:     When triggered, jump to resetPos (defaults to start).
    rate:     The amount of change per sample, i.e at a rate of 1 the value
              of each sample will be 1 greater than the preceding sample.
    start:    Start point of the ramp.
@@ -505,12 +507,16 @@ typedef struct {
     OPDS h;
     MYFLT *out, *trig, *rate, *start, *end, *resetPos;
     MYFLT level, previn;
+    int32_t started;
 } Phasor;
 
 static int32_t phasor_init(CSOUND *csound, Phasor *p) {
     IGN(csound);
     p->previn = 0;
     p->level = 0;
+    p->started = 0;
+    if (p->INOCOUNT < 5)
+        p->resetPos = p->start;
     return OK;
 }
 
@@ -520,26 +526,31 @@ phasor_a_aa(CSOUND *csound, Phasor *p) {
 
     SAMPLE_ACCURATE
 
+    if (UNLIKELY(offset >= nsmps))
+        return OK;
+
     MYFLT* restrict in = p->trig;
     const MYFLT *rate = p->rate;
     const MYFLT start = *p->start;
     const MYFLT end = *p->end;
     const MYFLT resetPos = *p->resetPos;
     MYFLT previn = p->previn;
-    MYFLT level = p->level;
+    MYFLT level = p->started ? p->level : start;
+    p->started = 1;
     const MYFLT range = end - start;
 
+    SC_WRAP_FAST(level, start, end, range);
     for(n=offset; n<nsmps; n++) {
         MYFLT curin = in[n];
         MYFLT zrate = rate[n];
         if (previn <= FL(0.0) && curin > FL(0.0)) {
             MYFLT frac = FL(1) - previn/(curin-previn);
             level = resetPos + frac * zrate;
+            SC_WRAP_FAST(level, start, end, range);
         }
         out[n] = level;
         level += zrate;
-        // level = sc_wrap(level, start, end);
-        level = sc_wrap_fast(level, start, end, range);
+        SC_WRAP_FAST(level, start, end, range);
         previn = curin;
     }
     p->previn = previn;
@@ -553,24 +564,30 @@ phasor_a_ak(CSOUND *csound, Phasor *p) {
 
     SAMPLE_ACCURATE
 
+    if (UNLIKELY(offset >= nsmps))
+        return OK;
+
     MYFLT* restrict in = p->trig;
     MYFLT rate = *p->rate;
     MYFLT start = *p->start;
     MYFLT end = *p->end;
     MYFLT resetPos = *p->resetPos;
     MYFLT previn = p->previn;
-    MYFLT level = p->level;
+    MYFLT level = p->started ? p->level : start;
+    p->started = 1;
     const MYFLT range = end - start;
 
+    SC_WRAP_FAST(level, start, end, range);
     for(n=offset; n<nsmps; n++) {
         MYFLT curin = in[n];
         if (previn <= FL(0.0) && curin > FL(0.0)) {
             MYFLT frac = FL(1.0) - previn/(curin-previn);
             level = resetPos + frac * rate;
+            SC_WRAP_FAST(level, start, end, range);
         }
         out[n] = level;
         level += rate;
-        level = sc_wrap_fast(level, start, end, range);
+        SC_WRAP_FAST(level, start, end, range);
         previn = curin;
     }
     p->previn = previn;
@@ -584,26 +601,28 @@ phasor_a_kk(CSOUND *csound, Phasor *p) {
 
     SAMPLE_ACCURATE
 
+    if (UNLIKELY(offset >= nsmps))
+        return OK;
+
     MYFLT curin    = *p->trig;
     MYFLT rate     = *p->rate;
     MYFLT start    = *p->start;
     MYFLT end      = *p->end;
     MYFLT resetPos = *p->resetPos;
     MYFLT previn   = p->previn;
-    MYFLT level    = p->level;
+    MYFLT level    = p->started ? p->level : start;
+    p->started = 1;
     int32_t trig = (previn <= FL(0.0)) && (curin > FL(0.0));
-    MYFLT frac = FL(1.0) - previn/(curin-previn);
-
     if (trig)
-        level = resetPos + frac * rate;
+        level = resetPos;
 
     const MYFLT range = end - start;
 
+    SC_WRAP_FAST(level, start, end, range);
     for(n=offset; n<nsmps; n++) {
         out[n] = level;
         level += rate;
-        // level  = sc_wrap(level, start, end);
-        level = sc_wrap_fast(level, start, end, range);
+        SC_WRAP_FAST(level, start, end, range);
     }
     p->previn = curin;
     p->level  = level;
@@ -619,7 +638,8 @@ phasor_k_kk(CSOUND *csound, Phasor *p) {
     MYFLT end      = *p->end;
     MYFLT resetPos = *p->resetPos;
     MYFLT previn   = p->previn;
-    MYFLT level    = p->level;
+    MYFLT level    = p->started ? p->level : start;
+    p->started = 1;
 
     if (UNLIKELY(previn <= FL(0.0) && curin > FL(0.0))) {
         level = resetPos;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -637,6 +637,7 @@ def runTest():
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
         ["test_oscil1i.csd", "oscil1i interpolates scans and holds their endpoints"],
+        ["test_trigphasor_range.csd", "trigphasor starts, wraps, and resets within its range"],
         ["test_sndwarp_bounds.csd", "sndwarp and sndwarpst bound sample indexes and handle zero time scale"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],
         ["test_instr0_labels.csd", "test labels in instr0 space"],

--- a/tests/commandline/test_trigphasor_range.csd
+++ b/tests/commandline/test_trigphasor_range.csd
@@ -1,0 +1,154 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  setksmps 1
+  kCycle init 0
+  kCycle += 1
+  kStart = p4
+  kEnd = p5
+  if p7 == 1 && kCycle >= 4 then
+    kStart = -3
+    kEnd = 2
+  endif
+  kRate = p6
+  aRate = kRate
+  kTrigger = 0
+  aTrigger = 0
+  kOut trigphasor kTrigger, kRate, kStart, kEnd
+  aKK trigphasor kTrigger, kRate, kStart, kEnd
+  aAK trigphasor aTrigger, kRate, kStart, kEnd
+  aAA trigphasor aTrigger, aRate, kStart, kEnd
+  kKK downsamp aKK
+  kAK downsamp aAK
+  kAA downsamp aAA
+  kLevel init 0
+  if kCycle == 1 then
+    kLevel = kStart
+  endif
+  kRange = kEnd - kStart
+  kExpected = kStart
+  if kRange != 0 then
+    kExpected = kLevel - kRange * floor((kLevel - kStart) / kRange)
+  endif
+  kLevel = kExpected + kRate
+  kError = abs(kOut - kExpected) + abs(kKK - kExpected)
+  kError += abs(kAK - kExpected) + abs(kAA - kExpected)
+  if !(kError <= .00001) then
+    printks "trigphasor range [%g,%g), step %g, sample %d: error %g\n", 0, kStart, kEnd, kRate, kCycle, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  setksmps 1
+  kCycle init 0
+  kCycle += 1
+  kTrigger = kCycle == 3 ? 1 : -1
+  kStart = -2
+  kEnd = 5
+  kDefault trigphasor kTrigger, .25, kStart, kEnd
+  kExplicit trigphasor kTrigger, .25, kStart, kEnd, 0
+  aDefault trigphasor kTrigger, .25, kStart, kEnd
+  aExplicit trigphasor kTrigger, .25, kStart, kEnd, 0
+  kADefault downsamp aDefault
+  kAExplicit downsamp aExplicit
+  kExpectedDefault = -2 + .25 * (kCycle - 1)
+  kExpectedExplicit = kExpectedDefault
+  if kCycle >= 3 then
+    kExpectedDefault = -2 + .25 * (kCycle - 3)
+    kExpectedExplicit = .25 * (kCycle - 3)
+  endif
+  kError = abs(kDefault - kExpectedDefault) + abs(kADefault - kExpectedDefault)
+  kError += abs(kExplicit - kExpectedExplicit) + abs(kAExplicit - kExpectedExplicit)
+  if !(kError <= .00001) then
+    printks "trigphasor control trigger did not reset to the requested position\n", 0
+    exitnowk(-1)
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  setksmps 1
+  kCycle init 0
+  kCycle += 1
+  aTrigger = kCycle == 3 ? 1 : -1
+  aRate = .25
+  aAK trigphasor aTrigger, .25, -2, 5, 5
+  aAA trigphasor aTrigger, aRate, -2, 5, 5
+  aDefault trigphasor aTrigger, aRate, -2, 5
+  kAK downsamp aAK
+  kAA downsamp aAA
+  kDefault downsamp aDefault
+  kExpected = -2 + .25 * (kCycle - 1)
+  if kCycle >= 3 then
+    ; Preserve the existing audio-trigger interpolation, then wrap the result.
+    kExpected = -2 + .375 + .25 * (kCycle - 3)
+  endif
+  kError = abs(kAK - kExpected) + abs(kAA - kExpected) + abs(kDefault - kExpected)
+  if !(kError <= .00001) then
+    printks "trigphasor audio reset escaped the range or changed interpolation\n", 0
+    exitnowk(-1)
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 4
+  kStart = 10
+  kEnd = p4
+  kTrigger = 1
+  aTrigger = 1
+  aRate = p5
+  aKK trigphasor kTrigger, p5, kStart, kEnd
+  aAK trigphasor aTrigger, p5, kStart, kEnd
+  aAA trigphasor aTrigger, aRate, kStart, kEnd
+  aReference = 10
+  aError = abs(aKK - aReference) + abs(aAK - aReference) + abs(aAA - aReference)
+  kError max_k aError, 1, 1
+  if !(kError <= .00001) then
+    printks "trigphasor partial block did not use the active start value\n", 0
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "trigphasor checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001 10 17 .25 0
+i 1 0 .001 10 17 -.25 0
+i 1 0 .001 10 17 20 0
+i 1 0 .001 10 17 -20 0
+i 1 0 .001 2 2 1 0
+i 1 0 .001 10 17 1 1
+i 2 .01 .001
+i 3 .02 .001
+i 4 .030625 .003 17 0
+i 4 .040625 .003 10 1
+i 99 .05 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `trigphasor` and its aliases:

- Start from the first active `kstart` value. Previously, audio output began at zero even outside the requested range; empty blocks now leave state untouched.
- Use `kstart` when the reset position is omitted, while preserving an explicit zero. Control-rate triggers now reset the audio output directly, without an extra phase step or an unused division.
- Wrap audio state before output after a range change or trigger. Equal bounds produce the start value instead of NaN.

The audio loops use a wrap macro and retain the existing interpolation for audio-rate triggers. Ordinary wrap arithmetic stays unchanged.
