### PR TITLE
Fix tabmorph weight endpoints and input overwrite

### DIFF
--- a/Opcodes/gab/tabmorph.c
+++ b/Opcodes/gab/tabmorph.c
@@ -22,6 +22,9 @@
 #endif
 #include "interlocks.h"
 
+#define TABMORPH_WEIGHT(x) \
+    ((x) < FL(0.0) ? FL(0.0) : ((x) > FL(1.0) ? FL(1.0) : (x)))
+
 typedef struct {
         OPDS    h;
         MYFLT   *out, *xindex, *xinterpoint, *xtabndx1, *xtabndx2,
@@ -93,8 +96,7 @@ static int32_t tabmorph(CSOUND *csound, TABMORPH *p)
     val2 = tab2val1 * (1-tabndx2frac) + tab2val2 * tabndx2frac;
 
     interpoint = *p->xinterpoint;
-    interpoint = (interpoint < 0 ? 0 : (interpoint > 1.0 ? 1.0 : interpoint));
-    /* interpoint -= (int32_t) interpoint;  to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     *p->out = val1 * (1 - interpoint) + val2 * interpoint;
     return OK;
@@ -145,7 +147,7 @@ static int32_t tabmorphi(CSOUND *csound, TABMORPH *p) /* interpolation */
     val2  = val2a + (val2b-val2a) * index_frac;
 
     interpoint = *p->xinterpoint;
-    interpoint -= (int32_t) interpoint; /* to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     *p->out = val1 * (1 - interpoint) + val2 * interpoint;
     return OK;
@@ -161,7 +163,7 @@ static int32_t atabmorphia(CSOUND *csound, TABMORPH *p) /* all arguments at a-ra
     int32_t      tablen = p->length;
     MYFLT *out = p->out;
     MYFLT *index = p->xindex;
-    MYFLT *interpoint = p->xinterpoint;
+    const MYFLT *interpoint = p->xinterpoint;
     MYFLT *tabndx1 = p->xtabndx1;
     MYFLT *tabndx2 = p->xtabndx2;
 
@@ -210,9 +212,9 @@ static int32_t atabmorphia(CSOUND *csound, TABMORPH *p) /* all arguments at a-ra
 
       val2  = val2a + (val2b-val2a) * index_frac;
 
-      interpoint[n] -= (int32_t) interpoint[n]; /* to limit to zero to 1 range */
+      MYFLT weight = TABMORPH_WEIGHT(interpoint[n]);
 
-      out[n] = val1 * (1 - interpoint[n]) + val2 * interpoint[n];
+      out[n] = val1 * (1 - weight) + val2 * weight;
     }
     return OK;
 }
@@ -246,7 +248,7 @@ static int32_t atabmorphi(CSOUND *csound, TABMORPH *p)
     tabndx2int %= p->numOfTabs;
 
     interpoint = *p->xinterpoint;
-    interpoint -= (int32_t) interpoint; /* to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
@@ -349,8 +351,7 @@ static int32_t tabmorph_array(CSOUND *csound, TABMORPH_ARR *p)
     val2 = tab2val1 * (1-tabndx2frac) + tab2val2 * tabndx2frac;
 
     interpoint = *p->xinterpoint;
-    interpoint = (interpoint < 0 ? 0 : (interpoint > 1.0 ? 1.0 : interpoint));
-    /* interpoint -= (int32_t) interpoint;  to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     *p->out = val1 * (1 - interpoint) + val2 * interpoint;
     return OK;
@@ -401,7 +402,7 @@ static int32_t tabmorphi_array(CSOUND *csound, TABMORPH_ARR *p) /* interpolation
     val2  = val2a + (val2b-val2a) * index_frac;
 
     interpoint = *p->xinterpoint;
-    interpoint -= (int32_t) interpoint; /* to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     *p->out = val1 * (1 - interpoint) + val2 * interpoint;
     return OK;
@@ -417,7 +418,7 @@ static int32_t atabmorphia_array(CSOUND *csound, TABMORPH_ARR *p) /* all argumen
     int32_t      tablen = p->length;
     MYFLT *out = p->out;
     MYFLT *index = p->xindex;
-    MYFLT *interpoint = p->xinterpoint;
+    const MYFLT *interpoint = p->xinterpoint;
     MYFLT *tabndx1 = p->xtabndx1;
     MYFLT *tabndx2 = p->xtabndx2;
 
@@ -466,9 +467,9 @@ static int32_t atabmorphia_array(CSOUND *csound, TABMORPH_ARR *p) /* all argumen
 
       val2  = val2a + (val2b-val2a) * index_frac;
 
-      interpoint[n] -= (int32_t) interpoint[n]; /* to limit to zero to 1 range */
+      MYFLT weight = TABMORPH_WEIGHT(interpoint[n]);
 
-      out[n] = val1 * (1 - interpoint[n]) + val2 * interpoint[n];
+      out[n] = val1 * (1 - weight) + val2 * weight;
     }
     return OK;
 }
@@ -502,7 +503,7 @@ static int32_t atabmorphi_array(CSOUND *csound, TABMORPH_ARR *p)
     tabndx2int %= p->numOfTabs;
 
     interpoint = *p->xinterpoint;
