### PR TITLE
fix: correct centroid window state and spectral bins

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -1274,18 +1274,32 @@ typedef struct _centr{
 } CENTR;
 
 static int32_t array_centroid(CSOUND *csound, CENTR *p) {
-  if(p->in->sizes == NULL)
-    return csound->InitError(csound, "array not initialised\n");
+  if(p->in->sizes == NULL || p->in->dimensions != 1 || p->in->sizes[0] < 2)
+    return NOTOK;
   MYFLT *in = p->in->data,a=FL(0.0),b=FL(0.0);
   int32_t NP1 = p->in->sizes[0];
-  MYFLT f = CS_ESR/(2*(NP1 - 1)),cf;
+  MYFLT f = CS_ESR/(FL(2.0)*(NP1 - 1)),cf;
   int32_t i;
-  cf = f*FL(0.5);
-  for (i=0; i < NP1-1; i++, cf+=f) {
+  cf = FL(0.0);
+  for (i=0; i < NP1; i++, cf+=f) {
     a += in[i];
     b += in[i]*cf;
   }
   *p->out = a > FL(0.0) ? b/a : FL(0.0);
+  return OK;
+}
+
+static int32_t array_centroid_i(CSOUND *csound, CENTR *p) {
+  if (UNLIKELY(array_centroid(csound, p) != OK))
+    return csound->InitError(csound, "%s",
+                            Str("centroid: expected at least two magnitude bins"));
+  return OK;
+}
+
+static int32_t array_centroid_k(CSOUND *csound, CENTR *p) {
+  if (UNLIKELY(array_centroid(csound, p) != OK))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("centroid: expected at least two magnitude bins"));
   return OK;
 }
 
