### PR TITLE
fix: correct squinewave sample offsets and phase state

### DIFF
--- a/Opcodes/squinewave.c
+++ b/Opcodes/squinewave.c
@@ -119,6 +119,10 @@ int32_t squinewave_init(CSOUND* csound, SQUINEWAVE *p)
 
     // Skip setting phase only if we have been inited at least once
     p->init_phase = (*p->iphase < 0 && p->Min_Sweep > 1.0) ? 0 : 1;
+    if (p->init_phase) {
+      p->hardsync_phase = p->hardsync_inc = 0.0;
+      p->neg_freq = 0;
+    }
     p->Min_Sweep = *p->iminsweep;
 
     // Allow range 4-sr/100
@@ -165,7 +169,7 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
     const double Max_Sweep_Inc = 1.0 / Min_Sweep;
     const double Max_Sync_Freq = p->Max_Sync_Freq;
 
-    MYFLT *aout = &p->aout[0];
+    MYFLT *aout = &p->aout[ksmps_offset];
     const MYFLT * const freq_sig = p->acps;
     const MYFLT * const clip_sig = p->aclip;
     const MYFLT * const skew_sig = p->askew;
@@ -179,12 +183,12 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
     int32_t sync = find_sync(p->sync_sig, ksmps_offset, ksmps_end);
 
     // Set main phase so it matches sweep_phase
-    if (p->init_phase) {
-      const double freq = fabs(freq_sig[0]);
+    if (p->init_phase && ksmps_offset < ksmps_end) {
+      const double freq = fabs(freq_sig[ksmps_offset]);
       const double phase_inc = Maxphase_By_sr * freq;
       const double min_sweep = phase_inc * Min_Sweep;
-      const double skew = 1.0 - Clamp(skew_sig[0], -1.0, 1.0);
-      const double clip = 1.0 - Clamp(clip_sig[0], 0.0, 1.0);
+      const double skew = 1.0 - Clamp(skew_sig[ksmps_offset], -1.0, 1.0);
+      const double clip = 1.0 - Clamp(clip_sig[ksmps_offset], 0.0, 1.0);
       const double midpoint = Clamp(skew, min_sweep, 2.0 - min_sweep);
 
       // Init phase range 0-2, has 4 segment parts (sweep down,
@@ -266,6 +270,12 @@ int32_t squinewave_gen(CSOUND* csound, SQUINEWAVE *p)
           sweep_phase = 2.0 - sweep_phase;
         }
         neg_freq = (raw_freq < 0);
+      }
+
+      /* A stopped oscillator holds its phase, even with a zero-length sweep. */
+      if (freq == 0.0) {
+        *aout++ = cos(PI * sweep_phase);
+        continue;
       }
 
       const double phase_inc = Maxphase_By_sr * freq;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -655,6 +655,7 @@ def runTest():
         ["test_rspline_invalid_rate.csd", "reject invalid rspline rates", 1],
         ["test_oscil1i.csd", "oscil1i interpolates scans and holds their endpoints"],
         ["test_trigphasor_range.csd", "trigphasor starts, wraps, and resets within its range"],
+        ["test_squinewave_state.csd", "squinewave sample offsets and phase reset"],
         ["test_sndwarp_bounds.csd", "sndwarp and sndwarpst bound sample indexes and handle zero time scale"],
         ["test_wterrain2_phase.csd", "wterrain2 phase stability and direction changes"],
         ["test_instr_redefinition.csd", "allow instr redefinition"],

