### PR TITLE
Fix loop envelope initial and retrigger phase wrapping

### DIFF
--- a/Opcodes/uggab.c
+++ b/Opcodes/uggab.c
@@ -488,6 +488,15 @@ static int32_t fold(CSOUND *csound, FOLD *p)
 /* by Gab Maldonado. Under GNU license with a special exception for
    Canonical Csound addition */
 
+/* Normalize before lookup as well as after advancing the loop. */
+#define LOOPSEG_WRAP_PHASE(phs) do {                                    \
+    if ((phs) < 0.0 || (phs) >= 1.0) {                                  \
+      (phs) -= floor(phs);                                              \
+      /* A tiny negative phase can round up to one. */                  \
+      if ((phs) >= 1.0) (phs) = 0.0;                                    \
+    }                                                                   \
+} while (0)
+
 static int32_t loopseg_set(CSOUND *csound, LOOPSEG *p)
 {
     p->nsegs   = p->INOCOUNT-3;
@@ -511,6 +520,7 @@ static int32_t loopseg(CSOUND *csound, LOOPSEG *p)
       phs=p->phs=*p->iphase;
     else
       phs=p->phs;
+    LOOPSEG_WRAP_PHASE(phs);
 
     for (j=1; j<nsegs; j++)
       argp[j] = *p->argums[j-1];
@@ -519,7 +529,7 @@ static int32_t loopseg(CSOUND *csound, LOOPSEG *p)
 
     for ( j=0; j <nsegs; j+=2)
       durtot += argp[j];
-    for ( j=0; j < nsegs; j+=2) {
+    for ( j=0; j < nsegs-1; j+=2) {
       beg_seg += argp[j] / durtot;
       end_seg = beg_seg + argp[j+2] / durtot;
 
@@ -533,10 +543,7 @@ static int32_t loopseg(CSOUND *csound, LOOPSEG *p)
       }
     }
     phs    += si;
-    while (phs >= 1.0)
-      phs -= 1.0;
-    while (phs < 0.0 )
-      phs += 1.0;
+    LOOPSEG_WRAP_PHASE(phs);
     p->phs = phs;
     return OK;
 }
@@ -554,6 +561,7 @@ static int32_t loopxseg(CSOUND *csound, LOOPSEG *p)
       phs=p->phs=*p->iphase;
     else
       phs=p->phs;
+    LOOPSEG_WRAP_PHASE(phs);
 
     for (j=1; j<nsegs; j++)
       argp[j] = *p->argums[j-1];
@@ -562,7 +570,7 @@ static int32_t loopxseg(CSOUND *csound, LOOPSEG *p)
 
     for ( j=0; j <nsegs; j+=2)
       durtot += argp[j];
-    for ( j=0; j < nsegs; j+=2) {
+    for ( j=0; j < nsegs-1; j+=2) {
       beg_seg += argp[j] / durtot;
       end_seg = beg_seg + argp[j+2] / durtot;
 
@@ -576,10 +584,7 @@ static int32_t loopxseg(CSOUND *csound, LOOPSEG *p)
       }
     }
     phs    += si;
-    while (phs >= 1.0)
-      phs -= 1.0;
-    while (phs < 0.0 )
-      phs += 1.0;
+    LOOPSEG_WRAP_PHASE(phs);
     p->phs = phs;
     return OK;
 }
@@ -604,6 +609,7 @@ static int32_t looptseg(CSOUND *csound, LOOPTSEG *p)
       phs=p->phs=*p->iphase;
     else
       phs=p->phs;
+    LOOPSEG_WRAP_PHASE(phs);
 
     for ( j=0; j<nsegs; j++)
       durtot += *(p->argums[j].time);
@@ -631,10 +637,7 @@ static int32_t looptseg(CSOUND *csound, LOOPTSEG *p)
       }
     }
     phs    += si;
