### PR TITLE
Fix babo feedback-delay initialization and reset state

### DIFF
--- a/Opcodes/babo.c
+++ b/Opcodes/babo.c
@@ -192,13 +192,16 @@ BaboMemory_end(const BaboMemory *this)
  * common delay/tapline methods
  */
 
-static void
+static int32_t
 _Babo_common_delay_create(CSOUND *csound, BaboDelay *this, MYFLT max_time)
 {
-    size_t num_floats =
-      (size_t)MYFLT2LRND((MYFLT)ceil((double)(max_time*this->sr)));
+    double samples = ceil((double)(max_time * this->sr));
 
-    BaboMemory_create(csound, &this->core, num_floats);
+    if (UNLIKELY(!(samples >= 1.0 && samples <= INT32_MAX &&
+                   samples <= SIZE_MAX / sizeof(MYFLT))))
+        return csound->InitError(csound, "%s", Str("Babo: delay size out of range"));
+    BaboMemory_create(csound, &this->core, (size_t)samples);
+    return OK;
 }
 
 /*
@@ -208,7 +211,8 @@ _Babo_common_delay_create(CSOUND *csound, BaboDelay *this, MYFLT max_time)
 static BaboDelay *
 BaboDelay_create(CSOUND *csound, BaboDelay *this, MYFLT max_time)
 {
-    _Babo_common_delay_create(csound, this, max_time);
+    if (_Babo_common_delay_create(csound, this, max_time) != OK)
+        return NULL;
 
     this->input = BaboMemory_start(&this->core);
 
@@ -226,14 +230,14 @@ BaboDelay_input(BaboDelay *this, MYFLT input)
     return input;
 }
 
-static MYFLT
+static inline MYFLT
 BaboDelay_output(const BaboDelay *this)
 {
-    size_t num_samples = BaboMemory_samples(&this->core);
-    MYFLT *output_ptr = this->input - (num_samples - 1);
+    /* Reading one slot ahead preserves the existing N - 1 sample delay. */
+    MYFLT *output_ptr = this->input + 1;
 
-    if (output_ptr < BaboMemory_start(&this->core))
-        output_ptr += num_samples;
+    if (output_ptr == BaboMemory_end(&this->core))
+        output_ptr = BaboMemory_start(&this->core);
 
     return *output_ptr;
 }
@@ -252,7 +256,8 @@ BaboTapline_create(CSOUND *csound, BaboTapline *this, MYFLT x, MYFLT y, MYFLT z)
 {
     MYFLT max_time = (FL(2.0) * SQRT((x*x) + (y*y) + (z*z))) / sound_speed;
 
-    _Babo_common_delay_create(csound, (BaboDelay *) this, max_time);
+    if (_Babo_common_delay_create(csound, (BaboDelay *) this, max_time) != OK)
+        return NULL;
 
     this->input = BaboMemory_start(&this->core);
 
@@ -420,7 +425,7 @@ BaboLowPass_create(BaboLowPass *this, MYFLT decay, MYFLT hidecay, MYFLT norm)
 
     this->a0 = (real_decay + real_hidecay) * FL(0.25);
     this->a1 = (real_decay - real_hidecay) * FL(0.5);
-    this->z1 = this->z2 = FL(0.0);
+    this->input = this->z1 = this->z2 = FL(0.0);
 
     return this;
 }
@@ -449,7 +454,8 @@ BaboNode_create(CSOUND *csound, BaboNode *this, MYFLT time,
                 MYFLT min_time, MYFLT decay,
     MYFLT hidecay)
 {
-    BaboDelay_create(csound, &this->delay, time);
+    if (BaboDelay_create(csound, &this->delay, time) == NULL)
+        return NULL;
     BaboLowPass_create(&this->filter, decay, hidecay, time/min_time);
 
     return this;
@@ -621,8 +627,9 @@ BaboMatrix_create(CSOUND *csound,
     BaboMatrix_create_FDN(this, diffusion);
 
     for (i = 0; i < BABO_NODES; ++i)
-        BaboNode_create(csound, &this->node[i], delays[i],
-                        min_delay, decay, hidecay);
+        if (BaboNode_create(csound, &this->node[i], delays[i],
+                            min_delay, decay, hidecay) == NULL)
+            return NULL;
 
     return this;
 }
@@ -752,18 +759,6 @@ set_expert_values(CSOUND *csound, BABO *p)
     p->early_diffuse= load_value_or_default(ftp, n++, BABO_DEFAULT_DIFFUSE);
 }
 
-static void
-verify_coherence(CSOUND *csound, BABO *p)
-{
-    if (UNLIKELY(*(p->lx) <= FL(0.0) ||
-                 *(p->ly) <= FL(0.0) ||
-                 *(p->lz) <= FL(0.0))) {
-      csound->Warning(csound, Str("Babo: resonator dimensions are incorrect "
-                              "(%.1f, %.1f, %.1f)"),
-                  *(p->lx), *(p->ly), *(p->lz));
-    }
-}
-
 /*
  * OPCODE FUNCTIONS - baboset(), babo()
  *
@@ -775,19 +770,29 @@ static int32_t
 baboset(CSOUND *csound, void *entry)
 {
     BABO *p = (BABO *) entry;   /* assuming the engine is right... :)   */
