### PR TITLE
fix: correct seqtime2 event timing and loop bounds

### DIFF
--- a/Opcodes/seqtime.c
+++ b/Opcodes/seqtime.c
@@ -36,13 +36,16 @@ typedef struct {
     OPDS   h;
     MYFLT  *ktrig, *ktrigin, *unit_time, *kstart, *kloop, *kinitndx, *kfn;
     int32  ndx;
-    int32_t    done, first_flag;
+    int32_t    done;
     double start, newtime;
     int32  pfn;
+    uint32_t flen;
     MYFLT  *table, curr_unit_time;
 } SEQTIM2;
 
 
+/* Preserve seqtime's legacy startup and loop timing for existing scores.
+   The timing corrections below apply to seqtime2. */
 static int32_t seqtim_set(CSOUND *csound, SEQTIM *p)    /* by G.Maldonado */
 {
     FUNC *ftp;
@@ -148,108 +151,127 @@ static int32_t seqtim(CSOUND *csound, SEQTIM *p)
 
 /**---------------------------------------**/
 
+/* A positive loop endpoint is exclusive. Equal start/end selects a one-shot
+   sequence with an inclusive endpoint. A negative endpoint reverses the loop
+   over [start, -loop). */
+static int32_t seqtim2_range(SEQTIM2 *p, int32_t *start, int32_t *loop)
+{
+    double first = *p->kstart, last = *p->kloop;
+    if (UNLIKELY(!(first >= 0.0 && first < p->flen &&
+                   last >= -(double)p->flen && last <= p->flen)))
+      return NOTOK;
+    *start = (int32_t)first;
+    *loop = (int32_t)last;
+    return (*loop < 0 ? *start < -*loop : *start <= *loop) ? OK : NOTOK;
+}
+
+static void seqtim2_advance(SEQTIM2 *p, int32_t start, int32_t loop)
+{
+    if (start == loop) {
+      if (p->ndx >= loop)
+        p->done = 1;
+      else
+        p->ndx++;
+    }
+    else if (loop > 0) {
+      p->ndx = (p->ndx + 1) % loop;
+      if (p->ndx == 0)
+        p->ndx = start;
+    }
+    else {
+      p->ndx--;
+      if (p->ndx < start) {
+        int32_t span = -loop - start;
+        p->ndx = start + (p->ndx - start) % span;
+        if (p->ndx < start)
+          p->ndx += span;
+      }
+    }
+}
+
 static int32_t seqtim2_set(CSOUND *csound, SEQTIM2 *p)
 {
     FUNC *ftp;
-    int32 start, loop;
-    int32 *ndx = &p->ndx;
-    p->pfn = (int32) *p->kfn;
-    if (UNLIKELY((ftp = csound->FTFind(csound, p->kfn)) == NULL)) {
-      return csound->InitError(csound, "%s", Str("seqtim: incorrect table number"));
-    }
-    *ndx = (int32) *p->kinitndx;
-    p->done=0;
-    p->table =  ftp->ftable;
+    int32_t start, loop;
+    double number = *p->kfn, index = *p->kinitndx;
+    if (UNLIKELY(!(number >= INT32_MIN && number <= INT32_MAX) ||
+                 (ftp = csound->FTFind(csound, p->kfn)) == NULL ||
+                 ftp->flen > INT32_MAX))
+      return csound->InitError(csound, "%s",
+                               Str("seqtime2: incorrect table number or size"));
+    p->pfn = (int32_t)number;
+    p->table = ftp->ftable;
+    p->flen = ftp->flen;
+    if (UNLIKELY(!(index >= 0.0 && index < p->flen) ||
+                 seqtim2_range(p, &start, &loop) != OK))
+      return csound->InitError(csound, "%s",
+                               Str("seqtime2: index or loop out of range"));
+    p->ndx = (int32_t)index;
+    p->done = 0;
+    /* The initial element sets the delay before the first event. */
     p->newtime = p->table[p->ndx];
-    p->start = CS_KCNT * CS_ONEDKR;
-    start = (int32) *p->kstart;
-    loop = (int32) *p->kloop;
-    if (loop > 0 ) {
-      (*ndx)++;
-      *ndx %= loop;
-      if (*ndx == 0)  {
-        *ndx += start;
-      }
-    }
-    else if (loop < 0 ){
-      (*ndx)--;
-      while (*ndx < start) {
-        *ndx -= loop + start;
-      }
-    }
+    p->start = (double)CS_KCNT * CS_ONEDKR;
     p->curr_unit_time = *p->unit_time;
-    p->first_flag = 1;
+    seqtim2_advance(p, start, loop);
     return OK;
 }
 
 static int32_t seqtim2(CSOUND *csound, SEQTIM2 *p)
 {
-    if (*p->ktrigin) {
-      p->ndx = (int32) *p->kinitndx;
+    int32_t start, loop;
+    double number = *p->kfn;
+    double now = (double)CS_KCNT * CS_ONEDKR;
+    if (p->done && *p->ktrigin == FL(0.0)) {
+      *p->ktrig = FL(0.0);
+      return OK;
     }
-
-    if (p->done)
-      goto end;
-    else {
-      int32 start = (int32) *p->kstart, loop = (int32) *p->kloop;
-      int32 *ndx = &p->ndx;
-
-      if (p->pfn != (int32)*p->kfn) {
-        FUNC *ftp;
-        if (UNLIKELY( (ftp = csound->FTFind(csound, p->kfn) ) == NULL)) goto err1;
-        p->pfn = (int32)*p->kfn;
-        p->table = ftp->ftable;
-      }
-      if (p->curr_unit_time != *p->unit_time) {
-        double constant = p->start - CS_KCNT * CS_ONEDKR;
-        double difference_new = p->newtime * p->curr_unit_time + constant;
-        double difference_old = p->newtime * *p->unit_time     + constant;
-        double difference = difference_new - difference_old;
-        p->start = p->start + difference;
-        p->curr_unit_time = *p->unit_time;
-      }
-      if (CS_KCNT * CS_ONEDKR
-          > p->newtime * *p->unit_time + p->start) {
-        float curr_val = p->table[p->ndx];
-        p->newtime += p->table[p->ndx];
-        if (loop > 0 ) {
-          (*ndx)++;
-          *ndx %= loop;
-          if (*ndx == 0){
-            if (start == loop) {
-              p->done =1;
-              return OK;
-            }
-            *ndx += start;
-          }
-        }
-        else if (loop < 0 ){
-          (*ndx)--;
-          while (p->ndx < 0) {
-            if (start == loop) {
-              p->done = 1;
-              return OK;
-            }
-            *ndx -= loop + start;
-          }
-        }
-        *p->ktrig = curr_val * p->curr_unit_time;
-      }
-      else {
-        if (UNLIKELY(p->first_flag)) {
-          *p->ktrig = p->table[p->ndx];
-          p->first_flag = 0;
-        }
-        else {
-        end:
-          *p->ktrig = FL(0.0);
-        }
+    if (UNLIKELY(!(number >= INT32_MIN && number <= INT32_MAX)))
+      goto table_error;
+    if (p->pfn != (int32_t)number) {
+      FUNC *ftp;
+      if (UNLIKELY((ftp = csound->FTFind(csound, p->kfn)) == NULL ||
+                   ftp->flen > INT32_MAX))
+        goto table_error;
+      p->pfn = (int32_t)number;
+      p->table = ftp->ftable;
+      p->flen = ftp->flen;
+    }
+    if (UNLIKELY(seqtim2_range(p, &start, &loop) != OK))
+      goto range_error;
+    if (*p->ktrigin != FL(0.0)) {
+      double index = *p->kinitndx;
+      if (UNLIKELY(!(index >= 0.0 && index < p->flen)))
+        goto range_error;
+      p->ndx = (int32_t)index;
+      if (p->done) {
+        /* A completed one-shot has no pending event. Resume this cycle. */
+        p->done = 0;
+        p->newtime = 0.0;
+        p->start = now - CS_ONEDKR;
       }
     }
+    if (UNLIKELY((uint32_t)p->ndx >= p->flen))
+      goto range_error;
+    if (p->curr_unit_time != *p->unit_time) {
+      /* Keep the pending deadline; rescale subsequent intervals. */
+      p->start += p->newtime * ((double)p->curr_unit_time - *p->unit_time);
+      p->curr_unit_time = *p->unit_time;
+    }
+    if (now > p->newtime * p->curr_unit_time + p->start) {
+      MYFLT curr_val = p->table[p->ndx];
+      p->newtime += (double)curr_val;
+      seqtim2_advance(p, start, loop);
+      *p->ktrig = curr_val * p->curr_unit_time;
+    }
+    else
+      *p->ktrig = FL(0.0);
     return OK;
- err1:
-    return csound->PerfError(csound, &(p->h),
-                             "%s", Str("seqtim: incorrect table number"));
+ table_error:
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("seqtime2: incorrect table number or size"));
+ range_error:
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("seqtime2: index or loop out of range"));
 }
 
 #define S(x)    sizeof(x)
@@ -265,4 +287,3 @@ int32_t seqtime_init_(CSOUND *csound)
                                  (int32_t
                                   ) (sizeof(localops) / sizeof(OENTRY)));
 }
