### PR TITLE
fix: correct pvsbin output rates and bin selection

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -1165,8 +1165,21 @@ static int32_t pvsoscprocess(CSOUND *csound, PVSOSC *p)
 }
 
 
+static int32_t pvsbinset(CSOUND *csound, PVSBIN *p)
+{
+  IGN(csound);
+  p->lastframe = 0;
+  p->amp = p->freq = FL(0.0);
+  return OK;
+}
+
 static int32_t pvsbinprocess(CSOUND *csound, PVSBIN *p)
 {
+  if (!p->fin->sliding && p->lastframe >= p->fin->framecount) {
+    *p->kamp = p->amp;
+    *p->kfreq = p->freq;
+    return OK;
+  }
   double bin = *p->kbin;
   int32_t NB = p->fin->sliding ? p->fin->NB : p->fin->N / 2 + 1;
   int32_t pos;
@@ -1189,8 +1202,9 @@ static int32_t pvsbinprocess(CSOUND *csound, PVSBIN *p)
   }
   else {
     float *fin = (float *)p->fin->frame.auxp;
-    *p->kamp = (MYFLT)fin[2 * pos];
-    *p->kfreq = (MYFLT)fin[2 * pos + 1];
+    *p->kamp = p->amp = (MYFLT)fin[2 * pos];
+    *p->kfreq = p->freq = (MYFLT)fin[2 * pos + 1];
+    p->lastframe = p->fin->framecount;
   }
   return OK;
 }
