### PR TITLE
Fold unary +/- literals so functional init(-1) type-checks

### DIFF
--- a/Engine/csound_orc_expressions.c
+++ b/Engine/csound_orc_expressions.c
@@ -1104,6 +1104,13 @@ static TREE *create_synthetic_label(CSOUND *csound, int32 count)
 
 void handle_negative_number(CSOUND* csound, TREE* root)
 {
+  /* Fold unary +/- of a numeric literal into a constant token so
+     k = init(-1) is the same shape as k = init(1). Otherwise the
+     unary node is an expression and T_FUNCTION type-check matches a
+     multi-out init overload. */
+  if (root == NULL || root->right == NULL || root->right->value == NULL) {
+    return;
+  }
   if (root->type == S_UMINUS &&
       (root->right->type == INTEGER_TOKEN ||
        root->right->type == NUMBER_TOKEN)) {
@@ -1116,6 +1123,17 @@ void handle_negative_number(CSOUND* csound, TREE* root)
     root->value = root->right->type == INTEGER_TOKEN ?
       make_int(csound, negativeNumber, NULL) : make_num(csound, negativeNumber, NULL);
     root->value->lexeme = negativeNumber;
+  }
+  else if (root->type == S_UPLUS &&
+           (root->right->type == INTEGER_TOKEN ||
+            root->right->type == NUMBER_TOKEN)) {
+    int32_t len = (int32_t) strlen(root->right->value->lexeme);
+    char* positiveNumber = csound->Malloc(csound, len + 1);
+    strcpy(positiveNumber, root->right->value->lexeme);
+    root->type = root->right->type;
+    root->value = root->right->type == INTEGER_TOKEN ?
+      make_int(csound, positiveNumber, NULL) : make_num(csound, positiveNumber, NULL);
+    root->value->lexeme = positiveNumber;
   }
 }
 

--- a/Engine/csound_orc_semantics.c
+++ b/Engine/csound_orc_semantics.c
@@ -2615,9 +2615,12 @@ TREE* convert_statement_to_opcall(CSOUND* csound, TREE* root,
       TREE *arg = right->right;
       int32_t hasExpressionArg = 0;
 
-      while (arg != NULL && !hasExpressionArg) {
-        hasExpressionArg = is_expression_node(arg) ||
-                           is_boolean_expression_node(arg);
+      while (arg != NULL) {
+        handle_negative_number(csound, arg);
+        if (!hasExpressionArg) {
+          hasExpressionArg = is_expression_node(arg) ||
+                             is_boolean_expression_node(arg);
+        }
         arg = arg->next;
       }
 

--- a/H/csound_orc_expressions.h
+++ b/H/csound_orc_expressions.h
@@ -44,6 +44,7 @@ CONS_CELL* cs_cons_append(CONS_CELL* cons1, CONS_CELL* cons2);
 
 int32_t is_expression_node(TREE *node);
 int32_t is_boolean_expression_node(TREE *node);
+void handle_negative_number(CSOUND *csound, TREE *root);
 int32_t is_statement_expansion_required(TREE* root);
 void handle_optional_args(CSOUND *csound, TREE *l);
 TREE* tree_append(TREE *head, TREE *node);

--- a/tests/c/csound_orc_compile_test.cpp
+++ b/tests/c/csound_orc_compile_test.cpp
@@ -1676,3 +1676,36 @@ TEST_F (OrcCompileTests, StrcatDoesNotCopyUnusedInputCapacity)
         EXPECT_EQ('x', outputData[i]) << "write beyond output capacity at " << i;
     }
 }
+
+/* Functional init(-1) used to fail: unary minus is an expression, so
+   convert_statement_to_opcall type-checked init in isolation and matched a
+   multi-out overload ("out-args != 1"). Positive init(1) never hit that path. */
+TEST_F (OrcCompileTests, testFunctionalInitUnaryNumericLiteral)
+{
+    ASSERT_EQ(CSOUND_SUCCESS, csoundSetOption(csound, "-n -d -m0"));
+    const char *orchestra = R"(
+instr 1
+  k_neg = init(-1)
+  k_pos = init(1)
+  k_uplus = init(+1)
+  i_neg = init(-2)
+  k_classic init -3
+  chnset k_neg, "k_neg"
+  chnset k_pos, "k_pos"
+  chnset k_uplus, "k_uplus"
+  chnset i_neg, "i_neg"
+  chnset k_classic, "k_classic"
+endin
+)";
+    ASSERT_EQ(CSOUND_SUCCESS, csoundCompileOrc(csound, orchestra));
+    csoundReadScore(csound, "i 1 0 1\n");
+    ASSERT_EQ(CSOUND_SUCCESS, csoundStart(csound));
+    ASSERT_EQ(CSOUND_SUCCESS, csoundPerformKsmps(csound));
+    int32_t error = 0;
+    EXPECT_EQ(-1, csoundGetControlChannel(csound, "k_neg", &error));
+    EXPECT_EQ(CSOUND_SUCCESS, error);
+    EXPECT_EQ(1, csoundGetControlChannel(csound, "k_pos", &error));
+    EXPECT_EQ(1, csoundGetControlChannel(csound, "k_uplus", &error));
+    EXPECT_EQ(-2, csoundGetControlChannel(csound, "i_neg", &error));
+    EXPECT_EQ(-3, csoundGetControlChannel(csound, "k_classic", &error));
+}


### PR DESCRIPTION
`k_temp = init(-1)` failed with `opcode 'init' for expression with arg types c returns out-args != 1`. `init(1)` and classic `k_temp init -1` already worked.

`convert_statement_to_opcall()` treated unary minus as an expression and type-checked `init` in isolation, so `resolve_opcode_get_outarg` matched a multi-out `init` overload. `handle_negative_number()` already folded unary-minus literals, but only later in `expand_statement()`.

This folds unary `+/-` numeric literals on every `T_FUNCTION` argument before that type-check. `init(0-1)` (binary minus) is unchanged and still out of scope.

Test: `OrcCompileTests.testFunctionalInitUnaryNumericLiteral`.