### PR TITLE
Fix exact breakpoint handling in bpf and bpfcos

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -497,7 +497,8 @@ static int32_t bpfx_k(CSOUND *csound, BPFX *p);
 
 
 static int32 bpfx_i(CSOUND *csound, BPFX *p) {
-    bpfx_init(csound, p);
+    if (bpfx_init(csound, p) != OK)
+        return NOTOK;
     return bpfx_k(csound, p);
 }
 
@@ -517,10 +518,10 @@ static inline int32_t bpfx_find(MYFLT **data, MYFLT x, int32_t datalen, int32_t 
     if (x>=*data[datalen-2])
         return -2;
     if(lastidx >= 0) {
-        if(lastidx < datalen - 4 && *data[lastidx] <= x && x < *data[lastidx+2])
+        if(lastidx < datalen - 2 && *data[lastidx] <= x && x < *data[lastidx+2])
             return lastidx;
         // search next pair
-        if(lastidx < datalen - 6 && *data[lastidx+2] <= x && x < *data[lastidx+4])
+        if(lastidx < datalen - 4 && *data[lastidx+2] <= x && x < *data[lastidx+4])
             return lastidx+2;
     }
     // binary search
@@ -531,12 +532,12 @@ static inline int32_t bpfx_find(MYFLT **data, MYFLT x, int32_t datalen, int32_t 
 
     while (pairmin < pairmax) {
         pairmid = (pairmax + pairmin) / 2;
-        if (*data[pairmid * 2] < x)
+        if (*data[pairmid * 2] <= x)
             pairmin = pairmid + 1;
         else
             pairmax = pairmid;
     }
-    // now the right pair is in pairmin
+    // Select the segment starting at an exact interior breakpoint.
     return (pairmin-1)*2;
 }
 
@@ -607,7 +608,8 @@ static int32_t bpfxcos_k(CSOUND *csound, BPFX *p) {
 }
 
 static int32 bpfxcos_i(CSOUND *csound, BPFX *p) {
-    bpfx_init(csound, p);
+    if (bpfx_init(csound, p) != OK)
+        return NOTOK;
     return bpfxcos_k(csound, p);
 }
 
@@ -632,7 +634,7 @@ static inline int64_t bpfarr_find(MYFLT x, MYFLT *xs, int64_t xslen, int64_t las
     if(x >= xs[xslen-1]) {
         return -2;
     }
-    if(lastidx >= 0 && lastidx < xslen-2 && xs[lastidx] <= x && x < xs[lastidx+1]) {
+    if(lastidx >= 0 && lastidx < xslen-1 && xs[lastidx] <= x && x < xs[lastidx+1]) {
         return lastidx;
     }
 
@@ -642,24 +644,30 @@ static inline int64_t bpfarr_find(MYFLT x, MYFLT *xs, int64_t xslen, int64_t las
 
     while (imin < imax) {
         imid = (imax + imin) / 2;
-        if (xs[imid] < x)
+        if (xs[imid] <= x)
             imin = imid + 1;
         else
             imax = imid;
     }
-    // now the right pair is in pairmin
+    // Select the segment starting at an exact interior breakpoint.
     return imin - 1;
 }
 
 
+/* Point arrays must remain nonempty when their values change at k-rate. */
+#define BPF_POINTS_VALID(a) ((a)->dimensions == 1 && (a)->sizes != NULL && \
+                             (a)->sizes[0] > 0 && (a)->data != NULL)
+
 static int32_t bpf_k_kKK_init(CSOUND *csound, BPF_k_kKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys)))
+        return INITERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     p->lastidx = -1;
     return OK;
 }
 
 static int32_t bpf_k_kKK_kr(CSOUND *csound, BPF_k_kKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys)))
+        return PERFERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     int64_t numxs = p->xs->sizes[0];
     int64_t numys = p->ys->sizes[0];
     int64_t N = numxs < numys ? numxs : numys;
@@ -694,13 +702,15 @@ static int32_t bpf_k_kKK_kr(CSOUND *csound, BPF_k_kKK *p) {
 
 
 static int32_t bpf_k_kKK_ir(CSOUND *csound, BPF_k_kKK *p) {
-    bpf_k_kKK_init(csound, p);
+    if (bpf_k_kKK_init(csound, p) != OK)
+        return NOTOK;
     return bpf_k_kKK_kr(csound, p);
 }
 
 
 static int32_t bpfcos_k_kKK_kr(CSOUND *csound, BPF_k_kKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys)))
