### PR TITLE
Fix HVS configuration tables and grid endpoints

### DIFF
--- a/Opcodes/gab/hvs.c
+++ b/Opcodes/gab/hvs.c
@@ -28,7 +28,7 @@
 /*
 The iConfigTab is made up of the following parameters:
 f #  time size -2  inactive_flag1 inactive_flag2 ... inactiveflagN
-a 1 value means that corresponding parameter is left unchanged by the HVS opcode
+a -1 value means that corresponding parameter is left unchanged by the HVS opcode
 
 
 The iPositionsTab is made up of the positions of the snapshots
@@ -49,6 +49,18 @@ element 2 represents the third element of iSnapTab and so on.
 Obviously, iOutTab size must be >= inumParms.
 
 */
+
+/* Keep both interpolation vertices inside the grid, including at coordinate 1. */
+#define HVS_COORDINATE(value, count, pos, frac) do {                       \
+    MYFLT scaled_ = (value) * ((count) - 1);                              \
+    if (scaled_ <= FL(0.0)) {                                            \
+      (pos) = 0; (frac) = FL(0.0);                                       \
+    } else if (scaled_ >= (count) - 1) {                                  \
+      (pos) = (count) - 2; (frac) = FL(1.0);                              \
+    } else {                                                            \
+      (pos) = (int32_t)scaled_; (frac) = scaled_ - (pos);                  \
+    }                                                                   \
+} while (0)
 
 typedef struct {
         OPDS    h;
@@ -80,7 +92,7 @@ static int32_t hvs1_set(CSOUND *csound, HVS1 *p)
     else {
       if (UNLIKELY((ftp = csound->FTFind(csound, p->iConfigTab)) == NULL))
         return csound->InitError(csound, "%s", Str("hvs: no config table"));
-      p->outTable = ftp->ftable;
+      p->confTable = ftp->ftable;
       p->iconfFlag = 1;
     }
     return OK;
@@ -90,13 +102,11 @@ static int32_t hvs1_set(CSOUND *csound, HVS1 *p)
 static int32_t hvs1(CSOUND *csound, HVS1 *p)
 {
     IGN(csound);
-    MYFLT x = *p->kx * (*p->inumPointsX-1);
-    int32_t posX = (int32_t) x;
-
-    MYFLT fracX = x - posX;
-
+    int32_t posX;
+    MYFLT fracX;
     int32_t noc = (int32_t) *p->inumParms;
-//      int32_t linesX = (int32_t) *p->inumPointsX;
+    int32_t pointsX = (int32_t) *p->inumPointsX;
+    HVS_COORDINATE(*p->kx, pointsX, posX, fracX);
 
     int32_t ndx1 = (int32_t) p->posTable[posX];
     int32_t ndx2 = (int32_t) p->posTable[posX+1];
@@ -167,7 +177,7 @@ static int32_t hvs2_set(CSOUND *csound, HVS2 *p)
     else {
       if (UNLIKELY((ftp = csound->FTFind(csound, p->iConfigTab)) == NULL))
         return csound->InitError(csound, "%s", Str("hvs: no config table"));
-      p->outTable = ftp->ftable;
+      p->confTable = ftp->ftable;
       p->iconfFlag = 1;
     }
     return OK;
@@ -177,16 +187,13 @@ static int32_t hvs2_set(CSOUND *csound, HVS2 *p)
 static int32_t hvs2(CSOUND *csound, HVS2 *p)
 {
     IGN(csound);
-    MYFLT x = *p->kx * (*p->inumlinesX-1);
-    MYFLT y = *p->ky * (*p->inumlinesY-1);
-    int32_t posX = (int32_t) x;
-    int32_t posY = (int32_t) y;
-
-    MYFLT fracX = x - posX;
-    MYFLT fracY = y - posY;
-
+    int32_t posX, posY;
+    MYFLT fracX, fracY;
     int32_t noc = (int32_t) *p->inumParms;
     int32_t linesX = (int32_t) *p->inumlinesX;
+    int32_t linesY = (int32_t) *p->inumlinesY;
+    HVS_COORDINATE(*p->kx, linesX, posX, fracX);
+    HVS_COORDINATE(*p->ky, linesY, posY, fracY);
 
     int32_t ndx1 = (int32_t) p->posTable[posX   + posY     * linesX];
     int32_t ndx2 = (int32_t) p->posTable[posX+1 + posY     * linesX];
@@ -258,9 +265,10 @@ static int32_t hvs3_set(CSOUND *csound, HVS3 *p)
     if (UNLIKELY((ftp = csound->FTFind(csound, p->iSnapTab)) == NULL))
       return csound->InitError(csound, "%s", Str("hvs: No snap table"));
     p->snapTable = ftp->ftable;
-    if (UNLIKELY(*p->inumlinesX < 2 || *p->inumlinesY < 2))
-      return csound->InitError(csound, "%s", Str("hvs3: a square area must be "
-                                           "delimited by 2 lines at least"));
+    if (UNLIKELY(*p->inumlinesX < 2 || *p->inumlinesY < 2 ||
+                 *p->inumlinesZ < 2))
+      return csound->InitError(csound, "%s",
+                              Str("hvs3: each axis must have at least 2 points"));
 
 
     if (LIKELY(*p->iConfigTab == 0))
@@ -268,7 +276,7 @@ static int32_t hvs3_set(CSOUND *csound, HVS3 *p)
     else {
       if ((ftp = csound->FTFind(csound, p->iConfigTab)) == NULL)
         return csound->InitError(csound, "%s", Str("hvs: no config table"));
-      p->outTable = ftp->ftable;
+      p->confTable = ftp->ftable;
       p->iconfFlag = 1;
     }
     return OK;
@@ -278,21 +286,16 @@ static int32_t hvs3_set(CSOUND *csound, HVS3 *p)
 static int32_t hvs3(CSOUND *csound, HVS3 *p)
 {
     IGN(csound);
-    MYFLT x = *p->kx * (*p->inumlinesX-1);
-    MYFLT y = *p->ky * (*p->inumlinesY-1);
-    MYFLT z = *p->kz * (*p->inumlinesZ-1);
-    int32_t posX = (int32_t) x;
-    int32_t posY = (int32_t) y;
-    int32_t posZ = (int32_t) z;
-
-
-    MYFLT fracX = x - posX;
-    MYFLT fracY = y - posY;
-    MYFLT fracZ = z - posZ;
-
-    int32_t noc         = (int32_t) *p->inumParms;
-    int32_t linesX      = (int32_t) *p->inumlinesX;
-    int32_t linesXY  = linesX * (int32_t) *p->inumlinesY;
+    int32_t posX, posY, posZ;
+    MYFLT fracX, fracY, fracZ;
+    int32_t noc = (int32_t) *p->inumParms;
+    int32_t linesX = (int32_t) *p->inumlinesX;
+    int32_t linesY = (int32_t) *p->inumlinesY;
+    int32_t linesZ = (int32_t) *p->inumlinesZ;
+    int32_t linesXY = linesX * linesY;
+    HVS_COORDINATE(*p->kx, linesX, posX, fracX);
+    HVS_COORDINATE(*p->ky, linesY, posY, fracY);
+    HVS_COORDINATE(*p->kz, linesZ, posZ, fracZ);
 
     int32_t ndx1 = (int32_t) p->posTable[posX  +posY    *linesX+posZ*linesXY];
     int32_t ndx2 = (int32_t) p->posTable[posX+1+posY    *linesX+posZ*linesXY];
@@ -367,6 +370,8 @@ static int32_t hvs3(CSOUND *csound, HVS3 *p)
     }
     return OK;
 }
+
+#undef HVS_COORDINATE
 
 /* -------------------------------------------------------------------- */
 
@@ -518,4 +523,3 @@ int32_t hvs_init_(CSOUND *csound)
     return csound->AppendOpcodes(csound, &(hvs_localops[0]),
                                  (int32_t) (sizeof(hvs_localops) / sizeof(OENTRY)));
 }
-

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -643,6 +643,7 @@ def runTest():
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
         ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],