-

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -575,6 +575,8 @@ def runTest():
         ["test_splitrig_invalid_sequence.csd", "splitrig rejects invalid indexes and tick counts", 1],
         ["test_sequ_ranges.csd", "sequ ranges, permutations, state, and timing"],
         ["test_sequ_invalid_state.csd", "reject missing sequstate registration", 1],
+        ["test_seqtime2_timing.csd", "seqtime2 event timing and loop order"],
+        ["test_seqtime2_invalid_range.csd", "reject invalid seqtime2 ranges", 1],
         ["test_trighold_initial_trigger.csd", "trighold preserves its full duration after init and reinit"],
         ["test_udo_local_pool.csd", "test udos for separate local var pool"],
         ["test_ternary_expr.csd", "test ternary expr for backwards compatibility"],

--- a/tests/commandline/test_seqtime2_invalid_range.csd
+++ b/tests/commandline/test_seqtime2_invalid_range.csd
@@ -1,0 +1,74 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+giTimes ftgen 0, 0, 4, -2, 0, .5, .25, .75
+giShort ftgen 0, 0, 2, -2, 0, .5
+
+instr 1
+  kOut seqtime2 0, 1, p4, p5, p6, giTimes
+endin
+
+instr 2
+  kCycle init 0
+  kCycle += 1
+  kReset = (kCycle == 2 ? 1 : 0)
+  kIndex = (kCycle == 2 ? 4 : 0)
+  kOut seqtime2 kReset, 1, 0, 4, kIndex, giTimes
+endin
+
+instr 3
+  kCycle init 0
+  kLoop init -4
+  kCycle += 1
+  kLoop = (kCycle == 2 ? -1 : -4)
+  kOut seqtime2 0, 1, 1, kLoop, 0, giTimes
+endin
+
+instr 4
+  kCycle init 0
+  kTable init giTimes
+  kLoop init 4
+  kCycle += 1
+  kTable = (kCycle == 2 ? giShort : giTimes)
+  kLoop = (kCycle == 2 ? 2 : 4)
+  ; The new range fits the new table, but the pending index does not.
+  kOut seqtime2 0, 1, 0, kLoop, 2, kTable
+endin
+
+instr 5
+  kOut seqtime2 0, 1, 0, 4, 0, p4
+endin
+
+instr 6
+  kCycle init 0
+  kTable init giTimes
+  kCycle += 1
+  kTable = (kCycle == 2 ? p4 : giTimes)
+  kOut seqtime2 0, 1, 0, 4, 0, kTable
+endin
+</CsInstruments>
+<CsScore>
+; Six invalid initial ranges or indices, followed by three invalid changes.
+i 1 0 .1 0 4 4
+i 1 0 .1 0 4 -1
+i 1 0 .1 0 4 1e30
+i 1 0 .1 0 5 0
+i 1 0 .1 2 -2 0
+i 1 0 .1 -1 4 0
+i 2 0 .1
+i 3 0 .1
+i 4 0 .1
+; Reject table numbers before integer conversion at either rate.
+i 5 0 .1 1e30
+i 5 0 .1 -1e30
+i 6 0 .1 1e30
+i 6 0 .1 -1e30
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_seqtime2_timing.csd
+++ b/tests/commandline/test_seqtime2_timing.csd
@@ -1,0 +1,148 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 64
+nchnls = 1
+0dbfs = 1
+
+giZero ftgen 0, 0, 4, -2, 0, .5, .25, .75
+giDelay ftgen 0, 0, 4, -2, .25, .5, .125, .5
+giReverse ftgen 0, 0, 4, -2, 0, .125, .25, .5
+giPrecise ftgen 0, 0, 2, -2, 0, .5000000001
+giEmptyIntervals ftgen 0, 0, 4, -2, 0, 0, .25, .125
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kExpected = 0
+  if p4 == 1 then
+    ; Zero delay: the second control cycle must not trigger again.
+    kOut seqtime2 0, 1, 0, 4, 0, giZero
+    if kCycle == 1 then
+      kExpected = .5
+    elseif kCycle == 65 then
+      kExpected = .25
+    elseif kCycle == 97 then
+      kExpected = .75
+    endif
+  elseif p4 == 2 then
+    ; Initial delay and event values both use the time unit.
+    kOut seqtime2 0, 2, 0, 4, 0, giDelay
+    if kCycle == 65 then
+      kExpected = 1
+    elseif kCycle == 193 then
+      kExpected = .25
+    endif
+  elseif p4 == 3 then
+    ; Reverse range [1, 4) must never visit element zero.
+    kOut seqtime2 0, 1, 1, -4, 1, giReverse
+    if kCycle == 17 || kCycle == 129 then
+      kExpected = .5
+    elseif kCycle == 81 then
+      kExpected = .25
+    elseif kCycle == 113 then
+      kExpected = .125
+    endif
+  elseif p4 == 4 then
+    ; One-shot includes its endpoint, then stays silent until reset.
+    kReset = (kCycle == 161 ? 1 : 0)
+    kIndex = (kCycle < 161 ? 0 : 1)
+    kOut seqtime2 kReset, 1, 3, 3, kIndex, giZero
+    if kCycle == 1 || kCycle == 161 then
+      kExpected = .5
+    elseif kCycle == 65 || kCycle == 225 then
+      kExpected = .25
+    elseif kCycle == 97 || kCycle == 257 then
+      kExpected = .75
+    endif
+  elseif p4 == 5 then
+    ; Changing the time unit keeps the pending event's deadline.
+    kUnit init 1
+    kUnit = (kCycle < 33 ? 1 : 2)
+    kOut seqtime2 0, kUnit, 0, 4, 0, giZero
+    if kCycle == 1 || kCycle == 65 then
+      kExpected = .5
+    elseif kCycle == 129 then
+      kExpected = 1.5
+    endif
+  elseif p4 == 6 then
+    ; Reset changes the next index without moving its pending deadline.
+    ; Reusing the trigger variable as output must also work.
+    kOut = (kCycle == 33 ? 1 : 0)
+    kIndex = (kCycle < 33 ? 0 : 3)
+    kOut seqtime2 kOut, 1, 0, 4, kIndex, giZero
+    if kCycle == 1 then
+      kExpected = .5
+    elseif kCycle == 65 then
+      kExpected = .75
+    endif
+  elseif p4 == 7 then
+    ; Keep MYFLT precision in the event output.
+    kOut seqtime2 0, 1, 0, 2, 0, giPrecise
+    if kCycle == 1 then
+      kExpected table 1, giPrecise
+    endif
+  elseif p4 == 8 then
+    ; A table change affects the next event, not its pending deadline.
+    kTable init giZero
+    kTable = (kCycle < 33 ? giZero : giDelay)
+    kOut seqtime2 0, 1, 0, 4, 0, kTable
+    if kCycle == 1 then
+      kExpected = .5
+    elseif kCycle == 65 then
+      kExpected = .125
+    elseif kCycle == 81 then
+      kExpected = .5
+    endif
+  elseif p4 == 9 then
+    ; Zero intervals still consume one table element per control cycle.
+    kOut seqtime2 0, 1, 0, 4, 0, giEmptyIntervals
+    if kCycle == 2 || kCycle == 51 then
+      kExpected = .25
+    elseif kCycle == 33 then
+      kExpected = .125
+    endif
+  elseif p4 == 11 then
+    ; Play the intro once, then wrap to the nonzero loop start.
+    kOut seqtime2 0, 1, 2, 4, 0, giZero
+    if kCycle == 1 then
+      kExpected = .5
+    elseif kCycle == 65 || kCycle == 193 then
+      kExpected = .25
+    elseif kCycle == 97 || kCycle == 225 then
+      kExpected = .75
+    endif
+  else
+    kOut seqtime2 0, 1, 3, 3, 0, giZero
+    if kCycle == 1 then
+      kExpected = .5
+    elseif kCycle == 65 then
+      kExpected = .25
+    elseif kCycle == 97 then
+      kExpected = .75
+    endif
+  endif
+  if kOut != kExpected then
+    printks "seqtime2 case %g cycle %g: got %.12g, expected %.12g\n", 0, p4, kCycle, kOut, kExpected
+    exitnowk -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 1 1
+i 1 0 1.7 2
+i 1 0 1.1 3
+i 1 0 2.2 4
+i 1 0 1.1 5
+i 1 0 1 6
+i 1 0 .1 7
+i 1 0 1 8
+i 1 0 .4 9
+i 1 0 2 10
+i 1 0 2 11
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Correct `seqtime2` event timing while preserving the legacy `seqtime` behavior:

- Honor the initial delay and remove the extra startup trigger. Apply the time unit consistently and preserve MYFLT precision in event values.
- Emit the final one-shot event, clear subsequent output, and allow an input trigger to restart a completed sequence.
- Fix reverse wrapping with a nonzero loop start. Validate table numbers, indices, and loop ranges before conversion or lookup, including after runtime changes.
- Keep the pending event's deadline when the time unit changes, then use the new unit for later intervals.
