### PR TITLE
fix: define pinker state arithmetic and clear inactive samples

### DIFF
--- a/Opcodes/pinker.c
+++ b/Opcodes/pinker.c
@@ -37,17 +37,17 @@
 typedef struct {
   OPDS h;
   MYFLT *ar;
-  int32_t   inc;
-  int32_t   dec;
-  int32 accu;
-  int32 lfsr;
-  unsigned char cnt;
+  uint32_t inc;
+  uint32_t dec;
+  uint32_t accu;
+  uint32_t lfsr;
+  uint8_t cnt;
   int32_t offset;
 } PINKER;
 
 #define PINK_BIAS   FL(440.0)
 
-static int32_t instance_cnt = 0;    /* Is tis thread-safe? */
+static uint32_t instance_cnt = 0;    /* Is tis thread-safe? */
 
 // Let preprocessor and compiler calculate two lookup tables for 12-tap
 // FIR filter with these coefficients:
@@ -90,21 +90,24 @@ static const int32_t ind[] = {     0, 0x0800, 0x0400, 0x0800,
  /* generate samples of pink noise */
 static int32_t pink_perf(CSOUND* csound, PINKER *p)
 {
-    int32_t inc    =   p->inc;
-    int32_t dec    =   p->dec;
-    int32 accu =   p->accu;
-    int32 lfsr   =   p->lfsr;
-    int32_t cnt    =   p->cnt;
-    int32_t bit;
+    uint32_t inc    =   p->inc;
+    uint32_t dec    =   p->dec;
+    uint32_t accu =   p->accu;
+    uint32_t lfsr   =   p->lfsr;
+    uint8_t cnt    =   p->cnt;
+    uint32_t bit;
     int32_t n, nn, nsmps = CS_KSMPS;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    int32_t mask;
+    uint32_t mask;
     float yy;
     MYFLT *out = p->ar;
+    MYFLT scale = csound->Get0dBFS(csound);
     int32_t loffset = p->offset;
+    if (UNLIKELY(offset)) memset(out, 0, offset * sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
+      memset(&out[nsmps], 0, early * sizeof(MYFLT));
     }
     for (n=offset, nn=loffset; n<nsmps; n++, nn++) {
       int32_t k = nn%16;   /* algorithm is in 16 sample chunks */
@@ -118,19 +121,12 @@ static int32_t pink_perf(CSOUND* csound, PINKER *p)
 
       if (k==0) mask = pnmask[cnt++];
       else mask = ind[k];
-      bit = lfsr >> 31;            /* spill random to all bits        */
+      bit = 0u - (lfsr >> 31);     /* spill random to all bits        */
       dec &= ~mask;                /* blank old decrement bit         */
       lfsr <<= 1;                  /* shift lfsr                      */
       dec |= inc & mask;           /* copy increment to decrement bit */
       inc ^= bit & mask;           /* new random bit                  */
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-      *((int32_t *)(&yy)) = accu;      /* save biased value as float      */
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+      memcpy(&yy, &accu, sizeof(yy)); /* save biased value as float      */
       //printf("yy = %f ", yy);
       accu += inc - dec;           /* integrate                       */
       lfsr ^= bit & 0x46000001;    /* update lfsr                     */
@@ -139,7 +135,7 @@ static int32_t pink_perf(CSOUND* csound, PINKER *p)
       //printf("out = %f a,b = %f,%f mask = %.8x dec,inc = %x,%x acc = %x\n",
       //       yy, pfira[lfsr & 0x3F], pfirb[lfsr >>6 & 0x3F],
       //       mask, dec, inc, accu);
-      out[n] = yy*csound->Get0dBFS(csound);
+      out[n] = yy*scale;
     /* PINK(mask);   PINK(0x0800); PINK(0x0400); PINK(0x0800); */
     /* PINK(0x0200); PINK(0x0800); PINK(0x0400); PINK(0x0800); */
     /* PINK(0x0100); PINK(0x0800); PINK(0x0400); PINK(0x0800); */
@@ -157,16 +153,10 @@ static int32_t pink_perf(CSOUND* csound, PINKER *p)
 static int32_t pink_init(CSOUND *csound, PINKER *p)      // constructor
 {
     IGN(csound);
-    p->lfsr  = 0x5EED41F5 + instance_cnt++;   // seed for lfsr,
+    const float bias = PINK_BIAS;
+    p->lfsr  = 0x5EED41F5u + instance_cnt++;   // seed for lfsr,
                                               // decorrelate multiple instances
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-    *((float*)(&p->accu))  = PINK_BIAS;       // init float hack
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+    memcpy(&p->accu, &bias, sizeof(bias));
     p->cnt = 0;                               // counter from zero
     p->inc   = 0x0CCC;                        // balance initial states to avoid DC
     p->dec   = 0x0CCC;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -952,6 +952,8 @@ def runTest():
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
         ["test_comb_units.csd", "comb family delay units, rate handling and partial blocks"],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
+        ["test_pinker_sequence.csd", "pinker preserves its noise sequence across block sizes"],
+        ["test_pinker_sample_bounds.csd", "pinker clears inactive samples"],
         ["test_gausstrig_frequency_mode.csd", "gausstrig frequency-change and first-impulse modes"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],

--- a/tests/commandline/test_pinker_sample_bounds.csd
+++ b/tests/commandline/test_pinker_sample_bounds.csd
@@ -1,0 +1,49 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 2
+ aOut pinker
+ aGate = 1
+ kCount init 0
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kActual vaget kN, aOut
+  if kActive == 0 then
+   if kActual != 0 then
+    printks "pinker inactive sample=%g output=%g\n", 0, kN, kActual
+    exitnowk(-1)
+   endif
+  else
+   kCount += 1
+  endif
+  kN += 1
+ od
+ if kCount == p4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 2 then
+  prints "pinker checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Leading and trailing inactive samples, including a note inside one block.
+i 2 .0006103515625 .0042724609375 35
+i 2 .1256103515625 .0003662109375 3
+i 99 .15 .001
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pinker_sequence.csd
+++ b/tests/commandline/test_pinker_sequence.csd
@@ -1,0 +1,49 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 8192
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ ; Samples from the original sequence rendered with ksmps=16. A larger
+ ; block must preserve that sequence across each 256-entry mask cycle.
+ iPositions[] fillarray 0, 1, 7, 15, 4095, 4096, 8191, 8192, 12288, 16383
+ iValues[] fillarray -.06201171875, .06243896484375, -.03680419921875, .038116455078125, .0836181640625, .191741943359375, .11297607421875, .042724609375, .333099365234375, .285491943359375
+ aOut pinker
+ kBase init 0
+ kN = 0
+ while kN < lenarray(iPositions) do
+  kIndex = iPositions[kN]-kBase
+  if kIndex >= 0 && kIndex < ksmps then
+   kActual vaget kIndex, aOut
+   if !(abs(kActual-iValues[kN]) < .00000001) then
+    printks "pinker sequence sample=%g actual=%g expected=%g\n", 0, iPositions[kN], kActual, iValues[kN]
+    exitnowk(-1)
+   endif
+  endif
+  kN += 1
+ od
+ kBase += ksmps
+ if kBase == 16384 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 1 then
+  prints "pinker checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 2
+i 99 3 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pinker` leaves old samples after a note ends within a block. Its noise generator also relies on signed shifts and pointer casts that violate C's aliasing rules, and its mask counter only wraps between blocks.

Clear inactive samples, use unsigned arithmetic and fixed-size bit copies, and wrap the mask counter as it advances. These changes preserve the existing noise sequence across block sizes. Move the output-scale lookup out of the sample loop; the compiler emits the bit copy inline.
