### PR TITLE
fix: correct pvsosc frame timing and harmonic selection

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -1053,153 +1053,114 @@ static int32_t pvsfreezeprocess(CSOUND *csound, PVSFREEZE *p)
 
 static int32_t pvsoscset(CSOUND *csound, PVSOSC *p)
 {
-  int32_t     i;
-  int32    N = (int32) *p->framesize;
+  double size = *p->framesize;
+  double overlap = *p->olap, winsize = *p->winsize;
+  int32_t N, i;
+
+  if (UNLIKELY(!(size >= 2.0 && size <= INT32_MAX - 2 &&
+                 size <= (double)SIZE_MAX / sizeof(float) - 2)))
+    return csound->InitError(csound, "%s", Str("pvsosc: invalid frame size"));
+  N = (int32_t)size;
+  if (UNLIKELY(N & 1))
+    return csound->InitError(csound, "%s", Str("pvsosc: frame size must be even"));
+  if (overlap == 0.0)
+    overlap = N / 4;
+  if (winsize == 0.0)
+    winsize = N;
+  if (UNLIKELY(!(overlap >= 1.0 && overlap <= INT32_MAX &&
+                 winsize >= 1.0 && winsize <= INT32_MAX)))
+    return csound->InitError(csound, "%s",
+                             Str("pvsosc: invalid overlap or window size"));
+  if (UNLIKELY(!(*p->wintype >= INT32_MIN && *p->wintype <= (double)INT32_MAX)))
+    return csound->InitError(csound, "%s", Str("pvsosc: invalid window type"));
+  if (UNLIKELY(*p->format != PVS_AMP_FREQ))
+    return csound->InitError(csound, "%s", Str("pvsosc: format must be amp-freq"));
 
   p->fout->N = N;
-  p->fout->overlap = (int32)(*p->olap ? *p->olap : N/4);
-  p->fout->winsize = (int32)(*p->winsize ? *p->winsize : N);
-  p->fout->wintype = (int32) *p->wintype;
-  p->fout->format = (int32) *p->format;
+  p->fout->NB = N / 2 + 1;
+  p->fout->overlap = (int32_t)overlap;
+  p->fout->winsize = (int32_t)winsize;
+  p->fout->wintype = (int32_t)*p->wintype;
+  p->fout->format = PVS_AMP_FREQ;
   p->fout->framecount = 0;
   p->fout->sliding = 0;
-  if (p->fout->overlap<(int32_t)CS_KSMPS || p->fout->overlap<=10) {
-    return csound->InitError(csound, "%s", Str("pvsosc does not work while sliding"));
-#ifdef SOME_FINE_DAY
-    CMPLX *bframe;
-    int32_t NB = 1+N/2;
-    uint32_t offset = p->h.insdshead->ksmps_offset;
-    uint32_t n, nsmps = CS_KSMPS;
+  if (UNLIKELY(p->fout->overlap < (int32_t)CS_KSMPS ||
+               p->fout->overlap <= 10))
+    return csound->InitError(csound, "%s",
+                             Str("pvsosc does not work while sliding"));
 
-    p->fout->NB = NB;
-    p->fout->sliding = 1;
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < CS_KSMPS*sizeof(MYFLT) * (N + 2))
-      csound->AuxAlloc(csound,
-                       (N + 2) * CS_KSMPS* sizeof(MYFLT), &p->fout->frame);
-    else memset(p->fout->frame.auxp,
-                '\0', (N + 2) * CS_KSMPS* sizeof(MYFLT));
-    bframe = (CMPLX *)p->fout->frame.auxp;
-    for (n=0; n<nsmps; n++)
-      for (i = 0; i < NB; i++) {
-        bframe[i+NB*n].re = FL(0.0);
-        bframe[i+NB*n].im = (n<offset ? FL(0.0) : i * N * CS_ONEDSR);
-      }
-    return OK;
-#endif
-  }
-  else
-    {
-      float   *bframe;
-      int32_t j;
-      if (p->fout->frame.auxp == NULL ||
-          p->fout->frame.size < sizeof(float) * (N + 2))
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
-      bframe = (float *) p->fout->frame.auxp;
-      for (i = j = 0; i < N + 2; i += 2, j++) {
-        //bframe[i] = 0.0f;
-        bframe[i + 1] = j * N * CS_ONEDSR;
-      }
-      p->lastframe = 1;
-      p->incr = (MYFLT)CS_KSMPS/p->fout->overlap;
+  if (p->fout->frame.auxp == NULL ||
+      p->fout->frame.size < sizeof(float) * (size_t)(N + 2))
+    csound->AuxAlloc(csound, (size_t)(N + 2) * sizeof(float),
+                     &p->fout->frame);
+  {
+    float *bframe = (float *)p->fout->frame.auxp;
+    for (i = 0; i < N + 2; i += 2) {
+      bframe[i] = 0.0f;
+      bframe[i + 1] = (i / 2) * (CS_ESR / N);
     }
+  }
+  /* Produce the first frame immediately, then keep the hop remainder. */
+  p->samplecount = p->fout->overlap;
   return OK;
 }
 
 static int32_t pvsoscprocess(CSOUND *csound, PVSOSC *p)
 {
-  int32_t     i, harm, type;
-  int32    framesize;
-  MYFLT   famp, ffun,w;
-  float   *fout;
-  double  cfbin,a;
-  float   amp, freq;
-  int32_t     cbin, k, n;
+  if (p->samplecount >= (uint32_t)p->fout->overlap) {
+    int32_t i, n, k, cbin, harm = 1;
+    int32_t framesize = p->fout->N + 2;
+    double wave = *p->type;
+    int32_t type = (wave >= 0.5 && wave <= 3.5) ?
+      (int32_t)MYFLT2LRND(wave) : 0;
+    MYFLT famp = *p->ka;
+    double ffun = *p->kf;
+    MYFLT w = CS_ESR / p->fout->N;
+    float *fout = (float *)p->fout->frame.auxp;
+    int32_t step = type == 2 ? 2 : 1;
 
-  famp = *p->ka;
-  ffun = *p->kf;
-  type = (int32_t)MYFLT2LRND(*p->type);
-  fout = (float *) p->fout->frame.auxp;
+    if (UNLIKELY(!(ffun >= 0.0)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("pvsosc: frequency must be non-negative"));
+    memset(fout, 0, sizeof(float) * (size_t)framesize);
+    /* Zero and above-Nyquist fundamentals have no oscillating partials. */
+    if (ffun > 0.0 && ffun <= CS_ESR * 0.5) {
+      if (type >= 1 && type <= 3) {
+        double count = (CS_ESR * 0.5) / ffun;
+        if (UNLIKELY(!(count < INT32_MAX)))
+          return csound->PerfError(csound, &(p->h), "%s",
+                                   Str("pvsosc: frequency is too low"));
+        harm = (int32_t)count;
+      }
+      if (type == 1)
+        famp *= FL(1.456) / pow(harm, FL(1.0) / FL(2.4));
+      else if (type == 2)
+        famp *= FL(1.456) / POWER((MYFLT)harm, FL(0.25));
+      else if (type == 3)
+        famp *= FL(1.456) / POWER((MYFLT)harm, FL(1.0) / FL(160.0));
+      else
+        famp *= FL(1.456);
 
-  framesize = p->fout->N + 2;
-
-  if (p->fout->sliding) {
-    CMPLX *fout;
-    uint32_t offset = p->h.insdshead->ksmps_offset;
-    uint32_t n, nsmps = CS_KSMPS;
-    int32_t NB = p->fout->NB;
-    harm = (int32_t)(CS_ESR/(2*ffun));
-    if (type==1) famp *= FL(1.456)/POWER((MYFLT)harm, FL(1.0)/FL(2.4));
-    else if (type==2) famp *= FL(1.456)/POWER((MYFLT)harm, FL(0.25));
-    else if (type==3) famp *= FL(1.456)/POWER((MYFLT)harm, FL(1.0)/FL(160.0));
-    else {
-      harm = 1;
-      famp *= FL(1.456);
-    }
-
-    for (n=0; n<nsmps; n++) {
-      int32_t m;
-      fout = (CMPLX*) p->fout->frame.auxp + n*NB;
-      w = CS_ESR/p->fout->N;
-      /*         harm = (int32_t)(CS_ESR/(2*ffun)); */
-      memset(fout, '\0', NB*sizeof(CMPLX));
-      if (n<offset) continue;
-      for (m=1; m <= harm; m++) {
-        if (type == 3) amp = famp/(harm);
-        else amp = (famp/m);
-        freq = ffun*m;
-        cfbin = freq/w;
+      for (n = 1; n <= harm; n += step) {
+        float amp = (type == 3 ? famp / harm : famp / n);
+        float freq = ffun * n;
+        double cfbin = freq / w;
         cbin = (int32_t)MYFLT2LRND(cfbin);
-        if (cbin != 0)     {
-          for (i=cbin-1;i < cbin+3 &&i < NB ; i++) {
-            if (i-cfbin == 0) a = 1;
-            else a = sin(i-cfbin)/(i-cfbin);
-            fout[i].re = amp*a*a*a;
-            fout[i].im = freq;
+        if (cbin != 0) {
+          for (i = cbin - 1, k = i * 2;
+               i < cbin + 3 && i < framesize / 2; i++, k += 2) {
+            double distance = i - cfbin;
+            double a = (distance == 0.0 ? 1.0 : sin(distance) / distance);
+            fout[k] = amp * a * a * a;
+            fout[k + 1] = freq;
           }
-          if (type==2) m++;
         }
       }
     }
-    return OK;
+    p->fout->framecount++;
+    p->samplecount -= p->fout->overlap;
   }
-  if (p->lastframe > p->fout->framecount) {
-    w = CS_ESR/p->fout->N;
-    harm = (int32_t)(CS_ESR/(2*ffun));
-    if (type==1) famp *= FL(1.456)/pow(harm, FL(1.0)/FL(2.4));
-    else if (type==2) famp *= FL(1.456)/POWER(harm, FL(0.25));
-    else if (type==3) famp *= FL(1.456)/POWER(harm, FL(1.0)/FL(160.0));
-    else {
-      harm = 1;
-      famp *= FL(1.456);
-    }
-    memset(fout, 0, sizeof(float)*framesize);
-    /* for (i = 0; i < framesize; i ++) fout[i] = 0.f; */
-
-    for (n=1; n <= harm; n++) {
-      if (type == 3) amp = famp/(harm);
-      else amp = (famp/n);
-      freq = ffun*n;
-      cfbin = freq/w;
-      cbin = (int32_t)MYFLT2LRND(cfbin);
-      if (cbin != 0)     {
-        for (i=cbin-1,k = (cbin-1)<<1;i < cbin+3 &&i < framesize/2 ; i++, k+=2) {
-          //k = i<<1;
-          if (i-cfbin == 0) a = 1;
-          else a = sin(i-cfbin)/(i-cfbin);
-          fout[k] = amp*a*a*a;
-          fout[k+1] = freq;
-        }
-        if (type==2) n++;
-      }
-    }
-    p->fout->framecount = p->lastframe;
-  }
-  p->incr += p->incr;
-  if (p->incr > 1) {
-    p->incr = (MYFLT)CS_KSMPS/p->fout->overlap;
-    p->lastframe++;
-  }
+  p->samplecount += CS_KSMPS;
   return OK;
 }
 

--- a/Opcodes/pvsbasic.h
+++ b/Opcodes/pvsbasic.h
@@ -136,8 +136,7 @@ typedef struct _pvsosc {
     PVSDAT  *fout;
     MYFLT   *ka, *kf, *type;
     MYFLT   *framesize, *olap, *winsize, *wintype, *format;
-    MYFLT incr;
-    uint32  lastframe;
+    uint32_t samplecount;
 } PVSOSC;
 
 typedef struct _pvsbin {
@@ -222,4 +221,3 @@ static int32_t
 pvstencil(CSOUND *, PVSTENCIL *p);
 
 #endif
-

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -872,6 +872,8 @@ def runTest():
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
+        ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
+        ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
         ["test_sa.csd", "test sample accurate mode"],
         ["test_diode_ladder_saturation.csd", "diode_ladder saturation and filter history"],
         ["test_gain_sample_bounds.csd", "gain RMS and output over partial blocks"],

--- a/tests/commandline/test_pvsosc_frames.csd
+++ b/tests/commandline/test_pvsosc_frames.csd
@@ -1,0 +1,174 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  iHop = (p4 == 0 ? 256 : p4)
+  kCycle init 0
+  kBins[] init 1026
+  kCycle += 1
+  fSignal pvsosc .5, 512, p5, 1024, p4
+  kFrame pvs2tab kBins, fSignal
+  kExpected = 1 + int((kCycle - 1) * ksmps / iHop)
+  if kFrame != kExpected then
+    printks "pvsosc hop %g cycle %g: frame %g, expected %g\n", 0, iHop, kCycle, kFrame, kExpected
+    exitnowk -1
+  endif
+  ; The first harmonic is isolated: keep the existing spectral weights.
+  if p5 == 1 then
+    iAmp = .5 * 1.456 / (8 ^ (1 / 2.4))
+  elseif p5 == 2 then
+    iAmp = .5 * 1.456 / (8 ^ .25)
+  elseif p5 == 3 then
+    iAmp = .5 * 1.456 / (8 ^ (1 / 160)) / 8
+  else
+    iAmp = .5 * 1.456
+  endif
+  if abs(kBins[128] - iAmp) > .000001 || kBins[129] != 512 then
+    printks "pvsosc type %g: incorrect first harmonic\n", 0, p5
+    exitnowk -1
+  endif
+  if kCycle == 32 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; Below half a bin, skipped harmonics must not change square-wave parity.
+  kBins[] init 130
+  fSignal pvsosc .5, 10, 2, 128, 32
+  kFrame pvs2tab kBins, fSignal
+  kBin = 0
+  kFound = 0
+  while kBin < 65 do
+    if kBins[2 * kBin] != 0 then
+      kHarmonic = kBins[2 * kBin + 1] / 10
+      if kHarmonic % 2 != 1 then
+        printks "pvsosc square wave emitted harmonic %g\n", 0, kHarmonic
+        exitnowk -1
+      endif
+      kFound += 1
+    endif
+    kBin += 1
+  od
+  if kFound == 0 then
+    printks "pvsosc square wave has no partials\n", 0
+    exitnowk -1
+  endif
+endin
+
+instr 3
+  ; Zero and above-Nyquist frequencies produce empty frames for all types.
+  kBins[] init 130
+  fSignal pvsosc .5, p4, p5, 128, 32
+  kFrame pvs2tab kBins, fSignal
+  kIndex = 0
+  while kIndex < 130 do
+    if kBins[kIndex] != 0 then
+      printks "pvsosc frequency %g type %g: nonempty frame\n", 0, p4, p5
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+endin
+
+instr 4
+  ; Nyquist is a valid cosine partial, including the fallback wave type.
+  kBins[] init 130
+  fSignal pvsosc .5, 4096, p4, 128, 32
+  kFrame pvs2tab kBins, fSignal
+  if abs(kBins[128] - .728) > .000001 || kBins[129] != 4096 then
+    printks "pvsosc lost the Nyquist partial\n", 0
+    exitnowk -1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 8 then
+    prints "not all pvsosc frame checks ran\n"
+    exitnow -1
+  endif
+endin
+
+instr 5
+  kCycle init 0
+  kBins[] init 1026
+  kCycle += 1
+  if kCycle == 13 then
+    reinit SETUP
+  endif
+SETUP:
+  fSignal pvsosc .5, 512, 4, 1024, 256
+  rireturn
+  kFrame pvs2tab kBins, fSignal
+  kElapsed = (kCycle < 13 ? kCycle - 1 : kCycle - 13)
+  kExpected = 1 + int(kElapsed * ksmps / 256)
+  if kFrame != kExpected then
+    printks "pvsosc reinit cycle %g: frame %g, expected %g\n", 0, kCycle, kFrame, kExpected
+    exitnowk -1
+  endif
+endin
+; Changed controls take effect at the next frame, including a change to silence.
+instr 6
+  kCycle init 0
+  kCycle += 1
+  kBins[] init 1026
+  kFrequency = (kCycle == 1 ? 512 : (kCycle < 10 ? 1024 : 0))
+  kAmplitude = (kCycle == 1 ? .5 : .25)
+  fSignal pvsosc kAmplitude, kFrequency, 4, 1024, 256
+  kFrame pvs2tab kBins, fSignal
+  if kCycle < 9 then
+    if abs(kBins[128]-.728) > .000001 || kBins[129] != 512 || kBins[256] != 0 then
+      exitnowk -1
+    endif
+  elseif kCycle < 17 then
+    if abs(kBins[256]-.364) > .000001 || kBins[257] != 1024 || kBins[128] != 0 then
+      exitnowk -1
+    endif
+  else
+    kIndex = 0
+    while kIndex < 1026 do
+      if kBins[kIndex] != 0 then
+        printks "pvsosc retained a partial after switching to zero frequency\n", 0
+        exitnowk -1
+      endif
+      kIndex += 1
+    od
+  endif
+  if kCycle == 32 then
+    gkChecks += 1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .25 32 1
+i 1 0 .25 64 2
+i 1 0 .25 96 3
+i 1 0 .25 100 4
+i 1 0 .25 256 4
+i 1 0 .25 1024 4
+i 1 0 .25 0 4
+i 2 0 .05
+i 3 0 .05 0 1
+i 3 0 .05 0 2
+i 3 0 .05 0 3
+i 3 0 .05 0 4
+i 3 0 .05 8192 1
+i 3 0 .05 8192 2
+i 3 0 .05 8192 3
+i 3 0 .05 8192 4
+i 4 0 .05 4
+i 4 0 .05 1e30
+i 5 0 .25
+i 6 0 .25
+i 99 .3 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsosc_invalid_parameters.csd
+++ b/tests/commandline/test_pvsosc_invalid_parameters.csd
@@ -1,0 +1,32 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+instr 1
+  fSignal pvsosc .5, 512, 4, p4, p5, p6, p7, p8
+endin
+instr 2
+  fSignal pvsosc .5, p4, 1, 128, 32
+endin
+</CsInstruments>
+<CsScore>
+; Nine invalid initial settings and two invalid frequencies.
+i 1 0 .05 0 32 128 1 0
+i 1 0 .05 3 32 128 1 0
+i 1 0 .05 1e30 32 128 1 0
+i 1 0 .05 128 -1 128 1 0
+i 1 0 .05 128 1e30 128 1 0
+i 1 0 .05 128 16 128 1 0
+i 1 0 .05 128 32 -1 1 0
+i 1 0 .05 128 32 128 1e30 0
+i 1 0 .05 128 32 128 1 1
+i 2 0 .05 -1
+i 2 0 .05 1e-30
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Correct `pvsosc` frame timing and harmonic selection:

- Replace the doubling time accumulator with an integer sample count. Keep the first frame immediate and retain the hop remainder, so frame timing follows the requested overlap even when it is not a multiple of `ksmps`.
- Advance square-wave harmonics by two even when a low harmonic falls below the first usable bin, preserving odd-only partials.
- Clear frame amplitudes on initialization and set bin frequencies in Hz. Validate sizes and conversions, require the supported AMP-FREQ format, and produce empty frames for zero or above-Nyquist fundamentals.

Spectral calculations run only when a frame is due; the existing harmonic weights remain unchanged.
