### PR TITLE
fix: stabilize transeg curves and correct related timing

### DIFF
--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1709,6 +1709,31 @@ int32_t impulse(CSOUND *csound, IMPULSE *p)
 /* or                                                                     */
 /*         y0 + (y1 - y0) * t if alpha is zero                            */
 /* ********************************************************************** */
+/* Positive curves run backward from the endpoint so all exponents stay
+   nonpositive. expm1 preserves small curves without subtracting near equals. */
+static void trnseg_coefficients(NSEG *segp, double start, double end,
+                               double curve, double samples)
+{
+    segp->x = curve > 0.0 ? -curve : 0.0;
+    segp->val = curve > 0.0 ? end : start;
+    if (samples <= 0.0) {
+      segp->alpha = segp->c1 = 0.0;
+      return;
+    }
+    segp->alpha = curve / samples;
+    if (curve == 0.0)
+      segp->c1 = (end - start) / samples;
+    else if (curve > 0.0)
+      segp->c1 = (start - end) / -expm1(-curve);
+    else
+      segp->c1 = (end - start) / -expm1(curve);
+}
+
+/* A rounded segment length can advance a positive curve past its endpoint. */
+#define TRNSEG_VALUE(p, segp) \
+    ((segp)->val - (p)->curinc * \
+     expm1((p)->curx < 0.0 ? (p)->curx : 0.0))
+
 int32_t trnset(CSOUND *csound, TRANSEG *p)
 {
     NSEG        *segp;
@@ -1739,18 +1764,12 @@ int32_t trnset(CSOUND *csound, TRANSEG *p)
       MYFLT nxtval = **argp++;
       MYFLT d = dur * CS_ESR;
       if ((segp->acnt = segp->cnt = (int32)MYFLT2LONG(d)) < 0)
-        segp->cnt = 0;
+        segp->acnt = segp->cnt = 0;
       else
         segp->cnt = (int32)(dur * CS_EKR);
       segp->nxtpt = nxtval;
       segp->val = val;
-      if (alpha == FL(0.0)) {
-        segp->c1 = (nxtval-val)/d;
-      }
-      else {
-        segp->c1 = (nxtval - val)/(FL(1.0) - EXP(alpha));
-      }
-      segp->alpha = alpha/d;
+      trnseg_coefficients(segp, val, nxtval, alpha, d);
       val = nxtval;
       segp++;
     } while (--nsegs);
@@ -1792,19 +1811,13 @@ int32_t trnset_bkpt(CSOUND *csound, TRANSEG *p)
       dur -= totdur;
       totdur += dur;
       d = dur * CS_ESR;
-      if ((segp->cnt = (int32)MYFLT2LONG(d)) < 0)
-        segp->cnt = 0;
+      if ((segp->acnt = segp->cnt = (int32)MYFLT2LONG(d)) < 0)
+        segp->acnt = segp->cnt = 0;
       else
         segp->cnt = (int32)(dur * CS_EKR);
       segp->nxtpt = nxtval;
       segp->val = val;
-      if (alpha == FL(0.0)) {
-        segp->c1 = (nxtval-val)/d;
-      }
-      else {
-        segp->c1 = (nxtval - val)/(FL(1.0) - EXP(alpha));
-      }
-      segp->alpha = alpha/d;
+      trnseg_coefficients(segp, val, nxtval, alpha, d);
       val = nxtval;
       segp++;
     } while (--nsegs);
@@ -1818,7 +1831,7 @@ int32_t ktrnseg(CSOUND *csound, TRANSEG *p)
 {
     *p->rslt = p->curval;               /* put the cur value    */
     if (UNLIKELY(p->auxch.auxp==NULL)) { /* RWD fix */
-      csound->PerfError(csound,&(p->h),
+      return csound->PerfError(csound,&(p->h),
                         "%s", Str("Error: transeg not initialised (krate)\n"));
     }
     if (p->segsrem) {                   /* done if no more segs */
@@ -1836,14 +1849,13 @@ int32_t ktrnseg(CSOUND *csound, TRANSEG *p)
         }
         p->curinc = segp->c1;
         p->alpha = segp->alpha;
-        p->curx = FL(0.0);
+        p->curx = segp->x;
       }
       p->curx += (MYFLT)CS_KSMPS*p->alpha;
       if (p->alpha == FL(0.0))
         p->curval += p->curinc*CS_KSMPS;   /* advance the cur val  */
       else
-        p->curval = p->cursegp->val + p->curinc *
-          (FL(1.0) - EXP(p->curx));
+        p->curval = TRNSEG_VALUE(p, p->cursegp);
     }
     return OK;
 }
