### PR TITLE
Fix plltrack processing of constant input, silence and partial blocks

### DIFF
--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -619,6 +619,8 @@ int32_t plltrack_set(CSOUND *csound, PLLTRACK *p)
 int32_t plltrack_perf(CSOUND *csound, PLLTRACK *p)
 {
     int32_t ksmps, i, k;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
     MYFLT _0dbfs;
     double a0[6], a1[6], a2[6], b1[6], b2[6];
     double *mem1[6], *mem2[6];
@@ -627,27 +629,22 @@ int32_t plltrack_perf(CSOUND *csound, PLLTRACK *p)
     double scal,esr;
     BIQUAD *biquad = p->fils;
     MYFLT *asig=p->asig,kd=*p->kd,klpf,klpfQ,klf,khf,kthresh;
-    MYFLT *freq=p->freq, *lock =p->lock, itmp = asig[0];
-    int32_t
-      itest = 0;
+    MYFLT *freq=p->freq, *lock =p->lock;
 
     _0dbfs = csound->Get0dBFS(csound);
     ksmps = CS_KSMPS;
     esr = CS_ESR;
     scal = 2.0*CS_PIDSR;
 
-    /* check for muted input & bypass */
-    if (ksmps > 1){
-    for (i=0; i < ksmps; i++) {
-      if (asig[i] != 0.0 && asig[i] != itmp) {
-        itest = 1;
-        break;
-      }
-      itmp = asig[i];
+    if (UNLIKELY(offset)) {
+      memset(freq, 0, offset * sizeof(MYFLT));
+      memset(lock, 0, offset * sizeof(MYFLT));
     }
-    if (!itest)  return OK;
-    } else if (*asig == 0.0) return OK;
-
+    if (UNLIKELY(early)) {
+      ksmps -= early;
+      memset(&freq[ksmps], 0, early * sizeof(MYFLT));
+      memset(&lock[ksmps], 0, early * sizeof(MYFLT));
+    }
 
     if (*p->klpf == 0) klpf = 20.0;
     else klpf = *p->klpf;
@@ -700,7 +697,8 @@ int32_t plltrack_perf(CSOUND *csound, PLLTRACK *p)
     xce = &p->xce;
     ace = &p->ace;
 
-    for (i=0; i < ksmps; i++){
+    /* Process constant input and let filter state decay during silence. */
+    for (i=offset; i < ksmps; i++){
       double input = (double) (asig[i]/_0dbfs), env;
       double w, y, icef = 0.99, fosc, xd, c, s, oc;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -751,6 +751,7 @@ def runTest():
         ["test_vector_table_invalid_index.csd", "reject invalid vector table index", 1],
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
+        ["test_plltrack_samples.csd", "plltrack constant input, silence, and sample bounds"],
         ["test_cps_table_pitch.csd", "tuning-table pitch endpoints and negative pitches"],
         ["test_cps_missing_table.csd", "reject missing pitch tuning tables", 1],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],

--- a/tests/commandline/test_plltrack_samples.csd
+++ b/tests/commandline/test_plltrack_samples.csd
@@ -1,0 +1,86 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 48000
+ksmps = 120
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode TrackSample, aa, ak
+ setksmps 1
+ aInput, kGain xin
+ aFreq, aLock plltrack aInput, kGain
+ xout aFreq, aLock
+endop
+
+; Changing the block size must not change the samples that reach the PLL.
+; Include block-constant square waves, silence, DC, and ordinary audio.
+instr 1
+ kCycle init 0
+ kCycle += 1
+ aSine oscili .5, 200
+ if kCycle <= 400 then
+  aInput = (kCycle % 2 == 0 ? .5 : -.5)
+ elseif kCycle <= 800 || kCycle > 1600 then
+  aInput = 0
+ elseif kCycle <= 1200 then
+  aInput = aSine
+ else
+  aInput = .5
+ endif
+ kGain = (kCycle <= 800 ? .1 : .15)
+ aFreq, aLock plltrack aInput, kGain
+ aRefFreq, aRefLock TrackSample aInput, kGain
+ aAlias = aInput
+ aAlias, aAliasLock plltrack aAlias, kGain
+ kIndex = 0
+ while kIndex < ksmps do
+  kFreq vaget kIndex, aFreq
+  kLock vaget kIndex, aLock
+  kRefFreq vaget kIndex, aRefFreq
+  kRefLock vaget kIndex, aRefLock
+  kAlias vaget kIndex, aAlias
+  kAliasLock vaget kIndex, aAliasLock
+  if !(abs(kFreq-kRefFreq)+abs(kLock-kRefLock)+abs(kFreq-kAlias)+abs(kLock-kAliasLock) < .00001) then
+   printks "plltrack block mismatch: cycle=%g sample=%g freq=%g ref=%g alias=%g lock=%g ref=%g alias=%g\n", 0, kCycle, kIndex, kFreq, kRefFreq, kAlias, kLock, kRefLock, kAliasLock
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ if kCycle == 400 then
+  if !(kFreq > 190 && kFreq < 210) then
+   printks "plltrack failed to track a 200 Hz square: %g\n", 0, kFreq
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+ if kCycle == 800 || kCycle == 2000 then
+  if !(abs(kFreq)+abs(kLock) < .001) then
+   printks "plltrack retained output during silence: freq=%g lock=%g\n", 0, kFreq, kLock
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+ if kCycle == 1 then
+  gkChecks += 1
+ endif
+endin
+instr 99
+ if i(gkChecks) != 6 then
+  prints "plltrack checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 5
+; Partial first and last blocks, including a note contained in one block.
+i 1 .000625 .03125
+i 1 .00125 .000625
+i 99 5.01 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`plltrack` treats blocks of identical samples as muted and returns without updating its outputs or filter state. This can discard square-wave input when each half-cycle fills a block, and leave stale pitch and lock values during silence.

- Process every active sample so tracking works across block sizes and filter state can decay during silence.
- Clear inactive output samples at the start and end of a note, and exclude those samples from state updates.

The fix keeps the existing filter and oscillator calculations and adds no per-sample helper calls.
