### PR TITLE
fix: correct pitchac correlation bounds and window state

### DIFF
--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -473,7 +473,11 @@ typedef struct _pitchaf{
 } PITCHAF;
 
 int32_t pitchafset(CSOUND *csound, PITCHAF *p){
-    int32_t siz = (int32_t)(CS_ESR/ (*p->iflow));
+    double samples = CS_ESR / (double)*p->iflow;
+    if (UNLIKELY(!(samples >= 1.0 && samples <= INT32_MAX &&
+                   samples <= SIZE_MAX / sizeof(MYFLT))))
+      return csound->InitError(csound, "%s", Str("pitchac: invalid lowest frequency"));
+    int32_t siz = (int32_t)samples;
     if (p->buff1.auxp == NULL || p->buff1.size < siz*sizeof(MYFLT))
       csound->AuxAlloc(csound, siz*sizeof(MYFLT), &p->buff1);
     else
@@ -496,23 +500,34 @@ int32_t pitchafset(CSOUND *csound, PITCHAF *p){
 int32_t pitchafproc(CSOUND *csound, PITCHAF *p)
 {
 
-    int32_t lag = p->lag,n, i, j, imax = 0, len = p->len,
-      ksmps = CS_KSMPS;
+    int32_t lag = p->lag,n, i, j, len = p->len;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    int32_t ksmps = CS_KSMPS - p->h.insdshead->ksmps_no_end;
+    double samples;
+    int32_t nextlen;
+    if (UNLIKELY(!(*p->kfmin > FL(0.0))))
+      return csound->PerfError(csound, &p->h, "%s",
+                               Str("pitchac: minimum frequency must be positive"));
+    samples = CS_ESR / (double)*p->kfmin;
+    if (UNLIKELY(!(samples >= 1.0)))
+      return csound->PerfError(csound, &p->h, "%s",
+                               Str("pitchac: minimum frequency exceeds sample rate"));
+    nextlen = samples >= p->size ? p->size : (int32_t)samples;
     MYFLT *buff1 = (MYFLT *)p->buff1.auxp;
     MYFLT *buff2 = (MYFLT *)p->buff2.auxp;
     MYFLT *cor = (MYFLT *)p->cor.auxp;
     MYFLT *s = p->asig, pitch;
-    //MYFLT ifmax = *p->kfmax;
 
-    for (n=0; n < ksmps; n++) {
+    for (n=offset; n < ksmps; n++) {
       for (i=0,j=lag; i < len; i++) {
         cor[lag] += buff1[i]*buff2[j];
-        j = j != len ? j+1 : 0;
+        if (++j == len) j = 0;
       }
       buff2[lag++] = s[n];
 
       if (lag == len) {
-        float max = 0.0f;
+        MYFLT max = FL(0.0);
+        int32_t imax = 0;
         for (i=0; i < len; i++) {
           if (cor[i] > max) {
             max = cor[i];
@@ -521,17 +536,16 @@ int32_t pitchafproc(CSOUND *csound, PITCHAF *p)
           buff1[i] = buff2[i];
           cor[i] = FL(0.0);
         }
-        len = CS_ESR/(*p->kfmin);
-        if (len > p->size) len = p->size;
+        if (imax) {
+          pitch = CS_ESR/imax;
+          if (pitch <= *p->kfmax) p->pitch = pitch;
+        }
+        len = nextlen;
         lag  =  0;
       }
     }
     p->lag = lag;
     p->len = len;
-    if (imax) {
-      pitch = CS_ESR/imax;
-      if (pitch <= *p->kfmax) p->pitch = pitch;
-    }
     *p->kpitch = p->pitch;
 
     return OK;
@@ -759,7 +773,7 @@ static OENTRY pitchtrack_localops[] =
   {
    {"ptrack", S(PITCHTRACK), 0,  "kk", "aio",
     (SUBR)pitchtrackinit, (SUBR)pitchtrackprocess},
-   {"pitchac", S(PITCHTRACK), 0,  "k", "akki",
+   {"pitchac", S(PITCHAF), 0,  "k", "akki",
     (SUBR)pitchafset, (SUBR)pitchafproc},
    {"plltrack", S(PLLTRACK), 0,  "aa", "akOOOOO",
     (SUBR)plltrack_set, (SUBR)plltrack_perf}

--- a/Opcodes/pitchtrack.c
+++ b/Opcodes/pitchtrack.c
@@ -521,7 +521,7 @@ int32_t pitchafproc(CSOUND *csound, PITCHAF *p)
     for (n=offset; n < ksmps; n++) {
       for (i=0,j=lag; i < len; i++) {
         cor[lag] += buff1[i]*buff2[j];
-        if (++j == len) j = 0;
+        j = j != len - 1 ? j+1 : 0;
       }
       buff2[lag++] = s[n];
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -753,6 +753,8 @@ def runTest():
         ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
         ["test_cps_table_pitch.csd", "tuning-table pitch endpoints and negative pitches"],
         ["test_cps_missing_table.csd", "reject missing pitch tuning tables", 1],
+        ["test_pitchac_blocks.csd", "pitchac analysis windows and partial blocks"],
+        ["test_pitchac_invalid_size.csd", "pitchac rejects invalid buffer sizes", 1],
         ["test_arrays_fns.csd", "test functions on arrays (i.e. tabgen)", 1],
         ["test_tabslice_increment.csd", "reject zero tabslice increment", 1],
         ["test_tablefilter_values.csd", "tablefilter parameters, rational values, and table wrapping"],

--- a/tests/commandline/test_pitchac_blocks.csd
+++ b/tests/commandline/test_pitchac_blocks.csd
@@ -1,0 +1,62 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+gkDetected init 0
+
+opcode TrackSample, a, akki
+ setksmps 1
+ aInput, kMin, kMax, iLow xin
+ kPitch pitchac aInput, kMin, kMax, iLow
+ aPitch upsamp kPitch
+ xout aPitch
+endop
+
+; The last active sample must give the same result at either block size,
+; including several analysis windows per block and changing window lengths.
+instr 1
+ kCycle init 0
+ kCycle += 1
+ kMin = (kCycle % 9 < 4 ? 1024 : 256)
+ kMax = (kCycle % 7 < 3 ? 8192 : 1500)
+ aInput oscili .5, 700
+ if kCycle % 11 == 0 then
+  aInput = 0
+ endif
+ kPitch pitchac aInput, kMin, kMax, p4
+ aReference TrackSample aInput, kMin, kMax, p4
+ kEarly earlysmps
+ kRef vaget ksmps-kEarly-1, aReference
+ if !(abs(kPitch-kRef) < .01) then
+  printks "pitchac block mismatch: cycle=%g pitch=%g reference=%g\n", 0, kCycle, kPitch, kRef
+  exitnowk(-1)
+ endif
+ gkChecks += 1
+ if kPitch > 0 then
+  gkDetected += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) < 100 || i(gkDetected) == 0 then
+  prints "pitchac checks did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 1 256
+; A one-sample window, partial blocks, and a note within one block.
+i 1 0 .125 8192
+i 1 .0006103515625 .029296875 512
+i 1 .002197265625 .00244140625 1024
+i 99 1.01 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pitchac_invalid_size.csd
+++ b/tests/commandline/test_pitchac_invalid_size.csd
@@ -1,0 +1,34 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+instr 1
+ aInput = 0
+ kPitch pitchac aInput, 256, 4096, p4
+endin
+; Reject an invalid minimum frequency after a valid control cycle.
+instr 2
+ kCycle init 0
+ kMin = (kCycle == 0 ? 256 : p4)
+ aInput = 0
+ kPitch pitchac aInput, kMin, 4096, 256
+ kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0
+i 1 0 .01 -1
+i 1 0 .01 16384
+i 1 0 .01 1e-30
+i 2 0 .02 0
+i 2 0 .02 -1
+i 2 0 .02 16384
+i 2 0 .02 1e30
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pitchac` has no manual entry. Its signature is `kpitch pitchac asig, kfmin, kfmax, iflow`. It estimates pitch by correlating successive sample windows; `iflow` sets the lowest frequency used to size its buffers, while `kfmin` controls the window length and `kfmax` limits accepted pitch estimates.

Fix `pitchac` correlation indexing and window state:

- Wrap the circular index at the buffer length, preventing a read past its end, and process only active note samples.
- Reset the peak search and update pitch for every completed window. This preserves the latest accepted result when several windows finish in one control block. Keep correlation maxima in `MYFLT` to avoid narrowing double-precision values.
- Validate frequency-derived lengths before integer conversion and allocation. Clamp runtime window lengths to the allocated capacity and reject values that would produce an invalid length.
- Register the opcode with its actual `PITCHAF` instance size.