@@ -1881,7 +1893,7 @@ int32_t trnseg(CSOUND *csound, TRANSEG *p)
         }                                 /*   poslen = new slope */
         p->curinc = segp->c1;
         p->alpha = segp->alpha;
-        p->curx = FL(0.0);
+        p->curx = segp->x;
         p->curval = val;
       }
       if (p->alpha == FL(0.0)) {
@@ -1891,8 +1903,7 @@ int32_t trnseg(CSOUND *csound, TRANSEG *p)
       else {
           rs[n] = val;
           p->curx += p->alpha;
-          val = segp->val + p->curinc *
-            (FL(1.0) - EXP(p->curx));
+          val = TRNSEG_VALUE(p, segp);
        }
     }
     else{
@@ -1937,20 +1948,13 @@ int32_t trnsetr(CSOUND *csound, TRANSEG *p)
       MYFLT nxtval = **argp++;
       MYFLT d = dur * CS_ESR;
       if ((segp->acnt = segp->cnt = (int32)(d + FL(0.5))) < 0)
-        segp->cnt = 0;
+        segp->acnt = segp->cnt = 0;
       else
         segp->cnt = (int32)(dur * CS_EKR);
       segp->nxtpt = nxtval;
       segp->val = val;
-      if (alpha == FL(0.0)) {
-        segp->c1 = (nxtval-val)/d;
-        //printf("alpha zero val=%f c1=%f\n", segp->val, segp->c1);
-      }
-      else {
-        p->lastalpha = alpha;
-        segp->c1 = (nxtval - val)/(FL(1.0) - EXP(alpha));
-      }
-      segp->alpha = alpha/d;
+      p->lastalpha = alpha;
+      trnseg_coefficients(segp, val, nxtval, alpha, d);
       val = nxtval;
       segp++;
       p->finalval = nxtval;
@@ -1977,7 +1981,7 @@ int32_t ktrnsegr(CSOUND *csound, TRANSEG *p)
 {
     *p->rslt = p->curval;               /* put the cur value    */
     if (UNLIKELY(p->auxch.auxp==NULL)) { /* RWD fix */
-      csound->PerfError(csound,&(p->h),
+      return csound->PerfError(csound,&(p->h),
                         "%s", Str("Error: transeg not initialised (krate)\n"));
     }
     if (p->segsrem) {                   /* done if no more segs */
@@ -1989,16 +1993,8 @@ int32_t ktrnsegr(CSOUND *csound, TRANSEG *p)
           p->segsrem--;
         }                               /*   get univ relestim  */
         segp->cnt = p->xtra>=0 ? p->xtra : p->h.insdshead->xtratim;
-        if (segp->alpha == FL(0.0)) {
-          segp->c1 = (p->finalval-p->curval)/(segp->cnt*CS_KSMPS);
-          //printf("finalval = %f curval = %f, cnt = %d c1 = %f\n",
-          //       p->finalval, p->curval, segp->cnt, segp->c1);
-        }
-        else {
-          segp->c1 = (p->finalval - p->curval)/(FL(1.0) - EXP(p->lastalpha));
-          segp->alpha = p->lastalpha/(segp->cnt*CS_KSMPS);
-          segp->val = p->curval;
-        }
+        trnseg_coefficients(segp, p->curval, p->finalval, p->lastalpha,
+                            (double)segp->cnt * CS_KSMPS);
         goto newm;                      /*   and set new curmlt */
       }
       if (--p->curcnt <= 0) {           /* if done cur segment  */
@@ -2015,16 +2011,15 @@ int32_t ktrnsegr(CSOUND *csound, TRANSEG *p)
         }
         p->curinc = segp->c1;
         p->alpha = segp->alpha;
-        p->curx = FL(0.0);
+        p->curx = segp->x;
       }
+      p->curx += (double)CS_KSMPS * p->alpha;
       if (p->alpha == FL(0.0)) {
         p->curval += p->curinc *CS_KSMPS;   /* advance the cur val  */
         //printf("curval = %f\n", p->curval);
       }
       else
-        p->curval = p->cursegp->val + (p->curinc) *
-          (FL(1.0) - EXP(p->curx));
-      p->curx +=  (MYFLT)CS_KSMPS* p->alpha;
+        p->curval = TRNSEG_VALUE(p, p->cursegp);
     }
     return OK;
 }
