### PR TITLE
fix: restore cell reset state and bound generation storage

### DIFF
--- a/Opcodes/cellular.c
+++ b/Opcodes/cellular.c
@@ -37,27 +37,33 @@ typedef struct {
             *iRuleFunc, *ielements;
     MYFLT   *currLine, *outVec, *initVec, *ruleVec;
     int32_t     elements, NewOld;
+    uint32_t    rulelen;
   AUXCH   auxch;
 } CELL;
 
 static int32_t cell_set(CSOUND *csound,CELL *p)
 {
     FUNC        *ftp;
-    int32_t elements=0;
+    double count = *p->ielements;
+    int32_t elements;
     MYFLT *currLine, *initVec = NULL;
+
+    if (UNLIKELY(!(count >= 1.0 && count <= INT32_MAX &&
+                   count <= SIZE_MAX / (2 * sizeof(MYFLT)))))
+      return csound->InitError(csound, "%s", Str("cell: invalid num of elements"));
+    elements = p->elements = (int32_t)count;
 
     if (LIKELY((ftp = csound->FTFind(csound,p->ioutFunc)) != NULL)) {
       p->outVec = ftp->ftable;
-      elements = (p->elements = (int32_t) *p->ielements);
 
-      if (UNLIKELY( elements > (int32_t)ftp->flen ))
+      if (UNLIKELY((uint32_t)elements > ftp->flen))
         return csound->InitError(csound, "%s",
                                  Str("cell: invalid num of elements"));
     }
     else return csound->InitError(csound, "%s", Str("cell: invalid output table"));
     if (LIKELY((ftp = csound->FTFind(csound,p->initStateFunc)) != NULL)) {
       initVec = (p->initVec = ftp->ftable);
-      if (UNLIKELY(elements > (int32_t)ftp->flen ))
+      if (UNLIKELY((uint32_t)elements > ftp->flen))
         return csound->InitError(csound, "%s",
                                  Str("cell: invalid num of elements"));
     }
@@ -66,18 +72,19 @@ static int32_t cell_set(CSOUND *csound,CELL *p)
                                Str("cell: invalid initial state table"));
     if (LIKELY((ftp = csound->FTFind(csound,p->iRuleFunc)) != NULL)) {
       p->ruleVec = ftp->ftable;
+      p->rulelen = ftp->flen;
     }
     else
       return csound->InitError(csound, "%s", Str("cell: invalid rule table"));
 
-    if (p->auxch.auxp == NULL)
+    if (p->auxch.auxp == NULL ||
+        p->auxch.size < elements * sizeof(MYFLT) * 2)
       csound->AuxAlloc(csound, elements * sizeof(MYFLT) * 2, &p->auxch);
     currLine = (p->currLine = (MYFLT *) p->auxch.auxp);
     p->NewOld = 0;
     memcpy(currLine, initVec, sizeof(MYFLT)*elements);
-    /* do { */
-    /*   *currLine++ = *initVec++; */
-    /* } while (--elements); */
+    /* Both the next generation and the held output start at the initial state. */
+    memcpy(currLine + elements, initVec, sizeof(MYFLT)*elements);
 
 
     return OK;
