### PR TITLE
fix: correct dam gain tracking and response times

### DIFF
--- a/Opcodes/dam.c
+++ b/Opcodes/dam.c
@@ -50,8 +50,10 @@ static int32_t daminit(CSOUND *csound, DAM *p)
    /* the computed values are stored in the opcode data structure p */
    /* for later use in the main processing                          */
 
-    p->rspeed = (*p->rtime)*CS_ONEDSR*FL(1000.0);
-    p->fspeed = (*p->ftime)*CS_ONEDSR*FL(1000.0);
+    p->rspeed = *p->rtime > FL(0.0) ? CS_ONEDSR / *p->rtime
+                                  : (MYFLT)INFINITY;
+    p->fspeed = *p->ftime > FL(0.0) ? CS_ONEDSR / *p->ftime
+                                  : (MYFLT)INFINITY;
     p->kthr = -FL(1.0);
     return OK;
 }
@@ -67,9 +69,10 @@ static int32_t dam(CSOUND *csound, DAM *p)
     MYFLT threshold;
     MYFLT gain;
     MYFLT comp1,comp2;
+    MYFLT exponent;
     MYFLT *powerPos;
     MYFLT *powerBuffer;
-    MYFLT power;
+    double power;
     MYFLT tg;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
@@ -80,7 +83,7 @@ static int32_t dam(CSOUND *csound, DAM *p)
      */
     if (p->kthr < FL(0.0)) {
       MYFLT x = (p->kthr = *(p->kthreshold))/(MYFLT)POWER_BUFSIZE;
-      p->power = p->kthr;
+      p->power = (double)x * POWER_BUFSIZE;
       /* Initialise table as threshhold changed */
       for (i=0;i<POWER_BUFSIZE;i++) {
         p->powerBuffer[i] = x;
@@ -94,6 +97,8 @@ static int32_t dam(CSOUND *csound, DAM *p)
     gain        = p->gain;
     comp1       = *(p->icomp1);
     comp2       = *(p->icomp2);
+    exponent    = comp2 != FL(0.0) ? FL(1.0)/comp2 - FL(1.0)
+                                  : (MYFLT)INFINITY;
     powerPos    = p->powerPos;
     powerBuffer = p->powerBuffer;
     power       = p->power;
@@ -108,31 +113,39 @@ static int32_t dam(CSOUND *csound, DAM *p)
 
         /* Estimates the current power level */
 
+      power -= *powerPos;
       *powerPos = FABS(ain[i])/(MYFLT)(POWER_BUFSIZE*ROOT2);
       power    += (*powerPos++);
       if ((powerPos-powerBuffer)==POWER_BUFSIZE) {
         powerPos = p->powerBuffer;
       }
-      power -= (*powerPos);
+      if (power < FL(0.0)) power = FL(0.0);
 
       /* Looks where the power is related to the threshold
          and compute target gain */
 
       if (power>threshold) {
-        tg = ((power-threshold)*comp1+threshold)/power;
+        tg = comp1 + (FL(1.0)-comp1)*(threshold/power);
+      }
+      else if (power > FL(0.0)) {
+        tg = POWER(power/threshold, exponent);
       }
       else {
-        tg = threshold*(POWER((power/threshold),
-                                     FL(1.0)/comp2))/power;
+        /* Compression tends to zero gain at silence; unity stays unity.
+           Expansion has no finite limit, so retain its current gain. */
+        tg = comp2 < FL(1.0) ? FL(0.0)
+             : comp2 == FL(1.0) ? FL(1.0) : gain;
       }
 
       /* move gain toward target */
 
       if (gain<tg) {
         gain += p->rspeed;
+        if (gain>tg) gain = tg;
       }
-      else {
+      else if (gain>tg) {
         gain -= p->fspeed;
+        if (gain<tg) gain = tg;
       }
 
       /* compute output */

--- a/Opcodes/dam.h
+++ b/Opcodes/dam.h
@@ -39,7 +39,7 @@ typedef struct {
    MYFLT fspeed ;
 
    MYFLT gain ;
-   MYFLT power ;
+   double power ;    /* Limit cancellation drift in the running sum. */
    MYFLT powerBuffer[POWER_BUFSIZE] ;
    MYFLT *powerPos ;
    MYFLT kthr;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -948,6 +948,7 @@ def runTest():
         ["test_lag_state.csd", "lag state and partial audio blocks"],
         ["test_compress_control_gain.csd", "compressors update gain when ratio or knee controls change"],
         ["test_gain_sample_end.csd", "test gain sample-accurate note end"],
+        ["test_dam_gain.csd", "dam unity gain, timing, and moving level"],
         ["test_distort_sample_offset.csd", "test distort sample-accurate onset"],
         ["test_distort_istor_first_init.csd", "test distort state-preserving first init"],
         ["test_distort_invalid_kdist.csd", "reject non-finite distort amount", 1],

--- a/tests/commandline/test_dam_gain.csd
+++ b/tests/commandline/test_dam_gain.csd
@@ -1,0 +1,105 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  aInput = kCycle < 80 ? p4 : (kCycle < 160 ? 0 : p4)
+  aOutput dam aInput, .1, 1, 1, .01, .5
+  aInPlace = aInput
+  aInPlace dam aInPlace, .1, 1, 1, .01, .5
+  aError = abs(aOutput-aInput) + abs(aInPlace-aInput)
+  kError max_k aError, 1, 1
+  if !(kError <= .000001) then
+    printks "dam changed unity-ratio input: %g\n", 0, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  setksmps 1
+  kSample init 0
+  kSample += 1
+  aInput = .25
+  aOutput dam aInput, 0, p4, 1, p5/sr, p6/sr
+  kOutput downsamp aOutput
+  if p4 > 1 then
+    if p5 <= 0 then
+      kExpected = p4
+    else
+      kExpected = min(1+kSample/p5, p4)
+    endif
+  else
+    if p6 <= 0 then
+      kExpected = p4
+    else
+      kExpected = max(1-kSample/p6, p4)
+    endif
+  endif
+  if !(abs(kOutput-.25*kExpected) <= .000001) then
+    printks "dam gain timing failed at sample %d: expected %g, got %g\n", 0, kSample, .25*kExpected, kOutput
+    exitnowk(-1)
+  endif
+  if kSample == 40 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  setksmps 1
+  kSample init 0
+  kSample += 1
+  kInput = kSample <= 1200 ? 1 : (kSample <= 2300 ? 0 : .25)
+  aInput = kInput
+  aOutput dam aInput, .1, .5, .5, 0, 0
+  kOutput downsamp aOutput
+  kOnes = max(0, min(kSample,1200)-max(0,kSample-1000))
+  kQuarters = min(max(kSample-2300,0),1000)
+  kSeed = max(1000-kSample,0)
+  kPower = (.1*kSeed + (kOnes+.25*kQuarters)/sqrt(2))/1000
+  if kPower > .1 then
+    kGain = .5 + .05/kPower
+  else
+    kGain = kPower/.1
+  endif
+  if !(abs(kOutput-kInput*kGain) <= .000002) then
+    printks "dam moving level differs at sample %d: expected %g, got %g\n", 0, kSample, kInput*kGain, kOutput
+    exitnowk(-1)
+  endif
+  if kSample == 3400 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "dam checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .4 .5
+i 1 .410625 .004 -.05
+i 1 .420625 .001 .5
+i 2 .44 .005 1.3 16 32
+i 2 .45 .005 2 32 32
+i 2 .46 .005 .27 16 32
+i 2 .47 .005 .25 16 16
+i 2 .48 .005 2 0 0
+i 2 .49 .005 .25 0 0
+i 3 .5 .425
+i 99 .94 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Keep `dam` gain unchanged when it already equals its target, and clamp each gain step to that target. With both compression ratios set to 1, an input of 0.5 previously started at 0.46875 instead of passing through unchanged.

Calculate rise/fall speeds as one gain unit per requested number of seconds. The old formula made longer times move gain faster. Zero times now apply the target immediately.

Replace the outgoing sample in the rolling level estimate before adding the new one, and keep its sum in double precision to limit drift. Simplify the gain equations and handle zero level without division by zero. The lower-zone exponent is computed once per control block, with no new function calls in the sample loop.
