### PR TITLE
fix: correct comb family delay units and sample handling

### DIFF
--- a/OOps/ugens6.c
+++ b/OOps/ugens6.c
@@ -953,6 +953,7 @@ int32_t comb(CSOUND *csound, COMB *p)
     uint32_t n, nsmps = CS_KSMPS;
     MYFLT       *ar, *asig, *xp, *endp;
     MYFLT       coef = p->coef;
+    MYFLT loopTime = *p->insmps != 0 ? *p->ilpt * CS_ONEDSR : *p->ilpt;
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1; /* RWD fix */
     if (p->prvt != *p->krvt) {
@@ -963,7 +964,7 @@ int32_t comb(CSOUND *csound, COMB *p)
        * on Alpha. So if the result would be less than 1.0e-16, we
        * just say it's zero and don't call exp().  heh 981101
        */
-      double exp_arg = (double)(log001 * *p->ilpt / p->prvt);
+      double exp_arg = (double)(log001 * loopTime / p->prvt);
       if (UNLIKELY(exp_arg < -36.8413615))    /* ln(1.0e-16) */
         coef = p->coef = FL(0.0);
       else
@@ -995,9 +996,12 @@ int32_t comb(CSOUND *csound, COMB *p)
 
 int32_t invcomb(CSOUND *csound, COMB *p)
 {
-    int32_t n, nsmps = CS_KSMPS;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
+    uint32_t n, nsmps = CS_KSMPS;
     MYFLT       *ar, *asig, *xp, *endp;
     MYFLT       coef = p->coef;
+    MYFLT loopTime = *p->insmps != 0 ? *p->ilpt * CS_ONEDSR : *p->ilpt;
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1; /* RWD fix */
     if (p->prvt != *p->krvt) {
@@ -1008,7 +1012,7 @@ int32_t invcomb(CSOUND *csound, COMB *p)
        * on Alpha. So if the result would be less than 1.0e-16, we
        * just say it is zero and do not call exp().  heh 981101
        */
-      double exp_arg = (double)(log001 * *p->ilpt / p->prvt);
+      double exp_arg = (double)(log001 * loopTime / p->prvt);
       if (UNLIKELY(exp_arg < -36.8413615))    /* ln(1.0e-16) */
         coef = p->coef = FL(0.0);
       else
@@ -1017,9 +1021,14 @@ int32_t invcomb(CSOUND *csound, COMB *p)
     xp = p->pntr;
     endp = (MYFLT *) p->auxch.endp;
     ar = p->ar;
+    if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
+    if (UNLIKELY(early)) {
+      nsmps -= early;
+      memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
+    }
     asig = p->asig;
     MYFLT out;
-    for (n=0; n<nsmps; n++) {
+    for (n=offset; n<nsmps; n++) {
       out = *xp;
       ar[n] = (*xp = asig[n])-coef*out;
       if (UNLIKELY(++xp >= endp))
@@ -1040,11 +1049,13 @@ int32_t alpass(CSOUND *csound, COMB *p)
     MYFLT       *ar, *asig, *xp, *endp;
     MYFLT       y, z;
     MYFLT       coef = p->coef;
+    MYFLT loopTime = *p->insmps != 0 ? *p->ilpt * CS_ONEDSR : *p->ilpt;
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1; /* RWD fix */
-    if (p->prvt != *p->krvt) {
+    int32_t audioRvt = IS_ASIG_ARG(p->krvt);
+    if (!audioRvt && p->prvt != *p->krvt) {
       p->prvt = *p->krvt;
-      coef = p->coef = EXP(log001 * *p->ilpt / p->prvt);
+      coef = p->coef = EXP(log001 * loopTime / p->prvt);
     }
     xp = p->pntr;
     endp = (MYFLT *) p->auxch.endp;
@@ -1055,12 +1066,27 @@ int32_t alpass(CSOUND *csound, COMB *p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     asig = p->asig;
-    for (n=offset; n<nsmps; n++) {
-      y = *xp;
-      *xp++ = z = coef * y + asig[n];
-      ar[n] = y - coef * z;
-      if (UNLIKELY(xp >= endp))
-        xp = (MYFLT *) p->auxch.auxp;
+    if (audioRvt) {
+      for (n=offset; n<nsmps; n++) {
+        if (p->prvt != p->krvt[n]) {
+          p->prvt = p->krvt[n];
+          coef = p->coef = EXP(log001 * loopTime / p->prvt);
+        }
+        y = *xp;
+        *xp++ = z = coef * y + asig[n];
+        ar[n] = y - coef * z;
+        if (UNLIKELY(xp >= endp))
+          xp = (MYFLT *) p->auxch.auxp;
+      }
+    }
+    else {
+      for (n=offset; n<nsmps; n++) {
+        y = *xp;
+        *xp++ = z = coef * y + asig[n];
+        ar[n] = y - coef * z;
+        if (UNLIKELY(xp >= endp))
+          xp = (MYFLT *) p->auxch.auxp;
+      }
     }
     p->pntr = xp;
     return OK;

--- a/Opcodes/ugmoss.c
+++ b/Opcodes/ugmoss.c
@@ -704,6 +704,7 @@ static int32_t vcomb(CSOUND *csound, VCOMB *p)
     uint32_t      xlpt, maxlpt = (uint32)p->maxlpt;
     MYFLT       *ar, *asig, *rp, *endp, *startp, *wp, *lpt;
     MYFLT       g = p->g;
+    MYFLT timeScale = *p->insmps != 0 ? CS_ONEDSR : FL(1.0);
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1;
     ar = p->ar;
@@ -717,18 +718,19 @@ static int32_t vcomb(CSOUND *csound, VCOMB *p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     if (p->lpta) {                               /* if xlpt is a-rate */
-      lpt = p->xlpt;
+      lpt = p->xlpt + offset;
       for (n=offset; n<nsmps; n++) {
         xlpt = (uint32)((*p->insmps != 0) ? *lpt : *lpt * CS_ESR);
         if (xlpt > maxlpt) xlpt = maxlpt;
         if ((rp = wp - xlpt) < startp) rp += maxlpt;
         if ((p->rvt != *p->krvt) || (p->lpt != *lpt)) {
           p->rvt = *p->krvt, p->lpt = *lpt;
-          g = p->g = POWER(FL(0.001), (p->lpt / p->rvt));
+          g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
         }
         lpt++;
-        ar[n] = *rp++;
-        *wp++ = (ar[n] * g) + asig[n];
+        MYFLT output = *rp++;
+        *wp++ = (output * g) + asig[n];
+        ar[n] = output;
         if (wp >= endp) wp = startp;
         //if (rp >= endp) rp = startp;
       }
@@ -740,11 +742,12 @@ static int32_t vcomb(CSOUND *csound, VCOMB *p)
       if ((rp = wp - xlpt) < startp) rp += maxlpt;
       if ((p->rvt != *p->krvt) || (p->lpt != *p->xlpt)) {
         p->rvt = *p->krvt, p->lpt = *p->xlpt;
-        g = p->g = POWER(FL(0.001), (p->lpt / p->rvt));
+        g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
       }
       for (n=offset; n<nsmps; n++) {
-        ar[n] = *rp++;
-        *wp++ = (ar[n] * g) + asig[n];
+        MYFLT output = *rp++;
+        *wp++ = (output * g) + asig[n];
+        ar[n] = output;
         if (wp >= endp) wp = startp;
         if (rp >= endp) rp = startp;
       }
@@ -764,6 +767,7 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
     uint32_t xlpt, maxlpt = (uint32)p->maxlpt;
     MYFLT       *ar, *asig, *rp, *startp, *endp, *wp, *lpt;
     MYFLT       y, z, g = p->g;
+    MYFLT timeScale = *p->insmps != 0 ? CS_ONEDSR : FL(1.0);
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1;
     ar = p->ar;
@@ -784,7 +788,7 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
         if ((rp = wp - xlpt) < startp) rp += maxlpt;
         if ((p->rvt != *p->krvt) || (p->lpt != lpt[n])) {
           p->rvt = *p->krvt, p->lpt = lpt[n];
-          g = p->g = POWER(FL(0.001), (p->lpt / p->rvt));
+          g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
         }
         y = *rp++;
         *wp++ = z = y * g + asig[n];
@@ -800,7 +804,7 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
       if ((rp = wp - xlpt) < startp) rp += maxlpt;
       if ((p->rvt != *p->krvt) || (p->lpt != *p->xlpt)) {
         p->rvt = *p->krvt, p->lpt = *p->xlpt;
-        g = p->g = POWER(FL(0.001), (p->lpt / p->rvt));
+        g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
       }
       for (n=offset; n<nsmps; n++) {
         y = *rp++;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -935,6 +935,7 @@ def runTest():
         ["test_vdelay_reinit.csd", "test variable delay state across reinit"],
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
+        ["test_comb_units.csd", "comb family delay units, rate handling and partial blocks"],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],

--- a/tests/commandline/test_comb_units.csd
+++ b/tests/commandline/test_comb_units.csd
@@ -1,0 +1,108 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Reference, aaaaaaa, aaak
+ setksmps 1
+ aInput, aRvt, aDelay, kRvt xin
+ kAudioRvt downsamp aRvt
+ kDelay downsamp aDelay
+ aComb comb aInput, kRvt, 8/sr
+ aInv combinv aInput, kRvt, 8/sr
+ aAll alpass aInput, kAudioRvt, 8/sr
+ aVComb vcomb aInput, kRvt, 8/sr, 32/sr
+ aVAll valpass aInput, kRvt, 8/sr, 32/sr
+ aVCombAudio vcomb aInput, kRvt, kDelay, 32/sr
+ aVAllAudio valpass aInput, kRvt, kDelay, 32/sr
+ xout aComb, aInv, aAll, aVComb, aVAll, aVCombAudio, aVAllAudio
+endop
+
+instr 1
+ kCycle init 0
+ kCycle += 1
+ kRvt = kCycle < 8 ? .1 : .2
+ aInput oscili .05, 437
+ aInput += .05
+ aMod oscili 1, 173
+ aRvt = .1+.03*aMod
+ aDelaySamples = 8+4*floor((aMod+1)*.999)
+ aDelay = aDelaySamples/sr
+ aRefComb, aRefInv, aRefAll, aRefVComb, aRefVAll, aRefVCombAudio, aRefVAllAudio Reference aInput, aRvt, aDelay, kRvt
+ aComb comb aInput, kRvt, 8, 0, 1
+ aInv combinv aInput, kRvt, 8, 0, 1
+ aAll alpass aInput, aRvt, 8, 0, 1
+ aAllSeconds alpass aInput, aRvt, 8/sr
+ aFixedAll alpass aInput, kRvt, 8, 0, 1
+ aRefFixedAll alpass aInput, kRvt, 8/sr
+ aVComb vcomb aInput, kRvt, 8, 32, 0, 1
+ aVAll valpass aInput, kRvt, 8, 32, 0, 1
+ aVCombAudio vcomb aInput, kRvt, aDelaySamples, 32, 0, 1
+ aVAllAudio valpass aInput, kRvt, aDelaySamples, 32, 0, 1
+ aVCombSeconds vcomb aInput, kRvt, aDelay, 32/sr
+ aVAllSeconds valpass aInput, kRvt, aDelay, 32/sr
+ aCopy = aInput
+ aCopy vcomb aCopy, kRvt, 8, 32, 0, 1
+ aCopyAudio = aInput
+ aCopyAudio vcomb aCopyAudio, kRvt, aDelaySamples, 32, 0, 1
+ aRvtCopy = aRvt
+ aRvtCopy alpass aInput, aRvtCopy, 8, 0, 1
+ aError = abs(aComb-aRefComb)+abs(aInv-aRefInv)+abs(aAll-aRefAll)+abs(aAllSeconds-aRefAll)
+ aError += abs(aFixedAll-aRefFixedAll)
+ aError += abs(aVComb-aRefVComb)+abs(aVAll-aRefVAll)+abs(aVCombAudio-aRefVCombAudio)+abs(aVAllAudio-aRefVAllAudio)
+ aError += abs(aVCombSeconds-aRefVCombAudio)+abs(aVAllSeconds-aRefVAllAudio)
+ aError += abs(aCopy-aRefVComb)+abs(aCopyAudio-aRefVCombAudio)+abs(aRvtCopy-aRefAll)
+ kN = 0
+ while kN < ksmps do
+  kError vaget kN, aError
+  if !(kError < .00001) then
+   printks "comb family mismatch: cycle=%g sample=%g error=%g\n", 0, kCycle, kN, kError
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kCycle == 14 then
+  gkChecks += 1
+ endif
+endin
+
+; Check the decay against the expected impulse response independently of
+; the comparison above: after two loops, comb returns input * 0.001^(delay/rvt).
+instr 2
+ setksmps 1
+ kSample init 0
+ aInput = kSample == 0 ? .1 : 0
+ aComb comb aInput, .1, 8, 0, 1
+ kOutput downsamp aComb
+ if kSample == 16 then
+  iExpected = .1*.001^((8/sr)/.1)
+  if !(abs(kOutput-iExpected) < .000001) then
+   printks "comb decay mismatch: %g\n", 0, kOutput
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+ kSample += 1
+endin
+
+instr 99
+ if i(gkChecks) != 3 then
+  prints "comb family checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .030029296875
+i 1 .0396728515625 .030029296875
+i 2 .08 .004
+i 99 .1 .002
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`comb`, `combinv`, `alpass`, `vcomb` and `valpass` use sample-count delays as seconds when calculating decay. Convert them to seconds so equivalent delay settings produce the same decay.

Also make `combinv` respect partial blocks, align `vcomb`'s audio-rate delay input with the active samples, and read its input before overwriting a reused output buffer. Make `alpass` follow audio-rate decay changes while retaining its existing control-rate sample loop. No finite checks or sample-loop helper calls are added.
