### PR TITLE
fix: respect note start offsets in eqfil

### DIFF
--- a/Opcodes/eqfil.c
+++ b/Opcodes/eqfil.c
@@ -75,7 +75,7 @@ static int32_t equ_process(CSOUND *csound, equ *p)
       ksmps -= early;
       memset(&out[ksmps], '\0', early*sizeof(MYFLT));
     }
-    for (i=0; i < ksmps; i++){
+    for (i=offset; i < ksmps; i++){
       w = (double)(in[i]) + d*(1.0 + a)*z1 - a*z2;
       y = w*a - d*(1.0 + a)*z1 + z2;
       z2 = z1;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -803,6 +803,7 @@ def runTest():
             1,
         ],
         ["test_sa.csd", "test sample accurate mode"],
+        ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
         [
             "test_audio_input_sample_bounds.csd",
             "audio input opcodes align partial-block input frames",

--- a/tests/commandline/test_eqfil_sample_offset.csd
+++ b/tests/commandline/test_eqfil_sample_offset.csd
@@ -1,0 +1,61 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gaSource init 0
+gkChecks init 0
+
+opcode ReferenceEq, a, a
+  setksmps 1
+  aInput xin
+  aOutput eqfil aInput, 1000, 500, 2
+  xout aOutput
+endop
+
+instr 1
+  gaSource = 1
+endin
+
+instr 2
+  aLocal = 1
+  aFromGlobal eqfil gaSource, 1000, 500, 2
+  aFromLocal eqfil aLocal, 1000, 500, 2
+  aInPlace = gaSource
+  aInPlace eqfil aInPlace, 1000, 500, 2
+  aReference ReferenceEq gaSource
+  aError = abs(aFromGlobal - aReference) + abs(aFromLocal - aReference)
+  aError += abs(aInPlace - aReference)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "eqfil processed samples before note start %g: error %g\n", 0, p2, kError
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 5 then
+    prints "eqfil checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .07
+i 2 .004 .006
+i 2 .014125 .006
+i 2 .024625 .006
+i 2 .035875 .006
+i 2 .044625 .001
+i 99 .06 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Start `eqfil` processing at the note's sample offset. The loop previously started at zero, advancing filter state with input from before the note began and overwriting the cleared output prefix. This made partial-block notes sound different depending on whether their input came from a global or local buffer.

The change leaves the filter formulas and coefficient updates unchanged and adds no calls or checks to the sample loop.
