### PR TITLE
fix: correct hilbert2 input reuse and window reinitialization

### DIFF
--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -1532,9 +1532,10 @@ static int32_t hilbert_init(CSOUND *csound, HILB *p) {
     }
 
     size = N*sizeof(MYFLT);
-    if (p->win.auxp == NULL || p->win.size < size) {
-      MYFLT x = FL(2.0)*PI_F/N;
+    if (p->win.auxp == NULL || p->win.size < size)
       csound->AuxAlloc(csound, size, &p->win);
+    {
+      MYFLT x = FL(2.0)*PI_F/N;
       for (i=0; i < N; i++)
         ((MYFLT *)p->win.auxp)[i] = FL(0.5) - FL(0.5)*COS((MYFLT)i*x);
     }
@@ -1594,9 +1595,10 @@ static int32_t hilbert_proc(CSOUND *csound, HILB *p) {
         off += fftsize;
         p->off = off = off%(fftsize*decim);
       }
+      MYFLT input = in[n];
       out[0][n] = out[1][n] = FL(0.0);
       for (i = 0; i < decim; i++) {
-        inframe[iframecnt[i]+i*fftsize] = in[n];
+        inframe[iframecnt[i]+i*fftsize] = input;
         iframecnt[i] = iframecnt[i] == fftsize-1 ? 0 : iframecnt[i]+1;
         k = 2*i*fftsize;
         out[0][n] += outframe[oframecnt[i]+k];
@@ -1663,9 +1665,10 @@ static int32_t hilbert_array_init(CSOUND *csound, HILBA *p) {
     }
 
     size = N*sizeof(MYFLT);
-    if (p->win.auxp == NULL || p->win.size < size) {
-      MYFLT x = FL(2.0)*PI_F/N;
+    if (p->win.auxp == NULL || p->win.size < size)
       csound->AuxAlloc(csound, size, &p->win);
+    {
+      MYFLT x = FL(2.0)*PI_F/N;
       for (i=0; i < N; i++)
         ((MYFLT *)p->win.auxp)[i] = FL(0.5) - FL(0.5)*COS((MYFLT)i*x);
     }
@@ -1701,7 +1704,7 @@ static int32_t hilbert_array_proc(CSOUND *csound, HILBA *p) {
 
     if (UNLIKELY(early)) {
       nsmps -= early;
-      memset(out, '\0', early*sizeof(COMPLEXDAT));
+      memset(&out[nsmps], '\0', early*sizeof(COMPLEXDAT));
     }
     if (UNLIKELY(offset)) {
         memset(out, '\0', offset*sizeof(COMPLEXDAT));

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -599,6 +599,7 @@ def runTest():
             "pvsadsyn rejects invalid bin increments",
             1,
         ],
+        ["test_hilbert2_state.csd", "hilbert2 input reuse, partial blocks and reinit"],
         ["test_repluck_correctness.csd", "test plucked-string waveguide limits"],
         ["test_repluck_sample_offset.csd", "test repluck sample-accurate input"],
         [

--- a/tests/commandline/test_hilbert2_state.csd
+++ b/tests/commandline/test_hilbert2_state.csd
@@ -1,0 +1,102 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ aInput oscili .1, 437
+ aReal, aImag hilbert2 aInput, 128, 32
+ aCopy = aInput
+ aCopy, aCopyImag hilbert2 aCopy, 128, 32
+ aCopy2 = aInput
+ aCopyReal, aCopy2 hilbert2 aCopy2, 128, 32
+ kArray:Complex[] hilbert2 aInput, 128, 32
+ kCycle init 0
+ kPeak init 0
+ kN = 0
+ while kN < ksmps do
+  kReal vaget kN, aReal
+  kImag vaget kN, aImag
+  kCopy vaget kN, aCopy
+  kCopyImag vaget kN, aCopyImag
+  kCopyReal vaget kN, aCopyReal
+  kCopy2 vaget kN, aCopy2
+  kError = abs(kReal-kCopy) + abs(kImag-kCopyImag) + \
+           abs(kReal-kCopyReal) + abs(kImag-kCopy2) + \
+           abs(kReal-real(kArray[kN])) + abs(kImag-imag(kArray[kN]))
+  if !(kError < 1e-6) then
+   printks "hilbert2 input reuse/array mismatch: cycle=%g sample=%g error=%g\n", 0, kCycle, kN, kError
+   exitnowk(-1)
+  endif
+  kPeak = max(kPeak, abs(kReal), abs(kImag))
+  kN += 1
+ od
+ kCycle += 1
+ if kCycle == 50 then
+  if !(kPeak > .05) then
+   printks "hilbert2 reference stayed silent\n", 0
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+endin
+
+instr 2
+ aInput oscili .1, 437
+ kSize init 128
+ kCycle init 0
+ kCycle += 1
+ if kCycle == 10 then
+  kSize = 64
+  reinit TRANSFORMS
+ endif
+TRANSFORMS:
+ iSize = i(kSize)
+ aReal, aImag hilbert2 aInput, iSize, 16
+ kArray:Complex[] hilbert2 aInput, iSize, 16
+ ; Reinitializing the fixed-size reference resets its state without
+ ; changing its window.  Both transforms must then agree sample for sample.
+ aRefReal, aRefImag hilbert2 aInput, 64, 16
+ rireturn
+ if kCycle >= 10 then
+  kN = 0
+  while kN < ksmps do
+   kReal vaget kN, aReal
+   kImag vaget kN, aImag
+   kRefReal vaget kN, aRefReal
+   kRefImag vaget kN, aRefImag
+   kError = abs(kReal-kRefReal) + abs(kImag-kRefImag) + \
+            abs(real(kArray[kN])-kRefReal) + abs(imag(kArray[kN])-kRefImag)
+   if !(kError < 1e-6) then
+    printks "hilbert2 resized window mismatch: cycle=%g sample=%g error=%g\n", 0, kCycle, kN, kError
+    exitnowk(-1)
+   endif
+   kN += 1
+  od
+ endif
+ if kCycle == 50 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 3 then
+  prints "hilbert2 checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .103375
+i 1 .120625 .10275
+i 2 .24 .104
+i 99 .36 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`hilbert2` clears its outputs before reading the input sample, so reusing the input variable as either output produces silence. Save the input sample before writing either output.

Also clear the inactive tail of the complex-array output at a note's end, and rebuild the window at initialization so reducing the FFT size does not reuse a window for the old size. The audio loop adds no function calls.
