### PR TITLE
fix: preserve powershape input sign at zero exponent

### DIFF
--- a/Opcodes/shape.c
+++ b/Opcodes/shape.c
@@ -73,6 +73,7 @@ static int32_t PowerShape(CSOUND* csound, POWER_SHAPE* p)
       memset(&out[nsmps], '\0', early*sizeof(MYFLT));
     }
     amt = *(p->kshapeamount);
+    maxampl = p->maxamplitude;
     invmaxampl = p->one_over_maxamp;
     if (amt == FL(0.0)) {                    /* treat zero-power with care */
       for (n=offset; n<nsmps; n++) {
@@ -80,11 +81,10 @@ static int32_t PowerShape(CSOUND* csound, POWER_SHAPE* p)
         if (cur == FL(0.0))
           out[n] = FL(0.0);               /* make 0^0 = 0 for continuity */
         else
-          out[n] = FL(1.0)/invmaxampl;    /* otherwise, x^0 = 1.0 */
+          out[n] = cur < FL(0.0) ? -maxampl : maxampl;
       }
     }
     else {
-      maxampl = p->maxamplitude;
       for (n=offset; n<nsmps; n++) {
         cur = in[n] * invmaxampl;
         if (cur < FL(0.0))                /* treat negatives with care */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -976,6 +976,7 @@ def runTest():
         ["test_distort1_large_pregain.csd", "test distort1 with large pregain"],
         ["test_nlfilt2_feedback.csd", "test nonlinear filter feedback and output"],
         ["test_chebyshevpoly_high_order.csd", "test high-order Chebyshev evaluation"],
+        ["test_powershape_zero_exponent.csd", "powershape preserves sign at zero exponent"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_powershape_zero_exponent.csd
+++ b/tests/commandline/test_powershape_zero_exponent.csd
@@ -1,0 +1,69 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8000
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kBlock init 0
+ kBlock += 1
+ kAmount = (kBlock == 1 ? .000001 : (kBlock == 3 ? 2 : (kBlock == 4 ? 1 : 0)))
+ aPhase phasor 1000
+ aInput = p4*(2*aPhase-1)
+ aReference = aInput
+ aGate = 1
+ if p5 == 0 then
+  aOut powershape aInput, kAmount, p4
+ else
+  aInput powershape aInput, kAmount, p4
+  aOut = aInput
+ endif
+ kN = 0
+ while kN < ksmps do
+  kInput vaget kN, aReference
+  kActual vaget kN, aOut
+  kActive vaget kN, aGate
+  kExpected = 0
+  if kActive != 0 && kInput != 0 then
+   kExpected = (kInput < 0 ? -p4 : p4)*pow(abs(kInput/p4), kAmount)
+  endif
+  if !(abs(kActual-kExpected) < p4*.000002) then
+   printks "powershape fullscale=%g reuse=%g exponent=%g sample=%g actual=%g expected=%g\n", 0, p4, p5, kAmount, kN, kActual, kExpected
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 8 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 10 then
+  prints "powershape checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Sign, zero input, scaling, and input reuse across exponent changes.
+i 1 0 .02 1 0
+i 1 0 .02 1 1
+i 1 0 .02 2.5 0
+i 1 0 .02 2.5 1
+i 1 0 .02 .01 0
+i 1 0 .02 .01 1
+; Partial first and last blocks.
+i 1 .030625 .01975 1 0
+i 1 .030625 .01975 1 1
+i 1 .030625 .01975 2.5 0
+i 1 .030625 .01975 2.5 1
+i 99 .06 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`powershape` preserves the input sign for nonzero exponents, but its zero-exponent path makes every nonzero input positive. This causes a polarity jump when the exponent reaches zero.

Preserve the sign at zero and use the stored full-scale value directly, removing the division from that loop. Zero input still produces zero, and the nonzero-exponent calculation stays unchanged.
