### PR TITLE
fix: reschedule gausstrig delays on frequency changes

### DIFF
--- a/Opcodes/sc_noise.c
+++ b/Opcodes/sc_noise.c
@@ -260,6 +260,8 @@ static int32_t gausstrig_initk(CSOUND* csound, GAUSSTRIG *p)
 static int32_t gausstrig_process_krate(CSOUND* csound, GAUSSTRIG *p)
 {
     MYFLT frq, dev;
+    if (p->mmode && p->count > 0 && *p->kfrq != p->frq0)
+      p->first = 1;  /* Recalculate the pending delay at the new frequency. */
     p->frq0 = *p->kfrq;
     frq = (*p->kfrq > FL(0.001) ? *p->kfrq : FL(0.001));
     dev = *p->kdev;
@@ -308,8 +310,6 @@ static int32_t gausstrig_process_krate(CSOUND* csound, GAUSSTRIG *p)
       *p->out = *p->kamp;
     }
     else {
-      if (p->mmode && *p->kfrq != p->frq0)
-        p->count = 0;
       *p->out = FL(0.0);
     }
     p->count--;
@@ -323,6 +323,8 @@ static int32_t gausstrig_process_arate(CSOUND* csound, GAUSSTRIG *p)
     uint32_t n, nsmps = CS_KSMPS;
     MYFLT   *out = p->out;
     MYFLT frq, dev;
+    if (p->mmode && p->count > 0 && *p->kfrq != p->frq0)
+      p->first = 1;  /* Once per block: kfrq cannot change within the loop. */
     p->frq0 = *p->kfrq;
     frq = (p->frq0 > FL(0.001) ? p->frq0 : FL(0.001));
     dev = *p->kdev;
@@ -379,8 +381,6 @@ static int32_t gausstrig_process_arate(CSOUND* csound, GAUSSTRIG *p)
         out[n] = *p->kamp;
       }
       else {
-        if (p->mmode && *p->kfrq != p->frq0)
-          p->count = 0;
         out[n] = FL(0.0);
       }
       p->count--;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -936,6 +936,7 @@ def runTest():
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
+        ["test_gausstrig_frequency_mode.csd", "gausstrig frequency-change and first-impulse modes"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],

--- a/tests/commandline/test_gausstrig_frequency_mode.csd
+++ b/tests/commandline/test_gausstrig_frequency_mode.csd
@@ -1,0 +1,98 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 8
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kFrequency = kCycle < 3 ? 50 : (kCycle < 10 ? 500 : 100)
+  kPulse gausstrig 1, kFrequency, 0, p4, p5
+  aPulse gausstrig 1, kFrequency, 0, p4, p5
+  kReuse = kFrequency
+  kReuse gausstrig 1, kReuse, 0, p4, p5
+  kAudio max_k aPulse, 1, 1
+  if p4 == 0 then
+    kExpected = kCycle == 21 || kCycle == 31 ? 1 : 0
+  else
+    kExpected = kCycle == 5 || kCycle == 7 || kCycle == 9 || kCycle == 20 || kCycle == 30 ? 1 : 0
+  endif
+  if kCycle == 1 && p5 == 0 then
+    kExpected = 1
+  endif
+  if kPulse != kExpected || kReuse != kExpected || kAudio != kExpected then
+    printks "gausstrig mode=%d first=%d cycle=%d: expected %g, got k=%g a=%g reused=%g\n", 0, p4, p5, kCycle, kExpected, kPulse, kAudio, kReuse
+    exitnowk(-1)
+  endif
+  if kCycle == 32 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  kCycle init 0
+  kCycle += 1
+  kPulse gausstrig 1, 250, 0, p4, p5
+  aPulse gausstrig 1, 250, 0, p4, p5
+  kAudio max_k aPulse, 1, 1
+  kExpected = (kCycle-1) % 4 == 0 ? 1 : 0
+  if kCycle == 1 && p5 != 0 then
+    kExpected = 0
+  endif
+  if kPulse != kExpected || kAudio != kExpected then
+    printks "gausstrig constant frequency/first impulse failed: mode=%d first=%d cycle=%d\n", 0, p4, p5, kCycle
+    exitnowk(-1)
+  endif
+  if kCycle == 12 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  aPulse gausstrig 1, 1000, 0, p4, p5
+  aExpected mpulse 1, .001
+  if p5 != 0 then
+    aExpected delay aExpected, .001
+  endif
+  aError = abs(aPulse-aExpected)
+  kError max_k aError, 1, 1
+  if kError != 0 then
+    printks "gausstrig partial block timing failed: mode=%d first=%d\n", 0, p4, p5
+    exitnowk(-1)
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 12 then
+    prints "gausstrig checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .032 0 0
+i 1 0 .032 1 0
+i 1 0 .032 0 1
+i 1 0 .032 1 1
+i 2 .04 .012 0 0
+i 2 .04 .012 1 0
+i 2 .04 .012 0 1
+i 2 .04 .012 1 1
+i 3 .060625 .003 0 0
+i 3 .070625 .003 1 0
+i 3 .080625 .003 0 1
+i 3 .090625 .003 1 1
+i 99 .1 .001
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Make `gausstrig` detect frequency changes before replacing its saved frequency. Previously, `imode=1` compared the new value with itself and behaved like the default mode.

Recalculate a pending delay from the new frequency in both control and audio versions. Preserve the default mode's schedule and the first-impulse options. Check for frequency changes once per control block, removing the ineffective comparison from the audio sample loop without adding function calls.