+        ["test_hvs_interpolation.csd", "HVS configuration and grid endpoints"],
         ["test_physmod_vibrato_bounds.csd", "test waveguide vibrato bounds"],
         ["test_oscbnk_float_phase_state.csd", "oscbnk preserves non-power-of-two oscillator phase"],
         ["test_vco_float_phase_state.csd", "vco preserves non-power-of-two oscillator phase"],

--- a/tests/commandline/test_hvs_interpolation.csd
+++ b/tests/commandline/test_hvs_interpolation.csd
@@ -1,0 +1,95 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giConfig ftgen 0, 0, 2, -2, 0, -1
+giPos1 ftgen 0, 0, 2, -2, 0, 1
+giPos2 ftgen 0, 0, 4, -2, 0, 1, 2, 3
+giPos3 ftgen 0, 0, 8, -2, 0, 1, 2, 3, 4, 5, 6, 7
+giSnapshots ftgen 0, 0, 16, -2, 0, 100, 10, 110, 20, 120, 30, 130, 40, 140, 50, 150, 60, 160, 70, 170
+
+instr 1
+ iOut1 ftgen 0, 0, 2, -2, -10, 77
+ iConf1 ftgen 0, 0, 2, -2, -10, 77
+ iOut2 ftgen 0, 0, 2, -2, -10, 77
+ iConf2 ftgen 0, 0, 2, -2, -10, 77
+ iOut3 ftgen 0, 0, 2, -2, -10, 77
+ iConf3 ftgen 0, 0, 2, -2, -10, 77
+ hvs1 p4, 2, 2, iOut1, giPos1, giSnapshots
+ hvs1 p4, 2, 2, iConf1, giPos1, giSnapshots, giConfig
+ hvs2 p4, p5, 2, 2, 2, iOut2, giPos2, giSnapshots
+ hvs2 p4, p5, 2, 2, 2, iConf2, giPos2, giSnapshots, giConfig
+ hvs3 p4, p5, p6, 2, 2, 2, 2, iOut3, giPos3, giSnapshots
+ hvs3 p4, p5, p6, 2, 2, 2, 2, iConf3, giPos3, giSnapshots, giConfig
+ kExpected[] fillarray 10*p4, 10*p4+20*p5, 10*p4+20*p5+40*p6
+ kFirst1 table 0, iOut1
+ kSecond1 table 1, iOut1
+ kConfigFirst1 table 0, iConf1
+ kConfigSecond1 table 1, iConf1
+ kError1 = abs(kFirst1-kExpected[0])+abs(kSecond1-100-kExpected[0])
+ kError1 += abs(kConfigFirst1-kExpected[0])+abs(kConfigSecond1-77)
+ if !(kError1 < .00001) then
+  printks "hvs1 at (%g,%g,%g) error=%g\n", 0, p4, p5, p6, kError1
+  exitnowk(-1)
+ endif
+ kFirst2 table 0, iOut2
+ kSecond2 table 1, iOut2
+ kConfigFirst2 table 0, iConf2
+ kConfigSecond2 table 1, iConf2
+ kError2 = abs(kFirst2-kExpected[1])+abs(kSecond2-100-kExpected[1])
+ kError2 += abs(kConfigFirst2-kExpected[1])+abs(kConfigSecond2-77)
+ if !(kError2 < .00001) then
+  printks "hvs2 at (%g,%g,%g) error=%g\n", 0, p4, p5, p6, kError2
+  exitnowk(-1)
+ endif
+ kFirst3 table 0, iOut3
+ kSecond3 table 1, iOut3
+ kConfigFirst3 table 0, iConf3
+ kConfigSecond3 table 1, iConf3
+ kError3 = abs(kFirst3-kExpected[2])+abs(kSecond3-100-kExpected[2])
+ kError3 += abs(kConfigFirst3-kExpected[2])+abs(kConfigSecond3-77)
+ if !(kError3 < .00001) then
+  printks "hvs3 at (%g,%g,%g) error=%g\n", 0, p4, p5, p6, kError3
+  exitnowk(-1)
+ endif
+ kConfig0 table 0, giConfig
+ kConfig1 table 1, giConfig
+ if kConfig0 != 0 || kConfig1 != -1 then
+  printks "HVS changed the configuration table\n", 0
+  exitnowk(-1)
+ endif
+ kFirst init 1
+ if kFirst == 1 then
+  gkChecks += 1
+  kFirst = 0
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 10 then
+  prints "HVS checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0.0 .0078125 0 0 0
+i 1 0.015625 .0078125 0 0 1
+i 1 0.03125 .0078125 0 1 0
+i 1 0.046875 .0078125 0 1 1
+i 1 0.0625 .0078125 1 0 0
+i 1 0.078125 .0078125 1 0 1
+i 1 0.09375 .0078125 1 1 0
+i 1 0.109375 .0078125 1 1 1
+i 1 0.125 .0078125 0.25 0.5 0.75
+i 1 0.140625 .0078125 0.75 0.25 0.5
+i 99 .2 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix three related issues in `hvs1`, `hvs2`, and `hvs3`:

- Store the configuration table in `confTable`, preserving the output table pointer and making linear/skip settings usable.
- Keep coordinate 1 in the last valid grid cell with interpolation weight 1, so endpoint lookups stay within the grid. Coordinates outside [0, 1] clamp to the nearest edge.
- Check the Z-axis size in `hvs3`, which requires at least two points on every axis.
