### PR TITLE
Fix spectral centroid and bandwidth calculations

### DIFF
--- a/OOps/pvsanal.c
+++ b/OOps/pvsanal.c
@@ -406,7 +406,7 @@ int32_t pvssanal(CSOUND *csound, PVSANAL *p)
     return csound->PerfError(csound,&(p->h),
                              Str("pvsanal: Not Initialised.\n"));
   }
-  ain = p->ain;               /* The input samples */
+  ain = p->ain + offset;      /* The active input samples */
   loc = p->inptr;             /* Circular buffer */
   nsmps -= early;
   for (i=offset; i < nsmps; i++) {

--- a/Opcodes/pvscent.c
+++ b/Opcodes/pvscent.c
@@ -37,6 +37,7 @@ static int32_t pvscentset(CSOUND *csound, PVSCENT *p)
 {
     *p->ans = FL(0.0);
     p->lastframe = 0;
+    p->old = FL(0.0);
     if (UNLIKELY(!((p->fin->format==PVS_AMP_FREQ) ||
                    (p->fin->format==PVS_AMP_PHASE))))
       return csound->InitError(csound,
@@ -52,9 +53,10 @@ static int32_t pvscent(CSOUND *csound, PVSCENT *p)
     MYFLT d = FL(0.0);
     MYFLT j, binsize = CS_ESR/(MYFLT)N;
     if (p->fin->sliding) {
-      CMPLX *fin = (CMPLX*) p->fin->frame.auxp;
       int32_t NB = p->fin->NB;
-      for (i=0, j=FL(0.5)*binsize; i<NB; i++, j += binsize) {
+      CMPLX *fin = (CMPLX*) p->fin->frame.auxp +
+        p->h.insdshead->ksmps_offset*NB;
+      for (i=0, j=FL(0.0); i<NB; i++, j += binsize) {
         c += fin[i].re*j;
         d += fin[i].re;
       }
@@ -63,11 +65,9 @@ static int32_t pvscent(CSOUND *csound, PVSCENT *p)
     else {
       float *fin = (float *) p->fin->frame.auxp;
       if (p->lastframe < p->fin->framecount) {
-        // printf("N=%d binsize=%f\n", N, binsize);
-        for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
+        for (i=0,j=FL(0.0); i<N+2; i+=2, j += binsize) {
           c += fin[i]*j;         /* This ignores phase */
           d += fin[i];
-          //printf("%d (%f) sig=%f c=%f d=%f\n", i,j,fin[i],c,d);
         }
         p->lastframe = p->fin->framecount;
         p->old = (d==FL(0.0) ? FL(0.0) : c/d);
@@ -88,8 +88,6 @@ static int32_t pvsscent(CSOUND *csound, PVSCENT *p)
       uint32_t n, nsmps = CS_KSMPS;
       int32 i,N = p->fin->N;
 
-      MYFLT c = FL(0.0);
-      MYFLT d = FL(0.0);
       MYFLT j, binsize = CS_ESR/(MYFLT)N;
       int32_t NB = p->fin->NB;
       if (UNLIKELY(offset)) memset(a, '\0', offset*sizeof(MYFLT));
@@ -99,7 +97,8 @@ static int32_t pvsscent(CSOUND *csound, PVSCENT *p)
       }
       for (n=offset; n<nsmps; n++) {
         CMPLX *fin = (CMPLX*) p->fin->frame.auxp + n*NB;
-        for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
+        MYFLT c = FL(0.0), d = FL(0.0);
+        for (i=0,j=FL(0.0); i<NB; i++, j += binsize) {
           c += j*fin[i].re;         /* This ignores phase */
           d += fin[i].re;
         }
@@ -116,20 +115,20 @@ static int32_t pvsscent(CSOUND *csound, PVSCENT *p)
       MYFLT d = FL(0.0);
       MYFLT j, binsize = CS_ESR/(MYFLT)N;
       float *fin = (float *) p->fin->frame.auxp;
-      nsmps -= early;
-      for (n=offset; n<nsmps; n++) {
-        if (p->lastframe < p->fin->framecount) {
-          for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
-            c += fin[i]*j;         /* This ignores phase */
-            d += fin[i];
-          }
-          old = a[n] = (d==FL(0.0) ? FL(0.0) : c/d);
-          p->lastframe = p->fin->framecount;
-        }
-        else {
-          a[n] = old;
-        }
+      if (UNLIKELY(offset)) memset(a, '\0', offset*sizeof(MYFLT));
+      if (UNLIKELY(early)) {
+        nsmps -= early;
+        memset(&a[nsmps], '\0', early*sizeof(MYFLT));
       }
+      if (p->lastframe < p->fin->framecount) {
+        for (i=0,j=FL(0.0); i<N+2; i+=2, j += binsize) {
+          c += fin[i]*j;         /* This ignores phase */
+          d += fin[i];
+        }
+        old = (d==FL(0.0) ? FL(0.0) : c/d);
+        p->lastframe = p->fin->framecount;
+      }
+      for (n=offset; n<nsmps; n++) a[n] = old;
       p->old = old;
     }
     return OK;
@@ -142,36 +141,37 @@ static int32_t pvsbandw(CSOUND *csound, PVSCENT *p)
     MYFLT d = FL(0.0);
     MYFLT j, binsize = CS_ESR/(MYFLT)N;
     if (p->fin->sliding) {
-      CMPLX *fin = (CMPLX*) p->fin->frame.auxp;
       int32_t NB = p->fin->NB;
+      CMPLX *fin = (CMPLX*) p->fin->frame.auxp +
+        p->h.insdshead->ksmps_offset*NB;
       MYFLT cd;
-      for (i=0, j=FL(0.5)*binsize; i<NB; i++, j += binsize) {
+      for (i=0, j=FL(0.0); i<NB; i++, j += binsize) {
         c += fin[i].re*j;
         d += fin[i].re;
       }
       cd = (d==FL(0.0) ? FL(0.0) : c/d);
       c = FL(0.0);
-      for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
+      for (i=0,j=FL(0.0); i<NB; i++, j += binsize) {
         c += fin[i].re*(j - cd)*(j - cd);
       }
-      *p->ans = SQRT(c);
+      *p->ans = (d==FL(0.0) ? FL(0.0) : SQRT(c/d));
     }
     else {
       float *fin = (float *) p->fin->frame.auxp;
       if (p->lastframe < p->fin->framecount) {
         // compute centroid
         MYFLT cd;
-        for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
+        for (i=0,j=FL(0.0); i<N+2; i+=2, j += binsize) {
           c += fin[i]*j;         /* This ignores phase */
           d += fin[i];
         }
         cd = (d==FL(0.0) ? FL(0.0) : c/d);
         c = FL(0.0);
-        for (i=0,j=FL(0.5)*binsize; i<N+2; i+=2, j += binsize) {
+        for (i=0,j=FL(0.0); i<N+2; i+=2, j += binsize) {
           c += fin[i]*(j - cd)*(j - cd);
         }
         p->lastframe = p->fin->framecount;
-        p->old = *p->ans = SQRT(c);
+        p->old = (d==FL(0.0) ? FL(0.0) : SQRT(c/d));
       }
       *p->ans = p->old;
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -725,6 +725,7 @@ def runTest():
         ["test_for_loop_index_var_typed.csd", "for in loop with typed index var"],
         ["test_opcode_as_function.csd", "test expression"],
         ["test_fsig_udo.csd", "UDO with f-sig arg"],
+        ["test_pvs_spectral_moments.csd", "test spectral centroid and bandwidth"],
         ["test_karrays_udo.csd", "UDO with k[] arg"],
         ["test_vector_table_correctness.csd", "vector table indexing"],
         ["test_vector_table_invalid_index.csd", "reject invalid vector table index", 1],

--- a/tests/commandline/test_pvs_spectral_moments.csd
+++ b/tests/commandline/test_pvs_spectral_moments.csd
@@ -1,0 +1,143 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Compute each sliding spectrum separately as a reference for block processing.
+opcode Moments, aa, a
+  setksmps 1
+  aInput xin
+  fSig pvsanal aInput, 128, 1, 128, 0
+  kCenter pvscent fSig
+  kWidth pvsbandwidth fSig
+  aCenter = kCenter
+  aWidth = kWidth
+  xout aCenter, aWidth
+endop
+
+instr 1
+  kFrame[] init 130
+  kCycle init 0
+  kCycle += 1
+  ; Silence after a nonzero frame must clear the cached measurement.
+  kScale = kCycle < 10 ? p8 : 0
+  kFrame[p4*2] = p6*kScale
+  kFrame[p4*2+1] = p4*sr/128
+  kFrame[p5*2] = p7*kScale
+  kFrame[p5*2+1] = p5*sr/128
+  fSig pvsfromarray kFrame, 32
+  kCenter pvscent fSig
+  aCenter pvscent fSig
+  kWidth pvsbandwidth fSig
+  kAudio downsamp aCenter
+  iCenter = (p4*p6+p5*p7)/(p6+p7)*sr/128
+  iWidth = sqrt((p6*(p4*sr/128-iCenter)^2+p7*(p5*sr/128-iCenter)^2)/(p6+p7))
+  if kCycle == 8 || kCycle == 16 then
+    kExpectedCenter = kCycle == 8 ? iCenter : 0
+    kExpectedWidth = kCycle == 8 ? iWidth : 0
+    if !(abs(kCenter-kExpectedCenter) < .01 && abs(kWidth-kExpectedWidth) < .01 && abs(kAudio-kCenter) < .01) then
+      printks "spectral moments: centroid %g, bandwidth %g, audio centroid %g\n", 0, kCenter, kWidth, kAudio
+      exitnowk(-1)
+    endif
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; Changing spectra catch sums carried from one sample to the next.
+  aInput oscili .1, 370
+  aOther oscili .07, 1730
+  aInput += aOther
+  fSig pvsanal aInput, 128, 1, 128, 0
+  fLouder pvsgain fSig, 4
+  aCenter pvscent fSig
+  kCenter pvscent fSig
+  kWidth pvsbandwidth fSig
+  kLouder pvsbandwidth fLouder
+  aRefCenter, aRefWidth Moments aInput
+  kRefCenter downsamp aRefCenter
+  kRefWidth downsamp aRefWidth
+  kError max_k abs(aCenter-aRefCenter), 1, 1
+  if !(kError < .05 && abs(kCenter-kRefCenter) < .05 && abs(kWidth-kRefWidth) < .05 && abs(kLouder-kWidth) < .05) then
+    printks "sliding moments: audio error %g, centroid %g/%g, bandwidth %g/%g, scaled %g\n", 0, kError, kCenter, kRefCenter, kWidth, kRefWidth, kLouder
+    exitnowk(-1)
+  endif
+  kOnce init 1
+  if kOnce == 1 then
+    gkChecks += 1
+    kOnce = 0
+  endif
+endin
+
+instr 3
+  kFrame[] init 130
+  kFrame[32] = 1
+  fSig pvsfromarray kFrame, 32
+  kCenter pvscent fSig
+  aCenter = -1
+  aCenter pvscent fSig
+  kCycle init 0
+  kIndex = 0
+  while kIndex < ksmps do
+    kSample vaget kIndex, aCenter
+    kPosition = kCycle*ksmps+kIndex
+    kExpected = kPosition < 5 || kPosition >= 45 ? 0 : kCenter
+    if !(abs(kSample-kExpected) < .01) then
+      printks "centroid partial block: sample %g, expected %g, got %g\n", 0, kPosition, kExpected, kSample
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 3 then
+    gkChecks += 1
+  endif
+endin
+
+instr 4
+  ; A rectangular window gives two exact bins after the first 128 samples.
+  aLow oscili .1*p4, 500
+  aHigh oscili .3*p4, 1500
+  fSig pvsanal aLow+aHigh, 128, 1, 128, 9
+  kCenter pvscent fSig
+  kWidth pvsbandwidth fSig
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 12 then
+    if !(abs(kCenter-1250) < .05 && abs(kWidth-sqrt(187500)) < .05) then
+      printks "sliding two-bin spectrum: centroid %g, bandwidth %g\n", 0, kCenter, kWidth
+      exitnowk(-1)
+    endif
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 17 then
+    prints "spectral moment checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Bin positions, magnitudes, overall level.
+i 1 0 .034 16 48 1 1 1
+i 1 0 .034 16 48 1 1 4
+i 1 0 .034 0 64 1 3 1
+i 1 0 .034 0 64 1 3 .01
+i 1 0 .034 0 64 1 0 1
+i 1 0 .034 0 64 0 1 1
+i 2 .04 .04
+i 2 .080625 .039
+i 3 .140625 .005
+i 4 .15 .026 1
+i 4 .15 .026 4
+i 99 .18 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsbandwidth` omitted division by total magnitude, so making a spectrum four times louder doubled its reported bandwidth. Normalize the weighted variance before taking its square root, returning zero for silence.

Also correct the related centroid and sliding-analysis paths:

- Start bin frequencies at DC to remove the half-bin centroid bias.
- Visit each complex bin once and reset centroid sums for each sample, so sliding measurements use the right spectrum.
- Clear inactive audio output and reset cached measurements on initialization. Calculate non-sliding audio centroids once per new frame.
- Start sliding `pvsanal` input and control-rate measurements at the first active sample when a note starts partway through a block.