+        return PERFERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     int32_t numxs = p->xs->sizes[0];
     int32_t numys = p->ys->sizes[0];
     int32_t N = numxs < numys ? numxs : numys;
@@ -711,14 +721,13 @@ static int32_t bpfcos_k_kKK_kr(CSOUND *csound, BPF_k_kKK *p) {
     MYFLT x0, y0, x1, y1, dx;
     if(i == -1) {
         *p->y = ys[0];
+        p->lastidx = -1;
         return OK;
     }
     if(i == -2) {
         *p->y = ys[N-1];
+        p->lastidx = -1;
         return OK;
-    }
-    if(UNLIKELY(i == -3)) {
-        return NOTOK;
     }
     x0 = xs[i];
     x1 = xs[i+1];
@@ -726,11 +735,13 @@ static int32_t bpfcos_k_kKK_kr(CSOUND *csound, BPF_k_kKK *p) {
     y1 = ys[i+1];
     dx = ((x-x0) / (x1-x0)) * PI + PI;
     *p->y = y0 + ((y1 - y0) * (1 + COS(dx)) / 2.0);
+    p->lastidx = i;
     return OK;
 }
 
 static int32_t bpfcos_k_kKK_ir(CSOUND *csound, BPF_k_kKK *p) {
-    bpf_k_kKK_init(csound, p);
+    if (bpf_k_kKK_init(csound, p) != OK)
+        return NOTOK;
     return bpfcos_k_kKK_kr(csound, p);
 }
 
@@ -738,7 +749,8 @@ static int32_t bpfcos_k_kKK_ir(CSOUND *csound, BPF_k_kKK *p) {
 // ay bpf ax, kxs[], kys[]
 
 static int32_t bpf_a_aKK_kr(CSOUND *csound, BPF_k_kKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys)))
+        return PERFERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     int64_t numxs = p->xs->sizes[0];
     int64_t numys = p->ys->sizes[0];
     int64_t N = numxs < numys ? numxs : numys;
@@ -783,7 +795,8 @@ static int32_t bpf_a_aKK_kr(CSOUND *csound, BPF_k_kKK *p) {
 }
 
 static int32_t bpfcos_a_aKK_kr(CSOUND *csound, BPF_k_kKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys)))
+        return PERFERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     int64_t numxs = p->xs->sizes[0];
     int64_t numys = p->ys->sizes[0];
     int64_t N = numxs < numys ? numxs : numys;
@@ -836,13 +849,17 @@ typedef struct {
 } BPF_kk_kKKK;
 
 static int32_t bpf_kk_kKKK_init(CSOUND *csound, BPF_kk_kKKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys) ||
