### PR TITLE
fix: correct lineto and tlineto ramp timing

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -744,9 +744,8 @@ static int32_t lpsholdp(CSOUND *csound, LOOPSEGP *p)
 static int32_t lineto_set(CSOUND *csound, LINETO *p)
 {
     IGN(csound);
-    p->current_time = FL(0.0);
-    p->incr=FL(0.0);
-    p->old_time=FL(0.0);
+    p->remaining = 0.0;
+    p->incr = FL(0.0);
     p->flag = 1;
     return OK;
 }
@@ -756,24 +755,22 @@ static int32_t lineto(CSOUND *csound, LINETO *p)
     IGN(csound);
     if (UNLIKELY(p->flag)) {
       p->val_incremented = p->current_val = *p->ksig;
-      p->flag=0;
+      p->flag = 0;
     }
-    /* printf("lineto: ktime=%lf ksig=%lf\n " */
-    /*        "old_time=%lf val_inc=%lf incr=%lf val=%lf\n", */
-    /*        *p->ktime, *p->ksig, p->old_time, p->val_incremented, p->incr, */
-    /*        p->current_val); */
-    if (*p->ksig != p->current_val && p->current_time > p->old_time) {
-      p->old_time = *p->ktime;
-      p->val_incremented = p->current_val;
-      p->current_time = FL(0.0);
-      p->incr = (*p->ksig - p->current_val)
-                / ((int32) (CS_EKR * p->old_time) -1); /* by experiment */
-      p->current_val = *p->ksig;
-    }
-    else if (p->current_time < p->old_time) {
+    if (p->remaining > 0.0) {
       p->val_incremented += p->incr;
+      if (--p->remaining == 0.0)
+        p->val_incremented = p->current_val;
     }
-    p->current_time += 1/CS_EKR;
+    /* Accept a new target only after the current ramp has finished. */
+    if (p->remaining <= 0.0 && *p->ksig != p->current_val) {
+      p->current_val = *p->ksig;
+      p->remaining = ceil(*p->ktime * CS_EKR);
+      if (p->remaining > 0.0)
+        p->incr = (p->current_val - p->val_incremented) / p->remaining;
+      else
+        p->val_incremented = p->current_val;
+    }
     *p->kr = p->val_incremented;
     return OK;
 }
@@ -781,9 +778,8 @@ static int32_t lineto(CSOUND *csound, LINETO *p)
 static int32_t tlineto_set(CSOUND *csound, LINETO2 *p)
 {
     IGN(csound);
-    p->current_time = FL(0.0);
-    p->incr=FL(0.0);
-    p->old_time=FL(1.0);
+    p->remaining = 0.0;
+    p->incr = FL(0.0);
     p->flag = 1;
     return OK;
 }
@@ -793,19 +789,21 @@ static int32_t tlineto(CSOUND *csound, LINETO2 *p)
     IGN(csound);
     if (UNLIKELY(p->flag)) {
       p->val_incremented = p->current_val = *p->ksig;
-      p->flag=0;
+      p->flag = 0;
     }
     if (*p->ktrig) {
-      p->old_time = *p->ktime;
-      /* p->val_incremented = p->current_val; */
-      p->current_time = FL(0.0);
-      p->incr = (*p->ksig - p->current_val)
-                / ((int32) (CS_EKR * p->old_time) + 1);
       p->current_val = *p->ksig;
+      p->remaining = ceil(*p->ktime * CS_EKR);
+      /* A retrigger starts from the output, not the previous target. */
+      if (p->remaining > 0.0)
+        p->incr = (p->current_val - p->val_incremented) / p->remaining;
+      else
+        p->val_incremented = p->current_val;
     }
