### PR TITLE
fix: correct tablefilter parameters and fraction conversion

### DIFF
--- a/Opcodes/fareyseq.c
+++ b/Opcodes/fareyseq.c
@@ -217,8 +217,6 @@ int32_t FareyLength (int32_t n);
 int32_t PrimeFactors (int32_t n, PFACTOR p[]);
 MYFLT Digest (int32_t n);
 void float2frac (CSOUND *csound, MYFLT in, int32_t *p, int32_t *q);
-void float_to_cfrac (CSOUND *csound, double r, int32_t n,
-                     int32_t a[], int32_t p[], int32_t q[]);
 
 /* a filter and table copy opcode for filtering tables containing
    Farey Sequences generated with fateytable GEN */
@@ -234,8 +232,6 @@ int32_t tablefilterset(CSOUND *csound, TABFILT *p)
    IGN(csound);
     p->pdft = 0;
     p->psft = 0;
-    *p->ftype = 1;
-    *p->threshold = 7;
     return OK;
 }
 
@@ -355,32 +351,26 @@ static int32_t dotablefilter (CSOUND *csound, TABFILT *p)
     int32 indx = 0;              /* Index to be added to offsets */
     int32 indx2 = 0; /*index into source table*/
     MYFLT *based, *bases;       /* Base addresses of the two tables.*/
-    int32 masks;                 /* Binary masks for the source table */
+    int32 sourcelength;
     MYFLT *pdest, *ps;
     MYFLT threshold;
     int32 ftype;
     MYFLT previous = FL(0.0);
-    //int32 sourcelength;
 
     ftype = (int32) *p->ftype;
     threshold = Digest (*p->threshold);
     loopcount = p->funcd->flen;
-    //sourcelength = loopcount;
 
-    /* Now get the base addresses and length masks of the tables. */
+    /* Source and destination tables may have different lengths. */
     based  = p->funcd->ftable;
     bases = p->funcs->ftable;
-    masks = p->funcs->lenmask;
+    sourcelength = p->funcs->flen;
 
     do {
-      /* Create source pointers by ANDing index with mask, and adding to base
-       * address. This causes source  addresses to wrap around if the
-       * destination table is longer.
-       * Destination address is simply the index plus the base address since
-       * we know we will be writing within the table.          */
-
-      pdest = based  + indx;
-      ps    = bases  + (masks & indx2);
+      if (indx2 == sourcelength)
+        indx2 = 0;
+      pdest = based + indx;
+      ps = bases + indx2;
       switch (ftype) {
       default:
       case 0:
@@ -653,89 +643,36 @@ MYFLT Digest (int32_t n)
     }
 }
 