+                 !BPF_POINTS_VALID(p->zs)))
+        return INITERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     p->lastidx = -1;
     return OK;
 }
 
 static int32_t bpf_kk_kKKK_kr(CSOUND *csound, BPF_kk_kKKK *p) {
-    IGN(csound);
+    if (UNLIKELY(!BPF_POINTS_VALID(p->xs) || !BPF_POINTS_VALID(p->ys) ||
+                 !BPF_POINTS_VALID(p->zs)))
+        return PERFERR(Str("bpf: expected nonempty one-dimensional point arrays"));
     int32_t numxs = p->xs->sizes[0];
     int32_t numys = p->ys->sizes[0];
     int32_t numzs = p->zs->sizes[0];
@@ -879,10 +896,13 @@ static int32_t bpf_kk_kKKK_kr(CSOUND *csound, BPF_kk_kKKK *p) {
 }
 
 static int32_t bpf_kk_kKKK_ir(CSOUND *csound, BPF_kk_kKKK *p) {
-    bpf_kk_kKKK_init(csound, p);
+    if (bpf_kk_kKKK_init(csound, p) != OK)
+        return NOTOK;
     return bpf_kk_kKKK_kr(csound, p);
 }
 
+
+#undef BPF_POINTS_VALID
 
 // kys[] bpf kxs[], kx0, ky0, kx1, ky1, ...
 typedef struct {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -756,6 +756,8 @@ def runTest():
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
         ["test_tablefilter_values.csd", "tablefilter parameters, rational values, and table wrapping"],
+        ["test_bpf_breakpoints.csd", "bpf and bpfcos exact breakpoints across rates"],
+        ["test_bpf_invalid_points.csd", "reject empty or incomplete bpf points", 1],
         ["test_tabsum_ranges.csd", "tabsum handles valid table ranges"],
         ["test_tabsum_invalid_range.csd", "tabsum rejects out-of-range indexes", 1],
         ["test_newstyle_passbycopy.csd", "test newstyle udo with setksmps"],

--- a/tests/commandline/test_bpf_breakpoints.csd
+++ b/tests/commandline/test_bpf_breakpoints.csd
@@ -1,0 +1,103 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+instr 1
+ iXs[] fillarray 0, 1, 2, 3
+ iYs[] fillarray 10, 20, -5, 30
+ kXs[] fillarray 0, 1, 2, 3
+ kYs[] fillarray 10, 20, -5, 30
+ kTests[] fillarray 1, 2, 0, 3, -1, 4, 1.25, 1.75, .5, 2.5, 2, 1, 2.75, .25, 0, 3
+ kCycle init 0
+ kX = kTests[kCycle % 16]
+ kCycle += 1
+ if kX <= 0 then
+  kLinear = 10
+  kCosine = 10
+ elseif kX >= 3 then
+  kLinear = 30
+  kCosine = 30
+ else
+  kSegment = int(kX)
+  kFraction = kX-kSegment
+  kY0 = kYs[kSegment]
+  kY1 = kYs[kSegment+1]
+  kLinear = kY0 + (kY1-kY0)*kFraction
+  kCosine = kY0 + (kY1-kY0)*(1-cos(kFraction*3.141592653589793))*.5
+ endif
+ iLinear bpf 1, 0, 10, 1, 20, 2, -5, 3, 30
+ iCosine bpfcos 1, 0, 10, 1, 20, 2, -5, 3, 30
+ iArrayLinear bpf 1, iXs, iYs
+ iArrayCosine bpfcos 1, iXs, iYs
+ if iLinear != 20 || iCosine != 20 || iArrayLinear != 20 || iArrayCosine != 20 then
+  prints "bpf init-rate breakpoint mismatch\n"
+  exitnow(-1)
+ endif
+ kLinear1 bpf kX, 0, 10, 1, 20, 2, -5, 3, 30
+ kCosine1 bpfcos kX, 0, 10, 1, 20, 2, -5, 3, 30
+ kLinear2 bpf kX, iXs, iYs
+ kCosine2 bpfcos kX, iXs, iYs
+ kLinear3 bpf kX, kXs, kYs
+ kCosine3 bpfcos kX, kXs, kYs
+ kDual1, kDual2 bpf kX, kXs, kYs, kYs
+ kInput[] fillarray 0, 0
+ kInput[0] = kX
+ kInput[1] = kX
+ kLinearArray[] bpf kInput, 0, 10, 1, 20, 2, -5, 3, 30
+ kCosineArray[] bpfcos kInput, 0, 10, 1, 20, 2, -5, 3, 30
+ if !(abs(kLinear1-kLinear)+abs(kLinear2-kLinear)+abs(kLinear3-kLinear)+abs(kDual1-kLinear)+abs(kDual2-kLinear)+abs(kCosine1-kCosine)+abs(kCosine2-kCosine)+abs(kCosine3-kCosine)+abs(kLinearArray[0]-kLinear)+abs(kLinearArray[1]-kLinear)+abs(kCosineArray[0]-kCosine)+abs(kCosineArray[1]-kCosine) < .0001) then
+  printks "bpf control-rate mismatch at %g\n", 0, kX
+  exitnowk(-1)
+ endif
+ aX = kX
+ aLinear1 bpf aX, 0, 10, 1, 20, 2, -5, 3, 30
+ aCosine1 bpfcos aX, 0, 10, 1, 20, 2, -5, 3, 30
+ aLinear2 bpf aX, iXs, iYs
+ aCosine2 bpfcos aX, iXs, iYs
+ aLinear3 bpf aX, kXs, kYs
+ aCosine3 bpfcos aX, kXs, kYs
+ aAlias = aX
+ aAlias bpf aAlias, 0, 10, 1, 20, 2, -5, 3, 30
+ iOffset = round(frac(p2*sr/ksmps)*ksmps)
+ iSamples = round(p3*sr)
+ kIndex = 0
+ while kIndex < ksmps do
+  kPosition = (kCycle-1)*ksmps+kIndex-iOffset
+  kExpectedLinear = (kPosition >= 0 && kPosition < iSamples ? kLinear : 0)
+  kExpectedCosine = (kPosition >= 0 && kPosition < iSamples ? kCosine : 0)
+  kLinear1Sample vaget kIndex, aLinear1
+  kLinear2Sample vaget kIndex, aLinear2
+  kLinear3Sample vaget kIndex, aLinear3
+  kCosine1Sample vaget kIndex, aCosine1
+  kCosine2Sample vaget kIndex, aCosine2
+  kCosine3Sample vaget kIndex, aCosine3
+  kAliasSample vaget kIndex, aAlias
+  if !(abs(kLinear1Sample-kExpectedLinear)+abs(kLinear2Sample-kExpectedLinear)+abs(kLinear3Sample-kExpectedLinear)+abs(kAliasSample-kExpectedLinear)+abs(kCosine1Sample-kExpectedCosine)+abs(kCosine2Sample-kExpectedCosine)+abs(kCosine3Sample-kExpectedCosine) < .0001) then
+   printks "bpf audio-rate mismatch at x=%g sample=%g\n", 0, kX, kIndex
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ gkChecks += 1
+endin
+instr 99
+ if i(gkChecks) != 19 then
+  prints "bpf processing stopped early: %g checks\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03125
+i 1 .0006103515625 .00244140625
+i 1 .001953125 .000732421875
+i 99 .03515625 .001953125
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_bpf_invalid_points.csd
+++ b/tests/commandline/test_bpf_invalid_points.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+instr 1
+ iXs[] init 0
+ iYs[] fillarray 10, 20
+ iY bpf 1, iXs, iYs
+endin
+instr 2
+ iXs[] fillarray 0, 1
+ iYs[] init 0
+ iY bpfcos 1, iXs, iYs
+endin
+instr 3
+ ; An incomplete pair must stop initialization before evaluation.
+ iY bpf 1, 0, 10, 1
+endin
+instr 4
+ iY bpfcos 1, 0, 10, 1
+endin
+; Resize one point array without reinitializing the consuming opcode.
+instr 5
+ kCycle init 0
+ kSize init 2
+ if kCycle == 1 then
+  kSize = 0
+  reinit POINTS
+ endif
+POINTS:
+ kXs[] init (p4 == 0 || p4 == 2 ? i(kSize) : 2)
+ kYs[] init (p4 == 1 || p4 == 3 ? i(kSize) : 2)
+ kZs[] init (p4 == 4 ? i(kSize) : 2)
+ rireturn
+ if kSize > 0 then
+  kXs[0] = 0
+  kXs[1] = 1
+  kYs[0] = 10
+  kYs[1] = 20
+  kZs[0] = 30
+  kZs[1] = 40
+ endif
+ aX = .5
+ if p4 == 0 then
+  kY bpf .5, kXs, kYs
+ elseif p4 == 1 then
+  kY bpfcos .5, kXs, kYs
+ elseif p4 == 2 then
+  aY bpf aX, kXs, kYs
+ elseif p4 == 3 then
+  aY bpfcos aX, kXs, kYs
+ else
+  kY, kZ bpf .5, kXs, kYs, kZs
+ endif
+ kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+i 2 0 .01
+i 3 0 .01
+i 4 0 .01
+i 5 .1 .01 0
+i 5 .1 .01 1
+i 5 .1 .01 2
+i 5 .1 .01 3
+i 5 .1 .01 4
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`bpfcos` and audio/array forms of `bpf` can reject an input exactly on an interior breakpoint: the binary search selects the preceding segment, but evaluation expects the segment starting at that point.

- Make binary and cached searches agree at exact breakpoints, including the final segment.
- Stop i-rate evaluation after initialization fails, and reject empty or invalid point-array shapes before reading their elements, including after runtime resizing.
- Save the last segment in the scalar array form of `bpfcos`, avoiding repeated searches for values in the same segment.

Point-array checks run once per control block, outside audio sample loops.