-    else if (p->current_time < p->old_time) {
-      p->current_time += CS_ONEDKR;
+    else if (p->remaining > 0.0) {
       p->val_incremented += p->incr;
+      if (--p->remaining == 0.0)
+        p->val_incremented = p->current_val;
     }
     *p->kr = p->val_incremented;
     return OK;

--- a/Opcodes/uggab.h
+++ b/Opcodes/uggab.h
@@ -98,14 +98,16 @@ typedef struct {
 typedef struct {  /* gab f1 */
         OPDS    h;
         MYFLT   *kr, *ksig, *ktime;
-        MYFLT   current_val, current_time, incr, val_incremented, old_time;
+        MYFLT   current_val, incr, val_incremented;
+        double  remaining;
         int32_t flag;
 } LINETO;
 
 typedef struct {  /* gab f1 */
         OPDS    h;
         MYFLT   *kr, *ksig, *ktime, *ktrig;
-        MYFLT   current_val, current_time, incr, val_incremented, old_time;
+        MYFLT   current_val, incr, val_incremented;
+        double  remaining;
         int32_t flag;
 } LINETO2;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -946,6 +946,7 @@ def runTest():
         ["test_follow_period.csd", "test follow period handling"],
         ["test_follow_invalid_period.csd", "reject invalid follow period", 1],
         ["test_lag_state.csd", "lag state and partial audio blocks"],
+        ["test_lineto_ramp_timing.csd", "lineto/tlineto duration, endpoints, and retriggering"],
         ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
         ["test_gain_sample_end.csd", "test gain sample-accurate note end"],
         ["test_distort_sample_offset.csd", "test distort sample-accurate onset"],

--- a/tests/commandline/test_lineto_ramp_timing.csd
+++ b/tests/commandline/test_lineto_ramp_timing.csd
@@ -1,0 +1,94 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kInput = kCycle == 1 ? 0 : (kCycle < 12 ? 1 : .25)
+  kTrigger = kCycle == 2 ? 1 : (kCycle == 12 ? -1 : 0)
+  kLine lineto kInput, p4/kr
+  kTriggered tlineto kInput, p4/kr, kTrigger
+  if p4 <= 0 then
+    kExpected = kInput
+  elseif kCycle < 12 then
+    kExpected = min(max(kCycle-2, 0)/ceil(p4), 1)
+  else
+    kExpected = 1 - .75*min((kCycle-12)/ceil(p4), 1)
+  endif
+  kError = abs(kLine-kExpected) + abs(kTriggered-kExpected)
+  if !(kError <= .000001) then
+    printks "lineto/tlineto duration %g failed at cycle %d: %g\n", 0, p4, kCycle, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 20 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  kCycle init 0
+  kCycle += 1
+  kInput = kCycle == 1 ? 0 : (kCycle < 4 ? 1 : .6)
+  kTrigger = kCycle == 2 || kCycle == 4 ? 1 : 0
+  kOutput tlineto kInput, 4/kr, kTrigger
+  if kCycle < 4 then
+    kExpected = max(kCycle-2, 0)/4
+  else
+    kExpected = .25 + .35*min((kCycle-4)/4, 1)
+  endif
+  if !(abs(kOutput-kExpected) <= .000001) then
+    printks "tlineto retrigger failed at cycle %d: expected %g, got %g\n", 0, kCycle, kExpected, kOutput
+    exitnowk(-1)
+  endif
+  if kCycle == 12 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  kCycle init 0
+  kCycle += 1
+  kInput = kCycle == 1 ? 0 : (kCycle == 2 ? 1 : 2)
+  kTime = kCycle < 3 ? 4/kr : 2/kr
+  kOutput lineto kInput, kTime
+  if kCycle < 6 then
+    kExpected = max(kCycle-2, 0)/4
+  else
+    kExpected = 1 + min((kCycle-6)/2, 1)
+  endif
+  if !(abs(kOutput-kExpected) <= .000001) then
+    printks "lineto changed an active ramp at cycle %d: expected %g, got %g\n", 0, kCycle, kExpected, kOutput
+    exitnowk(-1)
+  endif
+  if kCycle == 12 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 8 then
+    prints "lineto/tlineto checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .02 -1
+i 1 0 .02 0
+i 1 0 .02 .5
+i 1 0 .02 1
+i 1 0 .02 4
+i 1 0 .02 4.5
+i 2 .03 .012
+i 3 .05 .012
+i 99 .07 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Make `lineto` and `tlineto` reach their targets after the requested ramp duration, rounded up to a control cycle. Their old step counts disagreed with their timing: a four-cycle `tlineto` ramp from 0 to 1 stopped at 0.8, and `lineto` mishandled one-cycle ramps.

Count remaining cycles and set the exact endpoint on the last step. Nonpositive durations jump immediately. This also removes elapsed-time drift and the duration-to-integer cast.

Start `tlineto` retriggers from the current output so a new target above that output cannot send the ramp downward. Keep `lineto`'s documented behavior of waiting for its current ramp to finish before accepting new parameters.