-    while (UNLIKELY(phs >= 1.0))
-      phs -= 1.0;
-    while (UNLIKELY(phs < 0.0 ))
-      phs += 1.0;
+    LOOPSEG_WRAP_PHASE(phs);
     p->phs = phs;
     return OK;
 }
@@ -652,6 +655,7 @@ static int32_t lpshold(CSOUND *csound, LOOPSEG *p)
       phs=p->phs=*p->iphase;
     else
       phs=p->phs;
+    LOOPSEG_WRAP_PHASE(phs);
 
     for (j=1; j<nsegs; j++)
       argp[j] = *p->argums[j-1];
@@ -659,7 +663,7 @@ static int32_t lpshold(CSOUND *csound, LOOPSEG *p)
     for ( j=0; j <nsegs; j+=2)
       durtot += argp[j];
 
-    for ( j=0; j < nsegs; j+=2) {
+    for ( j=0; j < nsegs-1; j+=2) {
       beg_seg += argp[j] / durtot;
       end_seg = beg_seg + argp[j+2] / durtot;
       if (beg_seg <= phs && end_seg > phs) {
@@ -670,10 +674,7 @@ static int32_t lpshold(CSOUND *csound, LOOPSEG *p)
       }
     }
     phs    += si;
-    while (phs >= 1.0)
-      phs -= 1.0;
-    while (phs < 0.0 )
-      phs += 1.0;
+    LOOPSEG_WRAP_PHASE(phs);
     p->phs = phs;
     return OK;
 }
@@ -697,10 +698,7 @@ static int32_t loopsegp(CSOUND *csound, LOOPSEGP *p)
 
     phs = *p->kphase;
 
-    while (phs >= FL(1.0))
-      phs -= FL(1.0);
-    while (phs < FL(0.0))
-      phs += FL(1.0);
+    LOOPSEG_WRAP_PHASE(phs);
 
     for (j=1; j<nsegs; j++)
       argp[j] = *p->argums[j-1];
@@ -709,7 +707,7 @@ static int32_t loopsegp(CSOUND *csound, LOOPSEGP *p)
 
     for ( j=0; j <nsegs; j+=2)
       durtot += argp[j];
