### PR TITLE
fix: stabilize expcurve and logcurve near linear steepness

### DIFF
--- a/Opcodes/ugakbari.c
+++ b/Opcodes/ugakbari.c
@@ -31,8 +31,8 @@
 #include "interlocks.h"
 #include <math.h>
 
-#define LOGCURVE(x,y) ((LOG(x * (y-FL(1.0))+FL(1.0)))/(LOG(y)))
-#define EXPCURVE(x,y) ((EXP(x * LOG(y))-FL(1.0))/(y-FL(1.0)))
+#define LOGCURVE(x,y) (log1p((double)(x) * ((double)(y)-1.0)) / log((double)(y)))
+#define EXPCURVE(x,y) (expm1((double)(x) * log((double)(y))) / ((double)(y)-1.0))
 #define GAINSLIDER(x) (FL(0.000145) * EXP(x * FL(0.06907)))
 
 typedef struct _scale {
@@ -131,7 +131,8 @@ static int32_t expcurve_perf(CSOUND *csound, expcurve *p)
     IGN(csound);
     MYFLT ki = *p->kin;
     MYFLT ks = *p->ksteepness;
-    if (ks <= FL(1.0)) *p->kout = ki;
+    if (ks <= FL(1.0) || ki == FL(0.0) || ki == FL(1.0))
+      *p->kout = ki;
     else
       *p->kout = EXPCURVE(ki, ks);
 
@@ -145,7 +146,8 @@ static int32_t logcurve_perf(CSOUND *csound, logcurve *p)
     IGN(csound);
     MYFLT ki = *p->kin;
     MYFLT ks = *p->ksteepness;
-    if (ks == FL(1.0)) *p->kout = ki;
+    if (ks == FL(1.0) || ki == FL(0.0) || ki == FL(1.0))
+      *p->kout = ki;
     else
       *p->kout = LOGCURVE(ki, ks);
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -648,6 +648,7 @@ def runTest():
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],
         ["test_envlpx_float_interpolation.csd", "envlpx interpolates non-power-of-two tables correctly"],
         ["test_transeg_curves.csd", "transeg family curve stability and timing"],
+        ["test_curve_precision.csd", "expcurve and logcurve precision and endpoints"],
         ["test_rspline_mixed_rates.csd", "test rspline mixed-rate bounds"],
         ["test_rspline_rate_parity.csd", "test rspline audio and control parity"],
         ["test_rspline_sample_offset.csd", "test rspline audio bounds at note onset"],

--- a/tests/commandline/test_curve_precision.csd
+++ b/tests/commandline/test_curve_precision.csd
@@ -1,0 +1,68 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ iSteepness[] fillarray 1, 1.0000001, 1.0000000000000002, 2, 16, 1e10, 1e30, .5, 1e-20
+ kCycle init 0
+ kSteepness = iSteepness[int(kCycle/5)]
+ kIndex = (kCycle%5)*.25
+ kExp expcurve kIndex, kSteepness
+ kLog logcurve kIndex, kSteepness
+ kRoundTrip logcurve kExp, kSteepness
+ kReverse expcurve kLog, kSteepness
+ if kIndex == 0 || kIndex == 1 then
+  if kExp != kIndex || kLog != kIndex then
+   printks "curve endpoint steepness=%g index=%g exp=%g log=%g\n", 0, kSteepness, kIndex, kExp, kLog
+   exitnowk(-1)
+  endif
+ elseif kSteepness >= 1 then
+  ; The normalized exponential and logarithmic curves are inverses.
+  if !(abs(kRoundTrip-kIndex) < .000003) || !(abs(kReverse-kIndex) < .000003) then
+   printks "curve inverse steepness=%.17g index=%g forward=%g reverse=%g\n", 0, kSteepness, kIndex, kRoundTrip, kReverse
+   exitnowk(-1)
+  endif
+  if kSteepness-1 < .000001 then
+   if !(abs(kExp-kIndex) < .000001) || !(abs(kLog-kIndex) < .000001) then
+    printks "curve near-linear limit failed\n", 0
+    exitnowk(-1)
+   endif
+  endif
+  if kSteepness == 16 && kIndex == .5 then
+   if !(abs(kExp-.2) < .000001) then
+    printks "curve known value failed\n", 0
+    exitnowk(-1)
+   endif
+  endif
+ else
+  ; Preserve expcurve's linear fallback and logcurve's existing curve below 1.
+  kExpectedLog = log((1-kIndex)+kIndex*kSteepness)/log(kSteepness)
+  if kExp != kIndex || !(abs(kLog-kExpectedLog) < .000001) then
+   printks "curve below-one steepness=%g index=%g exp=%g log=%g\n", 0, kSteepness, kIndex, kExp, kLog
+   exitnowk(-1)
+  endif
+ endif
+ kCycle += 1
+ gkChecks += 1
+endin
+
+instr 99
+ if i(gkChecks) != 45 then
+  prints "curve checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .087890625
+i 99 .1 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`expcurve` and `logcurve` lose precision near steepness 1: an input of `0.25` can produce `0` instead of approaching the linear result.

Use `expm1` and `log1p` with double intermediates to avoid cancellation, and return the normalized endpoints exactly. The existing behavior below steepness 1 stays unchanged. Both opcodes run at control rate.
