### PR TITLE
fix: reset pvsfreeze note state and respect sample bounds

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -951,7 +951,10 @@ int32_t pvstanal1(CSOUND *csound, PVST1 *p)
 
 static int32_t pvsfreezeset(CSOUND *csound, PVSFREEZE *p)
 {
-  int32    N = p->fin->N;
+  int32 N = p->fin->N;
+  size_t state_bytes = (size_t)(N + 2) *
+    (p->fin->sliding ? sizeof(MYFLT) : sizeof(float));
+  size_t output_bytes = state_bytes * (p->fin->sliding ? CS_KSMPS : 1);
 
   if (UNLIKELY(p->fin == p->fout))
     csound->Warning(csound, "%s", Str("Unsafe to have same fsig as in and out"));
@@ -962,32 +965,21 @@ static int32_t pvsfreezeset(CSOUND *csound, PVSFREEZE *p)
   p->fout->format = p->fin->format;
   p->fout->framecount = 1;
   p->lastframe = 0;
-
-  p->fout->NB = (N/2)+1;
+  p->fout->NB = (N / 2) + 1;
   p->fout->sliding = p->fin->sliding;
-  if (p->fin->sliding) {
-    uint32_t nsmps = CS_KSMPS;
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(MYFLT) * (N + 2) * nsmps)
-      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * nsmps,
-                       &p->fout->frame);
-    if (p->freez.auxp == NULL ||
-        p->freez.size < sizeof(MYFLT) * (N + 2) * nsmps)
-      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * nsmps, &p->freez);
-  }
-  else
-    {
-      if (p->fout->frame.auxp == NULL ||
-          p->fout->frame.size < sizeof(float) * (N + 2))
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
-      if (p->freez.auxp == NULL || p->freez.size < sizeof(float) * (N + 2))
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->freez);
 
-      if (UNLIKELY(!((p->fout->format == PVS_AMP_FREQ) ||
-                     (p->fout->format == PVS_AMP_PHASE))))
-        return csound->InitError(csound, "%s", Str("pvsfreeze: signal format "
+  if (UNLIKELY(!((p->fout->format == PVS_AMP_FREQ) ||
+                 (p->fout->format == PVS_AMP_PHASE))))
+    return csound->InitError(csound, "%s", Str("pvsfreeze: signal format "
                                              "must be amp-phase or amp-freq."));
-    }
+  if (p->fout->frame.auxp == NULL || p->fout->frame.size < output_bytes)
+    csound->AuxAlloc(csound, output_bytes, &p->fout->frame);
+  if (p->freez.auxp == NULL || p->freez.size < state_bytes)
+    csound->AuxAlloc(csound, state_bytes, &p->freez);
+  /* Each note starts without a captured spectrum, including reused instances.
+     Sliding mode also needs only one stored amplitude/frequency pair per bin. */
+  memset(p->freez.auxp, 0, state_bytes);
+  memset(p->fout->frame.auxp, 0, output_bytes);
   return OK;
 }
 
@@ -996,18 +988,23 @@ static int32_t pvssfreezeprocess(CSOUND *csound, PVSFREEZE *p)
    IGN(csound);
   int32_t i;
   uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
   int32_t NB = p->fin->NB;
   MYFLT freeza = *p->kfra, freezf = *p->kfrf;
   CMPLX *fz = (CMPLX*)p->freez.auxp;
+  CMPLX *fout = (CMPLX*)p->fout->frame.auxp;
 