@@ -1499,9 +1513,9 @@ static OENTRY arrayvars_localops[] =
     {"mfb", sizeof(MFB), 0, "i[]","i[]iii",
      (SUBR)mfbi, NULL, NULL},
     {"centroid", sizeof(CENTR), 0, "i","i[]",
-     (SUBR) array_centroid, NULL, NULL},
+     (SUBR) array_centroid_i, NULL, NULL},
     {"centroid", sizeof(CENTR), 0, "k","k[]", NULL,
-     (SUBR)array_centroid, NULL},
+     (SUBR)array_centroid_k, NULL},
     {"interleave", sizeof(INTERL), 0, "i[]","i[]i[]",
      (SUBR)interleave_i},
     {"interleave", sizeof(INTERL), 0, "k[]","k[]k[]",

--- a/Opcodes/pvscent.c
+++ b/Opcodes/pvscent.c
@@ -190,28 +190,30 @@ typedef struct _cent {
 
 static int32_t cent_i(CSOUND *csound, CENT *p)
 {
-    int32_t fftsize = *p->ifftsize;
+    MYFLT requested = *p->ifftsize;
+    uint32_t i;
+    MYFLT *win;
+    if (UNLIKELY(!(requested >= FL(2.0) && requested <= (1U << 30))))
+      return csound->InitError(csound, "%s", Str("centroid: FFT size out of range"));
     p->count = 0;
-    p->fsize = 1;
-    while(fftsize >>= 1) p->fsize <<= 1;
-    if (p->fsize < *p->ifftsize) {
-      p->fsize <<= 1;
+    p->fsize = 2;
+    while (p->fsize < requested) p->fsize <<= 1;
+    if (p->fsize != requested)
       csound->Warning(csound,
                       Str("centroid requested fftsize = %.0f, actual = %d\n"),
-                      *p->ifftsize, p->fsize);
-    }
+                      requested, p->fsize);
+    if (UNLIKELY(p->fsize > SIZE_MAX / sizeof(MYFLT)))
+      return csound->InitError(csound, "%s", Str("centroid: FFT size out of range"));
     if (p->frame.auxp == NULL || p->frame.size < p->fsize*sizeof(MYFLT))
       csound->AuxAlloc(csound, p->fsize*sizeof(MYFLT), &p->frame);
     if (p->windowed.auxp == NULL || p->windowed.size < p->fsize*sizeof(MYFLT))
       csound->AuxAlloc(csound, p->fsize*sizeof(MYFLT), &p->windowed);
-    if (p->win.auxp == NULL || p->win.size < p->fsize*sizeof(MYFLT)) {
-      uint32_t i;
-      MYFLT *win;
+    if (p->win.auxp == NULL || p->win.size < p->fsize*sizeof(MYFLT))
       csound->AuxAlloc(csound, p->fsize*sizeof(MYFLT), &p->win);
-      win = (MYFLT *) p->win.auxp;
+    /* Rebuild even when a smaller transform reuses the allocation. */
+    win = (MYFLT *) p->win.auxp;
     for (i=0; i < p->fsize; i++)
       win[i] = 0.5 - 0.5*cos(i*TWOPI/p->fsize);
-    }
     p->old = 0;
     memset(p->frame.auxp, 0, p->fsize*sizeof(MYFLT));
     memset(p->windowed.auxp, 0, p->fsize*sizeof(MYFLT));
@@ -252,11 +254,12 @@ static int32_t cent_k(CSOUND *csound, CENT *p)
         else k++;
       }
       csound->RealFFT(csound, p->setup, windowed);
-      cf=FL(0.5)*binsize;
-      mag = fabs(windowed[0])/fsize;
-      c += mag*cf;
+      /* Real FFT packing stores DC and Nyquist separately. */
+      d = fabs(windowed[0])/fsize;
+      mag = fabs(windowed[1])/fsize;
+      c = mag * (FL(0.5)*CS_ESR);
       d += mag;
-      cf += binsize;
+      cf = binsize;
       for (i=2; i < fsize; i+=2, cf += binsize) {
         windowed[i] /= fsize;
         windowed[i+1] /= fsize;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -746,6 +746,8 @@ def runTest():
         ["test_opcode_as_function.csd", "test expression"],
         ["test_fsig_udo.csd", "UDO with f-sig arg"],
         ["test_pvs_spectral_moments.csd", "test spectral centroid and bandwidth"],
+        ["test_centroid_state.csd", "centroid FFT windows and bin frequencies"],
+        ["test_centroid_invalid_size.csd", "reject invalid centroid sizes", 1],
         ["test_karrays_udo.csd", "UDO with k[] arg"],
         ["test_vector_table_correctness.csd", "vector table indexing"],
         ["test_vector_table_invalid_index.csd", "reject invalid vector table index", 1],

--- a/tests/commandline/test_centroid_invalid_size.csd
+++ b/tests/commandline/test_centroid_invalid_size.csd
@@ -1,0 +1,47 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+#ifndef SIZE
+#define SIZE #0#
+#endif
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+instr 1
+ aInput = 0
+ kCentroid centroid aInput, 1, $SIZE
+endin
+instr 2
+ iBins[] fillarray 1
+ iCentroid centroid iBins
+endin
+instr 3
+ kBins[] fillarray 1
+ kCentroid centroid kBins
+endin
+; Validate the current array size, including after reinitialization.
+instr 4
+ kCycle init 0
+ kLength init 2
+ if kCycle == 1 then
+  kLength = 1
+  reinit BINS
+ endif
+BINS:
+ kBins[] init i(kLength)
+ rireturn
+ kCentroid centroid kBins
+ kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+i 2 0 .01
+i 3 0 .01
+i 4 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_centroid_state.csd
+++ b/tests/commandline/test_centroid_state.csd
@@ -1,0 +1,106 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Changing FFT size must produce the same window as a fresh instance.
+instr 1
+ kCycle init 0
+ kCycle += 1
+ aFirst oscili .5, 512
+ aSecond oscili .2, 1536
+ aInput = aFirst+aSecond+.1
+ if kCycle == 65 then
+  reinit ANALYZE
+ endif
+ANALYZE:
+ iSize = (i(kCycle) >= 65 ? p5 : p4)
+ kActual centroid aInput, 1, iSize
+ rireturn
+ kReference centroid aInput, 1, p5
+ if kCycle >= 128 && !(abs(kActual-kReference) < .01) then
+  printks "centroid reset %g->%g: %g versus %g\n", 0, p4, p5, kActual, kReference
+  exitnowk(-1)
+ endif
+ if kCycle == 160 then
+  gkChecks += 1
+ endif
+endin
+
+; Exact FFT-bin tones must not acquire a half-bin frequency offset.
+; DC and Nyquist each have one neighboring Hann-window side bin.
+instr 2
+ kCycle init 0
+ kCycle += 1
+ aTone oscili .5, 512
+ aDC = 1
+ aPhase phasor sr/2
+ aNyquist = cos(aPhase*6.283185307179586)
+ kTone centroid aTone, 1, 64
+ kDC centroid aDC, 1, 64
+ kNyquist centroid aNyquist, 1, 64
+ kTrigger = (kCycle <= 16 ? 1 : 0)
+ kHeld centroid aTone, kTrigger, 64
+ if kCycle >= 16 then
+  if !(abs(kTone-512)+abs(kDC-128/3)+abs(kNyquist-(4096-128/3))+abs(kHeld-512) < .02) then
+   printks "centroid bin frequencies: tone=%g DC=%g Nyquist=%g held=%g\n", 0, kTone, kDC, kNyquist, kHeld
+   exitnowk(-1)
+  endif
+ endif
+ if kCycle == 160 then
+  gkChecks += 1
+ endif
+endin
+
+instr 3
+ iDC[] fillarray 1, 0, 0, 0, 0
+ iNyquist[] fillarray 0, 0, 0, 0, 1
+ iMixed[] fillarray 1, 2, 0, 0, 1
+ iSilence[] fillarray 0, 0
+ iD centroid iDC
+ iN centroid iNyquist
+ iM centroid iMixed
+ iZ centroid iSilence
+ if iD != 0 || iN != 4096 || iM != 1536 || iZ != 0 then
+  prints "centroid magnitude-bin mismatch: %g %g %g %g\n", iD, iN, iM, iZ
+  exitnow(-1)
+ endif
+ kBins[] fillarray 0, 0, 0, 0, 0
+ kCycle init 0
+ kCycle += 1
+ kBins[0] = 1
+ kBins[4] = kCycle
+ kActual centroid kBins
+ kExpected = 4096*kCycle/(1+kCycle)
+ if !(abs(kActual-kExpected) < .001) then
+  printks "centroid changing magnitude bins: %g versus %g\n", 0, kActual, kExpected
+  exitnowk(-1)
+ endif
+ if kCycle == 160 then
+  gkChecks += 1
+ endif
+endin
+instr 99
+ if i(gkChecks) != 6 then
+  prints "centroid checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .3125 256 64
+i 1 0 .3125 64 256
+i 1 0 .3125 128 128
+i 1 0 .3125 256 63
+i 2 0 .3125
+i 3 0 .3125
+i 99 .32 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Correct `centroid` window state and spectral weighting:

- Rebuild the Hann window on initialization, including when a smaller FFT reuses an existing allocation. Otherwise it retains the window for the old size.
- Weight bins at their actual frequencies, starting at DC, and include Nyquist in both the audio and array forms. This removes the half-bin offset and restores the omitted Nyquist contribution.
- Reject unsupported FFT sizes before rounding or allocation, and require a one-dimensional array with at least two bins. Invalid k-rate arrays report a performance error, including after resizing.