-/* interface for the function float_to_cfrac, which is a
-   continued fraction expansion
-   in order to convert a real number <in>
-   into an integer fraction <num, denom> with an error less than 10^-5 */
+/* Return the first continued-fraction approximation within 10^-5.
+   Stop before an exact remainder is inverted or a convergent exceeds int32. */
 void float2frac (CSOUND *csound, MYFLT in, int32_t *num, int32_t *denom)
 {
-#define  N (10)
-    int32_t a[N+1];
-    int32_t p[N+2];
-    int32_t q[N+2];
-    int32_t P = 0; int32_t Q = 0;
+    IGN(csound);
+    double value = fabs((double)in), x = value;
+    int64_t prevnum = 1, prevden = 0, oldnum = 0, oldden = 1;
     int32_t i;
 
-    float_to_cfrac (csound, (double)in, N, a, p, q);
-
-    for (i=0; i <= N; i++) {
-      double temp;
-      float error;
-      if (!q[i+1])
-        continue;
-      temp = (double) p[i+1] / (double) q[i+1];
-      error = in - temp;
-      if ((fabs(error)) < 0.00001) {
-        P = p[i+1];
-        Q = q[i+1];
+    *num = *denom = 0;
+    for (i = 0; i <= 10; i++) {
+      int64_t a, nextnum, nextden;
+      if (!(x <= INT32_MAX))
         break;
+      a = (int64_t)x;
+      nextnum = a * prevnum + oldnum;
+      nextden = a * prevden + oldden;
+      if (nextnum > INT32_MAX || nextden > INT32_MAX)
+        break;
+      if (fabs(value - (double)nextnum / nextden) < 0.00001) {
+        *num = in < FL(0.0) ? -(int32_t)nextnum : (int32_t)nextnum;
+        *denom = (int32_t)nextden;
+        return;
       }
+      if (x == (double)a)
+        break;
+      oldnum = prevnum; oldden = prevden;
+      prevnum = nextnum; prevden = nextden;
+      x = 1.0 / (x - (double)a);
     }
-    *num = P;
-    *denom = Q;
-}
-
-/* continued fraction expansion */
-void float_to_cfrac (CSOUND *csound, double r, int32_t n,
-                     int32_t a[], int32_t p[], int32_t q[])
-{
-    int32_t i;
-    double r_copy;
-    double *x;
-
-    if (r == 0.0) {
-      memset(a, 0, sizeof(int32_t)*(n+1));
-      /* for (i = 0; i <= n; i++) {  */
-      /*   a[i] = 0;  */
-      /* }  */
-      memset(p, 0, sizeof(int32_t)*(n+2));
-      /* for (i = 0; i <= n+1; i++) {  */
-      /*   p[i] = 0;  */
-      /* }  */
-      memset(q, 0, sizeof(int32_t)*(n+2));
-      /* for ( i = 0; i <= n+1; i++ ) {  */
-      /*   q[i] = 0;  */
-      /* }  */
-      return;
-    }
-
-    x = csound->Calloc(csound, (n+1)* sizeof(double));
-
-    r_copy = fabs (r);
-
-    p[0] = 1;
-    q[0] = 0;
-
-    p[1] = (int32_t) r_copy;
-    q[1] = 1;
-    x[0] = r_copy;
-    a[0] = (int32_t) x[0];
-
-    for (i = 1; i <= n; i++) {
-      x[i] = 1.0 / (x[i-1] - (double) a[i-1]);
-      a[i] = (int32_t
-              ) x[i];
-      p[i+1] = a[i] * p[i] + p[i-1];
-      q[i+1] = a[i] * q[i] + q[i-1];
-    }
-
-    if (r < 0.0) {
-      for (i = 0; i <= n+1; i++) {
-        p[i] = -p[i];
-      }
-    }
-
-    csound->Free(csound, x);
 }
 
 #define S sizeof

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -743,6 +743,7 @@ def runTest():
         ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
+        ["test_tablefilter_values.csd", "tablefilter parameters, rational values, and table wrapping"],
         ["test_tabsum_ranges.csd", "tabsum handles valid table ranges"],
         ["test_tabsum_invalid_range.csd", "tabsum rejects out-of-range indexes", 1],
         ["test_newstyle_passbycopy.csd", "test newstyle udo with setksmps"],

--- a/tests/commandline/test_tablefilter_values.csd
+++ b/tests/commandline/test_tablefilter_values.csd
@@ -1,0 +1,73 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giSource0 ftgen 101, 0, -8, -2, 0.0, 0.25, 0.5, 0.75, 1.0, 0.3333333333333333, 0.6666666666666666, -0.5
+giSource1 ftgen 102, 0, -5, -2, 0.0, 0.25, 0.5, 0.75, 1.0
+giExpected0 ftgen 110, 0, 8, -2, 0.0, 0.5, 1.0, -0.5
+giExpected1 ftgen 111, 0, 8, -2, 0.25, 0.5, 0.75, 0.3333333333333333, 0.6666666666666666, -0.5
+giExpected2 ftgen 112, 0, 8, -2, 0.0, 0.25, 0.5, 0.75, 1.0, -0.5
+giExpected3 ftgen 113, 0, 8, -2, 0.25, 0.75, 0.3333333333333333, 0.6666666666666666
+giExpected4 ftgen 114, 0, 8, -2, 0.0, 0.5, 1.0, 0.0, 0.5
+giExpected5 ftgen 115, 0, 8, -2, 0.25, 0.5, 0.75, 0.25, 0.5
+giExpected6 ftgen 116, 0, 8, -2, 0.0, 0.25, 0.5, 0.75, 1.0, 0.0, 0.25, 0.5
+giExpected7 ftgen 117, 0, 8, -2, 0.25, 0.75, 0.25
+
+instr 1
+ iOutI ftgen 0, 0, 8, -2, -99
+ iOutK ftgen 0, 0, 8, -2, -99
+ iCount tablefilteri iOutI, p4, p6, p5
+ if iCount != p8 then
+  prints "tablefilteri count=%g expected=%g\n", iCount, p8
+  exitnow(-1)
+ endif
+ kMode init p6
+ kThreshold init p5
+ kCount tablefilter iOutK, p4, kMode, kThreshold
+ if kMode != p6 || kThreshold != p5 || kCount != p8 then
+  printks "tablefilter mode=%g threshold=%g count=%g expected=%g\n", 0, kMode, kThreshold, kCount, p8
+  exitnowk(-1)
+ endif
+ kIndex = 0
+ while kIndex < kCount do
+  kInit table kIndex, iOutI
+  kPerf table kIndex, iOutK
+  kExpected table kIndex, p7
+  if !(abs(kInit-kExpected)+abs(kPerf-kExpected) < .00001) then
+   printks "tablefilter index=%g init=%g perf=%g expected=%g\n", 0, kIndex, kInit, kPerf, kExpected
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ kFirst init 1
+ if kFirst == 1 then
+  gkChecks += 1
+  kFirst = 0
+ endif
+endin
+instr 99
+ if i(gkChecks) != 8 then
+  prints "tablefilter checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0.0 .0078125 101 2 1 110 4
+i 1 0.015625 .0078125 101 2 2 111 6
+i 1 0.03125 .0078125 101 4 1 112 6
+i 1 0.046875 .0078125 101 4 2 113 4
+i 1 0.0625 .0078125 102 2 1 114 5
+i 1 0.078125 .0078125 102 2 2 115 5
+i 1 0.09375 .0078125 102 4 1 116 8
+i 1 0.109375 .0078125 102 4 2 117 3
+i 99 .15 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Preserve the mode and threshold supplied to `tablefilter` instead of replacing them during initialization.

Stop fraction conversion once it reaches the required accuracy, with checked integer intermediates. This avoids division by zero and integer overflow for ordinary rational table values, and removes per-value allocation.

Wrap source indices by the actual table length so non-power-of-two Farey tables also work correctly.