--- a/tests/commandline/test_squinewave_state.csd
+++ b/tests/commandline/test_squinewave_state.csd
@@ -1,0 +1,140 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode OneSample, aa, aaaai
+ setksmps 1
+ aFreq, aClip, aSkew, aSync, iPhase xin
+ aOut, aPulse squinewave aFreq, aClip, aSkew, aSync, 8, iPhase
+ xout aOut, aPulse
+endop
+
+instr 1
+ aFreq = p4
+ aClip = p5
+ aSkew = p6
+ aSync mpulse p8, .01
+ aExpected, aExpectedPulse OneSample aFreq, aClip, aSkew, aSync, p7
+ aActual, aPulse squinewave aFreq, aClip, aSkew, aSync, 8, p7
+ kBlock init 0
+ kBlock += 1
+ kN = 0
+ while kN < ksmps do
+  kActual vaget kN, aActual
+  kExpected vaget kN, aExpected
+  kPulse vaget kN, aPulse
+  kExpectedPulse vaget kN, aExpectedPulse
+  if !(abs(kActual-kExpected) < .000003) || kPulse != kExpectedPulse then
+   printks "squinewave start=%g freq=%g phase=%g block=%g sample=%g actual=%g expected=%g sync=%g expectedSync=%g\n", 0, p2, p4, p7, kBlock, kN, kActual, kExpected, kPulse, kExpectedPulse
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 8 then
+  gkChecks += 1
+ endif
+endin
+
+instr 2
+ setksmps 1
+ kCount init 0
+ kCount += 1
+ aFreq = (p4 == 0 && kCount < 20 ? -100 : 100)
+ aClip = .7
+ aSkew = .3
+ aSync = (p4 != 0 && kCount == 19 ? 1 : 0)
+ ; Negative iphase preserves history, including a pending sync sweep.
+ if p4 == 2 then
+  aExpected, aExpectedPulse squinewave aFreq, aClip, aSkew, aSync, 8, -1
+ endif
+ if kCount == 20 then
+  reinit RESET
+ endif
+RESET:
+ aActual, aPulse squinewave aFreq, aClip, aSkew, aSync, 8, p5
+ rireturn
+ if kCount >= 20 then
+  if p4 != 2 then
+   ; This instance starts performing at the same sample as the phase reset.
+   aExpected, aExpectedPulse squinewave aFreq, aClip, aSkew, aSync, 8, p5
+  endif
+  kActual downsamp aActual
+  kExpected downsamp aExpected
+  kPulse downsamp aPulse
+  kExpectedPulse downsamp aExpectedPulse
+  if !(abs(kActual-kExpected) < .000003) || kPulse != kExpectedPulse then
+   printks "squinewave reinit case=%g sample=%g actual=%g expected=%g sync=%g expectedSync=%g\n", 0, p4, kCount, kActual, kExpected, kPulse, kExpectedPulse
+   exitnowk(-1)
+  endif
+ endif
+ if kCount == 80 then
+  gkChecks += 1
+ endif
+endin
+
+instr 3
+ setksmps 1
+ kCount init 0
+ kHold init 0
+ kCount += 1
+ aFreq = (kCount <= 16 || (kCount >= 40 && kCount < 56) ? 0 : 100)
+ aClip = p4
+ aSkew = p5
+ aOut squinewave aFreq, aClip, aSkew, 0, 8, p6
+ kActual downsamp aOut
+ if kCount <= 16 then
+  kExpected = cos(2*$M_PI*p6)
+ elseif kCount == 40 then
+  kHold = kActual
+  kExpected = kHold
+ elseif kCount > 40 && kCount < 56 then
+  kExpected = kHold
+ else
+  kExpected = kActual
+ endif
+ if !(abs(kActual-kExpected) < .000003) then
+  printks "squinewave stopped clip=%g skew=%g sample=%g actual=%g expected=%g\n", 0, p4, p5, kCount, kActual, kExpected
+  exitnowk(-1)
+ endif
+ if kCount == 80 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 16 then
+  prints "squinewave checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Aligned and partial blocks, sine and shaped waves, and hard sync.
+i 1 0 .025 1000 0 0 0 0
+i 1 0 .025 100 .7 .3 .75 0
+i 1 0 .025 100 .7 .3 1.75 1
+i 1 .030625 .02525 1000 0 0 0 0
+i 1 .030625 .02525 100 .7 .3 .75 0
+i 1 .030625 .02525 100 .7 -.3 1.75 0
+i 1 .030625 .02525 100 1 .9 .25 0
+i 1 .030625 .02525 -100 .7 .3 .25 0
+i 1 .030625 .02525 100 .7 .3 1.75 1
+i 1 .030625 .02525 100 .7 .3 -1 0
+; Explicit phase reset and documented phase preservation.
+i 2 .06 .0125 0 .25
+i 2 .06 .0125 1 .25
+i 2 .06 .0125 2 -1
+i 3 .06 .0125 1 0 0
+i 3 .06 .0125 0 1 0
+i 3 .06 .0125 1 -1 .25
+i 99 .08 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`squinewave` reads from the note's sample offset but writes from sample zero, shifting output before the intended start. Phase initialization also reads inactive samples.

- Align output and phase setup with the first active sample, and defer phase setup when a block has no active samples.
- Clear old hard-sync and direction state on an explicit phase reset. Negative `iphase` still preserves state.
- Hold phase at zero frequency. Square and extreme-skew shapes otherwise divide zero by zero and can advance while stopped.

The existing waveform equations stay unchanged for running oscillators.
