### PR TITLE
fix: reset sndloop recording state and bound playback phase

### DIFF
--- a/Opcodes/sndloop.c
+++ b/Opcodes/sndloop.c
@@ -214,15 +214,25 @@ typedef struct _pvsmorph {
 
 static int32_t sndloop_init(CSOUND *csound, sndloop *p)
 {
-    p->durs = (int32) (*(p->dur)*CS_ESR); /* dur in samps */
-    p->cfds = (int32) (*(p->cfd)*CS_ESR); /* fade in samps */
+    double durs = *(p->dur)*CS_ESR, cfds = *(p->cfd)*CS_ESR;
+    if (UNLIKELY(!(durs >= 1.0 && durs <= INT32_MAX &&
+                   durs <= SIZE_MAX / sizeof(MYFLT) &&
+                   cfds >= 0.0 && cfds <= INT32_MAX)))
+      return csound->InitError(csound, "%s",
+                               Str("sndloop: invalid loop or crossfade duration"));
+    p->durs = (int32)durs;
+    p->cfds = (int32)cfds;
     if (UNLIKELY(p->durs < p->cfds))
       return
         csound->InitError(csound, "%s", Str("crossfade cannot be longer than loop\n"));
 
-    p->inc  = FL(1.0)/p->cfds;    /* inc/dec */
+    if (UNLIKELY(p->durs > INT32_MAX - p->cfds))
+      return csound->InitError(csound, "%s",
+                               Str("sndloop: recording is too long"));
+    p->inc  = p->cfds ? FL(1.0)/p->cfds : FL(0.0);
     p->a    = FL(0.0);
     p->wp   = 0;                  /* intialise write pointer */
+    p->rp   = 0.0;
     p->rst  = 1;                  /* reset the rec control */
     if (p->buffer.auxp==NULL ||
        p->buffer.size<p->durs*sizeof(MYFLT)) /* allocate memory if necessary */
@@ -232,8 +242,7 @@ static int32_t sndloop_init(CSOUND *csound, sndloop *p)
 
 static int32_t sndloop_process(CSOUND *csound, sndloop *p)
 {
-     IGN(csound);
-    int32_t on = (int32_t) *(p->on), recon;
+    int32_t on = FABS(*p->on) >= FL(1.0), recon;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t i, nsmps = CS_KSMPS;
@@ -241,7 +250,15 @@ static int32_t sndloop_process(CSOUND *csound, sndloop *p)
     double rp = p->rp;
     MYFLT a = p->a, inc = p->inc;
     MYFLT *out = p->out, *sig = p->sig, *buffer = p->buffer.auxp;
-    MYFLT pitch = *(p->pitch);
+    double pitch = *(p->pitch);
+
+    /* Reduce the step once per control block, so sample wrapping is bounded. */
+    if (UNLIKELY(!(pitch > -durs && pitch < durs))) {
+      pitch = fmod(pitch, (double)durs);
+      if (UNLIKELY(!(pitch > -durs && pitch < durs)))
+        return csound->PerfError(csound, &p->h, "%s",
+                                 Str("sndloop: invalid pitch ratio"));
+    }
 
     if (on) recon = p->rst; /* restart recording if switched on again */
     else recon = 0;  /* else do not record */
@@ -271,20 +288,23 @@ static int32_t sndloop_process(CSOUND *csound, sndloop *p)
         if (wp == durs+cfds) {  /* end of recording */
           recon = 0;  /* OFF */
           p->rst = 0; /* reset to 0 */
-          p->rp = (MYFLT) wp; /* rp pointer to start from here */
+          /* Continue after the samples already used by the crossfade. */
+          rp = cfds < durs ? cfds : 0;
         }
       }
       else {
         if (on) { /* if opcode is ON */
           out[i] = buffer[(int32_t)rp]; /* output the looped sound */
           rp += pitch;        /* read pointer increment */
-          while (rp >= durs) rp -= durs; /* wrap-around */
-          while (rp < 0) rp += durs;
+          if (rp < 0) rp += durs;
+          /* The addition above can round up to durs. */
+          if (rp >= durs) rp -= durs;
         }
         else {   /* if opocde is OFF */
           out[i] = sig[i]; /* copy input to the output */
           p->rst = 1;   /* reset: ready for new recording */
           wp = 0; /* zero write pointer */
+          a = FL(0.0);
         }
       }
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -638,6 +638,8 @@ def runTest():
         ["test_fof2_float_rise_range.csd", "reject fof2 rise beyond the float-phase range", 1],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
         ["test_flooper_stereo_frame_bounds.csd", "reject flooper ranges past stereo frames", 1],
+        ["test_sndloop_state.csd", "sndloop recording, playback, and partial blocks"],
+        ["test_sndloop_invalid_size.csd", "sndloop rejects invalid recording sizes", 1],
         ["test_flooper_zero_duration.csd", "reject zero flooper duration", 1],
         ["test_flooper2_sample_offset.csd", "flooper2 handles partial blocks and stereo bounce"],
         ["test_ftaudio_frame_range.csd", "ftaudio writes bounded stereo frame ranges"],

--- a/tests/commandline/test_sndloop_invalid_size.csd
+++ b/tests/commandline/test_sndloop_invalid_size.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+instr 1
+ aInput = 0
+ aLoop, kRec sndloop aInput, 1, 1, p4/sr, p5/sr
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0 0
+i 1 0 .01 -1 0
+i 1 0 .01 .5 0
+i 1 0 .01 1e30 0
+i 1 0 .01 8 -1
+i 1 0 .01 8 1e30
+i 1 0 .01 8 9
+; The recording count includes both the loop and the crossfade.
+i 1 0 .01 1073741824 1073741824
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_sndloop_state.csd
+++ b/tests/commandline/test_sndloop_state.csd
@@ -1,0 +1,157 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giNoFade ftgen 0, 0, -8, -2, 1, 2, 3, 4, 5, 6, 7, 8
+giFade ftgen 0, 0, -8, -2, 3, 4, 5, 6, 7, 8, 9, 6
+giFullFade ftgen 0, 0, -8, -2, 9, 9, 9, 9, 9, 9, 9, 9
+
+; Interrupt recording during each fade and in the middle, or stop playback.
+; A new capture must match a fresh instance recording the same input.
+instr 1
+ setksmps 1
+ kCycle init 0
+ kCycle += 1
+ aInput = 1
+ kOn = (kCycle <= p4 || kCycle >= p4+3 ? 1 : 0)
+ kFreshOn = (kCycle >= p4+3 ? 1 : 0)
+ aRestart, kRec sndloop aInput, 1, kOn, 32/sr, 8/sr
+ aFresh, kFreshRec sndloop aInput, 1, kFreshOn, 32/sr, 8/sr
+ kRestart downsamp aRestart
+ kFresh downsamp aFresh
+ if kCycle >= p4+3 then
+  if !(abs(kRestart-kFresh) < .00001) || kRec != kFreshRec then
+   printks "sndloop restart mismatch at sample %g: %g / %g\n", 0, kCycle, kRestart, kFresh
+   exitnowk(-1)
+  endif
+ endif
+ if kCycle == 200 then
+  gkChecks += 1
+ endif
+endin
+
+; Capture the ramp 1, 2, ... with an eight-sample loop. The tables above
+; give the exact playback order, starting just after the recorded fade.
+instr 2
+ setksmps 1
+ kCycle init 0
+ kPosition init 0
+ kCycle += 1
+ aInput = kCycle
+ aLoop, kRec sndloop aInput, p4, 1, 8/sr, p5/sr
+ kLoop downsamp aLoop
+ if kCycle <= 8+p5 then
+  kExpected = kCycle
+ else
+  iTable = (p5 == 0 ? giNoFade : (p5 == 2 ? giFade : giFullFade))
+  kExpected table kPosition, iTable
+  kPosition += p4
+  kPosition -= floor(kPosition/8)*8
+ endif
+ kExpectedRec = (kCycle < 8+p5 ? 1 : 0)
+ if !(abs(kLoop-kExpected) < .00001) || kRec != kExpectedRec then
+  printks "sndloop playback mismatch: pitch=%g fade=%g sample=%g: %g / %g, recording=%g / %g\n", 0, p4, p5, kCycle, kLoop, kExpected, kRec, kExpectedRec
+  exitnowk(-1)
+ endif
+ if kCycle == 200 then
+  gkChecks += 1
+ endif
+endin
+
+opcode LoopSample, aa, ak
+ setksmps 1
+ aInput, kOn xin
+ aLoop, kRec sndloop aInput, -.5, kOn, 16/sr, 4/sr
+ aRec upsamp kRec
+ xout aLoop, aRec
+endop
+
+; Block size and inactive samples must not alter recording or playback.
+instr 3
+ kCycle init 0
+ kCycle += 1
+ aInput oscili .5, 700
+ kOn = (kCycle % 5 == 0 ? 0 : 1)
+ aLoop, kRec sndloop aInput, -.5, kOn, 16/sr, 4/sr
+ aReference, aRefRec LoopSample aInput, kOn
+ kIndex = 0
+ while kIndex < ksmps do
+  kLoop vaget kIndex, aLoop
+  kReference vaget kIndex, aReference
+  if !(abs(kLoop-kReference) < .00001) then
+   printks "sndloop block mismatch at cycle %g sample %g: %g / %g\n", 0, kCycle, kIndex, kLoop, kReference
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ kEarly earlysmps
+ kReferenceRec vaget ksmps-kEarly-1, aRefRec
+ if kRec != kReferenceRec then
+  printks "sndloop recording status differs between block sizes\n", 0
+  exitnowk(-1)
+ endif
+ if kCycle == 1 then
+  gkChecks += 1
+ endif
+endin
+
+; A one-sample loop must always read its sole sample, at any playback step.
+instr 4
+ setksmps 1
+ kCycle init 0
+ kCycle += 1
+ aInput = kCycle
+ aLoop, kRec sndloop aInput, p4, 1, 1/sr, p5/sr
+ kLoop downsamp aLoop
+ kExpected = (kCycle <= 1+p5 ? kCycle : 1+p5)
+ kExpectedRec = (kCycle < 1+p5 ? 1 : 0)
+ if !(abs(kLoop-kExpected) < .00001) || kRec != kExpectedRec then
+  printks "sndloop one-sample loop mismatch: pitch=%g fade=%g sample=%g: %g / %g\n", 0, p4, p5, kCycle, kLoop, kExpected
+  exitnowk(-1)
+ endif
+ if kCycle == 200 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 22 then
+  prints "sndloop checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03125 4
+i 1 0 .03125 20
+i 1 0 .03125 36
+i 1 0 .03125 60
+i 2 0 .03125 1 2
+i 2 0 .03125 -1 2
+i 2 0 .03125 .5 2
+i 2 0 .03125 -.5 2
+i 2 0 .03125 0 2
+i 2 0 .03125 16 2
+i 2 0 .03125 -16 2
+i 2 0 .03125 8000001 2
+i 2 0 .03125 -8000001 2
+i 2 0 .03125 1 0
+i 2 0 .03125 1 8
+; Reuse an instance after its first capture has ended.
+i 2 .0625 .03125 1 2
+i 3 0 .125
+i 3 .0006103515625 .029296875
+i 3 .002197265625 .00244140625
+i 4 0 .03125 -1e-30 0
+i 4 0 .03125 1e30 0
+i 4 0 .03125 -1 1
+i 99 .14 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `sndloop` recording resets and playback phase:

- Reset the fade gain when bypassed so a new capture starts cleanly, including after an interrupted recording. Initialize the read pointer and start playback after the samples already consumed by the crossfade.
- Reduce large pitch steps once per control block, then wrap with bounded comparisons in the sample loop. This keeps the read index within the loop and avoids long wrapping loops.
- Validate durations before integer conversion and allocation, check the combined recording length, and allow zero crossfade without division by zero. Read the on/off control without an integer cast that can overflow.