@@ -2054,15 +2049,8 @@ int32_t trnsegr(CSOUND *csound, TRANSEG *p)
           p->segsrem--;
         }                                 /*   get univ relestim  */
         segp->cnt = p->xtra>=0 ? p->xtra : p->h.insdshead->xtratim;
-        if (segp->alpha == FL(0.0)) {
-          segp->c1 = (p->finalval-val)/segp->acnt;
-        }
-        else {
-          /* this is very wrong */
-          segp->c1 = (p->finalval - val)/(FL(1.0) - EXP(p->lastalpha));
-          segp->alpha = p->lastalpha/segp->acnt;
-          segp->val = val;
-        }
+        trnseg_coefficients(segp, val, p->finalval, p->lastalpha,
+                            segp->acnt);
         goto newm;                        /*   and set new curmlt */
       }
       if (--p->curcnt <= 0) {             /*  if done cur segment */
@@ -2081,7 +2069,7 @@ int32_t trnsegr(CSOUND *csound, TRANSEG *p)
         }                                 /*   poslen = new slope */
         p->curinc = segp->c1;
         p->alpha = segp->alpha;
-        p->curx = FL(0.0);
+        p->curx = segp->x;
         p->curval = val;
       }
       if (p->alpha == FL(0.0)) {
@@ -2092,7 +2080,7 @@ int32_t trnsegr(CSOUND *csound, TRANSEG *p)
         segp = p->cursegp;
           rs[n] = val;
           p->curx += p->alpha;
-          val = segp->val + p->curinc * (FL(1.0) - EXP(p->curx));
+          val = TRNSEG_VALUE(p, segp);
       }
     }
     else {
@@ -2104,6 +2092,8 @@ int32_t trnsegr(CSOUND *csound, TRANSEG *p)
 
     return OK;
 }
