### PR TITLE
fix: refresh statevar coefficients after reinitialization

### DIFF
--- a/Opcodes/newfils.c
+++ b/Opcodes/newfils.c
@@ -840,10 +840,12 @@ static int32_t statevar_init(CSOUND *csound,statevar *p)
   IGN(csound);
   if (*p->istor==FL(0.0)) {
     p->bpd = p->lpd = p->lp = 0.0;
-    p->oldfreq = FL(0.0);
-    p->oldres = FL(0.0);
   }
+  /* Coefficients depend on oversampling even when filter history is kept. */
+  p->oldfreq = -FL(1.0);
+  p->oldres = -FL(1.0);
   if (*p->osamp<=FL(0.0)) p->ostimes = 3;
+  else if (*p->osamp<FL(1.0)) p->ostimes = 1;
   else p->ostimes = (int32_t) *p->osamp;
   return OK;
 }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -865,6 +865,7 @@ def runTest():
         ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
         ["test_areson_audio.csd", "test areson audio coefficients and preserved state"],
         ["test_svfilter_state.csd", "svfilter reset, preserved state, and input reuse"],
+        ["test_statevar_oversampling.csd", "statevar oversampling and preserved filter history"],
         ["test_phaser_reinit.csd", "phaser reset and preserved state on reinit"],
         [
             "test_audio_input_sample_bounds.csd",

--- a/tests/commandline/test_statevar_oversampling.csd
+++ b/tests/commandline/test_statevar_oversampling.csd
@@ -1,0 +1,103 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 1
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kCount init 0
+ kOversample init p6
+ kLp init 0
+ kBpd init 0
+ kLpd init 0
+ kCount += 1
+ aInput = .1
+ aFreq = 500
+ aQ = p5
+ if kCount == 20 || kCount == 40 || kCount == 60 then
+  if kCount == 20 then
+   kOversample = 6
+  elseif kCount == 40 then
+   kOversample = 1
+  else
+   kOversample = 0
+  endif
+  if p4 == 0 then
+   kLp = 0
+   kBpd = 0
+   kLpd = 0
+  endif
+  reinit FILTER
+ endif
+FILTER:
+ iOversample = i(kOversample)
+ if p7 == 0 then
+  aHp, aLp, aBp, aBr statevar aInput, 500, p5, iOversample, p4
+ elseif p7 == 1 then
+  aHp, aLp, aBp, aBr statevar aInput, aFreq, p5, iOversample, p4
+ elseif p7 == 2 then
+  aHp, aLp, aBp, aBr statevar aInput, 500, aQ, iOversample, p4
+ else
+  aHp, aLp, aBp, aBr statevar aInput, aFreq, aQ, iOversample, p4
+ endif
+ rireturn
+
+ ; Keep the reference history independently across oversampling changes.
+ kSteps = (kOversample <= 0 ? 3 : max(1, int(kOversample)))
+ kF = 2*sin(500*$M_PI/sr/kSteps)
+ kQ = max(1/p5, (2-kF)*.05/kSteps)
+ kStep = 0
+ while kStep < kSteps do
+  kHp = .1-kQ*kBpd-kLp
+  kBp = kHp*kF+kBpd
+  kLp = kBpd*kF+kLpd
+  kBr = kLp+kHp
+  kBpd = kBp
+  kLpd = kLp
+  kStep += 1
+ od
+ kActualHp downsamp aHp
+ kActualLp downsamp aLp
+ kActualBp downsamp aBp
+ kActualBr downsamp aBr
+ kError = abs(kActualHp-kHp)+abs(kActualLp-kLp)+abs(kActualBp-kBp)+abs(kActualBr-kBr)
+ if !(kError < .00004) then
+  printks "statevar istor=%g Q=%g rates=%g sample=%g oversampling=%g error=%g\n", 0, p4, p5, p7, kCount, kOversample, kError
+  exitnowk(-1)
+ endif
+ if kCount == 80 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 12 then
+  prints "statevar checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Preserve and reset history, all parameter rate combinations, and Q limiting.
+i 1 0 .0125 1 1 3 0
+i 1 0 .0125 1 1 3 1
+i 1 0 .0125 1 1 3 2
+i 1 0 .0125 1 1 3 3
+i 1 0 .0125 1 100 3 0
+i 1 0 .0125 1 100 3 3
+i 1 0 .0125 0 1 3 0
+i 1 0 .0125 0 100 3 3
+; Sub-unit counts take one step; other fractional counts still truncate.
+i 1 0 .0125 1 1 .5 0
+i 1 0 .0125 1 1 3.75 0
+i 1 0 .0125 1 1 0 0
+i 1 0 .0125 1 1 -1 0
+i 99 .02 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`statevar` caches coefficients that depend on oversampling. Reinitializing with a different count and `istor=1` keeps the old coefficients, so the filter uses the wrong tuning and Q limit.

Refresh the coefficients after initialization while preserving filter history when requested. Positive counts below one now take one filtering step instead of truncating to zero and producing silence. Other count rounding and the audio loop stay unchanged.