@@ -85,13 +92,11 @@ static int32_t cell_set(CSOUND *csound,CELL *p)
 
 static int32_t cell(CSOUND *csound,CELL *p)
 {
-     IGN(csound);
     if (*p->kreinit) {
       p->NewOld = 0;
       memcpy(p->currLine, p->initVec, sizeof(MYFLT)*p->elements);
-      /* do { */
-      /*   *currLine++ = *initVec++; */
-      /* } while (--elements); */
+      memcpy(p->currLine + p->elements, p->initVec,
+             sizeof(MYFLT)*p->elements);
     }
     if (*p->ktrig) {
       int32_t j, elements = p->elements, jm1;
@@ -106,10 +111,16 @@ static int32_t cell(CSOUND *csound,CELL *p)
       for (j=0; j < elements; j++) {
 
         jm1 = (j < 1) ? elements-1 : j-1;
-        outVec[j] = previous[j];
-        actual[j] = ruleVec[(int32_t)(previous[jm1]*4 + previous[j]*2 +
-                                  previous[(j+1) % elements])];
+        double index = previous[jm1]*4 + previous[j]*2 +
+                       previous[j+1 == elements ? 0 : j+1];
+        /* Truncate fractional indices, as before, but check before converting. */
+        if (UNLIKELY(!(index > -1.0 && index < p->rulelen)))
+          return csound->PerfError(csound, &p->h, "%s",
+                                   Str("cell: rule index out of range"));
+        actual[j] = ruleVec[(uint32_t)index];
       }
+      /* Finish reading the rule before writing an output table that may alias it. */
+      memcpy(outVec, previous, sizeof(MYFLT)*elements);
 
     } else {
       int32_t

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -972,6 +972,8 @@ def runTest():
         ["test_nestedap_invalid_delay.csd", "reject invalid nestedap delay layout", 1],
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_pinker_sequence.csd", "pinker preserves its noise sequence across block sizes"],
+        ["test_cell_state.csd", "cell generation, reset, and table reuse"],
+        ["test_cell_invalid_inputs.csd", "cell rejects invalid sizes and rule indices", 1],
         ["test_pinker_sample_bounds.csd", "pinker clears inactive samples"],
         ["test_gausstrig_frequency_mode.csd", "gausstrig frequency-change and first-impulse modes"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],

--- a/tests/commandline/test_cell_invalid_inputs.csd
+++ b/tests/commandline/test_cell_invalid_inputs.csd
@@ -1,0 +1,41 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+giInitial ftgen 0, 0, 8, -2, 0
+giRules ftgen 0, 0, 8, -2, 0
+instr 1
+ iOutput ftgen 0, 0, 8, -2, 0
+ cell 1, 0, iOutput, giInitial, giRules, p4
+endin
+instr 2
+ iInitial ftgen 0, 0, 8, -2, p4
+ iRules ftgen 0, 0, -p5, -2, 0
+ iOutput ftgen 0, 0, 8, -2, 0
+ cell 1, 0, iOutput, iInitial, iRules, 8
+endin
+instr 3
+ iRules ftgen 0, 0, 8, -2, 2
+ iOutput ftgen 0, 0, 8, -2, 0
+ ; The first lookup is valid, but its result cannot index the next generation.
+ cell 1, 0, iOutput, giInitial, iRules, 8
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .02 0
+i 1 0 .02 -1
+i 1 0 .02 .5
+i 1 0 .02 1e30
+i 1 0 .02 9
+i 2 0 .02 -1 8
+i 2 0 .02 1e30 8
+i 2 0 .02 1 1
+i 3 0 .02
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_cell_state.csd
+++ b/tests/commandline/test_cell_state.csd
@@ -1,0 +1,158 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giInitial ftgen 0, 0, 64, -2, 1
+giRule90 ftgen 0, 0, 8, -2, 0, 1, 0, 1, 1, 0, 1, 0
+
+; Rule 90 moves a single live cell to its two neighbors on a circular row.
+; Check the existing trigger order, held output, and reset with either trigger.
+instr 1
+ iOutput ftgen 0, 0, 64, -2, 0
+ kCycle init 0
+ kCycle += 1
+ kTrigger = (kCycle == 2 || kCycle == 4 || kCycle == 5 || kCycle >= 9 && kCycle <= 11 ? 1 : 0)
+ kReset = (kCycle == 7 || kCycle == 10 ? 1 : 0)
+ cell kTrigger, kReset, iOutput, giInitial, giRule90, p4
+ kGeneration = (kCycle == 4 || kCycle >= 11 ? 1 : (kCycle == 5 || kCycle == 6 ? 2 : 0))
+ kIndex = 0
+ while kIndex < p4 do
+  kValue table kIndex, iOutput
+  if kGeneration == 0 then
+   kExpected = (kIndex == 0 ? 1 : 0)
+  elseif p4 == 1 then
+   kExpected = 0
+  else
+   kExpected = (kIndex == kGeneration || kIndex == p4-kGeneration ? 1 : 0)
+  endif
+  if kValue != kExpected then
+   printks "cell generation mismatch: cycle=%g element=%g got=%g expected=%g\n", 0, kCycle, kIndex, kValue, kExpected
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ if kCycle == 12 then
+  gkChecks += 1
+ endif
+endin
+
+; Sharing the output and rule tables must not overwrite rules before use.
+instr 2
+ iInitial ftgen 0, 0, 8, -2, 1
+ iShared ftgen 0, 0, 8, -2, 0, 0, 1, 1, 1, 1, 0, 0
+ kCycle init 0
+ kCycle += 1
+ cell 1, 0, iShared, iInitial, iShared, 8
+ if kCycle == 2 then
+  kIndex = 0
+  while kIndex < 8 do
+   kValue table kIndex, iShared
+   kExpected = (kIndex < 2 ? 1 : 0)
+   if kValue != kExpected then
+    printks "cell changed a rule while computing the generation\n", 0
+    exitnowk(-1)
+   endif
+   kIndex += 1
+  od
+  gkChecks += 1
+ endif
+endin
+
+; Reinitializing can change the row length while retaining the same tables.
+instr 3
+ iOutput ftgen 0, 0, 64, -2, 0
+ kCycle init 0
+ kCycle += 1
+ if kCycle == 7 then
+  reinit SETUP
+ endif
+ kStep = (kCycle < 7 ? kCycle : kCycle-6)
+ kTrigger = (kStep == 2 || kStep == 4 ? 1 : 0)
+SETUP:
+ iCount = (i(kCycle) < 7 ? p4 : p5)
+ cell kTrigger, 0, iOutput, giInitial, giRule90, iCount
+ rireturn
+ kCount = iCount
+ kIndex = 0
+ while kIndex < kCount do
+  kValue table kIndex, iOutput
+  kExpected = (kStep < 4 ? (kIndex == 0 ? 1 : 0) : (kIndex == 1 || kIndex == kCount-1 ? 1 : 0))
+  if kValue != kExpected then
+   printks "cell reinit mismatch: cycle=%g element=%g got=%g expected=%g\n", 0, kCycle, kIndex, kValue, kExpected
+   exitnowk(-1)
+  endif
+  kIndex += 1
+ od
+ if kCycle == 12 then
+  gkChecks += 1
+ endif
+endin
+
+; Fractional states still use the truncated weighted neighborhood index.
+instr 4
+ iInitial ftgen 0, 0, 4, -2, .25, .5, .75, 0
+ iRules ftgen 0, 0, 8, -2, 0, .125, .25, .375, .5, .625, .75, .875
+ iOutput ftgen 0, 0, 4, -2, 0
+ iExpected ftgen 0, 0, 4, -2, .125, .25, .375, .375
+ kCycle init 0
+ kCycle += 1
+ cell 1, 0, iOutput, iInitial, iRules, 4
+ if kCycle == 2 then
+  kIndex = 0
+  while kIndex < 4 do
+   kValue table kIndex, iOutput
+   kExpected table kIndex, iExpected
+   if kValue != kExpected then
+    printks "cell fractional rule lookup mismatch\n", 0
+    exitnowk(-1)
+   endif
+   kIndex += 1
+  od
+  gkChecks += 1
+ endif
+endin
+
+; A weighted index between -1 and 0 still truncates to rule zero.
+instr 5
+ iInitial ftgen 0, 0, 8, -2, -.125
+ iRules ftgen 0, 0, 8, -2, .5
+ iOutput ftgen 0, 0, 8, -2, 0
+ kCycle init 0
+ kCycle += 1
+ cell 1, 0, iOutput, iInitial, iRules, 1
+ if kCycle == 2 then
+  kValue table 0, iOutput
+  if kValue != .5 then
+   printks "cell negative fractional index did not select rule zero\n", 0
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 8 then
+  prints "cell checks did not complete: %g\n", i(gkChecks)
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .09375 1
+i 1 0 .09375 8
+i 1 0 .09375 64
+i 2 0 .015625
+i 3 0 .09375 8 64
+i 3 0 .09375 64 8
+i 4 0 .015625
+i 5 0 .015625
+i 99 .1 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `cell` state after initialization and reset:

- Initialize both generation buffers so held output reflects the initial state instead of zeros or an older generation. Preserve the existing trigger order.
- Grow storage when reinitialization increases the row length, and validate the element count before conversion and allocation.
- Check each rule index before conversion and lookup while preserving fractional-index truncation. Finish computing the generation before copying to the output table, so shared output and rule tables cannot overwrite rules during use.