-  for (n=0; n<offset; n++) {
-    CMPLX *fo = (CMPLX*)p->fout->frame.auxp + n*NB;
-    for (i = 0; i < NB; i++) fo[i].re = fo[i].im = FL(0.0);
+  if (UNLIKELY(offset))
+    memset(fout, 0, (size_t)offset * NB * sizeof(CMPLX));
+  if (UNLIKELY(early)) {
+    nsmps -= early;
+    memset(fout + (size_t)nsmps * NB, 0,
+           (size_t)early * NB * sizeof(CMPLX));
   }
   for (n=offset; n<nsmps; n++) {
-    CMPLX *fo = (CMPLX*)p->fout->frame.auxp + n*NB;
-    CMPLX *fi = (CMPLX*)p->fin->frame.auxp + n*NB;
+    CMPLX *fo = fout + (size_t)n * NB;
+    CMPLX *fi = (CMPLX*)p->fin->frame.auxp + (size_t)n * NB;
     for (i = 0; i < NB; i++) {
       if (freeza < 1)
         fz[i].re = fi[i].re;
@@ -1032,12 +1029,10 @@ static int32_t pvsfreezeprocess(CSOUND *csound, PVSFREEZE *p)
   fout = (float *) p->fout->frame.auxp;
   fin = (float *) p->fin->frame.auxp;
   freez = (float *) p->freez.auxp;
-   int32    N = p->fin->N;
 
   framesize = p->fin->N + 2;
 
   if (p->lastframe < p->fin->framecount) {
-    memset(fout, 0, sizeof(float)*(N+2));
     for (i = 0; i < framesize; i += 2) {
       if (freeza < 1)
         freez[i] = fin[i];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -602,6 +602,7 @@ def runTest():
             "pvsadsyn rejects an out-of-range oscillator count",
             1,
         ],
+        ["test_pvsfreeze_state.csd", "pvsfreeze note state, reinit, and partial blocks"],
         [
             "test_pvsadsyn_invalid_increment.csd",
             "pvsadsyn rejects invalid bin increments",

--- a/tests/commandline/test_pvsfreeze_state.csd
+++ b/tests/commandline/test_pvsfreeze_state.csd
@@ -1,0 +1,124 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1, 2
+  ; Warm and reuse one instance; instrument 2 supplies a fresh comparison.
+  kCycle init 0
+  kCycle += 1
+  kInput[] init 1026
+  kOutput[] init 1026
+  fInput pvsosc .5, 512, 4, 1024, 256
+  fFrozen pvsfreeze fInput, p4, p5
+  kInputFrame pvs2tab kInput, fInput
+  kOutputFrame pvs2tab kOutput, fFrozen
+  kIndex = 0
+  while kIndex < 1026 do
+    kExpectedAmp = (p4 >= 1 ? 0 : kInput[kIndex])
+    kExpectedFreq = (p5 >= 1 ? 0 : kInput[kIndex + 1])
+    if kOutput[kIndex] != kExpectedAmp || kOutput[kIndex + 1] != kExpectedFreq then
+      printks "pvsfreeze note at %g retained an earlier spectrum in bin %g\n", 0, p2, kIndex / 2
+      exitnowk -1
+    endif
+    kIndex += 2
+  od
+  if kCycle == 8 then
+    gkChecks += 1
+  endif
+endin
+
+opcode FreezeReference, a, aaaa
+  setksmps 1
+  aInput, aFreezeA, aFreezeF, aReset xin
+  kFreezeA downsamp aFreezeA
+  kFreezeF downsamp aFreezeF
+  kReset downsamp aReset
+  fInput pvsanal aInput, 64, 1, 64, 1
+  if kReset != 0 then
+    reinit FREEZE
+  endif
+FREEZE:
+  fFrozen pvsfreeze fInput, kFreezeA, kFreezeF
+  rireturn
+  aOutput pvsynth fFrozen
+  xout aOutput
+endop
+
+instr 3, 4
+  kCycle init 0
+  kCycle += 1
+  aTone oscili .25, 3072
+  aInput = 1 + aTone
+  kFreeze = (p4 == 3 || (kCycle >= 3 && kCycle < 7) ? 2 : .5)
+  kFreezeA = (p4 == 2 ? .5 : kFreeze)
+  kFreezeF = (p4 == 1 ? .5 : kFreeze)
+  fInput pvsanal aInput, 64, 1, 64, 1
+  aReset = 0
+  if kCycle == p5 then
+    vaset 1, 0, aReset
+    reinit FREEZE
+  endif
+FREEZE:
+  fFrozen pvsfreeze fInput, kFreezeA, kFreezeF
+  rireturn
+  aActual pvsynth fFrozen
+  aFreezeA = kFreezeA
+  aFreezeF = kFreezeF
+  aExpected FreezeReference aInput, aFreezeA, aFreezeF, aReset
+  kFirst = (kCycle == 1 ? p6 : 0)
+  kEnd = (kCycle == p8 ? p7 : ksmps)
+  kIndex = 0
+  while kIndex < ksmps do
+    kActual vaget kIndex, aActual
+    kExpected vaget kIndex, aExpected
+    if kIndex < kFirst || kIndex >= kEnd || p4 == 3 || (p4 != 2 && p5 > 0 && kCycle >= p5 && kCycle < 7) then
+      kExpected = 0
+    endif
+    if abs(kActual - kExpected) > .00001 * (1 + abs(kExpected)) then
+      printks "pvsfreeze mode %g cycle %g sample %g: got %g, expected %g\n", 0, p4, kCycle, kIndex, kActual, kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kCycle == p8 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 16 then
+    prints "not all pvsfreeze state checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Amplitude/frequency freeze flags for fresh and reused frame-based streams.
+i 1 0 .03125 0 0
+i 1 .0625 .03125 1 1
+i 2 .0625 .03125 1 1
+i 1 .125 .03125 0 0
+i 1 .1875 .03125 1 0
+i 1 .25 .03125 0 0
+i 1 .3125 .03125 0 1
+; Sliding mode: switch mode, reinit block, first/end samples, block count.
+i 3 0 .03125 0 5 0 32 8
+i 3 .0625 .03125 3 0 0 32 8
+i 4 .0625 .03125 3 0 0 32 8
+i 3 .125 .03125 1 5 0 32 8
+i 3 .1875 .03125 2 5 0 32 8
+i 3 .2506103515625 .0130615234375 0 0 5 16 4
+i 3 .2740478515625 .0130615234375 1 0 5 16 4
+i 3 .2974853515625 .0130615234375 2 0 5 16 4
+i 3 .3131103515625 .0013427734375 0 0 5 16 1
+i 99 .36 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `pvsfreeze` state across notes and reinitialization:

- Clear the saved spectrum and output on initialization, so a note that starts frozen cannot inherit a previous note's spectrum.
- Allocate one stored amplitude/frequency pair per bin in sliding mode, using the correct sample type rather than reserving state for every sample position.
- Clear inactive sliding output samples and update captured state only within the note. Use `size_t` for frame offsets.
- Remove the frame-mode output clear that immediately preceded a complete overwrite.
