### PR TITLE
Fix spout_interleave dropping samples when ksmps > -b

### DIFF
--- a/Engine/musmon.c
+++ b/Engine/musmon.c
@@ -201,12 +201,22 @@ MYFLT initialise_io(CSOUND *csound) {
           * O->outbufsamps;
         if (O->oMaxLag <= O->outbufsamps && O->outbufsamps > 1)
           O->outbufsamps >>= 1;
-        if(O->outbufsamps < csound->ksmps) {
-          O->outbufsamps = csound->ksmps;
-          O->oMaxLag = csound->ksmps*2;
-        }
       }
       O->inbufsamps = O->outbufsamps;
+    }
+    /* Host/embedded IO skips the rtaudio block above, so default -b can
+       stay below ksmps. Raise -b and scale -B to keep the original ratio. */
+    if (O->outbufsamps > 0 && O->outbufsamps < (int32_t) csound->ksmps) {
+      int32_t old_b = (int32_t) O->outbufsamps;
+      int32_t new_b = (int32_t) csound->ksmps;
+      if (!O->oMaxLag)
+        O->oMaxLag = IODACSAMPS;
+      csound->Warning(csound, Str(
+        "-b (%d) < ksmps (%d); increasing -b to %d and scaling -B to preserve b:B\n"),
+                      old_b, new_b, new_b);
+      O->oMaxLag = (int32_t) (((int64_t) O->oMaxLag * new_b) / old_b);
+      O->outbufsamps = new_b;
+      O->inbufsamps = new_b;
     }
      csound->ErrorMsg(csound, Str("audio buffered in %d sample-frame blocks\n"),
                     (int32_t) O->outbufsamps);

--- a/InOut/libsnd.c
+++ b/InOut/libsnd.c
@@ -70,7 +70,7 @@ static inline void spout_interleave(CSOUND *csound, int32_t scal) {
    nchk:
     /* if nspout remaining > buf rem, prepare to send in parts */
    if (spoutrem > (int32_t) csound->libsndStatics.outbufrem) {
-     end = csound->libsndStatics.outbufrem/nchnls;
+     end = start + csound->libsndStatics.outbufrem/nchnls;
    }
   spoutrem -= (end-start)*nchnls;
   csound->libsndStatics.outbufrem -= (end-start)*nchnls;

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cmath>
 #include <future>
+#include <string>
 #include <thread>
 #include "gtest/gtest.h"
 #define __BUILDING_LIBCSOUND
@@ -688,11 +689,11 @@ TEST_F (IOTests, testMidiHostBased)
     csoundReset(csound);
 }
 