@@ -1199,14 +1213,16 @@ static int32_t pvsbinprocessa(CSOUND *csound, PVSBIN *p)
 {
   double bin = *p->kbin;
   int32_t NB = p->fin->sliding ? p->fin->NB : p->fin->N / 2 + 1;
-  int32_t pos;
+  int32_t pos = 0;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  if (UNLIKELY(!(bin >= 0.0 && bin < NB)))
-    return csound->PerfError(csound, &(p->h), "%s",
-                             Str("pvsbin: bin index out of range"));
-  pos = (int32_t)bin;
+  if (p->fin->sliding || p->lastframe < p->fin->framecount) {
+    if (UNLIKELY(!(bin >= 0.0 && bin < NB)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("pvsbin: bin index out of range"));
+    pos = (int32_t)bin;
+  }
   if (UNLIKELY(offset)) {
     memset(p->kamp, 0, offset * sizeof(MYFLT));
     memset(p->kfreq, 0, offset * sizeof(MYFLT));
@@ -1224,13 +1240,16 @@ static int32_t pvsbinprocessa(CSOUND *csound, PVSBIN *p)
     }
   }
   else {
-    float *fin = (float *)p->fin->frame.auxp;
-    MYFLT amp = (MYFLT)fin[2 * pos];
-    MYFLT freq = (MYFLT)fin[2 * pos + 1];
-    /* Hold the current frame, including blocks without a new frame. */
+    if (p->lastframe < p->fin->framecount) {
+      float *fin = (float *)p->fin->frame.auxp;
+      p->amp = (MYFLT)fin[2 * pos];
+      p->freq = (MYFLT)fin[2 * pos + 1];
+      p->lastframe = p->fin->framecount;
+    }
+    /* Hold the bin chosen at the last PVS frame update. */
     for (n = offset; n < nsmps; n++) {
-      p->kamp[n] = amp;
-      p->kfreq[n] = freq;
+      p->kamp[n] = p->amp;
+      p->kfreq[n] = p->freq;
     }
   }
   return OK;
@@ -2802,8 +2821,8 @@ static OENTRY localops[] = {
   {"pvstencil", sizeof(PVSTENCIL), TR, "f", "fkki", (SUBR) pvstencilset,
    (SUBR) pvstencil},
   {"pvsinit", sizeof(PVSINI),0,  "f", "ioopo", (SUBR) pvsinit, NULL, NULL},
-  {"pvsbin", sizeof(PVSBIN),0, "kk", "fk", NULL, (SUBR) pvsbinprocess},
-  {"pvsbin", sizeof(PVSBIN),0, "aa", "fk", NULL, (SUBR) pvsbinprocessa},
+  {"pvsbin", sizeof(PVSBIN),0, "kk", "fk", (SUBR) pvsbinset, (SUBR) pvsbinprocess},
+  {"pvsbin", sizeof(PVSBIN),0, "aa", "fk", (SUBR) pvsbinset, (SUBR) pvsbinprocessa},
   {"pvsfreeze", sizeof(PVSFREEZE),0, "f", "fkk", (SUBR) pvsfreezeset,
    (SUBR) pvsfreezeprocess, NULL},
   {"pvsmooth", sizeof(PVSFREEZE),0, "f", "fxx", (SUBR) pvsmoothset,

--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -1165,78 +1165,72 @@ static int32_t pvsoscprocess(CSOUND *csound, PVSOSC *p)
 }
 
 
-static int32_t pvsbinset(CSOUND *csound, PVSBIN *p)
-{
-   IGN(csound);
-  p->lastframe = 0;
-  return OK;
-}
-
 static int32_t pvsbinprocess(CSOUND *csound, PVSBIN *p)
 {
-   IGN(csound);
-  int32    framesize, pos;
+  double bin = *p->kbin;
+  int32_t NB = p->fin->sliding ? p->fin->NB : p->fin->N / 2 + 1;
+  int32_t pos;
+  if (UNLIKELY(!(bin >= 0.0 && bin < NB)))
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("pvsbin: bin index out of range"));
+  pos = (int32_t)bin;
   if (p->fin->sliding) {
-    CMPLX *fin = (CMPLX *) p->fin->frame.auxp;
-    framesize = p->fin->NB;
-    pos=*p->kbin;
-    if (pos >= 0 && pos < framesize) {
-      *p->kamp = (MYFLT)fin[pos].re;
-      *p->kfreq = (MYFLT)fin[pos].im;
+    uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t end = CS_KSMPS - p->h.insdshead->ksmps_no_end;
+    CMPLX *fin = (CMPLX *)p->fin->frame.auxp;
+    if (UNLIKELY(offset >= end)) {
+      *p->kamp = *p->kfreq = FL(0.0);
+      return OK;
     }
+    /* A control-rate output reads the first active sample. */
+    fin += (size_t)offset * NB + pos;
+    *p->kamp = fin->re;
+    *p->kfreq = fin->im;
   }
-  else
-    {
-      float   *fin;
-      fin = (float *) p->fin->frame.auxp;
-      if (p->lastframe < p->fin->framecount) {
-        framesize = p->fin->N + 2;
-        pos=*p->kbin*2;
-        if (pos >= 0 && pos < framesize) {
-          *p->kamp = (MYFLT)fin[pos];
-          *p->kfreq = (MYFLT)fin[pos+1];
-        }
-        p->lastframe = p->fin->framecount;
-      }
-    }
+  else {
+    float *fin = (float *)p->fin->frame.auxp;
+    *p->kamp = (MYFLT)fin[2 * pos];
+    *p->kfreq = (MYFLT)fin[2 * pos + 1];
+  }
   return OK;
 }
 
 static int32_t pvsbinprocessa(CSOUND *csound, PVSBIN *p)
 {
-   IGN(csound);
-  int32    framesize, pos;
+  double bin = *p->kbin;
+  int32_t NB = p->fin->sliding ? p->fin->NB : p->fin->N / 2 + 1;
+  int32_t pos;
+  uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
+  uint32_t n, nsmps = CS_KSMPS;
+  if (UNLIKELY(!(bin >= 0.0 && bin < NB)))
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("pvsbin: bin index out of range"));
+  pos = (int32_t)bin;
+  if (UNLIKELY(offset)) {
+    memset(p->kamp, 0, offset * sizeof(MYFLT));
+    memset(p->kfreq, 0, offset * sizeof(MYFLT));
+  }
+  if (UNLIKELY(early)) {
+    nsmps -= early;
+    memset(p->kamp + nsmps, 0, early * sizeof(MYFLT));
+    memset(p->kfreq + nsmps, 0, early * sizeof(MYFLT));
+  }
   if (p->fin->sliding) {
-    uint32_t offset = p->h.insdshead->ksmps_offset;
-    uint32_t k, nsmps = CS_KSMPS;
-    CMPLX *fin = (CMPLX *) p->fin->frame.auxp;
-    int32_t NB = p->fin->NB;
-    pos = *p->kbin;
-    if (pos >= 0 && pos < NB) {
-      for (k=0; k<offset; k++)  p->kamp[k]  = p->kfreq[k] = FL(0.0);
-      for (k=offset; k<nsmps; k++) {
-        p->kamp[k]  = (MYFLT)fin[pos+NB*k].re;
-        p->kfreq[k] = (MYFLT)fin[pos+NB*k].im;
-      }
+    CMPLX *fin = (CMPLX *)p->fin->frame.auxp;
+    for (n = offset; n < nsmps; n++) {
+      p->kamp[n] = fin[pos + (size_t)NB * n].re;
+      p->kfreq[n] = fin[pos + (size_t)NB * n].im;
     }
   }
   else {
-    float   *fin;
-    uint32_t offset = p->h.insdshead->ksmps_offset;
-    uint32_t k, nsmps = CS_KSMPS;
-    fin = (float *) p->fin->frame.auxp;
-    if (p->lastframe < p->fin->framecount) {
-      framesize = p->fin->N + 2;
-      pos=*p->kbin*2;
-      if (pos >= 0 && pos < framesize) {
-        memset(p->kamp, '\0', offset*sizeof(MYFLT));
-        memset(p->kfreq, '\0', offset*sizeof(MYFLT));
-        for (k=offset; k<nsmps; k++) {
-          p->kamp[k]  = (MYFLT)fin[pos];
-          p->kfreq[k] = (MYFLT)fin[pos+1];
-        }
-        p->lastframe = p->fin->framecount;
-      }
+    float *fin = (float *)p->fin->frame.auxp;
+    MYFLT amp = (MYFLT)fin[2 * pos];
+    MYFLT freq = (MYFLT)fin[2 * pos + 1];
+    /* Hold the current frame, including blocks without a new frame. */
+    for (n = offset; n < nsmps; n++) {
+      p->kamp[n] = amp;
+      p->kfreq[n] = freq;
     }
   }
   return OK;
@@ -2808,8 +2802,8 @@ static OENTRY localops[] = {
   {"pvstencil", sizeof(PVSTENCIL), TR, "f", "fkki", (SUBR) pvstencilset,
    (SUBR) pvstencil},
   {"pvsinit", sizeof(PVSINI),0,  "f", "ioopo", (SUBR) pvsinit, NULL, NULL},
-  {"pvsbin", sizeof(PVSBIN),0, "ss", "fk", (SUBR) pvsbinset,
-   (SUBR) pvsbinprocess, (SUBR) pvsbinprocessa},
+  {"pvsbin", sizeof(PVSBIN),0, "kk", "fk", NULL, (SUBR) pvsbinprocess},
+  {"pvsbin", sizeof(PVSBIN),0, "aa", "fk", NULL, (SUBR) pvsbinprocessa},
   {"pvsfreeze", sizeof(PVSFREEZE),0, "f", "fkk", (SUBR) pvsfreezeset,
    (SUBR) pvsfreezeprocess, NULL},
   {"pvsmooth", sizeof(PVSFREEZE),0, "f", "fxx", (SUBR) pvsmoothset,

--- a/Opcodes/pvsbasic.h
+++ b/Opcodes/pvsbasic.h
@@ -144,6 +144,8 @@ typedef struct _pvsbin {
     MYFLT   *kamp, *kfreq;
     PVSDAT  *fin;
     MYFLT   *kbin;
+    uint32_t lastframe;
+    MYFLT amp, freq;
 } PVSBIN;
 
 typedef struct _pvsfreez {

--- a/Opcodes/pvsbasic.h
+++ b/Opcodes/pvsbasic.h
@@ -144,7 +144,6 @@ typedef struct _pvsbin {
     MYFLT   *kamp, *kfreq;
     PVSDAT  *fin;
     MYFLT   *kbin;
-    uint32  lastframe;
 } PVSBIN;
 
 typedef struct _pvsfreez {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -607,6 +607,8 @@ def runTest():
             "pvsadsyn rejects invalid bin increments",
             1,
         ],
+        ["test_pvsbin_output.csd", "pvsbin output rates, bin changes, and partial blocks"],
+        ["test_pvsbin_invalid_bin.csd", "reject invalid pvsbin indices", 1],
         ["test_hilbert2_state.csd", "hilbert2 input reuse, partial blocks and reinit"],
         ["test_gtf_complex_state.csd", "gtf complex impulse response and sample bounds"],
         ["test_repluck_correctness.csd", "test plucked-string waveguide limits"],

--- a/tests/commandline/test_connect_gain_fsig.csd
+++ b/tests/commandline/test_connect_gain_fsig.csd
@@ -94,7 +94,8 @@ instr SlidingSource
   atone oscili aenv, 1875
   fsig pvsanal atone, 256, 1, 256, 1
   adirect, afreq pvsbin fsig, 10
-  kdirect rms adirect
+  ; Check current bin samples without an RMS filter's decay tail.
+  kdirect max_k abs(adirect), 1, 1
   gkampSlidingDirect = kdirect
   outletf "fout", fsig
 endin
@@ -102,7 +103,7 @@ endin
 instr SlidingSink
   fsig inletf "fin"
   ainlet, afreq pvsbin fsig, 10
-  kinlet rms ainlet
+  kinlet max_k abs(ainlet), 1, 1
   if timeinstk() == 300 then
     if gkampSlidingDirect > 0.001 then
       printks "connect sliding fsig decay setup failed: direct amp=%f\n", 0, gkampSlidingDirect

--- a/tests/commandline/test_pvsbin_invalid_bin.csd
+++ b/tests/commandline/test_pvsbin_invalid_bin.csd
@@ -1,0 +1,40 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+instr 1
+  if p5 == 0 then
+    fInput pvsosc .5, 512, 4, 128, 32
+  else
+    aInput = .5
+    fInput pvsanal aInput, 128, 1, 128, 1
+  endif
+  if p6 == 0 then
+    kAmp, kFreq pvsbin fInput, p4
+  else
+    aAmp, aFreq pvsbin fInput, p4
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Each case must report a bin-range error, in both stream and output modes.
+i 1 0 .01 -.25 0 0
+i 1 0 .01 65 0 0
+i 1 0 .01 1e30 0 0
+i 1 0 .01 -.25 0 1
+i 1 0 .01 65 0 1
+i 1 0 .01 1e30 0 1
+i 1 0 .01 -.25 1 0
+i 1 0 .01 65 1 0
+i 1 0 .01 1e30 1 0
+i 1 0 .01 -.25 1 1
+i 1 0 .01 65 1 1
+i 1 0 .01 1e30 1 1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsbin_output.csd
+++ b/tests/commandline/test_pvsbin_output.csd
@@ -20,15 +20,21 @@ opcode BinReference, aa, ai
 endop
 
 instr 1
-  ; Read the current frame, including bin changes between frame updates.
+  ; Accept bin changes only when a new PVS frame arrives.
   kCycle init 0
   kCycle += 1
   kBins[] init 1026
   fInput pvsosc .5, p4, 4, 1024, 256
   kFrame pvs2tab kBins, fInput
   kBin = (kCycle % 3 == 1 ? 64.75 : (kCycle % 3 == 2 ? 128 : 512.75))
-  kExpectedAmp = kBins[2 * int(kBin)]
-  kExpectedFreq = kBins[2 * int(kBin) + 1]
+  kLastFrame init 0
+  kExpectedAmp init 0
+  kExpectedFreq init 0
+  if kFrame > kLastFrame then
+    kExpectedAmp = kBins[2 * int(kBin)]
+    kExpectedFreq = kBins[2 * int(kBin) + 1]
+    kLastFrame = kFrame
+  endif
   ; Overwrite both buffers so stale samples cannot pass as held values.
   aAmp = -1
   aFreq = -1

--- a/tests/commandline/test_pvsbin_output.csd
+++ b/tests/commandline/test_pvsbin_output.csd
@@ -1,0 +1,119 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode BinReference, aa, ai
+  setksmps 1
+  aInput, iBin xin
+  fInput pvsanal aInput, 64, 1, 64, 1
+  kAmp, kFreq pvsbin fInput, iBin
+  aAmp = kAmp
+  aFreq = kFreq
+  xout aAmp, aFreq
+endop
+
+instr 1
+  ; Read the current frame, including bin changes between frame updates.
+  kCycle init 0
+  kCycle += 1
+  kBins[] init 1026
+  fInput pvsosc .5, p4, 4, 1024, 256
+  kFrame pvs2tab kBins, fInput
+  kBin = (kCycle % 3 == 1 ? 64.75 : (kCycle % 3 == 2 ? 128 : 512.75))
+  kExpectedAmp = kBins[2 * int(kBin)]
+  kExpectedFreq = kBins[2 * int(kBin) + 1]
+  ; Overwrite both buffers so stale samples cannot pass as held values.
+  aAmp = -1
+  aFreq = -1
+  aAmp, aFreq pvsbin fInput, kBin
+  kAmp, kFreq pvsbin fInput, kBin
+  if kAmp != kExpectedAmp || kFreq != kExpectedFreq then
+    printks "pvsbin control output missed bin %g on cycle %g\n", 0, kBin, kCycle
+    exitnowk -1
+  endif
+  kFirst = (kCycle == 1 ? p5 : 0)
+  kEnd = (kCycle == p7 ? p6 : ksmps)
+  kIndex = 0
+  while kIndex < ksmps do
+    kActualAmp vaget kIndex, aAmp
+    kActualFreq vaget kIndex, aFreq
+    kWantAmp = (kIndex >= kFirst && kIndex < kEnd ? kExpectedAmp : 0)
+    kWantFreq = (kIndex >= kFirst && kIndex < kEnd ? kExpectedFreq : 0)
+    if kActualAmp != kWantAmp || kActualFreq != kWantFreq then
+      printks "pvsbin frame cycle %g sample %g: amp %g/%g, freq %g/%g\n", 0, kCycle, kIndex, kActualAmp, kWantAmp, kActualFreq, kWantFreq
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kCycle == p7 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; A sliding stream must expose every sample, not only the block's first.
+  kCycle init 0
+  kCycle += 1
+  aTone oscili .25, 3072
+  aInput = 1 + aTone
+  fInput pvsanal aInput, 64, 1, 64, 1
+  aAmp, aFreq pvsbin fInput, p4
+  kAmp, kFreq pvsbin fInput, p4
+  aExpectedAmp, aExpectedFreq BinReference aInput, p4
+  kFirst = (kCycle == 1 ? p5 : 0)
+  kEnd = (kCycle == p7 ? p6 : ksmps)
+  kIndex = 0
+  while kIndex < ksmps do
+    kActualAmp vaget kIndex, aAmp
+    kActualFreq vaget kIndex, aFreq
+    kWantAmp vaget kIndex, aExpectedAmp
+    kWantFreq vaget kIndex, aExpectedFreq
+    if kIndex < kFirst || kIndex >= kEnd then
+      kWantAmp = 0
+      kWantFreq = 0
+    endif
+    if abs(kActualAmp - kWantAmp) > .000001 * (1 + abs(kWantAmp)) || abs(kActualFreq - kWantFreq) > .000001 * (1 + abs(kWantFreq)) then
+      printks "pvsbin sliding bin %g cycle %g sample %g: amp %g/%g, freq %g/%g\n", 0, p4, kCycle, kIndex, kActualAmp, kWantAmp, kActualFreq, kWantFreq
+      exitnowk -1
+    endif
+    if kIndex == kFirst && (kAmp != kActualAmp || kFreq != kActualFreq) then
+      printks "pvsbin control output did not use the first active sample\n", 0
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kCycle == p7 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "not all pvsbin output checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Frequency/bin, first sample, final sample, number of blocks.
+i 1 0 .0625 512 0 32 16
+i 1 0 .0625 4096 0 32 16
+i 1 .0006103515625 .0130615234375 512 5 16 4
+i 1 .0006103515625 .0013427734375 512 5 16 1
+i 2 0 .0625 .75 0 32 16
+i 2 0 .0625 24.75 0 32 16
+i 2 0 .0625 32.75 0 32 16
+i 2 .0006103515625 .0130615234375 24.75 5 16 4
+i 2 .0006103515625 .0130615234375 32.75 5 16 4
+i 2 .0006103515625 .0013427734375 24.75 5 16 1
+i 99 .07 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Correct `pvsbin` output dispatch and bin selection:

- Register separate control-rate and audio-rate forms so audio outputs use the sample-processing function.
- Keep bin selection at the PVS frame rate for frame-based streams. Hold the selected amplitude and frequency between frames and fill audio outputs on every block.
- For sliding streams, read each active sample at audio rate and the first active sample at control rate. Clear inactive audio samples.
- Check bin bounds before integer conversion, and truncate the bin number before locating its amplitude/frequency pair. This prevents fractional indices from selecting mismatched values or reading past the frame.
