### PR TITLE
fix: handle zero saturation in diode_ladder

### DIFF
--- a/Opcodes/wpfilters.c
+++ b/Opcodes/wpfilters.c
@@ -633,6 +633,17 @@ static int32_t diode_ladder_perf(CSOUND* csound,
 
     MYFLT cutoff = cutoff_arate ? 0.0 : *p->cutoff;
     MYFLT k = k_arate ? 0.0 : *p->kval;
+    MYFLT nlp = *p->nlp;
+    double saturation = *p->saturation;
+    double normalization = 1.0;
+
+    if (nlp == 1.0) {
+      /* tanh(saturation * input) / tanh(saturation) tends to input at zero. */
+      if (saturation == 0.0)
+        nlp = 0.0;
+      else
+        normalization = tanh(saturation);
+    }
 
     if (UNLIKELY(offset)) {
       memset(p->out, '\0', offset*sizeof(MYFLT));
@@ -701,11 +712,11 @@ static int32_t diode_ladder_perf(CSOUND* csound,
       SIGMA = (SG1 * fbo1) + (SG2 * fbo2) + (SG3 * fbo3) + (SG4 * fb4);
 
       // non-linear processing
-      if (*p->nlp == 1.0) {
-        in = (1.0 / tanh(*p->saturation)) * tanh(*p->saturation * in);
+      if (nlp == 1.0) {
+        in = tanh(saturation * in) / normalization;
       }
-      else if (*p->nlp == 2.0) {
-        in = tanh(*p->saturation * in);
+      else if (nlp == 2.0) {
+        in = tanh(saturation * in);
       }
 
       // form input to loop

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -849,6 +849,7 @@ def runTest():
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
         ["test_sa.csd", "test sample accurate mode"],
+        ["test_diode_ladder_saturation.csd", "diode_ladder saturation and filter history"],
         ["test_gain_sample_bounds.csd", "gain RMS and output over partial blocks"],
         ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
         ["test_svfilter_state.csd", "svfilter reset, preserved state, and input reuse"],

--- a/tests/commandline/test_diode_ladder_saturation.csd
+++ b/tests/commandline/test_diode_ladder_saturation.csd
@@ -1,0 +1,95 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kBlock init 0
+ kBlock += 1
+ ; Cross zero with live filter history, including negative and tiny values.
+ if kBlock < 3 then
+  kSaturation = 0
+ elseif kBlock < 5 then
+  kSaturation = 2
+ elseif kBlock < 7 then
+  kSaturation = (p6 == 0 ? 1e-20 : p6)
+ elseif kBlock < 9 then
+  kSaturation = -2
+ else
+  kSaturation = 0
+ endif
+ aInput oscili .5, 1000
+ aCutoff = 1000
+ aFeedback = 2
+
+ ; Applying the nonlinearity before the linear filter must give the same
+ ; result, including state carried across changes in saturation.
+ if p4 == 1 && kSaturation != 0 then
+  aShaped = tanh(kSaturation*aInput)/tanh(kSaturation)
+ elseif p4 == 2 then
+  aShaped = tanh(kSaturation*aInput)
+ else
+  aShaped = aInput
+ endif
+ aExpected diode_ladder aShaped, 1000, 2, 0
+ if p5 == 0 then
+  aActual diode_ladder aInput, 1000, 2, p4, kSaturation
+ elseif p5 == 1 then
+  aActual diode_ladder aInput, aCutoff, 2, p4, kSaturation
+ elseif p5 == 2 then
+  aActual diode_ladder aInput, 1000, aFeedback, p4, kSaturation
+ elseif p5 == 3 then
+  aActual diode_ladder aInput, aCutoff, aFeedback, p4, kSaturation
+ else
+  aInput diodeladder aInput, aCutoff, aFeedback, p4, kSaturation
+  aActual = aInput
+ endif
+ kN = 0
+ while kN < ksmps do
+  kActual vaget kN, aActual
+  kExpected vaget kN, aExpected
+  if !(abs(kActual-kExpected) < .000003) then
+   printks "diode_ladder mode=%g rates=%g block=%g sample=%g actual=%g expected=%g\n", 0, p4, p5, kBlock, kN, kActual, kExpected
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 12 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 13 then
+  prints "diode_ladder checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; All input parameter rates, the alias, and input reuse.
+i 1 0 .025 1 0
+i 1 0 .025 1 1
+i 1 0 .025 1 2
+i 1 0 .025 1 3
+i 1 0 .025 1 4
+i 1 0 .025 0 0
+i 1 0 .025 2 0
+i 1 0 .025 2 4
+; A tiny double-precision value whose reciprocal would overflow.
+i 1 0 .025 1 0 1e-310
+; Partial first and last blocks.
+i 1 .030625 .02525 1 0
+i 1 .030625 .02525 1 3
+i 1 .030625 .02525 1 4
+i 1 .030625 .02525 2 3
+i 99 .06 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
With normalized saturation enabled, `diode_ladder` divides by zero when saturation reaches zero. The resulting NaNs persist in the filter history even after saturation increases again.

Use the curve's linear limit at zero, preserving the filter history. Divide by `tanh(saturation)` directly to avoid reciprocal overflow at tiny nonzero values. Calculate this normalization once per control block, removing one `tanh` call per sample. The unnormalized mode keeps its zero-output behavior at zero saturation.
