### PR TITLE
fix: correct fmanal input reuse and leading sample clearing

### DIFF
--- a/Opcodes/pvlock.c
+++ b/Opcodes/pvlock.c
@@ -1775,13 +1775,13 @@ int32_t am_fm(CSOUND *csound, AMFM *p) {
       memset(&fm[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (UNLIKELY(offset)) {
-      memset(&am[nsmps], '\0', offset*sizeof(MYFLT));
-      memset(&fm[nsmps], '\0', offset*sizeof(MYFLT));
+      memset(am, '\0', offset*sizeof(MYFLT));
+      memset(fm, '\0', offset*sizeof(MYFLT));
     }
 
     for (n=offset; n < nsmps; n++) {
-      am[n] = HYPOT(re[n], im[n]);
       ph = ATAN2(im[n], re[n]);
+      am[n] = HYPOT(re[n], im[n]);
       f = ph - oph;
       oph = ph;
       if (f >= PI) f -= 2*PI;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -589,6 +589,7 @@ def runTest():
             "test_pvsadsyn_last_bin.csd",
             "pvsadsyn accepts a stepped selection ending at the last bin",
         ],
+        ["test_fmanal_samples.csd", "fmanal input reuse and partial blocks"],
         [
             "test_pvsadsyn_invalid_count.csd",
             "pvsadsyn rejects an out-of-range oscillator count",

--- a/tests/commandline/test_fmanal_samples.csd
+++ b/tests/commandline/test_fmanal_samples.csd
@@ -1,0 +1,74 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ aPhase phasor p4
+ aReal = .1*cos(2*$M_PI*aPhase)
+ aImag = .1*sin(2*$M_PI*aPhase)
+ aGate = 1
+ aAmp, aFreq fmanal aReal, aImag
+ ; Cover both inputs reused as either output, including both at once.
+ aRealCopy = aReal
+ aImagCopy = aImag
+ aRealCopy, aImagCopy fmanal aRealCopy, aImagCopy
+ aRealSwap = aReal
+ aImagSwap = aImag
+ aImagSwap, aRealSwap fmanal aRealSwap, aImagSwap
+ kStarted init 0
+ kCycle init 0
+ kN = 0
+ while kN < ksmps do
+  kGate vaget kN, aGate
+  kAmp vaget kN, aAmp
+  kFreq vaget kN, aFreq
+  kAmpCopy vaget kN, aRealCopy
+  kFreqCopy vaget kN, aImagCopy
+  kAmpSwap vaget kN, aImagSwap
+  kFreqSwap vaget kN, aRealSwap
+  kExpectedAmp = 0
+  kExpectedFreq = 0
+  if kGate != 0 then
+   kExpectedAmp = .1
+   if kStarted != 0 then
+    kExpectedFreq = p4
+   endif
+   kStarted = 1
+  endif
+  kAmpError = abs(kAmp-kExpectedAmp) + abs(kAmpCopy-kExpectedAmp) + abs(kAmpSwap-kExpectedAmp)
+  kFreqError = abs(kFreq-kExpectedFreq) + abs(kFreqCopy-kExpectedFreq) + abs(kFreqSwap-kExpectedFreq)
+  if !(kAmpError < 1e-6) || !(kFreqError < .01) then
+   printks "fmanal mismatch: frequency=%g cycle=%g sample=%g amplitude error=%g frequency error=%g\n", 0, p4, kCycle, kN, kAmpError, kFreqError
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ kCycle += 1
+ if kCycle == 10 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 4 then
+  prints "fmanal checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03 1000
+i 1 .04 .03 -1000
+i 1 .080625 .02975 1000
+i 1 .120625 .02975 -1000
+i 99 .16 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`fmanal` writes the amplitude before calculating phase. If that output reuses either input, it changes the signal used to calculate frequency. Calculate phase first so both calculations use the original inputs.

Also clear the leading output samples from the start of each buffer. The old address could write past the buffer when a note starts partway through a block. No function calls or checks are added to the audio loop.
