### PR TITLE
Fix gtadsr stage transitions and retriggering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1273,6 +1273,7 @@ else()
         Opcodes/arrayops.cpp
         Opcodes/bformdec2.cpp
         Opcodes/padsynth_gen.cpp
+        Opcodes/pvsops.cpp
         Opcodes/signalflowgraph.cpp)
 endif()
 

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -307,90 +307,91 @@ struct TVConv : csnd::Plugin<1, 6> {
 };
 
 
+// Keep the shared sample update free of function calls in the audio loop.
+#define GTADSR_TICK()                                                       \
+  do {                                                                      \
+    if (gate) {                                                             \
+      if (a > 0) {                                                          \
+        e = --a == 0 ? MYFLT(1) : e + ainc;                                 \
+      } else if (d > 0) {                                                   \
+        e = --d == 0 ? s : e + (s - 1) * dfac;                              \
+        if (e < s) e = s;                                                   \
+      } else {                                                              \
+        e = s;                                                              \
+      }                                                                     \
+    } else {                                                                \
+      e = e < MYFLT(0.00001) ? MYFLT(0) : e * rfac;                         \
+    }                                                                       \
+  } while (0)
+
 struct Gtadsr : public csnd::Plugin<1,6> {
-  uint64_t a,d;
-  MYFLT e,ainc,dfac;
-  uint64_t t;
+  uint64_t a, d;
+  MYFLT e, ainc, dfac;
+  double rfac;
+  bool gate;
 
   int32_t init() {
-    t = 0;
+    gate = false;
     e = MYFLT(0);
     return OK;
   }
 
-  int32_t kperf() {
-    MYFLT gate = inargs[5];
-    MYFLT s = inargs[3];
-    s = s  > 0  ? (s < 1 ? s : 1.) : 0.;
-    if(gate > 0) {
-      if(t == 0) {
-        a = inargs[1]*this->kr();
-	d = inargs[2]*this->kr();
-	if(a < 1) a = 1;
-	if(d < 1) d = 1;
-	ainc = 1./a;
-	dfac = 1./d;
-      }
-      if (t < a && e < (1 - ainc))
-       e +=  ainc;
-     else if (t < a + d && e > s)
-       e += (s - 1) * dfac;
-     else
-       e = s;
-      t += 1;
-    } else {
-      if (e < 0.00001)
-        e = 0;
-      else
-        e *= pow(0.001, 1. / (inargs[4]*this->kr()));
-      t = 0;   
+  // Gate and envelope parameters are control-rate inputs in all variants.
+  int32_t prepare(MYFLT rate) {
+    bool nextgate = inargs[5] > 0;
+    if (nextgate && !gate) {
+      MYFLT attack = inargs[1] * rate;
+      MYFLT decay = inargs[2] * rate;
+      // 2^64 is the first value outside the range of uint64_t.
+      if (!(attack >= 0 && attack < 18446744073709551616.0 &&
+            decay >= 0 && decay < 18446744073709551616.0))
+        return csound->perf_error("gtadsr: attack and decay times out of range", this);
+      // Preserve the one-step minimum for zero and sub-step stage times.
+      a = attack < 1 ? 1 : static_cast<uint64_t>(attack);
+      d = decay < 1 ? 1 : static_cast<uint64_t>(decay);
+      // A new gate starts the full attack from the current release level.
+      ainc = (1 - e) / a;
+      dfac = 1. / d;
+    } else if (!nextgate) {
+      rfac = inargs[4] > 0 ? pow(0.001, 1. / (inargs[4] * rate)) : 0;
     }
-    outargs[0] = e*inargs[0];
+    gate = nextgate;
+    return OK;
+  }
+
+  int32_t kperf() {
+    if (prepare(this->kr()) != OK)
+      return NOTOK;
+    MYFLT s = inargs[3];
+    s = s > 0 ? (s < 1 ? s : 1.) : 0.;
+    GTADSR_TICK();
+    outargs[0] = e * inargs[0];
     return OK;
   }
 
   int32_t aperf() {
-    MYFLT gate = inargs[5];
+    if (offset >= nsmps)
+      return OK;
+    if (prepare(this->sr()) != OK)
+      return NOTOK;
     MYFLT s = inargs[3];
     s = s > 0 ? (s < 1 ? s : 1.) : 0.;
-    MYFLT *sig  = NULL, amp = MYFLT(0);
-    if(csound->is_asig(inargs(0)))
-       sig = inargs(0);
+    MYFLT *sig = NULL, amp = MYFLT(0);
+    if (csound->is_asig(inargs(0)))
+      sig = inargs(0);
     else
       amp = inargs[0];
     MYFLT *out = outargs(0);
 
-    for(auto n = offset; n < nsmps; n++) {
-       if(gate > 0) {
-      if(t == 0) {
-        a = inargs[1]*this->sr();
-	d = inargs[2]*this->sr();
-	if(a < 1) a = 1;
-	if(d < 1) d = 1;
-	ainc = 1./a;
-	dfac = 1./d;
-      }
-      if (t < a && e < (1 - ainc))
-       e +=  ainc;
-     else if (t < a + d && e > s)
-       e += (s - 1) * dfac;
-     else
-       e = s;
-      t += 1;
-    } else {
-      if (e < 0.00001)
-        e = 0;
-      else
-        e *= pow(0.001, 1. / (inargs[4]*this->sr()));
-      t = 0;   
-    }
-       out[n] = sig ? sig[n]*e : amp*e;
- 
+    for (auto n = offset; n < nsmps; n++) {
+      GTADSR_TICK();
+      out[n] = sig ? sig[n] * e : amp * e;
     }
     return OK;
   }
-  
 };
+
+#undef GTADSR_TICK
 
 
 

--- a/Opcodes/pvsops.cpp
+++ b/Opcodes/pvsops.cpp
@@ -307,28 +307,26 @@ struct TVConv : csnd::Plugin<1, 6> {
 };
 
 
-// Keep the shared sample update free of function calls in the audio loop.
-#define GTADSR_TICK()                                                       \
-  do {                                                                      \
-    if (gate) {                                                             \
-      if (a > 0) {                                                          \
-        e = --a == 0 ? MYFLT(1) : e + ainc;                                 \
-      } else if (d > 0) {                                                   \
-        e = --d == 0 ? s : e + (s - 1) * dfac;                              \
-        if (e < s) e = s;                                                   \
-      } else {                                                              \
-        e = s;                                                              \
-      }                                                                     \
-    } else {                                                                \
-      e = e < MYFLT(0.00001) ? MYFLT(0) : e * rfac;                         \
-    }                                                                       \
-  } while (0)
-
 struct Gtadsr : public csnd::Plugin<1,6> {
   uint64_t a, d;
   MYFLT e, ainc, dfac;
   double rfac;
   bool gate;
+
+  void process(MYFLT s) {
+    if (gate) {
+      if (a > 0) {
+        e = --a == 0 ? MYFLT(1) : e + ainc;
+      } else if (d > 0) {
+        e = --d == 0 ? s : e + (s - 1) * dfac;
+        if (e < s) e = s;
+      } else {
+        e = s;
+      }
+    } else {
+      e = e < MYFLT(0.00001) ? MYFLT(0) : e * rfac;
+    }
+  }
 
   int32_t init() {
     gate = false;
@@ -364,7 +362,7 @@ struct Gtadsr : public csnd::Plugin<1,6> {
       return NOTOK;
     MYFLT s = inargs[3];
     s = s > 0 ? (s < 1 ? s : 1.) : 0.;
-    GTADSR_TICK();
+    process(s);
     outargs[0] = e * inargs[0];
     return OK;
   }
@@ -384,14 +382,12 @@ struct Gtadsr : public csnd::Plugin<1,6> {
     MYFLT *out = outargs(0);
 
     for (auto n = offset; n < nsmps; n++) {
-      GTADSR_TICK();
+      process(s);
       out[n] = sig ? sig[n] * e : amp * e;
     }
     return OK;
   }
 };
-
-#undef GTADSR_TICK
 
 
 

--- a/Top/csmodule.c
+++ b/Top/csmodule.c
@@ -1299,13 +1299,13 @@ typedef int32_t (*INITFN2)(CSOUND *);
  int32_t newgabopc_ModuleInit(CSOUND *csound);
  int32_t csoundModuleInit_signalflowgraph(CSOUND *csound);
  int32_t arrayops_init_modules(CSOUND *csound);
+ int32_t pvsops_init_modules(CSOUND *csound);
  #ifndef __wasi__
  int32_t csoundModuleInit_ampmidid(CSOUND *csound);
  int32_t csoundModuleCreate_mixer(CSOUND *csound);
  int32_t csoundModuleInit_mixer(CSOUND *csound);
  int32_t csoundModuleInit_doppler(CSOUND *csound);
  int32_t lfsr_init_modules(CSOUND *csound);
- int32_t pvsops_init_modules(CSOUND *csound);
  int32_t trigEnv_init_modules(CSOUND *csound);
  #endif
  #ifndef BARE_METAL
@@ -1402,13 +1402,13 @@ CS_NOINLINE int32_t csoundInitStaticModules(CSOUND *csound)
     sfont_ModuleInit,
     csoundModuleInit_signalflowgraph,
     arrayops_init_modules,
+    pvsops_init_modules,
 #if !defined(__wasi__)
     csoundModuleInit_ampmidid,
     csoundModuleCreate_mixer,
     csoundModuleInit_mixer,
     csoundModuleInit_doppler,
     lfsr_init_modules,
-    pvsops_init_modules,
     trigEnv_init_modules,
     csoundModuleInit_fractalnoise,
 #endif

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -828,27 +828,27 @@ public:
 
   /** vector beginning
    */
-  iterator begin() { return &ptrs[0]; }
+  iterator begin() { return ptrs.data(); }
 
   /** vector end
    */
-  iterator end() { return  &ptrs[N]; }
+  iterator end() { return ptrs.data() + N; }
 
   /** vector beginning
    */
-  const_iterator begin() const { return (const MYFLT **)&ptrs[0]; }
+  const_iterator begin() const { return (const MYFLT **)ptrs.data(); }
 
   /** vector end
    */
-  const_iterator end() const { return (const MYFLT **)&ptrs[N]; }
+  const_iterator end() const { return (const MYFLT **)(ptrs.data() + N); }
 
   /** vector beginning
    */
-  const_iterator cbegin() const { return (const MYFLT **)&ptrs[0]; }
+  const_iterator cbegin() const { return (const MYFLT **)ptrs.data(); }
 
   /** vector end
    */
-  const_iterator cend() const { return (const MYFLT **)&ptrs[N]; }
+  const_iterator cend() const { return (const MYFLT **)(ptrs.data() + N); }
 
   /** parameter data (MYFLT pointer) at index n
    */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -629,6 +629,8 @@ def runTest():
         ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
         ["test_lorenz_skip.csd", "lorenz integration steps per sample"],
         ["test_looptseg_curves.csd", "looptseg curve stability"],
+        ["test_gtadsr_stages.csd", "gtadsr stage endpoints, retriggering and sample offsets"],
+        ["test_gtadsr_invalid_times.csd", "reject out-of-range gtadsr stage times", 1],
         ["test_loop_envelope_phase.csd", "loop envelope phase wrapping and retriggers"],
         ["test_grain4_region_rounding.csd", "grain4 preserves sample rounding for source regions"],
         ["test_grain4_zero_length.csd", "reject zero grain4 source length", 1],

--- a/tests/commandline/test_gtadsr_invalid_times.csd
+++ b/tests/commandline/test_gtadsr_invalid_times.csd
@@ -1,0 +1,36 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+instr 1
+ kEnv gtadsr 1, p4, p5, .5, .1, 1
+endin
+instr 2
+ aEnv gtadsr 1, p4, p5, .5, .1, 1
+endin
+instr 3
+ aInput = 1
+ aEnv gtadsr aInput, p4, p5, .5, .1, 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 -1 .1
+i 1 0 .01 .1 -1
+i 1 0 .01 1e20 .1
+i 1 0 .01 .1 1e20
+i 2 0 .01 -1 .1
+i 2 0 .01 .1 -1
+i 2 0 .01 1e20 .1
+i 2 0 .01 .1 1e20
+i 3 0 .01 -1 .1
+i 3 0 .01 .1 -1
+i 3 0 .01 1e20 .1
+i 3 0 .01 .1 1e20
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_gtadsr_stages.csd
+++ b/tests/commandline/test_gtadsr_stages.csd
@@ -1,0 +1,175 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Compare all overloads against piecewise linear curves at one sample per cycle.
+instr 1
+ setksmps 1
+ iAttack = max(1, int(p4))
+ iDecay = max(1, int(p5))
+ iHigh = (p7 > 0 ? p7 : iAttack + iDecay + 2)
+ kStep init -1
+ kExpected init 0
+ kRestart init 0
+ kGate = (kStep >= 0 && kStep != iHigh && kStep < iHigh + 8 ? 1 : 0)
+ kAttack = (kStep == 0 ? p4/sr : 1000)
+ kDecay = (kStep == 0 ? p5/sr : 1000)
+ kSustain = p6
+ kRelease = log(.001)/log(.5)/sr
+ if kStep > iHigh then
+  kSustain = .25
+  if kStep == iHigh + 1 then
+   kAttack = 2/sr
+   kDecay = 3/sr
+  endif
+ endif
+ if kStep >= iHigh + 8 then
+  kRelease = p8
+ endif
+ kAmp = 1 + (kStep + 1)*.125
+ kEnv gtadsr kAmp, kAttack, kDecay, kSustain, kRelease, kGate
+ aEnv gtadsr kAmp, kAttack, kDecay, kSustain, kRelease, kGate
+ aInput = 2*kAmp
+ aProcessed gtadsr aInput, kAttack, kDecay, kSustain, kRelease, kGate
+ kAudio downsamp aEnv
+ kProcessed downsamp aProcessed
+
+ if kStep < 0 then
+  kExpected = 0
+ elseif kStep < iHigh then
+  if kStep < iAttack then
+   kExpected = (kStep + 1)/iAttack
+  elseif kStep < iAttack + iDecay then
+   kExpected = 1 + (p6 - 1)*(kStep - iAttack + 1)/iDecay
+  else
+   kExpected = p6
+  endif
+ elseif kStep == iHigh then
+  kExpected *= .5
+  kRestart = kExpected
+ elseif kStep < iHigh + 3 then
+  kExpected = kRestart + (1-kRestart)*(kStep-iHigh)/2
+ elseif kStep < iHigh + 6 then
+  kExpected = 1 - .75*(kStep-iHigh-2)/3
+ elseif kStep < iHigh + 8 then
+  kExpected = .25
+ else
+  kExpected = 0
+ endif
+ if !(abs(kEnv-kExpected*kAmp) < .00001 && abs(kAudio-kExpected*kAmp) < .00001 && abs(kProcessed-2*kExpected*kAmp) < .00002) then
+  printks "gtadsr curve: attack=%g decay=%g sustain=%g step=%g expected=%g k=%g a=%g processor=%g\n", 0, p4, p5, p6, kStep, kExpected*kAmp, kEnv, kAudio, kProcessed
+  exitnowk -1
+ endif
+ if kStep == iHigh + 9 then
+  gkChecks += 1
+  turnoff
+ endif
+ kStep += 1
+endin
+
+; Audio processing must cross stage boundaries within a block and advance only
+; over active samples. The control-rate envelope uses the same durations.
+instr 2
+ kCycle init 0
+ kGate = (kCycle < 8 ? 1 : 0)
+ kRelease = (kCycle == 8 ? 48/sr : 24/sr)
+ kEnv gtadsr 1, 64/sr, 64/sr, .5, kRelease, kGate
+ aEnv gtadsr 1, 64/sr, 64/sr, .5, kRelease, kGate
+ aInput phasor 1
+ aInput = 1 + aInput
+ aProcessed gtadsr aInput, 64/sr, 64/sr, .5, kRelease, kGate
+ kStart offsetsmps
+ kEnd init 16
+ kCount init 0
+ kReleaseStart init 0
+ kReleaseAge init 0
+ kPrevRelease init 0
+ if kCycle == 10 then
+  kEnd = p5
+ endif
+ kIndex = 0
+ while kIndex < 16 do
+  kActual vaget kIndex, aEnv
+  kProcessed vaget kIndex, aProcessed
+  kInput vaget kIndex, aInput
+  if kIndex < kStart || kIndex >= kEnd then
+   kExpected = 0
+  else
+   if kGate == 1 then
+    if kCount < 64 then
+     kExpected = (kCount+1)/64
+    elseif kCount < 128 then
+     kExpected = 1 - .5*(kCount-63)/64
+    else
+     kExpected = .5
+    endif
+   else
+    if kRelease != kPrevRelease then
+     kReleaseStart = kExpected
+     kReleaseAge = 0
+     kPrevRelease = kRelease
+    endif
+    kReleaseAge += 1
+    kExpected = kReleaseStart*pow(.001, kReleaseAge/(kRelease*sr))
+   endif
+   kCount += 1
+  endif
+  if !(abs(kActual-kExpected) < .00001 && abs(kProcessed-kExpected*kInput) < .00002) then
+   printks "gtadsr block: offset=%g cycle=%g index=%g expected=%g actual=%g processor=%g\n", 0, p4, kCycle, kIndex, kExpected, kActual, kProcessed
+   exitnowk -1
+  endif
+  kIndex += 1
+ od
+ if kCycle < 4 then
+  kRef = (kCycle+1)/4
+ elseif kCycle < 8 then
+  kRef = 1 - .5*(kCycle-3)/4
+ elseif kCycle == 8 then
+  kRef = .05
+ else
+  kRef = .05*pow(.001, (kCycle-8)/1.5)
+ endif
+ if !(abs(kEnv-kRef) < .00001) then
+  printks "gtadsr control curve: cycle=%g expected=%g actual=%g\n", 0, kCycle, kRef, kEnv
+  exitnowk -1
+ endif
+ if kCycle == 10 then
+  gkChecks += 1
+ endif
+ kCycle += 1
+endin
+
+instr 99
+ if i(gkChecks) != 13 then
+  prints "gtadsr: not all checks ran\n"
+  exitnow -1
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Attack, decay, sustain, optional early gate-off, final release.
+i 1 0 .1 4 4 .5 0 0
+i 1 0 .1 1 1 .5 0 0
+i 1 0 .1 0 0 .5 0 0
+i 1 0 .1 .5 .5 .5 0 0
+i 1 0 .1 4 4 0 0 0
+i 1 0 .1 4 4 1 0 0
+i 1 0 .1 4 4 .5 2 0
+i 1 0 .1 4 4 .5 6 0
+i 1 0 .1 4 4 .5 0 -1
+; Eleven blocks, including a five-sample start offset and partial last blocks.
+i 2 .25 .021484375 0 16
+i 2 .375 .0206298828125 0 9
+i 2 .5006103515625 .0208740234375 5 16
+i 2 .6256103515625 .02001953125 5 9
+i 99 .75 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`gtadsr` can start decay before attack reaches its peak. With amplitude 1 and a four-step attack, it outputs `0.25, 0.5, 0.75, 0.625` instead of reaching `1`. This affects the control-rate and both audio-rate forms.

- Count down each stage so attack reaches its peak and decay reaches sustain at their endpoints. A new gate during release starts a full attack from the current level.
- Check attack and decay durations before converting them to integer counts, preventing undefined conversions. Separate countdowns also avoid overflow from adding stage lengths. Preserve the existing one-step minimum for zero and short stages.
- End nonpositive release times immediately, so negative release cannot make the envelope grow.
- Share the sample update through `process()`, defined inside the class, and compute the release coefficient once per control block, removing `pow` from the audio loop.