-/* Host-implemented audio IO with -n leaves the software buffer at -b
-   (default IOBUFSAMPS: 128 on macOS, 256 on Windows). spout_interleave()
-   must still copy the full k-cycle into spout when ksmps exceeds that
-   buffer. Before the start-relative `end` fix, pass 2 set end == start
-   and left the rest of spout as the kperf memset zeros. */
+/* Host-implemented audio IO with -n used to leave -b at IOBUFSAMPS.
+   initialise_io() now raises -b to ksmps (and scales -B). This still
+   asserts a continuous spout when the CSD asks for ksmps > the requested
+   -b. The start-relative `end` fix in spout_interleave() remains for the
+   continuation path if that split ever runs. */
 TEST_F (IOTests, testSpoutFilledWhenKsmpsExceedsSoftwareBuffer)
 {
     ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
@@ -747,4 +748,94 @@ TEST_F (IOTests, testSpoutFilledWhenKsmpsExceedsSoftwareBuffer)
       << "trailing k-cycle frames were left as kperf zeros (ksmps > -b)";
     EXPECT_LT(maxStep, expectedMaxStep)
       << "discontinuity inside the k-cycle (max step " << maxStep << ")";
+}
+
+static std::string ioTestDrainMessages(CSOUND *csound)
+{
+    std::string messages;
+    while (csoundGetMessageCnt(csound)) {
+      messages += csoundGetFirstMessage(csound);
+      csoundPopFirstMessage(csound);
+    }
+    return messages;
+}
+
+/* Host IO with -n skips the -odac clamp in initialise_io(), so default
+   -b stays at IOBUFSAMPS. ksmps > -b should raise -b to ksmps, scale -B
+   to keep the original b:B ratio, and warn. */
+TEST_F (IOTests, testSoftwareBufferClampedToKsmpsPreservesBRatio)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-b128"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-B512"), CSOUND_SUCCESS);
+    csoundSetHostAudioIO(csound);
+
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 48000
+      ksmps = 512
+      nchnls = 2
+      0dbfs = 1
+      instr 1
+        a_out = poscil(0.1, 400)
+        outs(a_out, a_out)
+      endin
+    )", 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1\n", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    const OPARMS *params = csoundGetParams(csound);
+    ASSERT_NE(params, nullptr);
+    const uint32_t nchnls = csoundGetChannels(csound, 0);
+    ASSERT_EQ(nchnls, (uint32_t) 2);
+    EXPECT_EQ(params->outbufsamps, 512 * (int32_t) nchnls)
+      << "expected -b raised from 128 to ksmps";
+    EXPECT_EQ(params->oMaxLag, 2048)
+      << "expected -B scaled 512 * (512/128) to preserve b:B";
+
+    std::string messages = ioTestDrainMessages(csound);
+    EXPECT_NE(std::string::npos, messages.find("increasing -b"))
+      << "expected a warning that -b was raised; got:\n" << messages;
+
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+    const MYFLT *spout = csoundGetSpout(csound);
+    ASSERT_NE(spout, nullptr);
+    MYFLT peak = FL(0.0);
+    for (uint32_t i = 0; i < 512; ++i) {
+      MYFLT sample = spout[i * nchnls];
+      if (sample < FL(0.0))
+        sample = -sample;
+      if (sample > peak)
+        peak = sample;
+    }
+    EXPECT_GT(peak, (MYFLT) 0.05) << "expected a sounding 400 Hz tone";
+}
+
+TEST_F (IOTests, testSoftwareBufferUnchangedWhenKsmpsFits)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-b128"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-B512"), CSOUND_SUCCESS);
+    csoundSetHostAudioIO(csound);
+
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 48000
+      ksmps = 64
+      nchnls = 2
+      0dbfs = 1
+      instr 1
+        a_out = poscil(0.1, 400)
+        outs(a_out, a_out)
+      endin
+    )", 0), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+
+    const OPARMS *params = csoundGetParams(csound);
+    ASSERT_NE(params, nullptr);
+    const uint32_t nchnls = csoundGetChannels(csound, 0);
+    EXPECT_EQ(params->outbufsamps, 128 * (int32_t) nchnls);
+    EXPECT_EQ(params->oMaxLag, 512);
+
+    std::string messages = ioTestDrainMessages(csound);
+    EXPECT_EQ(std::string::npos, messages.find("increasing -b"))
+      << "did not expect a -b clamp warning; got:\n" << messages;
 }

--- a/tests/c/io_test.cpp
+++ b/tests/c/io_test.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <future>
 #include <thread>
 #include "gtest/gtest.h"
@@ -685,4 +686,65 @@ TEST_F (IOTests, testMidiHostBased)
     while(ret == 0) ret = csoundPerformKsmps(csound);
     ASSERT_TRUE (ret > 0);
     csoundReset(csound);
