### PR TITLE
Add opt-in corrected resony linear spacing

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -345,6 +345,11 @@ static int32_t product(CSOUND *csound, SUM *p)
 
 static int32_t rsnsety(CSOUND *csound, RESONY *p)
 {
+    /* icorrect opts into base-relative linear spacing; old calls keep
+       the original spacing and integer conversion of isepmode. */
+    if (UNLIKELY(*p->icorrect != FL(0.0) && *p->icorrect != FL(1.0)))
+      return csound->InitError(csound, "%s",
+                               Str("resony: icorrect must be 0 or 1"));
     double order = (double)*p->ord;
     double scale_value = (double)*p->iscl;
     size_t state_size;
@@ -393,12 +398,13 @@ static int32_t resony(CSOUND *csound, RESONY *p)
     int32_t loop = p->loop;
     if (UNLIKELY(loop==0))
       return csound->InitError(csound, "%s", Str("loop cannot be zero"));
-    if (UNLIKELY(*p->kcf == FL(0.0)))
+    if (UNLIKELY(*p->icorrect && *p->kcf == FL(0.0)))
       return csound->PerfError(csound, &(p->h),
                                "%s", Str("resony: base frequency must be nonzero"));
     {
       MYFLT   sep = (*p->sep / (MYFLT) loop);
-      int32_t     flag = (*p->iflag != FL(0.0));
+      int32_t     flag = *p->icorrect ? (*p->iflag != FL(0.0)) :
+                        (int32_t)*p->iflag;
       MYFLT   *buffer = (MYFLT*) (p->buffer.auxp);
       uint32_t offset = p->h.insdshead->ksmps_offset;
       uint32_t early  = p->h.insdshead->ksmps_no_end;
@@ -417,8 +423,11 @@ static int32_t resony(CSOUND *csound, RESONY *p)
       yt2 = p->yt2;
 
       for (j = 0; j < loop; j++) {
-        if (flag)                     /* linear separation in hertz */
+        if (flag && *p->icorrect)      /* linear separation in hertz */
           cosf = (MYFLT) cos((cf = (double) (*p->kcf + sep * j))
+                             * (double) CS_TPIDSR);
+        else if (flag)                /* original linear spacing */
+          cosf = (MYFLT) cos((cf = (double) (*p->kcf * sep * j))
                              * (double) CS_TPIDSR);
         else                          /* logarithmic separation in octaves */
           cosf = (MYFLT) cos((cf = (double) (*p->kcf * pow(2.0, sep * j)))
@@ -1686,7 +1695,7 @@ static OENTRY localops[] = {
 { "trigger",  S(TRIG),  0, "k", "kkk",  (SUBR)trig_set, (SUBR)trig,   NULL  },
 { "sum",      S(SUM),   0, "a", "y",    (SUBR)sum_init, (SUBR)sum_               },
 { "product",  S(SUM),   0, "a", "y",    (SUBR)product_init, (SUBR)product },
-{ "resony",  S(RESONY), 0, "a", "akkikooo", (SUBR)rsnsety, (SUBR)resony }
+{ "resony",  S(RESONY), 0, "a", "akkikoooo", (SUBR)rsnsety, (SUBR)resony }
 };
 
 int32_t uggab_init_(CSOUND *csound)

--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -393,9 +393,12 @@ static int32_t resony(CSOUND *csound, RESONY *p)
     int32_t loop = p->loop;
     if (UNLIKELY(loop==0))
       return csound->InitError(csound, "%s", Str("loop cannot be zero"));
+    if (UNLIKELY(*p->kcf == FL(0.0)))
+      return csound->PerfError(csound, &(p->h),
+                               "%s", Str("resony: base frequency must be nonzero"));
     {
       MYFLT   sep = (*p->sep / (MYFLT) loop);
-      int32_t     flag = (int32_t) *p->iflag;
+      int32_t     flag = (*p->iflag != FL(0.0));
       MYFLT   *buffer = (MYFLT*) (p->buffer.auxp);
       uint32_t offset = p->h.insdshead->ksmps_offset;
       uint32_t early  = p->h.insdshead->ksmps_no_end;
@@ -415,7 +418,7 @@ static int32_t resony(CSOUND *csound, RESONY *p)
 
       for (j = 0; j < loop; j++) {
         if (flag)                     /* linear separation in hertz */
-          cosf = (MYFLT) cos((cf = (double) (*p->kcf * sep * j))
+          cosf = (MYFLT) cos((cf = (double) (*p->kcf + sep * j))
                              * (double) CS_TPIDSR);
         else                          /* logarithmic separation in octaves */
           cosf = (MYFLT) cos((cf = (double) (*p->kcf * pow(2.0, sep * j)))

--- a/Opcodes/uggab.h
+++ b/Opcodes/uggab.h
@@ -51,7 +51,7 @@ typedef struct {
 
 typedef struct {
     OPDS        h;
-    MYFLT       *ar, *asig, *kcf, *kbw, *ord, *sep, *iflag, *iscl, *istor;
+    MYFLT       *ar, *asig, *kcf, *kbw, *ord, *sep, *iflag, *iscl, *istor, *icorrect;
     int32_t     scale, loop;
     AUXCH       aux;
     AUXCH       buffer;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -985,6 +985,8 @@ def runTest():
         ["test_butterworth_audio.csd", "test Butterworth audio parameters and partial blocks"],
         ["test_clfilt_ripple.csd", "clfilt small ripple and coefficient updates"],
         ["test_filterx_order_growth.csd", "test filter state after order growth"],
+        ["test_resony_spacing.csd", "test resony frequency spacing and bandwidth"],
+        ["test_resony_zero_base.csd", "reject undefined resony bandwidth scaling", 1],
         ["test_dcblock2_order_reinit.csd", "test dcblock2 order changes"],
         ["test_dcblock2_invalid_order.csd", "reject invalid dcblock2 order", 1],
         ["test_dbap.csd", "test dbap and dbapgains opcodes"],

--- a/tests/commandline/test_resony_spacing.csd
+++ b/tests/commandline/test_resony_spacing.csd
@@ -15,11 +15,19 @@ instr 1
   kCycle += 1
   kBase = kCycle < 5 ? 700 : 1100
   kWidth = kCycle < 7 ? 100 : 150
-  ; A single resonator always starts at the base frequency.
-  aBank resony aInput, kBase, kWidth, 1, 400, p4, p5
-  aRef reson aInput, kBase, kWidth, p5
+  ; Corrected spacing starts at the base; legacy linear spacing starts at zero.
+  if p7 == 0 then
+    aBank resony aInput, kBase, kWidth, 1, 400, p4, p5
+  else
+    aBank resony aInput, kBase, kWidth, 1, 400, p4, p5, 0, p7
+  endif
+  kFirst = p7 == 0 && int(p4) != 0 ? 0 : kBase
+  aRef reson aInput, kFirst, kWidth*kFirst/kBase, p5
   kError max_k abs(aBank-aRef), 1, 1
-  if !(kError < .00001) then
+  ; The legacy zero-frequency recurrence grows without damping.
+  kMagnitude max_k abs(aRef), 1, 1
+  kTolerance = p7 == 0 ? .0001*(1+kMagnitude) : .00001
+  if !(kError < kTolerance) then
     printks "resony single filter: mode %g scale %g error %g\n", 0, p4, p5, kError
     exitnowk(-1)
   endif
@@ -36,21 +44,33 @@ instr 2
   kBase = kCycle < 5 ? 600 : 800
   kWidth = kCycle < 7 ? 80 : 120
   kSeparation = kCycle < 9 ? p6 : p6*.5
-  if p4 == 0 then
+  kFirst = kBase
+  if (p7 == 0 && int(p4) == 0) || (p7 == 1 && p4 == 0) then
     kSecond = kBase*2^(kSeparation/3)
     kThird = kBase*2^(2*kSeparation/3)
+  elseif p7 == 0 then
+    kFirst = 0
+    kSecond = kBase*kSeparation/3
+    kThird = kBase*2*kSeparation/3
   else
     kSecond = kBase+kSeparation/3
     kThird = kBase+2*kSeparation/3
   endif
-  aFirst reson aInput, kBase, kWidth, p5
+  aFirst reson aInput, kFirst, kWidth*kFirst/kBase, p5
   aSecond reson aInput, kSecond, kWidth*kSecond/kBase, p5
   aThird reson aInput, kThird, kWidth*kThird/kBase, p5
   aRef = aFirst+aSecond+aThird
-  aBank resony aInput, kBase, kWidth, 3, kSeparation, p4, p5
-  aCopy resony aCopy, kBase, kWidth, 3, kSeparation, p4, p5
+  if p7 == 0 then
+    aBank resony aInput, kBase, kWidth, 3, kSeparation, p4, p5
+    aCopy resony aCopy, kBase, kWidth, 3, kSeparation, p4, p5
+  else
+    aBank resony aInput, kBase, kWidth, 3, kSeparation, p4, p5, 0, p7
+    aCopy resony aCopy, kBase, kWidth, 3, kSeparation, p4, p5, 0, p7
+  endif
   kError max_k abs(aBank-aRef)+abs(aCopy-aBank), 1, 1
-  if !(kError < .00002) then
+  kMagnitude max_k abs(aRef), 1, 1
+  kTolerance = p7 == 0 ? .0001*(1+kMagnitude) : .00002
+  if !(kError < kTolerance) then
     printks "resony bank: mode %g scale %g separation %g error %g\n", 0, p4, p5, kSeparation, kError
     exitnowk(-1)
   endif
@@ -60,39 +80,64 @@ instr 2
 endin
 
 instr 99
-  if i(gkChecks) != 24 then
+  if i(gkChecks) != 48 then
     prints "resony spacing checks did not complete\n"
     exitnow(-1)
   endif
 endin
 </CsInstruments>
 <CsScore>
-; Mode and normalization. Every nonzero mode value selects linear spacing.
-i 1 0 .03 0 0
-i 1 0 .03 0 1
-i 1 0 .03 0 2
-i 1 0 .03 1 0
-i 1 0 .03 1 1
-i 1 0 .03 1 2
-i 1 0 .03 .5 0
-i 1 0 .03 .5 1
-i 1 0 .03 .5 2
-i 1 0 .03 -.5 0
-i 1 0 .03 -.5 1
-i 1 0 .03 -.5 2
+; Corrected mode: every nonzero isepmode selects linear spacing.
+i 1 0 .03 0 0 0 1
+i 1 0 .03 0 1 0 1
+i 1 0 .03 0 2 0 1
+i 1 0 .03 1 0 0 1
+i 1 0 .03 1 1 0 1
+i 1 0 .03 1 2 0 1
+i 1 0 .03 .5 0 0 1
+i 1 0 .03 .5 1 0 1
+i 1 0 .03 .5 2 0 1
+i 1 0 .03 -.5 0 0 1
+i 1 0 .03 -.5 1 0 1
+i 1 0 .03 -.5 2 0 1
 ; Compare the bank with explicit parallel resonators across partial blocks.
-i 2 .040625 .029 1 0 900
-i 2 .040625 .029 1 1 900
-i 2 .040625 .029 1 2 900
-i 2 .040625 .029 .5 0 -300
-i 2 .040625 .029 .5 1 -300
-i 2 .040625 .029 .5 2 -300
-i 2 .040625 .029 0 0 1.5
-i 2 .040625 .029 0 1 1.5
-i 2 .040625 .029 0 2 1.5
-i 2 .040625 .029 1 0 0
-i 2 .040625 .029 1 1 0
-i 2 .040625 .029 1 2 0
+i 2 .040625 .029 1 0 900 1
+i 2 .040625 .029 1 1 900 1
+i 2 .040625 .029 1 2 900 1
+i 2 .040625 .029 .5 0 -300 1
+i 2 .040625 .029 .5 1 -300 1
+i 2 .040625 .029 .5 2 -300 1
+i 2 .040625 .029 0 0 1.5 1
+i 2 .040625 .029 0 1 1.5 1
+i 2 .040625 .029 0 2 1.5 1
+i 2 .040625 .029 1 0 0 1
+i 2 .040625 .029 1 1 0 1
+i 2 .040625 .029 1 2 0 1
+; Omitted icorrect keeps the legacy result, including fractional isepmode.
+i 1 0 .03 0 0 0 0
+i 1 0 .03 0 1 0 0
+i 1 0 .03 0 2 0 0
+i 1 0 .03 1 0 0 0
+i 1 0 .03 1 1 0 0
+i 1 0 .03 1 2 0 0
+i 1 0 .03 .5 0 0 0
+i 1 0 .03 .5 1 0 0
+i 1 0 .03 .5 2 0 0
+i 1 0 .03 -.5 0 0 0
+i 1 0 .03 -.5 1 0 0
+i 1 0 .03 -.5 2 0 0
+i 2 .040625 .029 1 0 1.5 0
+i 2 .040625 .029 1 1 1.5 0
+i 2 .040625 .029 1 2 1.5 0
+i 2 .040625 .029 .5 0 -300 0
+i 2 .040625 .029 .5 1 -300 0
+i 2 .040625 .029 .5 2 -300 0
+i 2 .040625 .029 0 0 1.5 0
+i 2 .040625 .029 0 1 1.5 0
+i 2 .040625 .029 0 2 1.5 0
+i 2 .040625 .029 1 0 0 0
+i 2 .040625 .029 1 1 0 0
+i 2 .040625 .029 1 2 0 0
 i 99 .08 .002
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_resony_spacing.csd
+++ b/tests/commandline/test_resony_spacing.csd
@@ -1,0 +1,98 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  aInput oscili .01, 370
+  kCycle init 0
+  kCycle += 1
+  kBase = kCycle < 5 ? 700 : 1100
+  kWidth = kCycle < 7 ? 100 : 150
+  ; A single resonator always starts at the base frequency.
+  aBank resony aInput, kBase, kWidth, 1, 400, p4, p5
+  aRef reson aInput, kBase, kWidth, p5
+  kError max_k abs(aBank-aRef), 1, 1
+  if !(kError < .00001) then
+    printks "resony single filter: mode %g scale %g error %g\n", 0, p4, p5, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  aInput oscili .01, 370
+  aCopy = aInput
+  kCycle init 0
+  kCycle += 1
+  kBase = kCycle < 5 ? 600 : 800
+  kWidth = kCycle < 7 ? 80 : 120
+  kSeparation = kCycle < 9 ? p6 : p6*.5
+  if p4 == 0 then
+    kSecond = kBase*2^(kSeparation/3)
+    kThird = kBase*2^(2*kSeparation/3)
+  else
+    kSecond = kBase+kSeparation/3
+    kThird = kBase+2*kSeparation/3
+  endif
+  aFirst reson aInput, kBase, kWidth, p5
+  aSecond reson aInput, kSecond, kWidth*kSecond/kBase, p5
+  aThird reson aInput, kThird, kWidth*kThird/kBase, p5
+  aRef = aFirst+aSecond+aThird
+  aBank resony aInput, kBase, kWidth, 3, kSeparation, p4, p5
+  aCopy resony aCopy, kBase, kWidth, 3, kSeparation, p4, p5
+  kError max_k abs(aBank-aRef)+abs(aCopy-aBank), 1, 1
+  if !(kError < .00002) then
+    printks "resony bank: mode %g scale %g separation %g error %g\n", 0, p4, p5, kSeparation, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 24 then
+    prints "resony spacing checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Mode and normalization. Every nonzero mode value selects linear spacing.
+i 1 0 .03 0 0
+i 1 0 .03 0 1
+i 1 0 .03 0 2
+i 1 0 .03 1 0
+i 1 0 .03 1 1
+i 1 0 .03 1 2
+i 1 0 .03 .5 0
+i 1 0 .03 .5 1
+i 1 0 .03 .5 2
+i 1 0 .03 -.5 0
+i 1 0 .03 -.5 1
+i 1 0 .03 -.5 2
+; Compare the bank with explicit parallel resonators across partial blocks.
+i 2 .040625 .029 1 0 900
+i 2 .040625 .029 1 1 900
+i 2 .040625 .029 1 2 900
+i 2 .040625 .029 .5 0 -300
+i 2 .040625 .029 .5 1 -300
+i 2 .040625 .029 .5 2 -300
+i 2 .040625 .029 0 0 1.5
+i 2 .040625 .029 0 1 1.5
+i 2 .040625 .029 0 2 1.5
+i 2 .040625 .029 1 0 0
+i 2 .040625 .029 1 1 0
+i 2 .040625 .029 1 2 0
+i 99 .08 .002
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_resony_zero_base.csd
+++ b/tests/commandline/test_resony_zero_base.csd
@@ -1,0 +1,19 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+instr 1
+  aInput = .01
+  kBase linseg 1000, .004, 0, .004, 0
+  aOutput resony aInput, kBase, 100, 3, 400, 1, 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_resony_zero_base.csd
+++ b/tests/commandline/test_resony_zero_base.csd
@@ -10,7 +10,7 @@ nchnls = 1
 instr 1
   aInput = .01
   kBase linseg 1000, .004, 0, .004, 0
-  aOutput resony aInput, kBase, 100, 3, 400, 1, 1
+  aOutput resony aInput, kBase, 100, 3, 400, 1, 1, 0, 1
 endin
 </CsInstruments>
 <CsScore>


### PR DESCRIPTION
Add an optional trailing `icorrect` argument to select corrected `resony` spacing while preserving existing calls.

```csound
ares resony asig, kbf, kbw, inum, ksep [, isepmode, iscl, iskip, icorrect]
```

- `icorrect = 0` (default) keeps the original spacing formula and integer conversion of `isepmode`.
- `icorrect = 1` places the first filter at the base frequency and adds the spacing in hertz for each following filter when `isepmode` is nonzero. Zero `isepmode` keeps octave spacing. This mode also rejects a zero base frequency before relative bandwidth scaling divides by it.

For example, append `, 1, 1, 0, 1` after `ksep` to select corrected linear spacing, normalization mode 1, and cleared filter state.
