### PR TITLE
fix: reset nestedap buffers and rebuild delay layouts

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -1050,59 +1050,59 @@ static int32_t vco(CSOUND *csound, VCO *p)
 
     static int32_t nestedapset(CSOUND *csound, NESTEDAP *p)
     {
-      int32    npts, npts1=0, npts2=0, npts3=0;
-      void    *auxp;
+      int32_t npts, npts1, npts2 = 0, npts3 = 0;
+      double samples;
+      size_t size;
+      int32_t mode;
 
       if (*p->istor && p->auxch.auxp != NULL)
         return OK;
-
-      npts2 = (int32)(*p->del2 * CS_ESR);
-      npts3 = (int32)(*p->del3 * CS_ESR);
-      npts1 = (int32)(*p->del1 * CS_ESR) - npts2 -npts3;
-
-      if (UNLIKELY(((int32)(*p->del1 * CS_ESR)) <=
-                   ((int32)(*p->del2 * CS_ESR) +
-                    (int32)(*p->del3 * CS_ESR)))) {
-        return csound->InitError(csound, "%s", Str("illegal delay time"));
+      if (UNLIKELY(*p->mode != FL(1.0) && *p->mode != FL(2.0) &&
+                   *p->mode != FL(3.0)))
+        return csound->InitError(csound, Str("nestedap: mode must be 1, 2 or 3"));
+      mode = (int32_t)*p->mode;
+      samples = *p->del1 * CS_ESR;
+      if (UNLIKELY(!(samples >= 1.0 && samples <= INT32_MAX &&
+                     samples <= SIZE_MAX / sizeof(MYFLT))))
+        return csound->InitError(csound, Str("nestedap: invalid outer delay"));
+      npts = (int32_t)samples;
+      if (mode >= 2) {
+        samples = *p->del2 * CS_ESR;
+        if (UNLIKELY(!(samples >= 1.0 && samples < npts)))
+          return csound->InitError(csound, Str("nestedap: invalid second delay"));
+        npts2 = (int32_t)samples;
       }
-      npts = npts1 + npts2 + npts3;
-      /* new space if reqd */
-      if ((auxp = p->auxch.auxp) == NULL || npts != p->npts) {
-        csound->AuxAlloc(csound, (size_t)npts*sizeof(MYFLT), &p->auxch);
-        //auxp = p->auxch.auxp;
-        p->npts = npts;
-
-        if (*p->mode == FL(1.0)) {
-          if (UNLIKELY(npts1 <= 0)) {
-            return csound->InitError(csound, "%s", Str("illegal delay time"));
-          }
-          p->beg1p = (MYFLT *) p->auxch.auxp;
-          p->end1p = (MYFLT *) p->auxch.endp;
-        }
-        else if (*p->mode == FL(2.0)) {
-          if (UNLIKELY(npts1 <= 0 || npts2 <= 0)) {
-            return csound->InitError(csound, "%s", Str("illegal delay time"));
-          }
-          p->beg1p = (MYFLT *)  p->auxch.auxp;
-          p->beg2p = p->beg1p + npts1;
-          p->end1p = p->beg2p - 1;
-          p->end2p = (MYFLT *)  p->auxch.endp;
-        }
-        else if (*p->mode == FL(3.0)) {
-          if (UNLIKELY(npts1 <= 0 || npts2 <= 0 || npts3 <= 0)) {
-            return csound->InitError(csound, "%s", Str("illegal delay time"));
-          }
-          p->beg1p = (MYFLT *) p->auxch.auxp;
-          p->beg2p = (MYFLT *) p->auxch.auxp + (int32)npts1;
-          p->beg3p = (MYFLT *) p->auxch.auxp + (int32)npts1 + (int32)npts2;
-          p->end1p = p->beg2p - 1;
-          p->end2p = p->beg3p - 1;
-          p->end3p = (MYFLT *) p->auxch.endp;
-        }
+      if (mode == 3) {
+        samples = *p->del3 * CS_ESR;
+        if (UNLIKELY(!(samples >= 1.0 && samples < npts - npts2)))
+          return csound->InitError(csound, Str("nestedap: invalid third delay"));
+        npts3 = (int32_t)samples;
       }
-      /* else if requested */
-      else if (!(*p->istor)) {
-        memset(auxp, 0, npts*sizeof(int32));
+      npts1 = npts - npts2 - npts3;
+      size = (size_t)npts * sizeof(MYFLT);
+      if (p->auxch.auxp == NULL || npts != p->npts)
+        csound->AuxAlloc(csound, size, &p->auxch);
+      else
+        memset(p->auxch.auxp, 0, size);
+      p->npts = npts;
+      p->imode = mode;
+
+      /* Rebuild the layout even when the total allocation size is unchanged. */
+      p->beg1p = (MYFLT *)p->auxch.auxp;
+      p->beg2p = p->beg3p = NULL;
+      p->end2p = p->end3p = NULL;
+      p->end1p = p->beg1p + npts;
+      /* Nested modes historically shorten the outer stages by one sample.
+         Keep these endpoints and the filter equations for sound compatibility. */
+      if (mode >= 2) {
+        p->beg2p = p->beg1p + npts1;
+        p->end1p = p->beg2p - 1;
+        p->end2p = p->beg1p + npts;
+      }
+      if (mode == 3) {
+        p->beg3p = p->beg2p + npts2;
+        p->end2p = p->beg3p - 1;
+        p->end3p = p->beg1p + npts;
       }
       p->del1p = p->beg1p;
       p->del2p = p->beg2p;
@@ -1134,7 +1134,7 @@ static int32_t vco(CSOUND *csound, VCO *p)
         memset(&outp[nsmps], '\0', early*sizeof(MYFLT));
       }
       /* Ordinary All-Pass Filter */
-      if (*p->mode == FL(1.0)) {
+      if (p->imode == 1) {
 
         del1p = p->del1p;
         end1p = p->end1p;
@@ -1156,7 +1156,7 @@ static int32_t vco(CSOUND *csound, VCO *p)
       }
 
       /* Single Nested All-Pass Filter */
-      else if (*p->mode == FL(2.0)) {
+      else if (p->imode == 2) {
 
         del1p = p->del1p;
         end1p = p->end1p;
@@ -1192,7 +1192,7 @@ static int32_t vco(CSOUND *csound, VCO *p)
       }
 
       /* Double Nested All-Pass Filter */
-      else if (*p->mode == FL(3.0)) {
+      else if (p->imode == 3) {
 
         del1p = p->del1p;
         end1p = p->end1p;

--- a/Opcodes/biquad.h
+++ b/Opcodes/biquad.h
@@ -99,7 +99,7 @@ typedef struct {
     MYFLT   *curp, out1, out2, out3;
     MYFLT   *beg1p, *beg2p, *beg3p, *end1p, *end2p, *end3p;
     MYFLT   *del1p, *del2p, *del3p;
-    int32   npts;
+    int32   npts, imode;
     AUXCH   auxch;
 } NESTEDAP;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -951,6 +951,8 @@ def runTest():
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
         ["test_comb_units.csd", "comb family delay units, rate handling and partial blocks"],
+        ["test_nestedap_state.csd", "nestedap reset, mode changes, and preserved state"],
+        ["test_nestedap_invalid_delay.csd", "reject invalid nestedap delay layout", 1],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_gausstrig_frequency_mode.csd", "gausstrig frequency-change and first-impulse modes"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],

--- a/tests/commandline/test_nestedap_invalid_delay.csd
+++ b/tests/commandline/test_nestedap_invalid_delay.csd
@@ -1,0 +1,30 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+#ifndef MODE
+#define MODE #3#
+#endif
+#ifndef DELAY1
+#define DELAY1 #16#
+#endif
+#ifndef DELAY2
+#define DELAY2 #6#
+#endif
+#ifndef DELAY3
+#define DELAY3 #10#
+#endif
+sr = 8192
+ksmps = 16
+nchnls = 1
+instr 1
+ aInput = 1
+ aResult nestedap aInput, $MODE, 1, $DELAY1/sr, .2, $DELAY2/sr, .3, $DELAY3/sr, .4
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_nestedap_state.csd
+++ b/tests/commandline/test_nestedap_state.csd
@@ -1,0 +1,102 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; A reset must match a fresh filter, even when its mode or inner delays
+; change without changing the total buffer size. A skipped reset must
+; match the original filter running without interruption.
+instr 1
+ setksmps 1
+ kCycle init 0
+ kCycle += 1
+ kInput = (kCycle < 19 ? 1 : (kCycle < 35 ? 0 : (kCycle % 7 - 3) * .1))
+ aInput = kInput
+ if kCycle == 19 then
+  reinit FILTER
+ endif
+FILTER:
+ iChanged = (i(kCycle) >= 19 ? 1 : 0)
+ iMode = (iChanged == 1 ? p5 : p4)
+ iDelay2 = (iChanged == 1 ? 6 : 4) / sr
+ iDelay3 = (iChanged == 1 ? 2 : 3) / sr
+ aActual nestedap aInput, iMode, 1, 16/sr, .2, iDelay2, .3, iDelay3, .4, p6
+ rireturn
+ aContinuous nestedap aInput, p4, 1, 16/sr, .2, 4/sr, .3, 3/sr, .4, 1
+ if kCycle >= 19 then
+  aFresh nestedap aInput, p5, 1, 16/sr, .2, 6/sr, .3, 2/sr, .4
+  kActual downsamp aActual
+  if p6 == 0 then
+   kExpected downsamp aFresh
+  else
+   kExpected downsamp aContinuous
+  endif
+  if !(abs(kActual - kExpected) < .00001) then
+   printks "nestedap mode=%g->%g skip=%g cycle=%g: got=%g expected=%g\n", 0, p4, p5, p6, kCycle, kActual, kExpected
+   exitnowk(-1)
+  endif
+ endif
+ if kCycle == 64 then
+  gkChecks += 1
+ endif
+endin
+
+; A pure three-sample delay over a partial block, also with reused input.
+instr 2
+ aInput = 1
+ if p4 == 0 then
+  aResult nestedap aInput, 1, 1, 3/sr, 0
+ else
+  aInput nestedap aInput, 1, 1, 3/sr, 0
+  aResult = aInput
+ endif
+ kIndex = 0
+ while kIndex < 16 do
+  kActual vaget kIndex, aResult
+  kExpected = (kIndex >= 6 && kIndex < 11 ? 1 : 0)
+  if kActual != kExpected then
+   printks "nestedap partial sample=%g: got=%g expected=%g\n", 0, kIndex, kActual, kExpected
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ gkChecks += 1
+endin
+instr 99
+ if i(gkChecks) != 20 then
+  prints "nestedap checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .0078125 1 1 0
+i 1 0 .0078125 1 2 0
+i 1 0 .0078125 1 3 0
+i 1 0 .0078125 2 1 0
+i 1 0 .0078125 2 2 0
+i 1 0 .0078125 2 3 0
+i 1 0 .0078125 3 1 0
+i 1 0 .0078125 3 2 0
+i 1 0 .0078125 3 3 0
+i 1 0 .0078125 1 1 1
+i 1 0 .0078125 1 2 1
+i 1 0 .0078125 1 3 1
+i 1 0 .0078125 2 1 1
+i 1 0 .0078125 2 2 1
+i 1 0 .0078125 2 3 1
+i 1 0 .0078125 3 1 1
+i 1 0 .0078125 3 2 1
+i 1 0 .0078125 3 3 1
+i 2 .0159912109375 .0009765625 0
+i 2 .0198974609375 .0009765625 1
+i 99 .03125 .001953125
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Clear the full `MYFLT` delay buffer on reset. Double builds previously cleared only half of it, allowing old samples to reappear.

Rebuild stage pointers when the mode or inner delays change, even if the total buffer size stays the same. Preserve the initialized mode when `istor` skips initialization, and validate the mode and active delays before converting sizes or allocating memory.

Keep the legacy stage endpoints and filter equations to preserve existing reverb sounds.