### PR TITLE
fix: calculate Farey lengths with integer arithmetic

### DIFF
--- a/Opcodes/fareygen.c
+++ b/Opcodes/fareygen.c
@@ -27,33 +27,6 @@
 #endif
 #include <math.h>
 
-#define MAX_PFACTOR 16
-static const int32_t MAX_PRIMES = 168; /* 168 primes < 1000 */
-static const int32_t primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37,
-                             41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83,
-                             89, 97, 101, 103, 107, 109, 113, 127, 131,
-                             137, 139, 149, 151, 157, 163, 167, 173, 179,
-                             181, 191, 193, 197, 199, 211, 223, 227, 229,
-                             233, 239, 241, 251, 257, 263, 269, 271, 277,
-                             281, 283, 293, 307, 311, 313, 317, 331, 337,
-                             347, 349, 353, 359, 367, 373, 379, 383, 389,
-                             397, 401, 409, 419, 421, 431, 433, 439, 443,
-                             449, 457, 461, 463, 467, 479, 487, 491, 499,
-                             503, 509, 521, 523, 541, 547, 557, 563, 569,
-                             571, 577, 587, 593, 599, 601, 607, 613, 617,
-                             619, 631, 641, 643, 647, 653, 659, 661, 673,
-                             677, 683, 691, 701, 709, 719, 727, 733, 739,
-                             743, 751, 757, 761, 769, 773, 787, 797, 809,
-                             811, 821, 823, 827, 829, 839, 853, 857, 859,
-                             863, 877, 881, 883, 887, 907, 911, 919, 929,
-                             937, 941, 947, 953, 967, 971, 977, 983, 991,
-                             997};
-
-typedef struct pfactor_ {
-    int32_t expon;
-    int32_t base;
-} PFACTOR;
-
 typedef struct _rat {
     int32_t p;
     int32_t q;
@@ -61,7 +34,6 @@ typedef struct _rat {
 
 static int32_t EulerPhi (int32_t n);
 static int32_t FareyLength (int32_t n);
-static int32_t PrimeFactors (int32_t n, PFACTOR p[]);
 static void GenerateFarey (int32_t n, RATIO flist[], int32_t size);
 
 static int32_t fareytable (FGDATA *ff, FUNC *ftp)
@@ -95,12 +67,8 @@ static int32_t fareytable (FGDATA *ff, FUNC *ftp)
 
       Implementation Notes:
 
-      The size of the array of fractions for any F_n is calculated
-      with the help Euler's function phi(n), also called totient
-      function. For its implementation we included an array of prime
-      numbers and a function to determine the prime factor composition
-      of a natural integer. The primes dividing the integer are stored
-      locally in a small array of ints.
+      The sequence length uses integer totients so the count is exact in
+      both float and double builds.
 
       Important: The length of the table declared by the user does not
       have to be equal to the length of the Farey Sequence. If the
@@ -120,12 +88,19 @@ static int32_t fareytable (FGDATA *ff, FUNC *ftp)
     }
     ff->e.p[4] *= -1;
     pp = &(ff->e.p[5]);
-    fareyseq = (int32_t) *pp;
+    if (UNLIKELY(!(*pp >= FL(1.0) && (double)*pp <= INT32_MAX)))
+      return csound->FtError(ff, Str("farey: invalid sequence order"));
+    fareyseq = (int32_t)*pp;
     pp2 = &(ff->e.p[6]);
-    mode = (int32_t) *pp2;
+    if (UNLIKELY(!(*pp2 >= FL(0.0) && *pp2 < FL(5.0))))
+      return csound->FtError(ff, Str("farey: mode must be between 0 and 4"));
+    mode = (int32_t)*pp2;
     farey_length = FareyLength(fareyseq);
-    flist = (RATIO*) csound->Calloc(csound, farey_length*sizeof(RATIO));
+    if (UNLIKELY(farey_length == 0 ||
+                 (size_t)farey_length > SIZE_MAX / sizeof(RATIO)))
+      return csound->FtError(ff, Str("farey: sequence is too large"));
     if (ff->flen <= 0) return csound->FtError(ff, "%s", Str("Illegal table size"));
+    flist = (RATIO*)csound->Calloc(csound, (size_t)farey_length * sizeof(RATIO));
 
     GenerateFarey (fareyseq, flist, farey_length);
 
@@ -179,95 +154,48 @@ static int32_t fareytable (FGDATA *ff, FUNC *ftp)
 /* utility functions. See the comments above. */
 static int32_t EulerPhi (int32_t n)
 {
-    int32_t i;
-    PFACTOR p[MAX_PFACTOR];
-    MYFLT result;
-
-    if (n == 1)
-      return 1;
-    if (n == 0)
-      return 0;
-    memset(p, 0, sizeof(PFACTOR)*MAX_PFACTOR);
-    /* for (i=0; i < MAX_PFACTOR; i++) { */
-    /*     p[i].expon = 0;  */
-    /*     p[i].base = 0; */
-    /* } */
-    (void)PrimeFactors (n, p);
-
-    result = (MYFLT) n;
-    for (i = 0; i < MAX_PFACTOR; i++) {
-      int32_t q = p[i].base;
-      if (!q)
-        break;
-      result *= (FL(1.0) - FL(1.0) / (MYFLT) q);
+    int32_t prime, result = n;
+    for (prime = 2; prime <= n / prime; prime++) {
+      if (n % prime == 0) {
+        result -= result / prime;
+        do {
+          n /= prime;
+        } while (n % prime == 0);
+      }
     }
-    return (int32_t) result;
+    if (n > 1)
+      result -= result / n;
+    return result;
 }
 
 static int32_t FareyLength (int32_t n)
 {
-    int32_t i = 1;
-    int32_t result = 1;
-    n++;
-    for (; i < n; i++)
-      result += EulerPhi (i);
+    int32_t i, result = 1;
+    for (i = 1; i <= n; i++) {
+      int32_t phi = EulerPhi(i);
+      if (phi > INT32_MAX - result)
+        return 0;
+      result += phi;
+    }
     return result;
 }
 
-
-static int32_t PrimeFactors (int32_t n, PFACTOR p[])
+static void GenerateFarey (int32_t n, RATIO flist[], int32_t size)
 {
-    int32_t i = 0; int32_t j = 0;
-    int32_t i_exp = 0;
-
-    if (!n)
-      return j;
-
-    while (i < MAX_PRIMES)
-    {
-      int32_t aprime = primes[i++];
-      if (j == MAX_PFACTOR || aprime > n) {
-        return j;
-      }
-      if (n == aprime)
-        {
-          p[j].expon = 1;
-          p[j].base = n;
-          return (++j);
-        }
-      i_exp = 0;
-      while (!(n % aprime))
-        {
-          i_exp++;
-          n /= aprime;
-        }
-      if (i_exp)
-        {
-          p[j].expon = i_exp;
-          p[j].base = aprime;
-          ++j;
-        }
-    }
-    return j;
-}
-
-static void GenerateFarey (int32_t n, RATIO flist[], int32_t size) {
-    int32_t a, b, c, d, k, i;
-    a = 0; b = 1, c = 1, d = n; i = 1;
+    int32_t a = 0, b = 1, c = 1, d = n, i;
     flist[0].p = a;
     flist[0].q = b;
-    while (c < n) {
-      k = (int32_t) ((n + b) / d);
-      int32_t tempa = a;
-      int32_t
-        tempb = b;
+    for (i = 1; i < size; i++) {
+      int32_t k, nextp, nextq;
+      flist[i].p = c;
+      flist[i].q = d;
+      if (c == d)
+        break;
+      k = (n + b) / d;
+      nextp = k * c - a;
+      nextq = k * d - b;
       a = c; b = d;
-      c = k * c - tempa;
-      d = k * d - tempb;
-      flist[i].p = a;
-      flist[i].q = b;
-      if (i < size)
-        i++;
+      c = nextp; d = nextq;
     }
 }
 

--- a/Opcodes/fareyseq.c
+++ b/Opcodes/fareyseq.c
@@ -32,7 +32,6 @@
 #include <math.h>
 #include <time.h>
 
-#define MAX_PFACTOR 16
 const int32_t MAX_PRIMES = 1229;
 const int32_t primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
                       47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103,
@@ -168,11 +167,6 @@ const int32_t primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
                       9851, 9857, 9859, 9871, 9883, 9887, 9901, 9907, 9923,
                       9929, 9931, 9941, 9949, 9967, 9973};
 
-typedef struct pfactor_ {
-    int32_t expon;
-    int32_t base;
-} PFACTOR;
-
 /* opcodes striuctures */
 typedef struct {
     OPDS h;
@@ -207,6 +201,7 @@ int32_t tablefilter (CSOUND*,TABFILT *p);
 int32_t tablefilterset (CSOUND*,TABFILT *p);
 int32_t tableifilter (CSOUND*, TABFILT *p);
 int32_t fareylen (CSOUND*, FAREYLEN *p);
+int32_t fareyleni (CSOUND*, FAREYLEN *p);
 int32_t tableshuffle (CSOUND*, TABSHUFFLE *p);
 int32_t tableshuffleset (CSOUND*, TABSHUFFLE *p);
 int32_t tableishuffle (CSOUND *, TABSHUFFLE *p);
@@ -214,7 +209,6 @@ int32_t tableishuffle (CSOUND *, TABSHUFFLE *p);
 /* utility functions */
 int32_t EulerPhi (int32_t n);
 int32_t FareyLength (int32_t n);
-int32_t PrimeFactors (int32_t n, PFACTOR p[]);
 MYFLT Digest (int32_t n);
 void float2frac (CSOUND *csound, MYFLT in, int32_t *p, int32_t *q);
 void float_to_cfrac (CSOUND *csound, double r, int32_t n,
@@ -527,9 +521,28 @@ static int32_t dotableshuffle (CSOUND *csound, TABSHUFFLE *p)
 
 int32_t fareylen (CSOUND *csound, FAREYLEN *p)
 {
-    IGN(csound);
-    int32_t n = (int32_t) *p->kn;
-    *p->kr = (MYFLT) FareyLength (n);
+    int32_t length;
+    if (UNLIKELY(!(*p->kn >= FL(1.0) && (double)*p->kn <= INT32_MAX)))
+      return csound->PerfError(csound, &(p->h),
+                               Str("fareylen: invalid sequence order"));
+    length = FareyLength((int32_t)*p->kn);
+    if (UNLIKELY(length == 0))
+      return csound->PerfError(csound, &(p->h),
+                               Str("fareylen: sequence length exceeds int32 range"));
+    *p->kr = (MYFLT)length;
+    return OK;
+}
+
+int32_t fareyleni (CSOUND *csound, FAREYLEN *p)
+{
+    int32_t length;
+    if (UNLIKELY(!(*p->kn >= FL(1.0) && (double)*p->kn <= INT32_MAX)))
+      return csound->InitError(csound, Str("fareylen: invalid sequence order"));
+    length = FareyLength((int32_t)*p->kn);
+    if (UNLIKELY(length == 0))
+      return csound->InitError(csound,
+                               Str("fareylen: sequence length exceeds int32 range"));
+    *p->kr = (MYFLT)length;
     return OK;
 }
 
@@ -537,74 +550,30 @@ int32_t fareylen (CSOUND *csound, FAREYLEN *p)
 
 int32_t EulerPhi (int32_t n)
 {
-    int32_t i = 0;
-    //int32_t pcount;
-    MYFLT result;
-    PFACTOR p[MAX_PFACTOR];
-    memset(p, 0, sizeof(PFACTOR)*MAX_PFACTOR);
-
-    if (n == 1)
-      return 1;
-    if (n == 0)
-      return 0;
-    (void)PrimeFactors (n, p);
-
-    result = (MYFLT)n;
-    for (i = 0; i < MAX_PFACTOR; i++) {
-      int32_t q = p[i].base;
-      if (!q)
-        break;
-      result *= (FL(1.0) - FL(1.0) / (MYFLT) q);
+    int32_t prime, result = n;
+    for (prime = 2; prime <= n / prime; prime++) {
+      if (n % prime == 0) {
+        result -= result / prime;
+        do {
+          n /= prime;
+        } while (n % prime == 0);
+      }
     }
-    return (int32_t) result;
+    if (n > 1)
+      result -= result / n;
+    return result;
 }
 
 int32_t FareyLength (int32_t n)
 {
-    int32_t i = 1;
-    int32_t result = 1;
-    n++;
-    for (; i < n; i++)
-      result += EulerPhi (i);
+    int32_t i, result = 1;
+    for (i = 1; i <= n; i++) {
+      int32_t phi = EulerPhi(i);
+      if (phi > INT32_MAX - result)
+        return 0;
+      result += phi;
+    }
     return result;
-}
-
-
-int32_t PrimeFactors (int32_t n, PFACTOR p[])
-{
-    int32_t i = 0; int32_t j = 0;
-    int32_t i_exp = 0;
-    int32_t pcount = 0;
-
-    if (!n)
-      return pcount;
-
-    while (i < MAX_PRIMES)
-      {
-        int32_t aprime = primes[i++];
-        if (j == MAX_PFACTOR || aprime > n) {
-          return pcount;
-        }
-        if (n == aprime)
-          {
-            p[j].expon = 1;
-            p[j].base = n;
-            return (++pcount);
-          }
-        i_exp = 0;
-        while (!(n % aprime))
-          {
-            i_exp++;
-            n /= aprime;
-          }
-        if (i_exp)
-          {
-            p[j].expon = i_exp;
-            p[j].base = aprime;
-            ++pcount; ++j;
-          }
-      }
-    return j;
 }
 
 /* ----------------------------------------------- *
@@ -744,7 +713,7 @@ static OENTRY fareyseq_localops[] = {
     {"tablefilteri", S(TABFILT),TB,  "i", "iiii", (SUBR) tableifilter,NULL,NULL},
     {"tablefilter", S(TABFILT), TB,  "k", "kkkk",
                                 (SUBR) tablefilterset, (SUBR) tablefilter, NULL},
-    {"fareyleni", S(FAREYLEN), TR,  "i", "i", (SUBR) fareylen, NULL, NULL},
+    {"fareyleni", S(FAREYLEN), TR,  "i", "i", (SUBR) fareyleni, NULL, NULL},
     {"fareylen", S(FAREYLEN), TR,  "k", "k", NULL, (SUBR) fareylen, NULL},
     {"tableshufflei", S(TABSHUFFLE), TB,  "", "i",
                                       (SUBR) tableishuffle, NULL, NULL},

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -543,6 +543,8 @@ def runTest():
             "test_gen41_gen42_bounds.csd",
             "test bounded GEN41 and GEN42 probability rounding",
         ],
+        ["test_farey_counts.csd", "Farey lengths and generator endpoints in every output mode"],
+        ["test_farey_invalid_order.csd", "reject invalid Farey sequence orders", 1],
         [
             "test_gen41_nonfinite_total.csd",
             "expected failure: GEN41 probability total overflows",

--- a/tests/commandline/test_farey_counts.csd
+++ b/tests/commandline/test_farey_counts.csd
@@ -1,0 +1,144 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giRef102 ftgen 102, 0, -2, -2, 0, 1
+giRef103 ftgen 103, 0, -2, -2, 1, 1
+giRef106 ftgen 106, 0, -5, -2, 0, 1, 1, 2, 1
+giRef107 ftgen 107, 0, -5, -2, 1, 3, 2, 3, 1
+giRef110 ftgen 110, 0, -11, -2, 0, 1, 1, 1, 2, 1, 3, 2, 3, 4, 1
+giRef111 ftgen 111, 0, -11, -2, 1, 5, 4, 3, 5, 2, 5, 3, 4, 5, 1
+instr 1
+ iLength fareyleni p4
+ kLength fareylen p4
+ if iLength != p5 then
+  prints "fareyleni(%g)=%g expected=%g\n", p4, iLength, p5
+  exitnow(-1)
+ endif
+ if kLength != p5 then
+  printks "fareylen(%g)=%g expected=%g\n", 0, p4, kLength, p5
+  exitnowk(-1)
+ endif
+endin
+
+; Check every output mode, including truncation and zero padding.
+instr 2
+ iTable ftgen 0, 0, -p6, "farey", p4, p5
+ iNumerators = 100 + p4*2
+ iDenominators = iNumerators + 1
+ iLength = ftlen(iNumerators)
+ iIndex = 0
+ while iIndex < p6 do
+  iExpected = 0
+  if p5 == 1 then
+   if iIndex < iLength-1 then
+    iP table iIndex, iNumerators
+    iQ table iIndex, iDenominators
+    iNextP table iIndex+1, iNumerators
+    iNextQ table iIndex+1, iDenominators
+    iExpected = iNextP/iNextQ - iP/iQ
+   endif
+  elseif iIndex < iLength then
+   iP table iIndex, iNumerators
+   iQ table iIndex, iDenominators
+   if p5 == 0 then
+    iExpected = iP/iQ
+   elseif p5 == 2 then
+    iExpected = iQ
+   elseif p5 == 3 then
+    iExpected = iQ/p4
+   else
+    iExpected = 1+iP/iQ
+   endif
+  endif
+  iActual table iIndex, iTable
+  if !(abs(iActual-iExpected) < .00001) then
+   prints "GENfarey order=%g mode=%g index=%g: got=%g expected=%g\n", p4, p5, iIndex, iActual, iExpected
+   exitnow(-1)
+  endif
+  iIndex += 1
+ od
+endin
+
+; Check a prime beyond the old fixed prime list.
+instr 3
+ iTable ftgen 0, 0, -p5, "farey", p4, 0
+ iFirst table 1, iTable
+ iBeforeLast table p5-2, iTable
+ iLast table p5-1, iTable
+ if !(abs(iFirst-1/p4) < .00001) || !(abs(iBeforeLast-(p4-1)/p4) < .00001) || iLast != 1 then
+  prints "GENfarey endpoint or count is wrong for order %g\n", p4
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001 1 2
+i 1 0 .001 2 3
+i 1 0 .001 3 5
+i 1 0 .001 4 7
+i 1 0 .001 5 11
+i 1 0 .001 6 13
+i 1 0 .001 7 19
+i 1 0 .001 8 23
+i 1 0 .001 9 29
+i 1 0 .001 10 33
+i 1 0 .001 20 129
+i 1 0 .001 100 3045
+i 1 0 .001 1009 309935
+i 1 0 .001 10007 30443915
+i 2 0 .001 1 0 1
+i 2 0 .001 1 0 2
+i 2 0 .001 1 0 5
+i 2 0 .001 1 1 1
+i 2 0 .001 1 1 2
+i 2 0 .001 1 1 5
+i 2 0 .001 1 2 1
+i 2 0 .001 1 2 2
+i 2 0 .001 1 2 5
+i 2 0 .001 1 3 1
+i 2 0 .001 1 3 2
+i 2 0 .001 1 3 5
+i 2 0 .001 1 4 1
+i 2 0 .001 1 4 2
+i 2 0 .001 1 4 5
+i 2 0 .001 3 0 1
+i 2 0 .001 3 0 5
+i 2 0 .001 3 0 8
+i 2 0 .001 3 1 1
+i 2 0 .001 3 1 5
+i 2 0 .001 3 1 8
+i 2 0 .001 3 2 1
+i 2 0 .001 3 2 5
+i 2 0 .001 3 2 8
+i 2 0 .001 3 3 1
+i 2 0 .001 3 3 5
+i 2 0 .001 3 3 8
+i 2 0 .001 3 4 1
+i 2 0 .001 3 4 5
+i 2 0 .001 3 4 8
+i 2 0 .001 5 0 1
+i 2 0 .001 5 0 11
+i 2 0 .001 5 0 14
+i 2 0 .001 5 1 1
+i 2 0 .001 5 1 11
+i 2 0 .001 5 1 14
+i 2 0 .001 5 2 1
+i 2 0 .001 5 2 11
+i 2 0 .001 5 2 14
+i 2 0 .001 5 3 1
+i 2 0 .001 5 3 11
+i 2 0 .001 5 3 14
+i 2 0 .001 5 4 1
+i 2 0 .001 5 4 11
+i 2 0 .001 5 4 14
+i 3 0 .001 1009 309935
+e
+</CsScore>
+</CsoundSynthesizer>
+

--- a/tests/commandline/test_farey_invalid_order.csd
+++ b/tests/commandline/test_farey_invalid_order.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+#ifndef ORDER
+#define ORDER #0#
+#endif
+#ifndef KIND
+#define KIND #0#
+#endif
+sr = 8192
+ksmps = 16
+nchnls = 1
+instr 1
+ if $KIND == 0 then
+  iLength fareyleni $ORDER
+ elseif $KIND == 1 then
+  kLength fareylen $ORDER
+ else
+  iTable ftgen 0, 0, 8, "farey", $ORDER, 0
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Use integer totients in `fareylen`, `fareyleni`, and GENfarey. Float rounding previously undercounted sequences, while the fixed prime lists also gave wrong counts for larger orders.

Check length and allocation limits before generating the sequence, and check the write bound before storing each fraction. This prevents an incorrect count from causing writes beyond the temporary array. Include the final `1/1` for order 1, and reject invalid orders and generator modes.