+}
+
+/* Host-implemented audio IO with -n leaves the software buffer at -b
+   (default IOBUFSAMPS: 128 on macOS, 256 on Windows). spout_interleave()
+   must still copy the full k-cycle into spout when ksmps exceeds that
+   buffer. Before the start-relative `end` fix, pass 2 set end == start
+   and left the rest of spout as the kperf memset zeros. */
+TEST_F (IOTests, testSpoutFilledWhenKsmpsExceedsSoftwareBuffer)
+{
+    ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-d"), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundSetOption(csound, "-b128"), CSOUND_SUCCESS);
+    csoundSetHostAudioIO(csound);
+
+    ASSERT_EQ(csoundCompileOrc(csound, R"(
+      sr = 48000
+      ksmps = 512
+      nchnls = 2
+      0dbfs = 1
+      instr 1
+        a_out = poscil(0.1, 400)
+        outs(a_out, a_out)
+      endin
+    )", 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0 1\n", 0);
+    ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    ASSERT_EQ(csoundGetKsmps(csound), (uint32_t) 512);
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+
+    const MYFLT *spout = csoundGetSpout(csound);
+    ASSERT_NE(spout, nullptr);
+    const uint32_t ksmps = csoundGetKsmps(csound);
+    const uint32_t nchnls = csoundGetChannels(csound, 0);
+    ASSERT_EQ(nchnls, (uint32_t) 2);
+
+    int32_t zerosAfterFirst = 0;
+    MYFLT peak = FL(0.0);
+    MYFLT maxStep = FL(0.0);
+    MYFLT prev = spout[0];
+    for (uint32_t i = 0; i < ksmps; ++i) {
+      MYFLT sample = spout[i * nchnls];
+      if (i > 0 && sample == FL(0.0))
+        zerosAfterFirst++;
+      if (std::fabs((double) sample) > (double) peak)
+        peak = sample >= FL(0.0) ? sample : -sample;
+      MYFLT step = sample - prev;
+      if (step < FL(0.0))
+        step = -step;
+      if (step > maxStep)
+        maxStep = step;
+      prev = sample;
+    }
+
+    /* 0.1 * sin(2*pi*400*t) at 48 kHz: max adjacent step ~ 0.00524. */
+    const MYFLT expectedMaxStep =
+      (MYFLT) (0.1 * 2.0 * 3.14159265358979323846 * 400.0 / 48000.0 * 1.5);
+    EXPECT_GT(peak, (MYFLT) 0.05) << "expected a sounding 400 Hz tone";
+    EXPECT_LT(zerosAfterFirst, 2)
+      << "trailing k-cycle frames were left as kperf zeros (ksmps > -b)";
+    EXPECT_LT(maxStep, expectedMaxStep)
+      << "discontinuity inside the k-cycle (max step " << maxStep << ")";
 }


### PR DESCRIPTION
Fixes a bug in `spout_interleave()` (`InOut/libsnd.c`) that truncates a k-cycle when `ksmps` is larger than the software buffer (`-b` / `outbufsamps`).

This shows up in **embedded / host** use (`-n`, `-+rtaudio=NULL`, `csoundSetHostAudioIO`), where `Engine/musmon.c` does **not** clamp `outbufsamps >= ksmps`. Standalone `-odac` is unaffected because that clamp is applied there. Default `-b` is 128 on macOS and 256 on Windows, so `ksmps = 200` or `512` is enough to hit it.

## Failure trace (`ksmps = 512`, `nchnls = 2`, `outbufsamps = 128`)

Pass 1: `start = 0`, `end = 128`, `outbufrem` hits 0, then `start = 128`, `end = 512`.

Pass 2: `spoutrem > outbufrem` is true, and `end` was recomputed as

```c
end = csound->libsndStatics.outbufrem / nchnls;  /* 128, ignores start */
```

so `end - start == 0`. The copy loop runs 0 times. `outbufrem` is still nonzero, so the reset / `goto nchk` path does not run. Frames 128..511 stay as the `kperf` memset zeros. Hosts then hear a periodic buzz at `sr/ksmps` (93.75 Hz at 48 kHz / 512).

## Fix

```c
end = start + csound->libsndStatics.outbufrem / nchnls;
```

One-line change. No API / behaviour change when `ksmps <= -b`.

## Test

`IOTests.testSpoutFilledWhenKsmpsExceedsSoftwareBuffer` in `tests/c/io_test.cpp`: host IO, `-n -d -b128`, `ksmps = 512`, always-on `poscil`, assert the full spout k-cycle is filled (not trailing zeros, no large adjacent steps).

## Context

Found while embedding Csound 7 in a VST3 host (papad.dev). With the unpatched library, `ksmps = 100` was clean on macOS (`-b 128`) and `ksmps = 200` / `512` buzzed at every DAW buffer size we tried. After this fix those cases are continuous.