### PR TITLE
Fix Butterworth audio-rate parameter handling

### DIFF
--- a/Opcodes/afilters.c
+++ b/Opcodes/afilters.c
@@ -534,22 +534,11 @@ static int32_t hibuta(CSOUND *csound, BFIL *p) /*      Hipass filter       */
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
 
-  if (UNLIKELY(p->afc[0] <= FL(0.0)))     {
-    memcpy(&out[offset], &in[offset], (nsmps-offset)*sizeof(MYFLT));
-    return OK;
-  }
-
-  /* if (p->afc[0] != p->lkf)      { */
-  /*   p->lkf = p->afc[0]; */
-  /*   c = tan((double)(CS_PIDSR * p->lkf)); */
-
-  /*   a[1] = 1.0 / ( 1.0 + ROOT2 * c + c * c); */
-  /*   a[2] = -(a[1] + a[1]); */
-  /*   a[3] = a[1]; */
-  /*   a[4] = 2.0 * ( c*c - 1.0) * a[1]; */
-  /*   a[5] = ( 1.0 - ROOT2 * c + c * c) * a[1]; */
-  /* } */
   for (nn=offset; nn<nsmps; nn++) {
+    if (UNLIKELY(p->afc[nn] <= FL(0.0))) {
+      out[nn] = in[nn];
+      continue;
+    }
     if (p->afc[nn] != p->lkf)      {
       double c;
       p->lkf = p->afc[nn];
@@ -584,11 +573,6 @@ static int32_t lobuta(CSOUND *csound, BFIL *p)       /*      Lopass filter      
   in = p->ain;
   out = p->sr;
 
-  if (UNLIKELY(*p->afc <= FL(0.0)))     {
-    memset(out, 0, CS_KSMPS*sizeof(MYFLT));
-    return OK;
-  }
-
   if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
   if (UNLIKELY(early)) {
     nsmps -= early;
@@ -596,6 +580,10 @@ static int32_t lobuta(CSOUND *csound, BFIL *p)       /*      Lopass filter      
   }
 
   for (nn=offset; nn<nsmps; nn++) {
+    if (UNLIKELY(p->afc[nn] <= FL(0.0))) {
+      out[nn] = FL(0.0);
+      continue;
+    }
     if (p->afc[nn] != p->lkf) {
       double c;
       p->lkf = p->afc[nn];
@@ -629,7 +617,7 @@ static int32_t bppasxx(CSOUND *csound, BBFIL *p)      /*      Bandpass filter   
 
   in = p->ain;
   out = p->sr;
-  if (UNLIKELY(p->kbw[0] <= FL(0.0)))     {
+  if (!asgbw && UNLIKELY(*p->kbw <= FL(0.0))) {
     memset(out, 0, CS_KSMPS*sizeof(MYFLT));
     return OK;
   }
@@ -642,6 +630,10 @@ static int32_t bppasxx(CSOUND *csound, BBFIL *p)      /*      Bandpass filter   
   for (nn=offset; nn<nsmps; nn++) {
     MYFLT bw, fr;
     bw = (asgbw ? p->kbw[nn] : *p->kbw);
+    if (asgbw && UNLIKELY(bw <= FL(0.0))) {
+      out[nn] = FL(0.0);
+      continue;
+    }
     fr = (asgfr ? p->kfo[nn] : *p->kfo);
     if (bw != p->lkb || fr != p->lkf) {
       double c, d;
@@ -685,14 +677,19 @@ static int32_t bpcutxx(CSOUND *csound, BBFIL *p)      /*      Band reject filter
     nsmps -= early;
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
-  if (UNLIKELY(p->kbw[0] <= FL(0.0)))     {
-    memcpy(&out[offset], &in[offset], (nsmps-offset)*sizeof(MYFLT));
+  if (!asgbw && UNLIKELY(*p->kbw <= FL(0.0))) {
+    if (out != in)
+      memcpy(&out[offset], &in[offset], (nsmps-offset)*sizeof(MYFLT));
     return OK;
   }
 
   for (nn=offset; nn<nsmps; nn++) {
     MYFLT bw, fr;
     bw = (asgbw ? p->kbw[nn] : *p->kbw);
+    if (asgbw && UNLIKELY(bw <= FL(0.0))) {
+      out[nn] = in[nn];
+      continue;
+    }
     fr = (asgfr ? p->kfo[nn] : *p->kfo);
     if (bw != p->lkb || fr != p->lkf) {
       double c, d;

--- a/Opcodes/butter.c
+++ b/Opcodes/butter.c
@@ -71,7 +71,8 @@ static int32_t hibut(CSOUND *csound, BFIL *p)       /*      Hipass filter       
     }
 
     if (*p->kfc <= FL(0.0))     {
-      memcpy(&out[offset], &in[offset], (nsmps-offset)*sizeof(MYFLT));
+      if (out != in)
+        memcpy(&out[offset], &in[offset], (nsmps-offset)*sizeof(MYFLT));
       return OK;
     }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -939,6 +939,7 @@ def runTest():
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],
         ["test_filterx_istor_first_init.csd", "test filter state on first init"],
+        ["test_butterworth_audio.csd", "test Butterworth audio parameters and partial blocks"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],
         ["test_dcblock2_order_reinit.csd", "test dcblock2 order changes"],
         ["test_dcblock2_invalid_order.csd", "reject invalid dcblock2 order", 1],

--- a/tests/commandline/test_butterworth_audio.csd
+++ b/tests/commandline/test_butterworth_audio.csd
@@ -1,0 +1,125 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Parameters, aa, i
+  setksmps 1
+  iPattern xin
+  kSample init 0
+  kPosition = kSample%16
+  kScale = 1
+  if iPattern == 1 then
+    kScale = kPosition < 4 ? 0 : 1
+  elseif iPattern == 2 then
+    kScale = kPosition < 4 || kPosition >= 12 ? 1 : (kPosition < 8 ? 0 : -1)
+  endif
+  aCutoff = 1000*kScale
+  aBandwidth = 200*kScale
+  kSample += 1
+  xout aCutoff, aBandwidth
+endop
+
+; The control-rate paths define silence/bypass and preserved state at zero.
+opcode Reference, aaaa, aaaa
+  setksmps 1
+  aInput, aCutoff, aCenter, aBandwidth xin
+  kCutoff downsamp aCutoff
+  kCenter downsamp aCenter
+  kBandwidth downsamp aBandwidth
+  aLP butterlp aInput, kCutoff
+  aHP butterhp aInput, kCutoff
+  aBP butterbp aInput, kCenter, kBandwidth
+  aBR butterbr aInput, kCenter, kBandwidth
+  xout aLP, aHP, aBP, aBR
+endop
+
+instr 1
+  aInput oscili .1, 370
+  aInput += .1
+  aCutoff, aBandwidth Parameters p4
+  aCenter = 1000
+  aLPRef, aHPRef, aBPRef, aBRRef Reference aInput, aCutoff, aCenter, aBandwidth
+  aLP butterlp aInput, aCutoff
+  aHP butterhp aInput, aCutoff
+  aBP butterbp aInput, aCenter, aBandwidth
+  aBR butterbr aInput, aCenter, aBandwidth
+  aBPMixed butterbp aInput, 1000, aBandwidth
+  aBRMixed butterbr aInput, 1000, aBandwidth
+  aError = abs(aLP-aLPRef)+abs(aHP-aHPRef)+abs(aBP-aBPRef)+abs(aBR-aBRRef)
+  aError += abs(aBPMixed-aBPRef)+abs(aBRMixed-aBRRef)
+
+  ; Reuse parameter buffers and input buffers, including bypassed samples.
+  aLPCopy = aCutoff
+  aHPCopy = aInput
+  aBPCopy = aBandwidth
+  aBRCopy = aInput
+  aLPCopy butlp aInput, aLPCopy
+  aHPCopy buthp aHPCopy, aCutoff
+  aBPCopy butbp aInput, aCenter, aBPCopy
+  aBRCopy butbr aBRCopy, aCenter, aBandwidth
+  aError += abs(aLPCopy-aLPRef)+abs(aHPCopy-aHPRef)+abs(aBPCopy-aBPRef)+abs(aBRCopy-aBRRef)
+  kError max_k aError, 1, 1
+  if !(kError < .000001) then
+    printks "Butterworth audio pattern %g differs: %g\n", 0, p4, kError
+    exitnowk(-1)
+  endif
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  aInput oscili .1, 370
+  aInput += .1
+  aMod oscili 200, 173
+  aCenter = 1000+aMod
+  kCycle init 0
+  kCycle += 1
+  kBandwidth = kCycle < 3 || kCycle >= 7 ? 200 : (kCycle < 5 ? 0 : -200)
+  kCutoff = kBandwidth*5
+  aBandwidth = kBandwidth
+  aCutoff = kCutoff
+  aLPRef, aHPRef, aBPRef, aBRRef Reference aInput, aCutoff, aCenter, aBandwidth
+  aBP butterbp aInput, aCenter, kBandwidth
+  aBR = aInput
+  aBR butterbr aBR, aCenter, kBandwidth
+  aHP = aInput
+  aHP butterhp aHP, kCutoff
+  kError max_k abs(aBP-aBPRef)+abs(aBR-aBRRef)+abs(aHP-aHPRef), 1, 1
+  if !(kError < .000001) then
+    printks "Butterworth control-rate bypass differs: %g\n", 0, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 8 then
+    prints "Butterworth checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03 0
+i 1 0 .03 1
+i 1 0 .03 2
+i 1 .040625 .029 0
+i 1 .040625 .029 1
+i 1 .040625 .029 2
+i 2 .08 .03
+i 2 .120625 .029
+i 99 .16 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Handle audio-rate cutoff and bandwidth per active sample in `butterlp`, `butterhp`, `butterbp`, `butterbr`, and their short aliases. Reading sample zero could silence or bypass an entire partial block. Nonpositive values later in a block could also reach coefficient calculations and corrupt filter state.

Match the existing control-rate behavior: silence lowpass/bandpass, bypass highpass/bandreject, and hold state until the parameter becomes positive again. Keep the control-rate block shortcuts and skip bypass copies when output already reuses input.