-    interpoint -= (int32_t) interpoint; /* to limit to zero to 1 range */
+    interpoint = TABMORPH_WEIGHT(interpoint);
 
     if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -557,6 +557,7 @@ def runTest():
             "test_ftest_wave_short_destination.csd",
             "reject an undersized wave table without crashing",
         ],
+        ["test_tabmorph_weights.csd", "tabmorph weight endpoints and input preservation"],
         ["test_ftload_binary_args_ownership.csd", "test binary ftload does not share args ownership"],
         ["test_getftargs_empty_after_ftload.csd", "test getftargs returns empty args after binary ftload"],
         ["test_fail_compilestr.csd", "testing clean compilestr fail"],

--- a/tests/commandline/test_tabmorph_weights.csd
+++ b/tests/commandline/test_tabmorph_weights.csd
@@ -1,0 +1,96 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giOne ftgen 0, 0, 8, -2, 0, 1, 2, 3, 4, 5, 6, 7
+giTwo ftgen 0, 0, 8, -2, 10, 12, 14, 16, 18, 20, 22, 24
+
+instr 1
+ iTables[] fillarray giOne, giTwo
+ iWeight limit p4, 0, 1
+ iStart = round(p2*sr)
+ iLength = round(p3*sr)
+ kPlain tabmorph 2.5, p4, .25, 1.5, giOne, giTwo
+ kPlainArray tabmorph 2.5, p4, .25, 1.5, iTables
+ kInterp tabmorphi 2.5, p4, .25, 1.5, giOne, giTwo
+ kInterpArray tabmorphi 2.5, p4, .25, 1.5, iTables
+ kError = abs(kPlain-(5+3*iWeight))+abs(kPlainArray-(5+3*iWeight))
+ kError += abs(kInterp-(5.625+3.125*iWeight))+abs(kInterpArray-(5.625+3.125*iWeight))
+ if !(kError < .00001) then
+  printks "tabmorph control weight=%g error=%g\n", 0, p4, kError
+  exitnowk(-1)
+ endif
+ aIndex phasor sr/16
+ aWeight = 2*aIndex-.5
+ aOriginal = aWeight
+ aFirst = .25
+ aSecond = 1.5
+ aAudio tabmorpha aIndex, aWeight, aFirst, aSecond, giOne, giTwo
+ aAudioArray tabmorpha aIndex, aWeight, aFirst, aSecond, iTables
+ aControl tabmorphak aIndex, p4, .25, 1.5, giOne, giTwo
+ aControlArray tabmorphak aIndex, p4, .25, 1.5, iTables
+ aAlias = aOriginal
+ aAlias tabmorpha aIndex, aAlias, aFirst, aSecond, giOne, giTwo
+ aBase tablei aIndex, giOne, 1
+ aOther tablei aIndex, giTwo, 1
+ kBlock init 0
+ kIndex = 0
+ while kIndex < ksmps do
+  kPosition = kBlock*ksmps+kIndex-iStart%ksmps
+  kExpected = 0
+  kExpectedControl = 0
+  kOriginal vaget kIndex, aOriginal
+  kWeight vaget kIndex, aWeight
+  if kPosition >= 0 && kPosition < iLength then
+   kBase vaget kIndex, aBase
+   kOther vaget kIndex, aOther
+   kStart = .75*kBase+.25*kOther
+   kEnd = .5*(kBase+kOther)
+   kMix limit kOriginal, 0, 1
+   kExpected = kStart+(kEnd-kStart)*kMix
+   kExpectedControl = kStart+(kEnd-kStart)*iWeight
+  endif
+  kAudio vaget kIndex, aAudio
+  kAudioArray vaget kIndex, aAudioArray
+  kControl vaget kIndex, aControl
+  kControlArray vaget kIndex, aControlArray
+  kAlias vaget kIndex, aAlias
+  kError = abs(kAudio-kExpected)+abs(kAudioArray-kExpected)+abs(kAlias-kExpected)
+  kError += abs(kControl-kExpectedControl)+abs(kControlArray-kExpectedControl)
+  kError += abs(kWeight-kOriginal)
+  if !(kError < .00001) then
+   printks "tabmorph audio weight=%g sample=%g error=%g\n", 0, kOriginal, kPosition, kError
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ if kBlock == 0 then
+  gkChecks += 1
+ endif
+ kBlock += 1
+endin
+
+instr 99
+ if i(gkChecks) != 6 then
+  prints "tabmorph checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .0078125 -.5
+i 1 .015625 .0078125 0
+i 1 .03125 .0078125 .5
+i 1 .046875 .0078125 1
+i 1 .0625 .0078125 1.5
+i 1 .0806884765625 .0042724609375 1
+i 99 .1 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`tabmorphi`, `tabmorpha`, and `tabmorphak` wrap weight 1 to 0, selecting the first table where the documented endpoint selects the second. Clamp weights to [0, 1], as `tabmorph` already does, in both the table-list and array forms.

`tabmorpha` also writes the wrapped weight back into its input buffer. Use a local clamped weight so later opcodes see the original input. The shared clamp is a macro and adds no function calls to the sample loop.