+
+#undef TRNSEG_VALUE
 
 extern int32 randint31(int32);
 

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -265,9 +265,9 @@ typedef struct {
 
 typedef struct {
         int32   cnt,acnt;
-        MYFLT   alpha;
+        double  alpha, x;
         MYFLT   val, nxtpt;
-        MYFLT   c1;
+        double  c1;
 } NSEG;
 
 typedef struct {
@@ -276,8 +276,8 @@ typedef struct {
         NSEG    *cursegp;
         int32   nsegs;
         int32   segsrem, curcnt;
-        MYFLT   curval, curinc, alpha;
-        MYFLT   curx;
+        MYFLT   curval;
+        double  curinc, alpha, curx;
         AUXCH   auxch;
         int32   xtra;
         MYFLT   finalval, lastalpha;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -640,6 +640,7 @@ def runTest():
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
+        ["test_transeg_curves.csd", "transeg family curve stability and timing"],
         ["test_rspline_mixed_rates.csd", "test rspline mixed-rate bounds"],
         ["test_rspline_rate_parity.csd", "test rspline audio and control parity"],
         ["test_rspline_sample_offset.csd", "test rspline audio bounds at note onset"],

--- a/tests/commandline/test_transeg_curves.csd
+++ b/tests/commandline/test_transeg_curves.csd
@@ -1,0 +1,143 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Curve, k, kk
+ kPosition, kType xin
+ if abs(kType) < 1e-6 then
+  kValue = kPosition
+ elseif kType > 50 then
+  kValue = (exp(kType*(kPosition-1))-exp(-kType))/(1-exp(-kType))
+ else
+  kValue = (1-exp(kType*kPosition))/(1-exp(kType))
+ endif
+ xout kValue
+endop
+
+instr 1
+ setksmps 1
+ kEnv transeg 0, .015625, p4, 1, .015625, -p4, 0
+ aEnv transeg 0, .015625, p4, 1, .015625, -p4, 0
+ kBreak transegb 0, .015625, p4, 1, .03125, -p4, 0
+ aBreak transegb 0, .015625, p4, 1, .03125, -p4, 0
+ kAudio downsamp aEnv
+ kAudioBreak downsamp aBreak
+ kSample init 0
+ if kSample < 125 then
+  kExpected Curve kSample/125, p4
+ elseif kSample < 250 then
+  kFall Curve (kSample-125)/125, -p4
+  kExpected = 1-kFall
+ else
+  kExpected = 0
+ endif
+ kError = abs(kEnv-kExpected)+abs(kAudio-kExpected)+abs(kBreak-kExpected)+abs(kAudioBreak-kExpected)
+ if !(kError < .00003) then
+  printks "transeg curve=%g sample=%g expected=%g control=%g audio=%g breakpoint=%g/%g\n", 0, p4, kSample, kExpected, kEnv, kAudio, kBreak, kAudioBreak
+  exitnowk(-1)
+ endif
+ if kSample == 260 then
+  gkChecks += 1
+ endif
+ kSample += 1
+endin
+
+instr 2
+ setksmps 1
+ kEnv transegr 0, .03125, p4, 1, .015625, p5, 0
+ aEnv transegr 0, .03125, p4, 1, .015625, p5, 0
+ kAudio downsamp aEnv
+ kSample init 0
+ kReleaseSample init 0
+ kReleasing release
+ if kReleasing != 0 then
+  if kReleaseSample == 0 then
+   kStart Curve kSample/250, p4
+  endif
+  kFall Curve kReleaseSample/125, p5
+  kExpected = kStart*(1-kFall)
+  kReleaseSample += 1
+ else
+  kExpected Curve kSample/250, p4
+ endif
+ kError = abs(kEnv-kExpected)+abs(kAudio-kExpected)
+ if !(kError < .00003) then
+  printks "transegr curve=%g release curve=%g sample=%g expected=%g control=%g audio=%g\n", 0, p4, p5, kSample, kExpected, kEnv, kAudio
+  exitnowk(-1)
+ endif
+ if kSample == 240 then
+  gkChecks += 1
+ endif
+ kSample += 1
+endin
+
+opcode AudioReference, a, i
+ setksmps 1
+ iCurve xin
+ aEnv transeg 0, .015625, iCurve, 1, .015625, -iCurve, 0
+ xout aEnv
+endop
+
+instr 3
+ aEnv transeg 0, .015625, p4, 1, .015625, -p4, 0
+ aBreak transegb 0, .015625, p4, 1, .03125, -p4, 0
+ aRef AudioReference p4
+ aError = abs(aEnv-aRef)+abs(aBreak-aRef)
+ kN = 0
+ while kN < ksmps do
+  kError vaget kN, aError
+  if !(kError < .00003) then
+   printks "transeg partial block differs: curve=%g sample=%g error=%g\n", 0, p4, kN, kError
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ kCycle init 0
+ kCycle += 1
+ if kCycle == 16 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 23 then
+  prints "transeg checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .034 0
+i 1 0 .034 1e-8
+i 1 0 .034 -1e-8
+i 1 0 .034 1e-20
+i 1 0 .034 -1e-20
+i 1 0 .034 2
+i 1 0 .034 -2
+i 1 0 .034 1000
+i 1 0 .034 -1000
+i 2 .04 .015625 0 0
+i 2 .04 .015625 1e-8 1e-8
+i 2 .04 .015625 -1e-8 -1e-8
+i 2 .04 .015625 1e-20 1e-20
+i 2 .04 .015625 -1e-20 -1e-20
+i 2 .04 .015625 2 2
+i 2 .04 .015625 -2 -2
+i 2 .04 .015625 1000 1000
+i 2 .04 .015625 -1000 -1000
+i 2 .04 .015625 2 0
+i 3 .100625 .034 2
+i 3 .100625 .034 -2
+i 3 .100625 .034 1e-20
+i 3 .100625 .034 1000
+i 99 .16 .002
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`transeg`, `transegb` and `transegr` can produce NaNs for small nonzero curves or overflow for large positive curves. Use `expm1`, double-precision coefficients and nonpositive exponents to keep those curves stable, including during release. Curved sample evaluation remains a macro with one exponential call.

Also initialize `transegb`'s missing audio-rate segment lengths and advance `transegr`'s curved control-rate envelopes at the same point as its linear and audio-rate paths. Treat skipped interior segments without dividing by their duration, and return immediately after an initialization error.
