### PR TITLE
fix: apply current cutoff to every tonex and atonex stage

### DIFF
--- a/OOps/ugens5.c
+++ b/OOps/ugens5.c
@@ -174,8 +174,8 @@ int32_t tonex(CSOUND *csound, TONEX *p)      /* From Gabriel Maldonado, modified
       double b;
       p->prvhp = (double)*p->khp;
       b = 2.0 - cos(p->prvhp * (double)CS_TPIDSR);
-      p->c2 = b - sqrt(b * b - 1.0);
-      p->c1 = 1.0 - p->c2;
+      p->c2 = c2 = b - sqrt(b * b - 1.0);
+      p->c1 = c1 = 1.0 - c2;
     }
 
     memmove(ar,p->asig,sizeof(MYFLT)*nsmps);
@@ -263,7 +263,7 @@ int32_t atonex(CSOUND *csound, TONEX *p)      /* Gabriel Maldonado, modified */
       double b;
       p->prvhp = *p->khp;
       b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
-      p->c2 = b - sqrt(b * b - 1.0);
+      p->c2 = c2 = b - sqrt(b * b - 1.0);
       /*p->c1 = 1. - p->c2;*/
     }
 

--- a/Opcodes/afilters.c
+++ b/Opcodes/afilters.c
@@ -45,24 +45,36 @@ static int32_t atonset(CSOUND *csound, TONE *p)
 
 static int32_t atonsetx(CSOUND *csound, TONEX *p)
 {                   /* From Gabriel Maldonado, modified for arbitrary order */
-  {
-    double b;
-    p->prvhp = *p->khp;
-    b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
-    p->c2 = b - sqrt(b * b - 1.0);
-    p->c1 = 1.0 - p->c2;
-  }
-  if (UNLIKELY((p->loop = (int32_t) (*p->ord + FL(0.5))) < 1)) p->loop = 4;
-  if (!*p->istor && (p->aux.auxp == NULL ||
-                     (uint32_t)(p->loop*sizeof(double)) > p->aux.size))
-    csound->AuxAlloc(csound, (int32_t)(p->loop*sizeof(double)), &p->aux);
-  p->yt1 = (double*)p->aux.auxp;
-  if (LIKELY(!(*p->istor))) {
-    memset(p->yt1, 0, p->loop*sizeof(double)); /* Punning zero and 0.0 */
-  }
-  return OK;
-}
+    double order = (double)*p->ord;
+    size_t state_size;
+    int32_t clear_state = !*p->istor;
+    int32_t new_loop;
 
+    {
+      double b;
+      p->prvhp = *p->khp;
+      b = 2.0 - cos((double)(*p->khp * CS_TPIDSR));
+      p->c2 = b - sqrt(b * b - 1.0);
+      p->c1 = 1.0 - p->c2;
+    }
+    if (UNLIKELY(!isfinite(order) || order > (double)INT32_MAX - 0.5))
+      return csound->InitError(csound, Str("tonex: invalid order %f"),
+                               *p->ord);
+    new_loop = order < 0.5 ? 4 : (int32_t)(order + 0.5);
+    if (UNLIKELY((size_t)new_loop > SIZE_MAX / sizeof(double)))
+      return csound->InitError(csound, Str("tonex: order is too large"));
+    clear_state |= p->aux.auxp == NULL || p->loop != new_loop;
+    p->loop = new_loop;
+    state_size = (size_t)p->loop * sizeof(double);
+    if (p->aux.auxp == NULL || state_size > p->aux.size) {
+      csound->AuxAlloc(csound, state_size, &p->aux);
+      clear_state = 1;
+    }
+    p->yt1 = (double*)p->aux.auxp;
+    if (clear_state)
+      memset(p->yt1, 0, state_size); /* Punning zero and 0.0 */
+    return OK;
+}
 
 static int32_t arsnset(CSOUND *csound, RESON *p)
 {
@@ -406,70 +418,73 @@ static int32_t tonea(CSOUND *csound, TONE *p)
   return OK;
 }
 
