### PR TITLE
Fix lowres audio-rate coefficient handling

### DIFF
--- a/Opcodes/lowpassr.c
+++ b/Opcodes/lowpassr.c
@@ -94,17 +94,6 @@ static int32_t lowpraa(CSOUND *csound, LOWPR *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    if (okf!= fco[0] || okr != res[0]) { /* Only if changed */
-      if (UNLIKELY(fco[0]<=FL(0.0)))
-        return csound->PerfError(csound, &(p->h),
-                                 "%s", Str("Cutoff parameter must be positive"));
-      b = 10.0 / (res[0] * sqrt((double)fco[0])) - 1.0;
-      p->k = k = 1000.0 / (double)fco[0];
-      p->coef1 = coef1 = (b+2.0 * k);
-      p->coef2 = coef2 = 1.0/(1.0 + b + k);
-      okf = fco[0]; okr = res[0];
-      /* remember to save recalculation */
-    }
     ar = p->ar;
     asig = p->asig;
     ynm1 = p->ynm1;
@@ -121,7 +110,7 @@ static int32_t lowpraa(CSOUND *csound, LOWPR *p)
           return csound->PerfError(csound, &(p->h),
                                  "%s", Str("Cutoff parameter must be positive"));
         b = 10.0 / (res[n] * sqrt((double)fco[n])) - 1.0;
-        p->k = k = 1000.0 / (double)fco[0];
+        p->k = k = 1000.0 / (double)fco[n];
         p->coef1 = coef1 = (b+2.0 * k);
         p->coef2 = coef2 = 1.0/(1.0 + b + k);
         okf = fco[n]; okr = res[n];
@@ -150,16 +139,6 @@ static int32_t lowprak(CSOUND *csound, LOWPR *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    if (okf != fco[0] || okr != kres) { /* Only if changed */
-      if (UNLIKELY(fco[0]<=FL(0.0)))
-        return csound->PerfError(csound, &(p->h),
-                                 "%s", Str("Cutoff parameter must be positive"));
-      b = 10.0 / (kres * sqrt((double)fco[0])) - 1.0;
-      p->k = k = 1000.0 / (double)fco[0];
-      p->coef1 = coef1 = (b+2.0 * k);
-      p->coef2 = coef2 = 1.0/(1.0 + b + k);
-      okf = fco[0]; okr = kres; /* remember to save recalculation */
-    }
     ar = p->ar;
     asig = p->asig;
     ynm1 = p->ynm1;
@@ -171,7 +150,7 @@ static int32_t lowprak(CSOUND *csound, LOWPR *p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps;n++) {
-      if (okf != fco[n]) { /* Only if changed */
+      if (okf != fco[n] || okr != kres) { /* Only if changed */
         if (UNLIKELY(fco[n]<=FL(0.0)))
           return csound->PerfError(csound, &(p->h),
                                    "%s", Str("Cutoff parameter must be positive"));
@@ -179,7 +158,7 @@ static int32_t lowprak(CSOUND *csound, LOWPR *p)
         p->k = k = 1000.0 / (double)fco[n];
         p->coef1 = coef1 = (b+2.0 * k);
         p->coef2 = coef2 = 1.0/(1.0 + b + k);
-        okf = fco[n]; /* remember to save recalculation */
+        okf = fco[n]; okr = kres; /* remember to save recalculation */
       }
       ar[n] = (MYFLT)(yn = (coef1 * ynm1 - k * ynm2 + (double)asig[n]) * coef2);
       ynm2 = ynm1;
@@ -205,16 +184,6 @@ static int32_t lowprka(CSOUND *csound, LOWPR *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
 
-    if (okf!= fco || okr != res[0]) { /* Only if changed */
-      if (UNLIKELY(fco<=FL(0.0)))
-        return csound->PerfError(csound, &(p->h),
-                                 "%s", Str("Cutoff parameter must be positive"));
-      b = 10.0 / (res[0] * sqrt((double)fco)) - 1.0;
-      p->k = k = 1000.0 / (double)fco;
-      p->coef1 = coef1 = (b+2.0 * k);
-      p->coef2 = coef2 = 1.0/(1.0 + b + k);
-      okf = fco; okr = res[0]; /* remember to save recalculation */
-    }
     ar = p->ar;
     asig = p->asig;
     ynm1 = p->ynm1;
@@ -226,13 +195,15 @@ static int32_t lowprka(CSOUND *csound, LOWPR *p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps;n++) {
-      // ****Optimise by remembering okf/okr
-      if (okr != res[n]) { /* Only if changed */
+      if (okf != fco || okr != res[n]) { /* Only if changed */
+        if (UNLIKELY(fco<=FL(0.0)))
+          return csound->PerfError(csound, &(p->h),
+                                   "%s", Str("Cutoff parameter must be positive"));
         b = 10.0 / (res[n] * sqrt((double)fco)) - 1.0;
         p->k = k = 1000.0 / (double)fco;
         p->coef1 = coef1 = (b+2.0 * k);
         p->coef2 = coef2 = 1.0/(1.0 + b + k);
-        okr = res[n]; /* remember to save recalculation */
+        okf = fco; okr = res[n]; /* remember to save recalculation */
       }
       ar[n] = (MYFLT)(yn = (coef1 * ynm1 - k * ynm2 + (double)asig[n]) * coef2);
       ynm2 = ynm1;
@@ -280,24 +251,24 @@ static int32_t lowprx(CSOUND *csound, LOWPRX *p)
       memset(&p->ar[nsmps], '\0', early*sizeof(MYFLT));
     }
 
-    for (j=0; j< p->loop; j++) {
-      ar = p->ar;
-
-      for (n=offset;n<nsmps;n++) {
-        MYFLT fco = (asgf ? kfco[n] : *kfco);
-        MYFLT res = (asgr ? kres[n] : *kres);
-        if (p->okf != fco || p->okr != res) { /* Only if changed */
-          b = FL(10.0) / (res * SQRT(fco)) - FL(1.0);
-          k = FL(1000.0) / fco;
-          coef1 = (b+FL(2.0) * k);
-          coef2 = FL(1.0)/(FL(1.0) + b + k);
-          p->okf = fco; p->okr = res; /* remember to save recalculation */
-        }
-        ar[n] = yn = (coef1 * ynm1[j] - k * ynm2[j] + asig[n]) * coef2;
+    ar = p->ar;
+    for (n=offset;n<nsmps;n++) {
+      MYFLT fco = (asgf ? kfco[n] : *kfco);
+      MYFLT res = (asgr ? kres[n] : *kres);
+      if (p->okf != fco || p->okr != res) { /* Only if changed */
+        b = FL(10.0) / (res * SQRT(fco)) - FL(1.0);
+        k = FL(1000.0) / fco;
+        coef1 = (b+FL(2.0) * k);
+        coef2 = FL(1.0)/(FL(1.0) + b + k);
+        p->okf = fco; p->okr = res; /* remember to save recalculation */
+      }
+      yn = asig[n];
+      for (j=0; j< p->loop; j++) {
+        yn = (coef1 * ynm1[j] - k * ynm2[j] + yn) * coef2;
         ynm2[j] = ynm1[j];
         ynm1[j] = yn;
       }
-      asig= p->ar;
+      ar[n] = yn;
     }
     p->k = k;
     p->coef1 = coef1;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -924,6 +924,7 @@ def runTest():
         ["test_adsr_zero_reinit.csd", "ADSR reinitialization with zero attack"],
         ["test_madsr_release_override.csd", "madsr release overrides"],
         ["test_mvmfilter_mixed_rate.csd", "test mvmfilter with mixed input rates"],
+        ["test_lowres_audio.csd", "test lowres audio parameters and input reuse"],
         ["test_flanger_buffer.csd", "test flanger buffer limits and reinit"],
         [
             "test_flanger_invalid_maximum.csd",

--- a/tests/commandline/test_lowres_audio.csd
+++ b/tests/commandline/test_lowres_audio.csd
@@ -1,0 +1,119 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Use control-rate parameters at one sample per cycle as the reference.
+opcode Reference, aa, aaa
+  setksmps 1
+  aInput, aCutoff, aResonance xin
+  kCutoff downsamp aCutoff
+  kResonance downsamp aResonance
+  aFirst lowres aInput, kCutoff, kResonance
+  aSecond lowres aFirst, kCutoff, kResonance
+  aThird lowres aSecond, kCutoff, kResonance
+  xout aFirst, aThird
+endop
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  ; Alternate constant blocks and per-sample modulation, exercising the cache.
+  kCutoff = kCycle < 5 ? 700 : 1100
+  kResonance = kCycle < 7 ? .8 : 1.2
+  aMod oscili 1, 173
+  aCutoff = kCutoff
+  aResonance = kResonance
+  if p4 == 1 || p4 == 2 then
+    aCutoff += (kCycle%3 == 0 ? 0 : 200)*aMod
+  endif
+  if p4 == 1 || p4 == 3 then
+    aResonance += (kCycle%3 == 0 ? 0 : .1)*aMod
+  endif
+  aInput oscili .2, 370
+  aRef, aCascade Reference aInput, aCutoff, aResonance
+  if p4 == 0 then
+    aSingle lowres aInput, kCutoff, kResonance
+    aMulti lowresx aInput, kCutoff, kResonance, 3
+  elseif p4 == 1 then
+    aSingle lowres aInput, aCutoff, aResonance
+    aMulti lowresx aInput, aCutoff, aResonance, 3
+  elseif p4 == 2 then
+    aSingle lowres aInput, aCutoff, kResonance
+    aMulti lowresx aInput, aCutoff, kResonance, 3
+  else
+    aSingle lowres aInput, kCutoff, aResonance
+    aMulti lowresx aInput, kCutoff, aResonance, 3
+  endif
+  kError max_k abs(aSingle-aRef)+abs(aMulti-aCascade), 1, 1
+  if !(kError < .00001) then
+    printks "lowres parameter-rate case %g differs on cycle %g: %g\n", 0, p4, kCycle, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  aInput oscili .2, 370
+  aMod oscili 1, 173
+  aCutoff = 1000+200*aMod
+  aResonance = 1+.1*aMod
+  aRef lowres aInput, aCutoff, aResonance
+  aMultiRef lowresx aInput, aCutoff, aResonance, p4
+  aSingleCutoff = aCutoff
+  aSingleResonance = aResonance
+  aMultiCutoff = aCutoff
+  aMultiResonance = aResonance
+  aCopy = aInput
+  aSingleCutoff lowres aInput, aSingleCutoff, aResonance
+  aSingleResonance lowres aInput, aCutoff, aSingleResonance
+  aMultiCutoff lowresx aInput, aMultiCutoff, aResonance, p4
+  aMultiResonance lowresx aInput, aCutoff, aMultiResonance, p4
+  aCopy lowresx aCopy, aCutoff, aResonance, p4
+  aError = abs(aSingleCutoff-aRef)+abs(aSingleResonance-aRef)
+  aError += abs(aMultiCutoff-aMultiRef)+abs(aMultiResonance-aMultiRef)+abs(aCopy-aMultiRef)
+  kError max_k aError, 1, 1
+  if !(kError < .00001) then
+    printks "lowres input reuse differs for %g stages: %g\n", 0, p4, kError
+    exitnowk(-1)
+  endif
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 14 then
+    prints "lowres checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03 0
+i 1 0 .03 1
+i 1 0 .03 2
+i 1 0 .03 3
+i 1 .040625 .029 0
+i 1 .040625 .029 1
+i 1 .040625 .029 2
+i 1 .040625 .029 3
+i 2 .08 .03 1
+i 2 .08 .03 3
+i 2 .08 .03 10
+i 2 .120625 .029 1
+i 2 .120625 .029 3
+i 2 .120625 .029 10
+i 99 .16 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Use the current cutoff sample in `lowres`'s audio/audio coefficient calculation. Previously, a constant audio-rate resonance could produce a different filter response from the identical control-rate value.

Update audio-rate coefficients only within active samples, so note offsets do not cause valid cutoffs to be rejected or inactive resonance samples to affect the filter. Continue tracking both parameters for mixed-rate changes.

Run each `lowresx` sample through every stage before writing output. This preserves audio-rate cutoff and resonance inputs when the output reuses their variables and shares each coefficient update across all stages.
