### PR TITLE
fix: correct harmon2/3/4 sample bounds and pulse state

### DIFF
--- a/Opcodes/harmon.c
+++ b/Opcodes/harmon.c
@@ -37,7 +37,7 @@ typedef struct {
 
 typedef struct {
         MYFLT   *kfrq;
-        int32    phase, phsinc;
+        uint32_t phase, phsinc;
 } VOCDAT;
 
 #define PULMAX  8
@@ -50,14 +50,16 @@ typedef struct {
   // or MYFLT   *kfrq3, *icpsmode, *ilowest, *ipolarity, *dummy;  //3
   // or MYFLT   *icpsmode, *ilowest, *ipolarity, *dummy, *dummy1; //2
   //Local
-        int16   nbufsmps, n2bufsmps, period, cpsmode, polarity, poslead;
+        int32_t nbufsmps, n2bufsmps, period;
+        int16   cpsmode, polarity, poslead;
         MYFLT   prvoct, minoct, sicvt;
         MYFLT   *bufp, *midp, *inp1, *inp2;
         MYFLT   *pulsbuf[4], *sigmoid, *curpuls;
         MYFLT   vocamp, vocinc, ampinc;
         PULDAT  puldat[PULMAX], *endp, *limp;
         VOCDAT  vocdat[VOCMAX], *vlim;
-        int16   pbufcnt, maxprd, pulslen, switching;
+        int32_t maxprd, pulslen;
+        int16   pbufcnt, switching;
         AUXCH   auxch;
         int32_t     hmrngflg;
 } HARM234;
@@ -105,11 +107,16 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
     p->hmrngflg = 0;
     /*if (p->auxch.auxp == NULL || minoct < p->minoct ) */ {
       MYFLT minfrq = POWER(FL(2.0), minoct) * ONEPT;
-      int16 nbufs = (int16)(CS_EKR * 3 / minfrq) + 1;/* recalc max pulse prd */
-      int16 nbufsmps = nbufs * CS_KSMPS;
-      int16 maxprd = (int16)(CS_ESR * 2 / minfrq);   /* incl sigmoid ends */
-      int16 cnt;
-      int32  totalsiz = nbufsmps * 2 + maxprd * 4 + (SLEN+1);
+      double nsamples = (floor(CS_EKR * 3 / minfrq) + 1.0) * CS_KSMPS;
+      double prdsamples = floor(CS_ESR * 2 / minfrq); /* incl sigmoid ends */
+      double total = nsamples * 2.0 + prdsamples * 4.0 + (SLEN+1);
+      if (UNLIKELY(!(nsamples >= CS_KSMPS && prdsamples >= 2.0 &&
+                     total <= INT32_MAX && total <= SIZE_MAX / sizeof(MYFLT))))
+        return csound->InitError(csound, "%s",
+                                 Str("harmon234: lowest pitch is out of range"));
+      int32_t nbufsmps = (int32_t)nsamples, maxprd = (int32_t)prdsamples;
+      int32_t cnt;
+      size_t totalsiz = (size_t)total;
       MYFLT *pulsbuf, *sigp;                            /*  & realloc buffers */
 
       csound->AuxAlloc(csound, totalsiz * sizeof(MYFLT), &p->auxch);
@@ -130,7 +137,6 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
     //p->minoct = minoct;
     p->sicvt = FL(65536.0) * CS_ONEDSR;
     //printf("sicvt = %f\n", p->sicvt);
-    //    p->polarity = (int16)*p->ipolarity;
     p->poslead = 0;
     p->inp1 = p->bufp;
     p->inp2 = p->midp;
@@ -140,6 +146,7 @@ static int32_t hm234set(CSOUND *csound, HARM234 *p)
     p->period = 0;
     p->curpuls = NULL;
     p->pbufcnt = 0;
+    p->pulslen = 0;
     p->vocamp = FL(0.0);                        /* begin unvoiced */
     p->ampinc = FL(10.0) * CS_ONEDSR;      /* .1 sec lin ramp for uv to v */
     //printf("ampinc = %f\n", p->ampinc);
@@ -154,15 +161,21 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
     MYFLT       koct, vocamp, diramp;
     PULDAT      *endp;
     VOCDAT      *vdp;
-    int16       nsmps = CS_KSMPS, oflow = 0;
+    uint32_t    nsmps = CS_KSMPS;
+    int32_t     oflow = 0;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     //print_data(p, 1);
 
-    if ((koct = *p->koct) != p->prvoct) {               /* if new pitch estimate */
+    /* A zero octave is also a valid first pitch estimate. */
+    if ((koct = *p->koct) != p->prvoct || p->period == 0) {
       if (koct >= p->minoct) {                          /*   above requested low */
         MYFLT cps = POWER(FL(2.0), koct) * ONEPT;     /*   recalc pulse period */
-        p->period = (int16) (CS_ESR / cps);
+        double period = CS_ESR / cps;
+        if (UNLIKELY(!(period >= 1.0 && period <= p->maxprd)))
+          return csound->PerfError(csound, &p->h, "%s",
+                                   Str("harmon234: pitch estimate is out of range"));
+        p->period = (int32_t)period;
         if (!p->cpsmode)
           p->sicvt = cps * FL(65536.0) * CS_ONEDSR; /* k64dsr;*/
       }
@@ -173,37 +186,40 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
     if (UNLIKELY(offset)) {
       memset(inp1, '\0', offset*sizeof(MYFLT));
       memset(inp2, '\0', offset*sizeof(MYFLT));
+      memset(p->ar, '\0', offset*sizeof(MYFLT));
     }
     if (UNLIKELY(early)) {
       nsmps -= early;
       memset(&inp1[nsmps], '\0', early*sizeof(MYFLT));
       memset(&inp2[nsmps], '\0', early*sizeof(MYFLT));
+      memset(&p->ar[nsmps], '\0', early*sizeof(MYFLT));
     }
+    if (UNLIKELY(nsmps <= offset)) return OK;
     memcpy(&inp1[offset], &p->asig[offset], sizeof(MYFLT)*(nsmps-offset));
     memcpy(&inp2[offset], &p->asig[offset], sizeof(MYFLT)*(nsmps-offset));
-    inp1 += nsmps-offset; inp2 += nsmps-offset;
+    /* Keep history writes aligned to whole blocks, with silence outside the note. */
+    inp1 += CS_KSMPS; inp2 += CS_KSMPS;
+    nsmps -= offset;
     //for (srcp = q->asig, nsmps = CS_KSMPS; nsmps--; )
     //  *inp1++ = *inp2++ = *srcp++;              /* dbl store the wavform */
 
     //print_data(p, 2);
     if (koct >= p->minoct) {                    /* PERIODIC: find the pulse */
       MYFLT     val0, *buf0, *p0, *plim, *x;
-      int16     period, triprd, xdist;
+      int32_t   period, triprd, xdist;
 
       period = p->period;                       /* set srch range of 2 periods */
       triprd = period * 3;
-      p0 = inp2 - triprd;                       /* btwn 3 prds back & 1 prd back */
-      plim = inp2 - period;
       buf0 = p->bufp;
-      if (UNLIKELY(p0 < buf0))
-        p0 = buf0;
+      p0 = inp2 - buf0 < triprd ? buf0 : inp2 - triprd;
+      plim = inp2 - period;                     /* btwn 3 prds back & 1 prd back */
 
       x = p0;                                   /* locate first zero crossing   */
       if ((val0 = *x++) == FL(0.0))
-        while (*x == FL(0.0) && ++x < plim);    /* if no signal in this range   */
+        while (x < plim && *x == FL(0.0)) x++;    /* if no signal in this range   */
       else if (val0 > FL(0.0))
-        while (*x > 0. && ++x < plim);          /* or unipolar with no z-crossing */
-      else while (*x < FL(0.0) && ++x < plim);
+        while (x < plim && *x > FL(0.0)) x++;          /* or unipolar with no z-crossing */
+      else while (x < plim && *x < FL(0.0)) x++;
       if (x >= plim) goto nonprd;               /*      then non-periodic       */
 
       if (p->polarity > 0) {
@@ -216,7 +232,8 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         if (posp == NULL)
           goto nonprd;
         for (x = posp;
-             x >= buf0 && *x > FL(0.0); x--);   /* & its preceding z-crossing */
+             x > buf0 && *x > FL(0.0); x--);   /* & its preceding z-crossing */
+        if (*x > FL(0.0)) goto nonprd;
         xdist = posp - x;
       } else if (p->polarity < 0) {
         MYFLT negpk = FL(0.0);                  /* NEGATIVE polarity:   */
@@ -228,13 +245,14 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         if (negp == NULL)
           goto nonprd;
         for (x = negp;
-             x >= buf0 && *x < FL(0.0); x--); /* & its preceding z-crossing */
+             x > buf0 && *x < FL(0.0); x--); /* & its preceding z-crossing */
+        if (*x < FL(0.0)) goto nonprd;
         xdist = negp - x;
       }
       else {
         MYFLT pospk, negpk, *posp, *negp;               /* NOT SURE:    */
         MYFLT *poscross, *negcross;
-        int16 posdist, negdist;
+        int32_t posdist, negdist;
         pospk = negpk = FL(0.0);
         posp = negp = NULL;
         for ( ; x < plim; x++) {                /* find ensuing max & min vals */
@@ -246,11 +264,13 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         }
         if (posp == NULL || negp == NULL)
           goto nonprd;
-        for (x = posp; x >= buf0 &&
+        for (x = posp; x > buf0 &&
                *x > FL(0.0); x--); /* & their preceding z-crossings */
+        if (*x > FL(0.0)) goto nonprd;
         posdist = posp - x;
         poscross = x;
-        for (x = negp; x >= buf0 && *x < FL(0.0); x--);
+        for (x = negp; x > buf0 && *x < FL(0.0); x--);
+        if (*x < FL(0.0)) goto nonprd;
         negdist = negp - x;
         negcross = x;
 
@@ -280,42 +300,40 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
       }
 
       if (x != p->curpuls) {                    /* if pulse positn is new       */
-        int16 nn, pulslen, sigdist, ndirect;
-        MYFLT *bufp, signdx, siginc;
-        MYFLT *z, zval;
+        int32_t nn, pulslen, sigdist, ndirect;
+        MYFLT *bufp;
+        /* Avoid float index drift when the sigmoid spans a long pulse. */
+        double signdx, siginc;
+        MYFLT *z, zval, *newpuls = x;
 
-        p->curpuls = x;                         /*      record this new positn  */
         z = x + period;                         /*  and from estimated end      */
         if ((zval = *z) != FL(0.0)) {
-          int16 n, nlim = inp2 - z;
+          int32_t n, nlim = inp2 - z, nback = z - buf0;
           for (n = 1; n < nlim; n++) {
             if (zval * *(z+n) <= FL(0.0)) {     /*       find nearest zcrossing */
               z += n;
               break;
-            } else if (zval * *(z-n) <= FL(0.0)) {
+            } else if (n <= nback && zval * *(z-n) <= FL(0.0)) {
               z -= n;
               break;
             }                                   /* (true period is now z - x) */
           }
         }
-        x -= xdist;                             /* now extend for sig ris-dec   */
-        z += xdist;
-        if (x < buf0)
-          x = buf0;                             /*      truncated if necessary  */
-        else if (z > inp2)
-          z = inp2;                             /*      by input limits         */
+        /* Extend both ends without forming pointers outside the history. */
+        x = x - buf0 < xdist ? buf0 : x - xdist;
+        z = inp2 - z < xdist ? inp2 : z + xdist;
         pulslen = z - x;
         if (pulslen > p->maxprd)
           pulslen = p->maxprd;                  /*      & storage limits        */
+        if (xdist > pulslen / 4) goto nostor;
         sigdist = xdist * 2;
         ndirect = pulslen - sigdist*2;
-        if (ndirect < 0) goto nostor;
 
         p->pbufcnt++;                           /* select a new puls buffr      */
         p->pbufcnt &= PBMSK;
         bufp = p->pulsbuf[p->pbufcnt];
         signdx = FL(0.0);                       /*      & store extended pulse  */
-        siginc = (MYFLT)SLEN / sigdist;
+        siginc = (double)SLEN / sigdist;
         for (nn = sigdist; nn--; signdx += siginc) {
           MYFLT *sigp = p->sigmoid + (int32_t)signdx;
           *bufp++ = *x++ * *sigp;               /*      w. sigmoid-envlpd ends  */
@@ -323,14 +341,16 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         //memcpy(bufp, x, sizeof(MYFLT)*ndirect);
         while (ndirect--)
           *bufp++ = *x++;
-        signdx = (MYFLT)SLEN - siginc;
+        signdx = (double)SLEN - siginc;
         for (nn = sigdist; nn--; signdx -= siginc) {
           MYFLT *sigp = p->sigmoid + (int32_t)signdx;
           *bufp++ = *x++ * *sigp;
         }
         p->pulslen = pulslen;
+        p->curpuls = newpuls;
       }
     nostor:
+      if (p->curpuls == NULL) goto nonprd;
       if (p->vocamp < FL(1.0)) {                /* if onset             */
         p->vocinc = p->ampinc;                  /*   set pos voice ramp */
         p->switching = 1;
@@ -345,12 +365,17 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
     }
     //print_data(p, 3);
     /* HARMONIZER */
-    for (vdp=p->vocdat; vdp<p->vlim; vdp++)     /* get new frequencies  */
-      vdp->phsinc = (int32)(*vdp->kfrq * p->sicvt);
-    outp = p->ar;
+    for (vdp=p->vocdat; vdp<p->vlim; vdp++) {   /* get new frequencies  */
+      double inc = *vdp->kfrq * p->sicvt;
+      if (UNLIKELY(!(inc >= INT32_MIN && inc <= INT32_MAX)))
+        return csound->PerfError(csound, &p->h, "%s",
+                                 Str("harmon234: voice frequency is out of range"));
+      vdp->phsinc = (uint32_t)(int32_t)inc;
+    }
+    outp = p->ar + offset;
     vocamp = p->vocamp;
     diramp = FL(1.0) - vocamp;
-    dirp = p->asig;
+    dirp = p->asig + offset;
     endp = p->endp;
     do {                                        /* insert pulses into output: */
       MYFLT sum = FL(0.0);
@@ -368,8 +393,8 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
         pdp++;
       }                                         /* if time to start a new one */
       for (vdp=p->vocdat; vdp<p->vlim; vdp++)
-        if (vdp->phsinc && (vdp->phase += vdp->phsinc) & (~0xFFFF)) {
-          vdp->phase &= 0x0000FFFFL;
+        if (vdp->phsinc && (vdp->phase += vdp->phsinc) & 0xFFFF0000u) {
+          vdp->phase &= 0x0000FFFFu;
         if (p->curpuls != NULL) {               /*      & pulses are current    */
             if (endp < p->limp) {               /*      set one up              */
               endp->srcp = p->pulsbuf[p->pbufcnt];
@@ -403,7 +428,7 @@ static int32_t harmon234(CSOUND *csound, HARM234 *p)
       p->inp1 = p->bufp;                         /*   reset all ptrs  */
       p->inp2 = p->midp;
       if (p->curpuls != NULL)
-        p->curpuls -= bsmps;
+        p->curpuls = p->curpuls >= p->midp ? p->curpuls - bsmps : NULL;
     }
     else {
       p->inp1 = inp1;
@@ -419,7 +444,7 @@ int32_t harm2set(CSOUND *csound, HARM234 *p)
     vdp->kfrq = p->kfrq1;       vdp->phase = 0; vdp++;
     vdp->kfrq = p->kfrq2;       vdp->phase = 0; vdp++;
     p->vlim = vdp;
-    p->polarity = (int16)*p->icpsmode;
+    p->polarity = (*p->icpsmode >= FL(1.0)) - (*p->icpsmode <= FL(-1.0));
     p->minoct = *p->kfrq4;
     p->cpsmode = ((*p->kfrq3 != FL(0.0)));
     return hm234set(csound, p);
@@ -434,7 +459,7 @@ int32_t harm3set(CSOUND *csound, HARM234 *p)
     p->vlim = vdp;
     //printf("mode, lowest, polar = %p,%p,%p\n",
     //       p->icpsmode, p->ilowest, p->ipolarity);
-    p->polarity = (int16)*p->ilowest;
+    p->polarity = (*p->ilowest >= FL(1.0)) - (*p->ilowest <= FL(-1.0));
     p->minoct = *p->icpsmode;
     p->cpsmode = (*p->kfrq4 != FL(0.0));
     //printf("mode, lowest, polar = (%d,%f,%d)\n",
@@ -450,7 +475,7 @@ int32_t harm4set(CSOUND *csound, HARM234 *p)
     vdp->kfrq = p->kfrq3;       vdp->phase = 0; vdp++;
     vdp->kfrq = p->kfrq4;       vdp->phase = 0; vdp++;
     p->vlim = vdp;
-    p->polarity = (int16)*p->ipolarity;
+    p->polarity = (*p->ipolarity >= FL(1.0)) - (*p->ipolarity <= FL(-1.0));
     p->minoct = *p->ilowest;
     p->cpsmode = (*p->icpsmode != FL(0.0));
     return hm234set(csound, p);

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -647,6 +647,8 @@ def runTest():
         ["test_diskgrain_envelope_bounds.csd", "diskgrain stops at envelope table bounds"],
         ["test_syncloop_envelope_end.csd", "syncloop retires grains at the envelope end"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
+        ["test_harmon_state.csd", "harmon234 partial blocks and pulse state"],
+        ["test_harmon_invalid_size.csd", "harmon234 rejects unsupported history sizes", 1],
         ["test_crossfm_correctness.csd", "test crossed FM and PM correctness"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
         ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],

--- a/tests/commandline/test_harmon_invalid_size.csd
+++ b/tests/commandline/test_harmon_invalid_size.csd
@@ -1,0 +1,45 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+instr 1
+ aInput = 0
+ aTwo harmon2 aInput, 9, 1, 1, 0, p4
+endin
+instr 2
+ aInput = 0
+ aThree harmon3 aInput, 9, 1, 1, 1, 0, p4
+endin
+instr 3
+ aInput = 0
+ aFour harmon4 aInput, 9, 1, 1, 1, 1, 0, p4
+endin
+; Reject unsupported controls after one valid performance cycle.
+instr 4
+ kCycle init 0
+ kOct = (kCycle == 0 ? 9 : p4)
+ kVoice = (kCycle == 0 ? 512 : p5)
+ aInput = 0
+ aTwo harmon2 aInput, kOct, kVoice, 0, 1, 6
+ kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 20
+i 1 0 .01 -100
+i 1 0 .01 1e30
+i 1 0 .01 -1e30
+i 2 0 .01 20
+i 3 0 .01 20
+i 4 0 .02 20 512
+i 4 0 .02 1e30 512
+i 4 0 .02 9 1e30
+i 4 0 .02 9 -1e30
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_harmon_state.csd
+++ b/tests/commandline/test_harmon_state.csd
@@ -1,0 +1,115 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+gkWet init 0
+
+; Unvoiced input must pass through, with silence outside the active samples.
+; Prefill outputs so an unwritten tail cannot pass by starting at zero.
+instr 1
+ aInput = .5
+ aTwo init .75
+ aThree init .75
+ aFour init .75
+ aTwo harmon2 aInput, p5, 1, 1, 0, p4, p6
+ aThree harmon3 aInput, p5, 1, 1, 1, 0, p4, p6
+ aFour harmon4 aInput, p5, 1, 1, 1, 1, 0, p4, p6
+ kOffset offsetsmps
+ kEarly earlysmps
+ kIndex = 0
+ while kIndex < ksmps do
+  kTwo vaget kIndex, aTwo
+  kThree vaget kIndex, aThree
+  kFour vaget kIndex, aFour
+  kExpected = (kIndex >= kOffset && kIndex < ksmps-kEarly ? .5 : 0)
+  if !(abs(kTwo-kExpected)+abs(kThree-kExpected)+abs(kFour-kExpected) < .00001) then
+   printks "harmon dry output mismatch: sample=%g expected=%g got=%g %g %g\n", 0, kIndex, kExpected, kTwo, kThree, kFour
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ if timeinstk() == 1 then
+  gkChecks += 1
+ endif
+endin
+
+; Disabled extra voices must make all three variants agree. Exercise voiced
+; and unvoiced transitions, both frequency modes, and input/output reuse.
+instr 2
+ kCycle init 0
+ kCycle += 1
+ aSine oscili .25, 512
+ if kCycle % 40 < 8 then
+  aInput = 0
+ elseif kCycle % 40 < 16 then
+  aInput = .25
+ else
+  aInput = aSine
+ endif
+ kOct = octcps(512)
+ kFirst = (p5 == 0 ? 1 : 512)
+ kSecond = (p5 == 0 ? .5 : 256)
+ aTwo harmon2 aInput, kOct, kFirst, kSecond, p5, 6, p4
+ aThree harmon3 aInput, kOct, kFirst, kSecond, 0, p5, 6, p4
+ aFour harmon4 aInput, kOct, kFirst, kSecond, 0, 0, p5, 6, p4
+ aAlias = aInput
+ aAlias harmon2 aAlias, kOct, kFirst, kSecond, p5, 6, p4
+ kOffset offsetsmps
+ kEarly earlysmps
+ kIndex = 0
+ while kIndex < ksmps do
+  kInput vaget kIndex, aInput
+  kTwo vaget kIndex, aTwo
+  kThree vaget kIndex, aThree
+  kFour vaget kIndex, aFour
+  kAlias vaget kIndex, aAlias
+  if !(abs(kTwo) < 4 && abs(kTwo-kThree)+abs(kTwo-kFour)+abs(kTwo-kAlias) < .00001) then
+   printks "harmon voice mismatch: cycle=%g sample=%g got=%g %g %g alias=%g\n", 0, kCycle, kIndex, kTwo, kThree, kFour, kAlias
+   exitnowk(-1)
+  endif
+  if (kIndex < kOffset || kIndex >= ksmps-kEarly) && kTwo != 0 then
+   printks "harmon wrote an inactive sample\n", 0
+   exitnowk(-1)
+  endif
+  if abs(kTwo) > .001 && abs(kTwo-kInput) > .001 then
+   gkWet += 1
+  endif
+  kIndex += 1
+ od
+ if kCycle == 1 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 12 || i(gkWet) == 0 then
+  prints "harmon checks did not complete: notes=%g wet samples=%g\n", i(gkChecks), i(gkWet)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .25 6 0 1
+i 1 .0006103515625 .251220703125 6 9 1
+i 1 .002197265625 .00244140625 6 0 -1
+; A history longer than 32767 samples and a first pitch estimate of zero.
+i 1 0 .25 -1 0 0
+i 2 0 .5 1 0
+i 2 0 .5 -1 0
+i 2 0 .5 0 0
+i 2 0 .5 1 1
+i 2 .0006103515625 .501220703125 -1 1
+i 2 .002197265625 .00244140625 0 1
+; Reuse instances with fresh state.
+i 1 .625 .25 6 0 1
+i 2 .625 .5 1 0
+i 99 1.14 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Correct sample and pulse state in the shared `harmon2`, `harmon3`, and `harmon4` implementation:

- Process active output samples at the correct offset, clear inactive samples, and keep history writes aligned to whole blocks.
- Widen history and pulse counters, validate sizes and frequency conversions, and use unsigned phase arithmetic to avoid truncation and signed overflow.
- Bound pulse searches before forming pointers outside the history. Mark a pulse current only after storing it, and clear stale pulse state on reset or history wrap.
- Accept zero as the first octave estimate and use double precision for sigmoid indices to avoid index drift on long pulses in float builds.
