### PR TITLE
fix: reset and preserve phaser state on reinitialization

### DIFF
--- a/Opcodes/ugsc.c
+++ b/Opcodes/ugsc.c
@@ -354,36 +354,35 @@ static int32_t resonz(CSOUND *csound, RESONZ *p)
     return OK;
 }
 
+static void phaser_grow_state(CSOUND *csound, AUXCH *state, size_t size)
+{
+    if (state->size < size) {
+      size_t oldSize = state->size;
+      void *saved = csound->Malloc(csound, oldSize);
+      memcpy(saved, state->auxp, oldSize);
+      csound->AuxAlloc(csound, size, state);
+      memcpy(state->auxp, saved, oldSize);
+      csound->Free(csound, saved);
+    }
+}
+
 static int32_t phaser1set(CSOUND *csound, PHASER1 *p)
 {
     int32_t  loop = (int32_t) MYFLT2LONG(*p->iorder);
     int32_t  nBytes = (int32_t) loop * (int32_t) sizeof(MYFLT);
 
     if (*p->istor == FL(0.0) || p->auxx.auxp == NULL ||
-        (int32_t)p->auxx.size<nBytes || p->auxy.auxp == NULL ||
-        (int32_t)p->auxy.size<nBytes) {
+        p->auxy.auxp == NULL) {
       csound->AuxAlloc(csound, nBytes, &p->auxx);
       csound->AuxAlloc(csound, nBytes, &p->auxy);
-      p->xnm1 = (MYFLT *) p->auxx.auxp;
-      p->ynm1 = (MYFLT *) p->auxy.auxp;
+      p->feedback = FL(0.0);
     }
-    else if ((int32_t) p->auxx.size < nBytes || (int32_t) p->auxy.size < nBytes) {
-      /* Existing arrays too small so copy */
-      void    *tmp1, *tmp2;
-      size_t  oldSize1 = (size_t) p->auxx.size;
-      size_t  oldSize2 = (size_t) p->auxy.size;
-      tmp1 = csound->Malloc(csound, oldSize1 + oldSize2);
-      tmp2 = (char*) tmp1 + (int32_t) oldSize1;
-      memcpy(tmp1, p->auxx.auxp, oldSize1);
-      memcpy(tmp2, p->auxy.auxp, oldSize2);
-      csound->AuxAlloc(csound, nBytes, &p->auxx);
-      csound->AuxAlloc(csound, nBytes, &p->auxy);
-      memcpy(p->auxx.auxp, tmp1, oldSize1);
-      memcpy(p->auxy.auxp, tmp2, oldSize2);
-      csound->Free(csound, tmp1);
-      p->xnm1 = (MYFLT *) p->auxx.auxp;
-      p->ynm1 = (MYFLT *) p->auxy.auxp;
+    else {
+      phaser_grow_state(csound, &p->auxx, (size_t)nBytes);
+      phaser_grow_state(csound, &p->auxy, (size_t)nBytes);
     }
+    p->xnm1 = (MYFLT *) p->auxx.auxp;
+    p->ynm1 = (MYFLT *) p->auxy.auxp;
     p->loop = loop;
     return OK;
 }
@@ -447,15 +446,17 @@ static int32_t phaser2set(CSOUND *csound, PHASER2 *p)
     }
     loop = p->loop = (int32_t) MYFLT2LONG(*p->order);
 