-    for ( j=0; j < nsegs; j+=2) {
+    for ( j=0; j < nsegs-1; j+=2) {
       beg_seg += argp[j] / durtot;
       end_seg = beg_seg + argp[j+2] / durtot;
 
@@ -736,10 +734,7 @@ static int32_t lpsholdp(CSOUND *csound, LOOPSEGP *p)
 
     phs = *p->kphase;
 
-    while (phs >= FL(1.0))
-      phs -= FL(1.0);
-    while (phs < FL(0.0))
-      phs += FL(1.0);
+    LOOPSEG_WRAP_PHASE(phs);
 
     for (j=1; j<nsegs; j++)
       argp[j] = *p->argums[j-1];
@@ -748,7 +743,7 @@ static int32_t lpsholdp(CSOUND *csound, LOOPSEGP *p)
 
     for ( j=0; j <nsegs; j+=2)
       durtot += argp[j];
-    for ( j=0; j < nsegs; j+=2) {
+    for ( j=0; j < nsegs-1; j+=2) {
       beg_seg += argp[j] / durtot;
       end_seg = beg_seg + argp[j+2] / durtot;
 
@@ -761,6 +756,8 @@ static int32_t lpsholdp(CSOUND *csound, LOOPSEGP *p)
     }
     return OK;
 }
+
+#undef LOOPSEG_WRAP_PHASE
 
 /* by Gab Maldonado. Under GNU license with a special exception
    for Canonical Csound addition */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -619,6 +619,7 @@ def runTest():
         ["test_grain4_correctness.csd", "grain4 handles envelopes, boundaries, and unused pitches"],
         ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
         ["test_looptseg_curves.csd", "looptseg curve stability"],
+        ["test_loop_envelope_phase.csd", "loop envelope phase wrapping and retriggers"],
         ["test_grain4_region_rounding.csd", "grain4 preserves sample rounding for source regions"],
         ["test_grain4_zero_length.csd", "reject zero grain4 source length", 1],
         ["test_grain4_subsample_length.csd", "reject sub-sample grain4 source length", 1],

--- a/tests/commandline/test_loop_envelope_phase.csd
+++ b/tests/commandline/test_loop_envelope_phase.csd
@@ -1,0 +1,81 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kCycle init 0
+ kPhase init p4
+ kTrig = (p6 == 1 || (p6 == 2 && kCycle%3 == 0) ? 1 : 0)
+ if kTrig != 0 then
+  kPhase = p4
+ endif
+ kPhase = kPhase-floor(kPhase)
+ if kPhase == 1 then
+  kPhase = 0
+ endif
+ kFrequency = p5*kr
+ ; The initial zero-duration segment must be skipped at the loop start.
+ kLinear loopseg kFrequency, kTrig, p4, 99, 0, 10, 1, 20, 2, 30, 1
+ kCurve loopxseg kFrequency, kTrig, p4, 99, 0, 10, 1, 20, 2, 30, 1
+ kHeld lpshold kFrequency, kTrig, p4, 99, 0, 10, 1, 20, 2, 30, 1
+ kTyped looptseg kFrequency, kTrig, p4, 99, 0, 0, 10, 0, 1, 20, 0, 2, 30, 0, 1
+ kDriven loopsegp kPhase+p7, 99, 0, 10, 1, 20, 2, 30, 1
+ kDrivenHeld lpsholdp kPhase+p7, 99, 0, 10, 1, 20, 2, 30, 1
+ if kPhase < .25 then
+  kStart = 10
+  kEnd = 20
+  kFraction = kPhase*4
+ elseif kPhase < .75 then
+  kStart = 20
+  kEnd = 30
+  kFraction = (kPhase-.25)*2
+ else
+  kStart = 30
+  kEnd = 99
+  kFraction = (kPhase-.75)*4
+ endif
+ kExpected = kStart+(kEnd-kStart)*kFraction
+ kExpectedCurve = kStart+(kEnd-kStart)*(exp(kFraction)-1)/(exp(1)-1)
+ kError = abs(kLinear-kExpected)+abs(kTyped-kExpected)+abs(kDriven-kExpected)
+ kError += abs(kHeld-kStart)+abs(kDrivenHeld-kStart)+abs(kCurve-kExpectedCurve)
+ if !(kError < .00005) then
+  printks "loop phase=%g step=%g retrigger=%g cycle=%g error=%g\n", 0, p4, p5, p6, kCycle, kError
+  exitnowk(-1)
+ endif
+ kPhase += p5
+ kCycle += 1
+ if kCycle == 16 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 10 then
+  prints "loop envelope checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Initial endpoints, continuous and pulsed retriggers, both directions.
+i 1 0 .03125 0 .125 0 0
+i 1 0 .03125 1 0 1 1
+i 1 0 .03125 1 .125 0 0
+i 1 0 .03125 1 -.125 2 -1
+i 1 0 .03125 .75 .125 2 1
+i 1 0 .03125 -.25 -.125 0 -1
+i 1 0 .03125 2.25 4.125 0 8
+i 1 0 .03125 -2.25 -4.125 0 -8
+i 1 0 .03125 -1e-20 0 1 0
+i 1 0 .03125 .5 0 0 0
+i 99 .04 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Wrap the phase before segment lookup in `loopseg`, `loopxseg`, `looptseg`, and `lpshold`. An initial phase of 1 currently misses every segment and leaves the output at zero; a continuous retrigger keeps it there. Phase 1 now starts at the loop beginning.

Use the same bounded wrap in the phase-driven variants, including reverse playback and steps spanning several cycles. Stop segment searches at the last defined segment so they cannot inspect a nonexistent next segment.
