### PR TITLE
fix: preserve product inputs and clear inactive sum output

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -294,12 +294,26 @@ static int32_t sum_(CSOUND *csound, SUM *p)
         accum[k] += in0[k];
       }
     }
-    memcpy(p->ar+offset, accum+offset, (nsmps - offset)*sizeof(MYFLT));
+    memcpy(p->ar, accum, CS_KSMPS*sizeof(MYFLT));
 
     return OK;
 }
 
 /* Actually by JPff but after Gabriel */
+static int32_t product_init(CSOUND *csound, SUM *p)
+{
+    if (UNLIKELY(p->INOCOUNT == 0))
+      return csound->InitError(csound, Str("product requires an input"));
+    /* Keep existing scratch space sized on reinit. */
+    if (p->aux.auxp != NULL)
+      return sum_init(csound, p);
+    for (int32_t i = 1; i < p->INOCOUNT; ++i) {
+      if (p->ar == p->argums[i])
+        return sum_init(csound, p);
+    }
+    return OK;
+}
+
 static int32_t product(CSOUND *csound, SUM *p)
 {
     IGN(csound);
@@ -307,7 +321,8 @@ static int32_t product(CSOUND *csound, SUM *p)
     uint32_t  offset = p->h.insdshead->ksmps_offset;
     uint32_t  early  = p->h.insdshead->ksmps_no_end;
     uint32_t   k, nsmps = CS_KSMPS;
-    MYFLT *ar = p->ar, **args = p->argums;
+    MYFLT *ar = p->aux.auxp != NULL ? (MYFLT *)p->aux.auxp : p->ar;
+    MYFLT **args = p->argums;
     MYFLT *ag = *args;
 
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
@@ -315,13 +330,16 @@ static int32_t product(CSOUND *csound, SUM *p)
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
-    memcpy(&ar[offset], &ag[offset], sizeof(MYFLT)*(nsmps-offset));
+    if (ar != ag)
+      memcpy(&ar[offset], &ag[offset], sizeof(MYFLT)*(nsmps-offset));
     while (--count) {
       ag = *(++args);                   /* over all arguments */
       for (k=offset; k<nsmps; k++) {
         ar[k] *= ag[k];                 /* Over audio vector */
       }
     }
+    if (ar != p->ar)
+      memcpy(p->ar, ar, CS_KSMPS*sizeof(MYFLT));
     return OK;
 }
 
@@ -1663,7 +1681,7 @@ static OENTRY localops[] = {
                                 (SUBR)Duserrnd_set,(SUBR)aDiscreteUserRand },
 { "trigger",  S(TRIG),  0, "k", "kkk",  (SUBR)trig_set, (SUBR)trig,   NULL  },
 { "sum",      S(SUM),   0, "a", "y",    (SUBR)sum_init, (SUBR)sum_               },
-{ "product",  S(SUM),   0, "a", "y",    NULL, (SUBR)product           },
+{ "product",  S(SUM),   0, "a", "y",    (SUBR)product_init, (SUBR)product },
 { "resony",  S(RESONY), 0, "a", "akkikooo", (SUBR)rsnsety, (SUBR)resony }
 };
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -583,6 +583,7 @@ def runTest():
         ["test_fillarray_audio.csd", "test Arr:a[] = [sig:a]"],
         ["test_fold_sampling.csd", "test fold sampling schedule"],
         ["test_fold_invalid_increment.csd", "reject invalid fold increment", 1],
+        ["test_sum_product_input_reuse.csd", "sum/product input reuse and inactive output"],
         ["test_oversample.csd", "test oversampling in new-style UDO"],
         ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
         [

--- a/tests/commandline/test_sum_product_input_reuse.csd
+++ b/tests/commandline/test_sum_product_input_reuse.csd
@@ -1,0 +1,89 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+gaInput init 0
+gaSum init 0
+gaProduct init 0
+gaExpected init 0
+
+instr 1
+  aWave oscili .1, 321
+  aFirst = .2 + aWave
+  aSecond = .3 - aWave
+  aThird = .4 + aWave
+  aExpected product aFirst, aSecond, aThird
+  aReuseFirst = aFirst
+  aReuseSecond = aSecond
+  aReuseThird = aThird
+  aReuseFirst product aReuseFirst, aSecond, aThird
+  aReuseSecond product aFirst, aReuseSecond, aThird
+  aReuseThird product aFirst, aSecond, aReuseThird
+  aRepeated = aSecond
+  aRepeated product aFirst, aRepeated, aRepeated
+  aOne = aFirst
+  aOne product aOne
+  aSum = aSecond
+  aSum sum aFirst, aSum, aThird, aFirst, aSecond
+  aError = abs(aExpected-aFirst*aSecond*aThird)
+  aError += abs(aReuseFirst-aExpected) + abs(aReuseSecond-aExpected)
+  aError += abs(aReuseThird-aExpected) + abs(aRepeated-aFirst*aSecond*aSecond)
+  aError += abs(aOne-aFirst) + abs(aSum-(2*aFirst+2*aSecond+aThird))
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "sum/product input reuse failed at start %g: %g\n", 0, p2, kError
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 2
+  gaInput = 2
+  gaSum = 1
+  gaProduct = 2
+  gaExpected = 1
+endin
+
+instr 3
+  gaSum sum gaInput, gaInput
+  gaProduct product gaInput, gaProduct
+  gaExpected = 4
+endin
+
+instr 4
+  aError = abs(gaSum-gaExpected) + abs(gaProduct-gaExpected)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "sum/product inactive output was not cleared: %g\n", 0, kError
+    exitnowk(-1)
+  endif
+  gkChecks += 1
+endin
+
+instr 99
+  if i(gkChecks) != 5 then
+    prints "sum/product checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .006
+i 1 .010625 .004
+i 1 .020625 .001
+i 2 .03 .004
+i 3 .030625 .002
+i 4 .03 .004
+i 99 .04 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Preserve `product` inputs when the output reuses a later input variable. For example, multiplying 0.2, 0.3, and 0.4 previously returned 0.016 instead of 0.024 when reusing the second input.

Detect that overlap at initialization and use scratch space only when needed. Keep the direct output path and multiplication order for ordinary calls, avoid copying a buffer onto itself, and reject calls with no inputs. No calls or checks are added inside the sample loop.

Also copy `sum`'s cleared inactive samples to its output. Previously, partial blocks could retain old output before the note starts or after it ends.