-    if (*p->iskip==0 || p->aux1.auxp==NULL || p->aux2.auxp==NULL ||
-        p->aux1.size<(size_t)loop*sizeof(MYFLT) ||
-        p->aux2.size< (size_t)loop*sizeof(MYFLT)) {
-
+    if (*p->iskip==0 || p->aux1.auxp==NULL || p->aux2.auxp==NULL) {
       csound->AuxAlloc(csound, (size_t)loop*sizeof(MYFLT), &p->aux1);
       csound->AuxAlloc(csound, (size_t)loop*sizeof(MYFLT), &p->aux2);
-      p->nm1 = (MYFLT *) p->aux1.auxp;
-      p->nm2 = (MYFLT *) p->aux2.auxp;
+      p->feedback = FL(0.0);
     }
+    else {
+      phaser_grow_state(csound, &p->aux1, (size_t)loop*sizeof(MYFLT));
+      phaser_grow_state(csound, &p->aux2, (size_t)loop*sizeof(MYFLT));
+    }
+    p->nm1 = (MYFLT *) p->aux1.auxp;
+    p->nm2 = (MYFLT *) p->aux2.auxp;
     return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -852,6 +852,7 @@ def runTest():
         ["test_gain_sample_bounds.csd", "gain RMS and output over partial blocks"],
         ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
         ["test_svfilter_state.csd", "svfilter reset, preserved state, and input reuse"],
+        ["test_phaser_reinit.csd", "phaser reset and preserved state on reinit"],
         [
             "test_audio_input_sample_bounds.csd",
             "audio input opcodes align partial-block input frames",

--- a/tests/commandline/test_phaser_reinit.csd
+++ b/tests/commandline/test_phaser_reinit.csd
@@ -1,0 +1,104 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kOrder init 2
+ kCount init 0
+ kX[] init 4
+ kY[] init 4
+ kN1[] init 4
+ kN2[] init 4
+ kFeedback1 init 0
+ kFeedback2 init 0
+ kCount += 1
+ kInput = .1 + .02*sin(kCount*.31)
+ aInput = kInput
+ ; Exercise unchanged, larger and smaller orders, then restore stages
+ ; whose storage remained allocated while the order was smaller.
+ kReinit = kCount == 40 || kCount == 80 || kCount == 120 || kCount == 160 || kCount == 200
+ if kReinit != 0 then
+  if kCount == 80 || kCount == 200 then
+   kOrder = 4
+  elseif kCount == 160 then
+   kOrder = 2
+  endif
+  reinit FILTERS
+ endif
+FILTERS:
+ iOrder = i(kOrder)
+ ; Start each score note from zero even if Csound recycles its instance.
+ iSkip = i(kCount) == 0 ? 0 : p4
+ aOne phaser1 aInput, 700, iOrder, p6, iSkip
+ aTwo phaser2 aInput, 500, 1, iOrder, p5, 1.5, p6, iSkip
+ rireturn
+
+ ; Independent sample recurrences retain each existing stage for iskip=1
+ ; and clear all history, including feedback, for iskip=0.
+ if kReinit != 0 && p4 == 0 then
+  kJ = 0
+  while kJ < 4 do
+   kX[kJ] = 0
+   kY[kJ] = 0
+   kN1[kJ] = 0
+   kN2[kJ] = 0
+   kJ += 1
+  od
+  kFeedback1 = 0
+  kFeedback2 = 0
+ endif
+ kBeta = (1-$M_PI*700/sr)/(1+$M_PI*700/sr)
+ kOne = kInput + p6*kFeedback1
+ kTwo = kInput + p6*kFeedback2
+ kJ = 0
+ while kJ < kOrder do
+  kNext = kBeta*(kOne+kY[kJ])-kX[kJ]
+  kX[kJ] = kOne
+  kY[kJ] = kNext
+  kOne = kNext
+  kFrequency = p5 == 1 ? 500*(1+1.5*kJ) : 500*1.5^kJ
+  kRadius = exp(-kFrequency*$M_PI/sr)
+  kB = -2*kRadius*cos(kFrequency*2*$M_PI/sr)
+  kA = kRadius*kRadius
+  kTemp = kTwo-kB*kN1[kJ]-kA*kN2[kJ]
+  kTwo = kA*kTemp+kB*kN1[kJ]+kN2[kJ]
+  kN2[kJ] = kN1[kJ]
+  kN1[kJ] = kTemp
+  kJ += 1
+ od
+ kFeedback1 = kOne
+ kFeedback2 = kTwo
+ kActualOne downsamp aOne
+ kActualTwo downsamp aTwo
+ if !(abs(kActualOne-kOne) < 1e-5) || !(abs(kActualTwo-kTwo) < 1e-5) then
+  printks "phaser reinit mismatch: skip=%g mode=%g sample=%g first=%g/%g second=%g/%g\n", 0, p4, p5, kCount, kActualOne, kOne, kActualTwo, kTwo
+  exitnowk(-1)
+ endif
+ if kCount == 240 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 4 then
+  prints "phaser reinit checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .031 0 1 .7
+i 1 .04 .031 1 1 .7
+i 1 .08 .031 0 2 -.7
+i 1 .12 .031 1 2 -.7
+i 99 .16 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`phaser1` and `phaser2` clear their filter arrays on reinitialization with `iskip=0`, but leave the feedback value intact. Clear feedback too, so a reset cannot feed the previous output into the new filter state.

When `iskip` is nonzero and the order grows, preserve the existing stages and initialize the added stages to zero. The old allocation path discarded that history; it also made `phaser1`'s state-copy path unreachable. All changes stay in initialization.
