### PR TITLE
fix: stabilize looptseg curve evaluation

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -600,9 +600,15 @@ static int32_t looptseg(CSOUND *csound, LOOPTSEG *p)
         MYFLT v2 = (j!=nsegs-1)?*(p->argums[j+1].start):*(p->argums[0].start);
         if (alpha==FL(0.0))
           *p->out = v1 + (v2 - v1) * fract;
+        else if (alpha > FL(0.0))
+          /* Keep exponents nonpositive to avoid overflow.  expm1 also
+             preserves the linear limit when the curve is close to zero. */
+          *p->out = v1 + (v2 - v1) *
+            exp((double)alpha * (fract - 1.0)) *
+            (expm1(-(double)alpha * fract) / expm1(-(double)alpha));
         else
-          *p->out = v1 +
-            (v2 - v1) * (FL(1.0)-EXP(alpha*fract))/(FL(1.0)-EXP(alpha));
+          *p->out = v1 + (v2 - v1) *
+            (expm1((double)alpha * fract) / expm1((double)alpha));
         break;
       }
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -614,6 +614,7 @@ def runTest():
         ["test_partikkel_float_table_index.csd", "partikkel uses the scaled index for float table lookup"],
         ["test_grain4_correctness.csd", "grain4 handles envelopes, boundaries, and unused pitches"],
         ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
+        ["test_looptseg_curves.csd", "looptseg curve stability"],
         ["test_grain4_region_rounding.csd", "grain4 preserves sample rounding for source regions"],
         ["test_grain4_zero_length.csd", "reject zero grain4 source length", 1],
         ["test_grain4_subsample_length.csd", "reject sub-sample grain4 source length", 1],

--- a/tests/commandline/test_looptseg_curves.csd
+++ b/tests/commandline/test_looptseg_curves.csd
@@ -1,0 +1,49 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kCurves[] fillarray 0, 1e-8, -1e-8, 1e-20, -1e-20, 2, -2, 1000, -1000
+ kMids[] fillarray .5, .5, .5, .5, .5, .2689414213699951, .7310585786300049, 0, 1
+ kIndex init 0
+ kCurve = kCurves[kIndex]
+ ; Change the curve at k-rate while holding the phase fixed.  Check both
+ ; segment starts and the middle of rising and falling segments.
+ kStart looptseg 0, 0, 0, 0, kCurve, 1, 1, kCurve, 1
+ kRise looptseg 0, 0, .25, 0, kCurve, 1, 1, kCurve, 1
+ kPeak looptseg 0, 0, .5, 0, kCurve, 1, 1, kCurve, 1
+ kFall looptseg 0, 0, .75, 0, kCurve, 1, 1, kCurve, 1
+ kExpected = kMids[kIndex]
+ if !(abs(kStart) < 1e-6) || !(abs(kPeak - 1) < 1e-6) || \
+    !(abs(kRise - kExpected) < 1e-6) || \
+    !(abs(kFall - (1 - kExpected)) < 1e-6) then
+  printks "FAIL looptseg curve=%g start=%g rise=%g peak=%g fall=%g\n", 0, kCurve, kStart, kRise, kPeak, kFall
+  exitnowk(-1)
+ endif
+ kIndex += 1
+ gkChecks += 1
+ if kIndex == lenarray(kCurves) then
+  turnoff
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 9 then
+  prints "looptseg curve checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .1
+i 99 .1 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`looptseg` can produce NaNs for small nonzero curve values because `1 - exp(x)` loses precision near zero. Large positive curves can also overflow, even though the envelope should stay between its endpoints.

Use `expm1` to preserve the near-linear curve and rewrite positive curves with nonpositive exponents to avoid overflow. Keep the zero-curve path and envelope timing unchanged. All curve calculations run at control rate.
