### PR TITLE
fix: correct ptrack analysis sizes and sample timing

### DIFF
--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -368,13 +368,15 @@ void ptrack(CSOUND *csound,PITCHTRACK *p)
 int32_t pitchtrackinit(CSOUND *csound, PITCHTRACK  *p)
 {
 
-    int32_t i, winsize = *p->size*2, powtwo, tmp;
+    int32_t i, winsize, powtwo, tmp;
+    MYFLT requested = *p->size * FL(2.0);
     MYFLT *tmpb;
 
-    if (UNLIKELY(winsize < MINWINSIZ || winsize > MAXWINSIZ)) {
+    if (UNLIKELY(!(requested >= MINWINSIZ && requested <= MAXWINSIZ))) {
       csound->Warning(csound, Str("ptrack: FFT size out of range; using %d\n"),
                       winsize = DEFAULTWINSIZ);
     }
+    else winsize = (int32_t) requested;
 
     tmp = winsize;
     powtwo = -1;
@@ -388,7 +390,8 @@ int32_t pitchtrackinit(CSOUND *csound, PITCHTRACK  *p)
       csound->Warning(csound, Str("ptrack: FFT size not a power of 2; using %d\n"),
                       winsize = (1 << powtwo));
     }
-    p->hopsize = *p->size;
+    /* Use the corrected size for both allocation and analysis. */
+    p->hopsize = winsize / 2;
     if (!p->signal.auxp || p->signal.size < p->hopsize*sizeof(MYFLT)) {
       csound->AuxAlloc(csound, p->hopsize*sizeof(MYFLT), &p->signal);
     }
@@ -416,7 +419,7 @@ int32_t pitchtrackinit(CSOUND *csound, PITCHTRACK  *p)
         tmpb[2*i+1] = -(MYFLT)sin((PI*i)/(winsize));
 
     p->cnt = 0;
-    if (*p->peak == 0 || *p->peak > MAXPEAKNOS)
+    if (!(*p->peak >= FL(1.0) && *p->peak <= MAXPEAKNOS))
       p->numpks = DEFAULTPEAKNOS;
     else
       p->numpks = *p->peak;
@@ -443,14 +446,15 @@ int32_t pitchtrackprocess(CSOUND *csound, PITCHTRACK *p)
     MYFLT *buf = (MYFLT *)p->signal.auxp;
     int32_t pos = p->cnt, h = p->hopsize;
     MYFLT scale = p->dbfs;
-    int32_t ksmps = CS_KSMPS;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    int32_t ksmps = CS_KSMPS - p->h.insdshead->ksmps_no_end;
 
-    for (i=0; i<ksmps; i++,pos++) {
+    for (i=offset; i<ksmps; i++) {
+      buf[pos++] = sig[i]*scale;
       if (pos == h) {
         ptrack(csound,p);
         pos = 0;
       }
-      buf[pos] = sig[i]*scale;
     }
     //if (p->cps)
     *p->freq = p->cps;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -752,6 +752,7 @@ def runTest():
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
         ["test_cps_table_pitch.csd", "tuning-table pitch endpoints and negative pitches"],
+        ["test_ptrack_analysis.csd", "ptrack active samples and consistent analysis sizes"],
         ["test_cps_missing_table.csd", "reject missing pitch tuning tables", 1],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],

--- a/tests/commandline/test_ptrack_analysis.csd
+++ b/tests/commandline/test_ptrack_analysis.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkAmps[] init 6
+gkChecks init 0
+
+; Measurements depend on active samples, including the last sample of a hop.
+instr 1
+ aInput oscili .5, 512
+ kPitch, kAmp ptrack aInput, 64
+ gkAmps[p4] = kAmp
+endin
+
+; Fallback sizes and peak counts must behave like their explicit equivalents.
+; Long enough to exercise the largest supported hop as well.
+instr 2
+ kCycle init 0
+ kCycle += 1
+ aInput oscili .5, 512
+ kPitch, kAmp ptrack aInput, p4, p6
+ kRefPitch, kRefAmp ptrack aInput, p5, p7
+ if !(abs(kPitch-kRefPitch)+abs(kAmp-kRefAmp) < .0001) then
+  printks "ptrack fallback mismatch: hop=%g peaks=%g pitch=%g/%g amp=%g/%g\n", 0, p4, p6, kPitch, kRefPitch, kAmp, kRefAmp
+  exitnowk(-1)
+ endif
+ if kCycle == 512 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if gkAmps[1] != -144 || gkAmps[5] != -144 then
+  printks "ptrack counted inactive samples: %g %g\n", 0, gkAmps[1], gkAmps[5]
+  exitnowk(-1)
+ endif
+ if !(gkAmps[2] > -100 && gkAmps[3] > -100 && gkAmps[4] > -100) then
+  printks "ptrack delayed a completed hop: %g %g %g\n", 0, gkAmps[2], gkAmps[3], gkAmps[4]
+  exitnowk(-1)
+ endif
+ if gkChecks != 12 then
+  printks "ptrack comparisons did not complete: %g\n", 0, gkChecks
+  exitnowk(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Start at sample 5; lengths 63, 64, 65, and 10 samples.
+i 1 .0006103515625 .0076904296875 1
+i 1 .0006103515625 .0078125 2
+i 1 .0006103515625 .0079345703125 3
+i 1 0 .0078125 4
+i 1 .0006103515625 .001220703125 5
+; requested hop, corrected hop, requested peaks, corrected peaks
+i 2 0 1 0 512 0 20
+i 2 0 1 -64 512 20 20
+i 2 0 1 1 512 -1 20
+i 2 0 1 63 512 .5 20
+i 2 0 1 65 64 101 20
+i 2 0 1 96 64 20 20
+i 2 0 1 100.75 64 20 20
+i 2 0 1 4097 512 20 20
+i 2 0 1 1e30 512 20 20
+i 2 0 1 64 64 1 1
+i 2 0 1 64 64 1e30 20
+i 2 0 1 4096 4096 100 100
+i 99 1.01 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Use the corrected FFT size for both buffer allocation and analysis in `ptrack`. Previously, initialization adjusted the FFT size but kept the requested hop size, leaving the buffers and analysis inconsistent. Check sizes and peak counts before converting them to integers, using the existing defaults for values outside the supported range.

Process only active note samples and analyze each hop as soon as its last sample arrives. This prevents inactive samples from entering the analysis and makes a completed hop available without waiting for another sample.
