### PR TITLE
Fix areson audio-rate coefficients

### DIFF
--- a/Opcodes/afilters.c
+++ b/Opcodes/afilters.c
@@ -110,20 +110,21 @@ static int32_t aresonaa(CSOUND *csound, RESON *p)
       }
       if (p->kbw[n] != (MYFLT)p->prvbw) {
         p->prvbw = (double)p->kbw[n];
-        p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        p->c3 = c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
         flag = 1;
       }
       if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;
@@ -142,20 +143,21 @@ static int32_t aresonaa(CSOUND *csound, RESON *p)
       }
       if (p->kbw[n] != (MYFLT)p->prvbw) {
         p->prvbw = (double)p->kbw[n];
-        p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        p->c3 = c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
         flag = 1;
       }
       if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;
@@ -171,7 +173,7 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
 {
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t n, nsmps = CS_KSMPS;
+  uint32_t flag = 0, n, nsmps = CS_KSMPS;
   MYFLT       *ar, *asig;
   double      c3p1, c3t4, omc3, c2sqr; /* 1/RMS = root2 (rand) */
   /*      or 1/.5  (sine) */
@@ -180,16 +182,7 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
   if (*p->kbw != (MYFLT)p->prvbw) {
     p->prvbw = (double)*p->kbw;
     p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
-    c3p1 = p->c3 + 1.0;
-    c3t4 = p->c3 * 4.0;
-    omc3 = 1.0 - p->c3;
-    p->c2 = c3t4 * p->cosf / c3p1;
-    c2sqr = p->c2 * p->c2;
-    if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-      p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
-    else if (p->scale == 2)                 /* i.e. D - A(reson) */
-      p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-    else p->c1 = 0.0;                        /* cannot tell        */
+    flag = 1;
   }
   asig = p->asig;
   ar = p->ar;
@@ -206,16 +199,20 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
       if (p->kcf[n] != (MYFLT)p->prvcf) {
         p->prvcf = (double)p->kcf[n];
         p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
+        flag = 1;
+      }
+      if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;
@@ -230,16 +227,20 @@ static int32_t aresonak(CSOUND *csound, RESON *p)
       if (p->kcf[n] != (MYFLT)p->prvcf) {
         p->prvcf = (double)p->kcf[n];
         p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
+        flag = 1;
+      }
+      if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;
@@ -255,7 +256,7 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
 {
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t n, nsmps = CS_KSMPS;
+  uint32_t flag = 0, n, nsmps = CS_KSMPS;
   MYFLT       *ar, *asig;
   double      c3p1, c3t4, omc3, c2sqr; /* 1/RMS = root2 (rand) */
   /*      or 1/.5  (sine) */
@@ -264,16 +265,7 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
   if (*p->kcf != (MYFLT)p->prvcf) {
     p->prvcf = (double)*p->kcf;
     p->cosf = cos(p->prvcf * (double)(CS_TPIDSR));
-    c3p1 = p->c3 + 1.0;
-    c3t4 = p->c3 * 4.0;
-    omc3 = 1.0 - p->c3;
-    p->c2 = c3t4 * p->cosf / c3p1;
-    c2sqr = p->c2 * p->c2;
-    if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-      p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
-    else if (p->scale == 2)                 /* i.e. D - A(reson) */
-      p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-    else p->c1 = 0.0;                        /* cannot tell        */
+    flag = 1;
   }
   asig = p->asig;
   ar = p->ar;
@@ -289,17 +281,21 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
       double ans;
       if (p->kbw[n] != (MYFLT)p->prvbw) {
         p->prvbw = (double)p->kbw[n];
-        p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        p->c3 = c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        flag = 1;
+      }
+      if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;
@@ -313,17 +309,21 @@ static int32_t aresonka(CSOUND *csound, RESON *p)
       double ans;
       if (p->kbw[n] != (MYFLT)p->prvbw) {
         p->prvbw = (double)p->kbw[n];
-        p->c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        p->c3 = c3 = exp(p->prvbw * (double)(CS_MTPIDSR));
+        flag = 1;
+      }
+      if (flag) {
         c3p1 = p->c3 + 1.0;
         c3t4 = p->c3 * 4.0;
         omc3 = 1.0 - p->c3;
-        p->c2 = c3t4 * p->cosf / c3p1;
+        p->c2 = c2 = c3t4 * p->cosf / c3p1;
         c2sqr = p->c2 * p->c2;
         if (p->scale == 1)                        /* i.e. 1 - A(reson) */
-          p->c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
+          p->c1 = c1 = 1.0 - omc3 * sqrt(1.0 - c2sqr / c3t4);
         else if (p->scale == 2)                 /* i.e. D - A(reson) */
-          p->c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
-        else p->c1 = 0.0;                        /* cannot tell        */
+          p->c1 = c1 = 2.0 - sqrt((c3p1*c3p1-c2sqr)*omc3/c3p1);
+        else p->c1 = c1 = 0.0;                        /* cannot tell        */
+        flag = 0;
       }
       ans = c1 * sig + c2 * yt1 - c3 * yt2;
       yt2 = yt1;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -851,6 +851,7 @@ def runTest():
         ["test_sa.csd", "test sample accurate mode"],
         ["test_gain_sample_bounds.csd", "gain RMS and output over partial blocks"],
         ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
+        ["test_areson_audio.csd", "test areson audio coefficients and preserved state"],
         ["test_svfilter_state.csd", "svfilter reset, preserved state, and input reuse"],
         [
             "test_audio_input_sample_bounds.csd",

--- a/tests/commandline/test_areson_audio.csd
+++ b/tests/commandline/test_areson_audio.csd
@@ -1,0 +1,137 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Reference, a, aaai
+  setksmps 1
+  aInput, aFrequency, aBandwidth, iScale xin
+  kFrequency downsamp aFrequency
+  kBandwidth downsamp aBandwidth
+  aOutput areson aInput, kFrequency, kBandwidth, iScale
+  xout aOutput
+endop
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  aInput oscili .01, 370
+  aInput += .01
+  kFrequency = kCycle < 5 ? 1000 : 1300
+  kBandwidth = kCycle < 7 ? 100 : 200
+  aMod oscili 1, 173
+  aFrequency = kFrequency
+  aBandwidth = kBandwidth
+  ; Constant blocks exercise reuse of the last calculated coefficients.
+  if (p4 == 1 || p4 == 2) && kCycle%3 != 0 then
+    aFrequency += 200*aMod
+  endif
+  if (p4 == 1 || p4 == 3) && kCycle%3 != 0 then
+    aBandwidth += 40*aMod
+  endif
+  aRef Reference aInput, aFrequency, aBandwidth, p5
+  if p4 == 0 || p4 == 1 then
+    aOutput areson aInput, aFrequency, aBandwidth, p5
+  elseif p4 == 2 then
+    aOutput areson aInput, aFrequency, kBandwidth, p5
+  else
+    aOutput areson aInput, kFrequency, aBandwidth, p5
+  endif
+  aCopy = aInput
+  aFrequencyCopy = aFrequency
+  aBandwidthCopy = aBandwidth
+  aCopy areson aCopy, aFrequency, aBandwidth, p5
+  aFrequencyCopy areson aInput, aFrequencyCopy, aBandwidth, p5
+  aBandwidthCopy areson aInput, aFrequency, aBandwidthCopy, p5
+  aError = abs(aOutput-aRef)+abs(aCopy-aRef)+abs(aFrequencyCopy-aRef)+abs(aBandwidthCopy-aRef)
+  kIndex = 0
+  while kIndex < ksmps do
+    kError vaget kIndex, aError
+    if !(kError < .000001) then
+      printks "areson rate case %g scale %g cycle %g sample %g differs: %g\n", 0, p4, p5, kCycle, kIndex, kError
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  setksmps 1
+  kCycle init 0
+  kCycle += 1
+  aInput = kCycle == 1 ? .1 : 0
+  aFrequency = 1000
+  aBandwidth = 100
+  if kCycle == 5 then
+    reinit FILTERS
+  endif
+FILTERS:
+  aRef areson aInput, 1000, 100, p5, p4
+  aBoth areson aInput, aFrequency, aBandwidth, p5, p4
+  aFrequencyOnly areson aInput, aFrequency, 100, p5, p4
+  aBandwidthOnly areson aInput, 1000, aBandwidth, p5, p4
+  rireturn
+  kRef downsamp aRef
+  kBoth downsamp aBoth
+  kFrequencyOnly downsamp aFrequencyOnly
+  kBandwidthOnly downsamp aBandwidthOnly
+  kError = abs(kBoth-kRef)+abs(kFrequencyOnly-kRef)+abs(kBandwidthOnly-kRef)
+  if !(kError < .000001) then
+    printks "areson reinit skip %g scale %g differs: %g\n", 0, p4, p5, kError
+    exitnowk(-1)
+  endif
+  if kCycle == 10 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 30 then
+    prints "areson checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03 0 0
+i 1 0 .03 0 1
+i 1 0 .03 0 2
+i 1 0 .03 1 0
+i 1 0 .03 1 1
+i 1 0 .03 1 2
+i 1 0 .03 2 0
+i 1 0 .03 2 1
+i 1 0 .03 2 2
+i 1 0 .03 3 0
+i 1 0 .03 3 1
+i 1 0 .03 3 2
+i 1 .040625 .029 0 0
+i 1 .040625 .029 0 1
+i 1 .040625 .029 0 2
+i 1 .040625 .029 1 0
+i 1 .040625 .029 1 1
+i 1 .040625 .029 1 2
+i 1 .040625 .029 2 0
+i 1 .040625 .029 2 1
+i 1 .040625 .029 2 2
+i 1 .040625 .029 3 0
+i 1 .040625 .029 3 1
+i 1 .040625 .029 3 2
+i 2 .08 .002 0 0
+i 2 .08 .002 0 1
+i 2 .08 .002 0 2
+i 2 .08 .002 1 0
+i 2 .08 .002 1 1
+i 2 .08 .002 1 2
+i 99 .09 .002
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`areson` updated cached coefficients but filtered with stale local copies when using audio-rate parameters. Mixed-rate startup could also calculate normalization before the audio-rate bandwidth initialized the decay coefficient, producing persistent NaNs with valid inputs.

Update local and cached coefficients together, and calculate mixed-rate normalization after both parameters are current. Clear the update flag after each recalculation so constant parameters reuse the coefficients. Keep the coefficient math inline.
