### PR TITLE
Fix min/max accumulators clearing other notes’ samples

### DIFF
--- a/Opcodes/minmax.c
+++ b/Opcodes/minmax.c
@@ -48,22 +48,18 @@ typedef struct {
     MYFLT   *xout, *xin1, *xin2toN[VARGMAX-1];
 } MINMAX;
 
-/* Which implementation is faster ?? */
+/* Accumulators may hold samples from other note instances. Leave samples
+   outside this note's active range unchanged. */
 static int32_t MaxAccumulate(CSOUND *csound, MINMAXACCUM *p)
 {
     IGN(csound);
     MYFLT   cur;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    uint32_t n, nsmps = CS_KSMPS;
+    uint32_t n, nsmps = CS_KSMPS - early;
     MYFLT   *out = p->accum;
     MYFLT   *in = p->ain;
 
-    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&out[nsmps], '\0', early*sizeof(MYFLT));
-    }
     for (n=offset; n<nsmps; n++) {
       cur = in[n];
       if (UNLIKELY(cur > out[n]))
@@ -79,15 +75,10 @@ static int32_t MinAccumulate(CSOUND *csound, MINMAXACCUM *p)
     MYFLT   cur;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    uint32_t n, nsmps = CS_KSMPS;
+    uint32_t n, nsmps = CS_KSMPS - early;
     MYFLT   *out = p->accum;
     MYFLT   *in = p->ain;
 
-    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&out[nsmps], '\0', early*sizeof(MYFLT));
-    }
     for (n=offset; n<nsmps; n++) {
       cur = in[n];
       if (UNLIKELY(cur < out[n]))
@@ -103,16 +94,11 @@ static int32_t MaxAbsAccumulate(CSOUND *csound, MINMAXACCUM *p)
     IGN(csound);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    uint32_t n, nsmps = CS_KSMPS;
+    uint32_t n, nsmps = CS_KSMPS - early;
     MYFLT   *out = p->accum;
     MYFLT   *in = p->ain;
     MYFLT   inabs;
 
-    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&out[nsmps], '\0', early*sizeof(MYFLT));
-    }
     for (n=offset; n<nsmps; n++) {
       inabs = FABS(in[n]);
       if (UNLIKELY(inabs > out[n]))
@@ -127,16 +113,11 @@ static int32_t MinAbsAccumulate(CSOUND *csound, MINMAXACCUM *p)
     IGN(csound);
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    uint32_t n, nsmps = CS_KSMPS;
+    uint32_t n, nsmps = CS_KSMPS - early;
     MYFLT   *out = p->accum;
     MYFLT   *in = p->ain;
     MYFLT   inabs;
 
-    if (UNLIKELY(offset)) memset(out, '\0', offset*sizeof(MYFLT));
-    if (UNLIKELY(early)) {
-      nsmps -= early;
-      memset(&out[nsmps], '\0', early*sizeof(MYFLT));
-    }
     for (n=offset; n<nsmps; n++) {
       inabs = FABS(in[n]);
       if (UNLIKELY(inabs < out[n]))

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -939,6 +939,7 @@ def runTest():
         ["test_gen01.csd", "testing GEN01 importing files"],
         ["test_raw_strings.csd", "test new-style raw strings"],
         ["test_min_max_values.csd", "test MIN_VALUE and MAX_VALUE math constants"],
+        ["test_minmax_accumulator_bounds.csd", "min/max accumulators preserve inactive samples"],
         ["test_all_math_constants.csd", "test all builtin math constant macros"],
         [
             "test_op_precedence.csd",

--- a/tests/commandline/test_minmax_accumulator_bounds.csd
+++ b/tests/commandline/test_minmax_accumulator_bounds.csd
@@ -1,0 +1,86 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gaMax init 0
+gaMin init 0
+gaMaxAbs init 0
+gaMinAbs init 0
+gkChecks init 0
+
+; Seed each block before the partial notes update the shared accumulators.
+instr 1
+ gaMax = -2
+ gaMin = 2
+ gaMaxAbs = .25
+ gaMinAbs = 2
+endin
+instr 2
+ aInput = p4
+ maxaccum gaMax, aInput
+ minaccum gaMin, aInput
+ maxabsaccum gaMaxAbs, aInput
+ minabsaccum gaMinAbs, aInput
+endin
+instr 3
+ kBase init 0
+ kIndex = 0
+ while kIndex < ksmps do
+  kSample = kBase + kIndex
+  kMax = -2
+  kMin = 2
+  kMaxAbs = .25
+  kMinAbs = 2
+  if kSample >= 5 && kSample < 15 then
+   kMax = 1
+   kMin = 1
+   kMaxAbs = 1
+   kMinAbs = 1
+  endif
+  if kSample >= 10 && kSample < 45 then
+   kMin = -3
+   kMaxAbs = 3
+  endif
+  if kSample >= 64 then
+   kMax = -.5
+   kMin = -.5
+   kMaxAbs = .5
+   kMinAbs = .5
+  endif
+  kActualMax vaget kIndex, gaMax
+  kActualMin vaget kIndex, gaMin
+  kActualMaxAbs vaget kIndex, gaMaxAbs
+  kActualMinAbs vaget kIndex, gaMinAbs
+  if kActualMax != kMax || kActualMin != kMin || kActualMaxAbs != kMaxAbs || kActualMinAbs != kMinAbs then
+   printks "accumulator mismatch at sample %g: max=%g min=%g maxabs=%g minabs=%g\n", 0, kSample, kActualMax, kActualMin, kActualMaxAbs, kActualMinAbs
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+  kIndex += 1
+ od
+ kBase += ksmps
+endin
+instr 99
+ if i(gkChecks) != 96 then
+  prints "accumulator checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01171875
+; A note within one block, an overlapping note spanning two blocks,
+; and a full-block note. Times are exact multiples of one sample.
+i 2 .0006103515625 .001220703125 1
+i 2 .001220703125 .0042724609375 -3
+i 2 .0078125 .00390625 -.5
+i 3 0 .01171875
+i 99 .015625 .00390625
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
With sample-accurate scheduling, `maxaccum`, `minaccum`, `maxabsaccum`, and `minabsaccum` clear accumulator samples outside the current note's active range. Since notes can share an accumulator, starting or ending one note partway through a block can erase values from other notes or overwrite the caller's initial values.

Remove that clearing and update only active samples in all four variants. This preserves earlier contributions and removes unnecessary buffer writes without adding work to the sample loops.