-static int32_t tonexa(CSOUND *csound, TONEX *p) /* From G Maldonado, modified */
+static int32_t tonexa(CSOUND *csound, TONEX *p)
 {
-  MYFLT       *ar = p->ar;
-  double      c2 = p->c2, *yt1 = p->yt1,c1 = p->c1;
-  uint32_t    offset = p->h.insdshead->ksmps_offset;
-  uint32_t    early  = p->h.insdshead->ksmps_no_end;
-  uint32_t    n, nsmps = CS_KSMPS;
-  int32_t     j, lp = p->loop;
-
-  memmove(ar,p->asig,sizeof(MYFLT)*nsmps);
-  if (UNLIKELY(offset))  memset(ar, '\0', offset*sizeof(MYFLT));
-  if (UNLIKELY(early)) {
-    nsmps -= early;
-    memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
-  }
-  for (j=0; j< lp; j++) {
-    /* Should *yt1 be reset to something?? */
-    for (n=offset; n<nsmps; n++) {
-      double x;
-      if (p->khp[n] != p->prvhp) {
-        double b;
-        p->prvhp = (double)p->khp[n];
-        b = 2.0 - cos(p->prvhp * (double)CS_TPIDSR);
-        p->c2 = b - sqrt(b * b - 1.0);
-        p->c1 = 1.0 - p->c2;
-      }
-      x = c1 * ar[n] + c2 * yt1[j];
-      yt1[j] = x;
-      ar[n] = (MYFLT)x;
-    }
-  }
-  return OK;
-}
-
-static int32_t atonexa(CSOUND *csound, TONEX *p) /* Gabriel Maldonado, modified */
-{
-  MYFLT       *ar = p->ar;
-  double      c2 = p->c2, *yt1 = p->yt1;
+  MYFLT *ar = p->ar, *asig = p->asig;
+  double c1 = p->c1, c2 = p->c2, prvhp = p->prvhp;
+  double *yt1 = p->yt1;
   uint32_t offset = p->h.insdshead->ksmps_offset;
-  uint32_t early  = p->h.insdshead->ksmps_no_end;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  int32_t  j, lp = p->loop;
-  MYFLT    prvhp = p->prvhp;
+  int32_t j, lp = p->loop;
 
-  memmove(ar,p->asig,sizeof(MYFLT)*nsmps);
   if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
   if (UNLIKELY(early)) {
     nsmps -= early;
     memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
   }
-  for (j=1; j<lp; j++) {
-    for (n=offset; n<nsmps; n++) {
-      double sig = (double)ar[n];
-      double x;
-      if (p->khp[n] != prvhp) {
-        double b;
-        prvhp = p->khp[n];
-        b = 2.0 - cos((double)(p->prvhp * CS_TPIDSR));
-        c2 = b - sqrt(b * b - 1.0);
-      }
-      x = c2 * (yt1[j] + sig);
-      yt1[j] = x - sig;            /* yt1 contains yt1-xt1 */
-      ar[n] = (MYFLT)x;
+  for (n=offset; n<nsmps; n++) {
+    MYFLT sample = asig[n];
+    if (p->khp[n] != prvhp) {
+      double b;
+      prvhp = p->khp[n];
+      b = 2.0 - cos(prvhp * (double)CS_TPIDSR);
+      c2 = b - sqrt(b * b - 1.0);
+      c1 = 1.0 - c2;
     }
+    /* All stages use this sample's cutoff, including when it aliases ar. */
+    for (j=0; j<lp; j++) {
+      double x = c1 * sample + c2 * yt1[j];
+      yt1[j] = x;
+      sample = (MYFLT)x;
+    }
+    ar[n] = sample;
+  }
+  p->c1 = c1;
+  p->c2 = c2;
+  p->prvhp = prvhp;
+  return OK;
+}
+
+static int32_t atonexa(CSOUND *csound, TONEX *p)
+{
+  MYFLT *ar = p->ar, *asig = p->asig;
+  double c2 = p->c2, prvhp = p->prvhp;
+  double *yt1 = p->yt1;
+  uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
+  uint32_t n, nsmps = CS_KSMPS;
+  int32_t j, lp = p->loop;
+
+  if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
+  if (UNLIKELY(early)) {
+    nsmps -= early;
+    memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
+  }
+  for (n=offset; n<nsmps; n++) {
+    MYFLT sample = asig[n];
+    if (p->khp[n] != prvhp) {
+      double b;
+      prvhp = p->khp[n];
+      b = 2.0 - cos(prvhp * (double)CS_TPIDSR);
+      c2 = b - sqrt(b * b - 1.0);
+    }
+    for (j=0; j<lp; j++) {
+      double x = c2 * (yt1[j] + sample);
+      yt1[j] = x - sample;
+      sample = (MYFLT)x;
+    }
+    ar[n] = sample;
   }
   p->c2 = c2;
   p->prvhp = prvhp;
@@ -723,7 +738,7 @@ static OENTRY afilts_localops[] =
     { "areson.aa", sizeof(RESON), 0,"a","aaaoo",(SUBR)arsnset,(SUBR)aresonaa},
     { "areson.ak", sizeof(RESON), 0,"a","aakoo",(SUBR)arsnset,(SUBR)aresonak},
     { "areson.ka", sizeof(RESON), 0,"a","akaoo",(SUBR)arsnset,(SUBR)aresonka},
-    { "atone.a",  sizeof(TONE),   0,"a","ako",  (SUBR)atonset,(SUBR)atonea  },
+    { "atone.a",  sizeof(TONE),   0,"a","aao",  (SUBR)atonset,(SUBR)atonea  },
     { "atonex.a", sizeof(TONEX),  0, "a","aaoo",(SUBR)atonsetx,(SUBR)atonexa},
     { "tone.a",  sizeof(TONE),    0,"a","aao",  (SUBR)atonset,(SUBR)tonea   },
     { "tonex.a", sizeof(TONEX),   0,"a","aaoo", (SUBR)atonsetx,(SUBR)tonexa },

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -938,6 +938,7 @@ def runTest():
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
+        ["test_tonex_cutoff.csd", "tonex/atonex cutoff updates, stages, and input reuse"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],
         ["test_dcblock2_order_reinit.csd", "test dcblock2 order changes"],

--- a/tests/commandline/test_tonex_cutoff.csd
+++ b/tests/commandline/test_tonex_cutoff.csd
@@ -1,0 +1,123 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kCutoff = kCycle == 1 ? 500 : (kCycle == 2 ? 1200 : 750)
+  aInput oscili .5, 321
+  aLow tonex aInput, kCutoff, p4
+  aHigh atonex aInput, kCutoff, p4
+  aRefLow tone aInput, kCutoff
+  aRefHigh atone aInput, kCutoff
+  if p4 == 3 then
+    aRefLow tone aRefLow, kCutoff
+    aRefLow tone aRefLow, kCutoff
+    aRefHigh atone aRefHigh, kCutoff
+    aRefHigh atone aRefHigh, kCutoff
+  endif
+  aError = abs(aLow-aRefLow) + abs(aHigh-aRefHigh)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "tonex/atonex control cutoff differs from cascade: %g\n", 0, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  aInput oscili .5, 321
+  aMod oscili 500, 500
+  aCutoff = 1000 + p5*aMod
+  aLow tonex aInput, aCutoff, p4
+  aHigh atonex aInput, aCutoff, p4
+  aLowIn = aInput
+  aHighIn = aInput
+  aLowCut = aCutoff
+  aHighCut = aCutoff
+  aLowIn tonex aLowIn, aCutoff, p4
+  aHighIn atonex aHighIn, aCutoff, p4
+  aLowCut tonex aInput, aLowCut, p4
+  aHighCut atonex aInput, aHighCut, p4
+  aRefLow tone aInput, aCutoff
+  aRefHigh atone aInput, aCutoff
+  if p4 == 3 then
+    aRefLow tone aRefLow, aCutoff
+    aRefLow tone aRefLow, aCutoff
+    aRefHigh atone aRefHigh, aCutoff
+    aRefHigh atone aRefHigh, aCutoff
+  endif
+  aError = abs(aLow-aRefLow) + abs(aHigh-aRefHigh)
+  aError += abs(aLowIn-aRefLow) + abs(aHighIn-aRefHigh)
+  aError += abs(aLowCut-aRefLow) + abs(aHighCut-aRefHigh)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "tonex/atonex audio cutoff differs from cascade: %g\n", 0, kError
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 3
+  setksmps 1
+  kCycle init 0
+  kCycle += 1
+  aInput = kCycle == 1 ? 1 : 0
+  aCutoff = 500
+  aRefLow tonex aInput, aCutoff, 3
+  aRefHigh atonex aInput, aCutoff, 3
+  if kCycle == 5 then
+    reinit FILTER
+  endif
+FILTER:
+  iSkip = i(kCycle) > 1 ? p4 : 0
+  aLow tonex aInput, aCutoff, 3, iSkip
+  aHigh atonex aInput, aCutoff, 3, iSkip
+  rireturn
+  kKeep = kCycle < 5 || p4 != 0 ? 1 : 0
+  aError = abs(aLow-kKeep*aRefLow) + abs(aHigh-kKeep*aRefHigh)
+  kError downsamp aError
+  if !(kError <= .000001) then
+    printks "tonex/atonex reinit iskip=%g failed: %g\n", 0, p4, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 16 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "tonex/atonex checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .006 1
+i 1 .01 .006 3
+i 2 .02 .006 1 0
+i 2 .03 .006 3 0
+i 2 .04 .006 1 1
+i 2 .05 .006 3 1
+i 2 .060625 .004 3 1
+i 2 .070625 .001 1 1
+i 3 .08 .002 0
+i 3 .09 .002 1
+i 99 .1 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Apply updated `tonex`/`atonex` coefficients in the current block instead of using the previous values. In the audio-cutoff versions, process every stage with the current sample's cutoff; `atonex` previously skipped its first stage, so a one-stage filter passed the input through unchanged.

Read each input and cutoff before writing output, allowing either input variable to be reused. Compute coefficients once per cutoff change rather than once per stage, keeping the same filter equations and stage rounding.

Correct `atone`'s audio-cutoff argument declaration. Bring audio filter-stack initialization in line with the control version so state allocation and reset behavior remain valid when preserving state or changing the stage count.