+    int32_t i;
+    if (UNLIKELY(!(*p->lx > FL(0.0) && *p->ly > FL(0.0) &&
+                   *p->lz > FL(0.0))))
+        return csound->InitError(csound, "%s",
+                                 Str("Babo: room dimensions must be positive"));
     p->tapline.sr = CS_ESR;
     p->matrix_delay.sr = CS_ESR;
+    for (i = 0; i < BABO_NODES; ++i)
+        p->matrix.node[i].delay.sr = CS_ESR;
     set_defaults(csound,p);
-    verify_coherence(csound,p);        /* exits if call is wrong */
 
-    BaboTapline_create(csound,&p->tapline, *(p->lx), *(p->ly), *(p->lz));
-    BaboDelay_create(csound, &p->matrix_delay,
-                     BaboTapline_maxtime(csound, &p->tapline));
-    BaboMatrix_create(csound, &p->matrix, p->diffusion_coeff, *(p->lx),
-                      *(p->ly), *(p->lz), p->decay, p->hidecay, p->early_diffuse);
+    if (BaboTapline_create(csound, &p->tapline, *p->lx, *p->ly, *p->lz) == NULL ||
+        BaboDelay_create(csound, &p->matrix_delay,
+                         BaboTapline_maxtime(csound, &p->tapline)) == NULL ||
+        BaboMatrix_create(csound, &p->matrix, p->diffusion_coeff, *p->lx,
+                          *p->ly, *p->lz, p->decay, p->hidecay,
+                          p->early_diffuse) == NULL)
+        return NOTOK;
     return OK;
 }
 
+/* Legacy babo leaves early-reflection tap sample rates at zero and ignores
+   the direct-signal gain. Preserve that sound; babo2 supplies both values. */
 static int32_t
 babo(CSOUND *csound, void *entry)
 {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -970,6 +970,8 @@ def runTest():
         ["test_comb_units.csd", "comb family delay units, rate handling and partial blocks"],
         ["test_nestedap_state.csd", "nestedap reset, mode changes, and preserved state"],
         ["test_nestedap_invalid_delay.csd", "reject invalid nestedap delay layout", 1],
+        ["test_babo_state.csd", "babo feedback delays and reset"],
+        ["test_babo_invalid_room.csd", "reject invalid babo room dimensions", 1],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_pinker_sequence.csd", "pinker preserves its noise sequence across block sizes"],
         ["test_pinker_sample_bounds.csd", "pinker clears inactive samples"],

--- a/tests/commandline/test_babo_invalid_room.csd
+++ b/tests/commandline/test_babo_invalid_room.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+#ifndef SIZE
+#define SIZE #0#
+#endif
+sr = 48000
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+instr 1
+ aInput = 0
+ aLeft, aRight babo aInput, 0, 0, 0, $SIZE, 5, 4
+endin
+instr 2
+ aInput = 0
+ aLeft, aRight babo2 aInput, 0, 0, 0, $SIZE, 5, 4
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+i 2 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_babo_state.csd
+++ b/tests/commandline/test_babo_state.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+gkChecks init 0
+; Disable early reflections so the energy check measures the feedback network.
+giRoom ftgen 0, 0, 8, -2, .99, .1, 0, 0, 0, .3, .5, 0
+
+opcode Room, aa, ai
+ aInput, iVersion xin
+ if iVersion == 1 then
+  aLeft, aRight babo aInput, 1, 1, 1, 6, 5, 4, 1, giRoom
+ else
+  aLeft, aRight babo2 aInput, 1, 1, 1, 6, 5, 4, 1, giRoom
+ endif
+ xout aLeft, aRight
+endop
+
+; Both versions need a working feedback network and a complete reset.
+instr 1
+ kCycle init 0
+ kEnergy init 0
+ kCycle += 1
+ aInput oscili .1, 731
+ if kCycle > 128 then
+  aInput = 0
+ endif
+ if kCycle == 129 then
+  reinit REVERB
+ endif
+REVERB:
+ aLeft, aRight Room aInput, p4
+ rireturn
+ kIndex = 0
+ while kIndex < ksmps do
+  kLeft vaget kIndex, aLeft
+  kRight vaget kIndex, aRight
+  if !(abs(kLeft)+abs(kRight) < 100) then
+   printks "babo%g invalid output at cycle %g\n", 0, p4, kCycle
+   exitnowk(-1)
+  endif
+  if kCycle > 128 && abs(kLeft)+abs(kRight) > .0000001 then
+   printks "babo%g retained filter state on reset: %g %g\n", 0, p4, kLeft, kRight
+   exitnowk(-1)
+  endif
+  kEnergy += kLeft*kLeft + kRight*kRight
+  kIndex += 1
+ od
+ if kCycle == 256 then
+  if !(kEnergy > .01) then
+   printks "babo%g produced no reverb\n", 0, p4
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+endin
+instr 99
+ if i(gkChecks) != 2 then
+  prints "babo checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 1 1
+i 1 0 1 2
+i 99 1.01 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`babo` and `babo2` leave their feedback-delay sample rates at zero, creating zero-length buffers even for ordinary room sizes.

- Set every feedback delay's sample rate before allocating its buffer.
- Clear the low-pass filter's saved input along with its other history, so reinitialization cannot bring back old signal.
- Reject nonpositive room dimensions and out-of-range delay sizes before conversion or allocation, and stop initialization if a delay cannot be created.
- Read feedback delays by advancing one slot and wrapping. This preserves the existing delay length without forming pointers before the buffer.

Keep `babo`'s legacy early-reflection timing and direct-gain behavior; the source comment explains that `babo2` supplies those corrections.
