### PR TITLE
fix: apply lorenz skip count to every output sample

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -1279,6 +1279,7 @@ static int32_t vco(CSOUND *csound, VCO *p)
       b     = *p->b;
       hstep = *p->hstep;
       skip  = (int32) *p->skip;
+      if (skip < 1) skip = 1;
       x     = p->valx;
       y     = p->valy;
       z     = p->valz;
@@ -1296,13 +1297,14 @@ static int32_t vco(CSOUND *csound, VCO *p)
       }
 
       for (n=offset; n<nsmps; n++) {
+        int32 remaining = skip;
         do {
           xx   =      x+hstep*s*(y-x);
           yy   =      y+hstep*(-x*z+r*x-y);
           z    =      z+hstep*(x*y-b*z);
           x    =      xx;
           y    =      yy;
-        } while (--skip>0);
+        } while (--remaining>0);
 
         /* Output the results */
         outx[n] = x;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -618,6 +618,7 @@ def runTest():
         ["test_partikkel_float_table_index.csd", "partikkel uses the scaled index for float table lookup"],
         ["test_grain4_correctness.csd", "grain4 handles envelopes, boundaries, and unused pitches"],
         ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
+        ["test_lorenz_skip.csd", "lorenz integration steps per sample"],
         ["test_looptseg_curves.csd", "looptseg curve stability"],
         ["test_grain4_region_rounding.csd", "grain4 preserves sample rounding for source regions"],
         ["test_grain4_zero_length.csd", "reject zero grain4 source length", 1],

--- a/tests/commandline/test_lorenz_skip.csd
+++ b/tests/commandline/test_lorenz_skip.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ aX, aY, aZ lorenz 10, 28, 8/3, .001, 1, 1, 1, p4
+ aGate = 1
+ kX init 1
+ kY init 1
+ kZ init 1
+ kCount init 0
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kActualX vaget kN, aX
+  kActualY vaget kN, aY
+  kActualZ vaget kN, aZ
+  kExpectedX = 0
+  kExpectedY = 0
+  kExpectedZ = 0
+  if kActive != 0 then
+   kStep = 0
+   while kStep < max(1, int(p4)) do
+    ; Euler integration uses all three coordinates from the same step.
+    kNextX = kX+.001*10*(kY-kX)
+    kNextY = kY+.001*(-kX*kZ+28*kX-kY)
+    kZ = kZ+.001*(kX*kY-(8/3)*kZ)
+    kX = kNextX
+    kY = kNextY
+    kStep += 1
+   od
+   kExpectedX = kX
+   kExpectedY = kY
+   kExpectedZ = kZ
+  endif
+  kError = abs(kActualX-kExpectedX)+abs(kActualY-kExpectedY)+abs(kActualZ-kExpectedZ)
+  if !(kError < .0001) then
+   printks "lorenz skip=%g block=%g sample=%g error=%g\n", 0, p4, kCount, kN, kError
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ kCount += 1
+ if kCount == 8 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 8 then
+  prints "lorenz checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .02 1
+i 1 0 .02 4
+i 1 0 .02 4.5
+i 1 0 .02 0
+i 1 0 .02 -1
+i 1 .030625 .01975 1
+i 1 .030625 .01975 4
+i 1 .030625 .01975 8
+i 99 .06 .002
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`lorenz` consumes its skip counter on the first sample of each block, then takes only one integration step for every remaining sample. This makes `iskip > 1` depend on `ksmps` instead of producing every requested Nth value.

Reset the counter for each active output sample. Keep the existing one-step behavior for skip values below one. The integration equations stay unchanged, and no function calls are added.
