### PR TITLE
fix: correct pvsblur maximum window and delay bounds

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -2186,48 +2186,50 @@ static int32_t pvswarp(CSOUND *csound, PVSWARP *p)
 
 static int32_t pvsblurset(CSOUND *csound, PVSBLUR *p)
 {
-  float   *delay;
-  int32    N = p->fin->N, i, j;
-  int32_t     olap = p->fin->overlap;
-  int32_t     delayframes, framesize = N + 2;
+  int32_t N = p->fin->N, olap = p->fin->overlap;
+  int32_t i, j, capacity;
+  double maxdel = *p->maxdel, frames;
+  size_t frame_bytes, delay_bytes;
+  float *delay;
+
   if (UNLIKELY(p->fin == p->fout))
     csound->Warning(csound, "%s", Str("Unsafe to have same fsig as in and out"));
-  if (p->fin->sliding) {
-    csound->InitError(csound, "%s", Str("pvsblur does not work sliding yet"));
-    delayframes = (int32_t) (FL(0.5) + *p->maxdel * CS_ESR);
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(MYFLT) * CS_KSMPS * (N + 2))
-      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * CS_KSMPS,
-                       &p->fout->frame);
+  if (UNLIKELY(p->fin->sliding))
+    return csound->InitError(csound, "%s",
+                             Str("pvsblur does not work sliding yet"));
+  if (UNLIKELY(N < 2 || N > INT32_MAX - 2 || (N & 1) || olap <= 0 ||
+               (size_t)(N + 2) > SIZE_MAX / sizeof(float)))
+    return csound->InitError(csound, "%s", Str("pvsblur: invalid frame size"));
+  if (UNLIKELY(p->fin->format != PVS_AMP_FREQ &&
+               p->fin->format != PVS_AMP_PHASE))
+    return csound->InitError(csound, "%s",
+                             Str("pvsblur: format must be amp-freq or amp-phase"));
 
-    if (p->delframes.auxp == NULL ||
-        p->delframes.size < (N + 2) * sizeof(MYFLT) * CS_KSMPS * delayframes)
-      csound->AuxAlloc(csound,
-                       (N + 2) * sizeof(MYFLT) * CS_KSMPS * delayframes,
-                       &p->delframes);
-  }
-  else
-    {
-      p->frpsec = CS_ESR / olap;
+  p->frpsec = (double)CS_ESR / olap;
+  frames = maxdel * p->frpsec;
+  if (UNLIKELY(!(maxdel >= 0.0 && frames <= INT32_MAX)))
+    return csound->InitError(csound, "%s", Str("pvsblur: invalid maximum delay"));
+  p->maxframes = (int32_t)frames;
+  capacity = p->maxframes > 0 ? p->maxframes : 1;
+  frame_bytes = (size_t)(N + 2) * sizeof(float);
+  if (UNLIKELY((size_t)capacity > SIZE_MAX / frame_bytes))
+    return csound->InitError(csound, "%s", Str("pvsblur: delay buffer too large"));
+  delay_bytes = frame_bytes * capacity;
 
-      delayframes = (int32_t) (*p->maxdel * p->frpsec);
-
-      if (p->fout->frame.auxp == NULL ||
-          p->fout->frame.size < sizeof(float) * (N + 2))
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
-
-      if (p->delframes.auxp == NULL ||
-          p->delframes.size < (N + 2) * sizeof(float) * CS_KSMPS * delayframes)
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float) * delayframes,
-                         &p->delframes);
-    }
-  delay = (float *) p->delframes.auxp;
-
-  for (j = 0; j < framesize * delayframes; j += framesize)
+  if (p->fout->frame.auxp == NULL || p->fout->frame.size < frame_bytes)
+    csound->AuxAlloc(csound, frame_bytes, &p->fout->frame);
+  if (p->delframes.auxp == NULL || p->delframes.size < delay_bytes)
+    csound->AuxAlloc(csound, delay_bytes, &p->delframes);
+  memset(p->fout->frame.auxp, 0, frame_bytes);
+  delay = (float *)p->delframes.auxp;
+  for (j = 0; j < capacity; j++) {
+    float *frame = delay + (size_t)j * (N + 2);
     for (i = 0; i < N + 2; i += 2) {
-      delay[i + j] = 0.0f;
-      delay[i + j + 1] = i * CS_ESR / N;
+      frame[i] = 0.0f;
+      frame[i + 1] = p->fin->format == PVS_AMP_FREQ ?
+        (i / 2) * ((double)CS_ESR / N) : 0.0f;
     }
+  }
 
   p->fout->N = N;
   p->fout->overlap = olap;
@@ -2237,101 +2239,64 @@ static int32_t pvsblurset(CSOUND *csound, PVSBLUR *p)
   p->fout->framecount = 1;
   p->lastframe = 0;
   p->count = 0;
-  p->fout->sliding = p->fin->sliding;
-  p->fout->NB = p->fin->NB;
+  p->fout->sliding = 0;
+  p->fout->NB = N / 2 + 1;
   return OK;
 }
 
 static int32_t pvsblur(CSOUND *csound, PVSBLUR *p)
 {
-  int32    j, i, N = p->fout->N, first, framesize = N + 2;
-  int32    countr = p->count;
-  double  amp = 0.0, freq = 0.0;
-  int32_t     delayframes = (int32_t) (*p->kdel * p->frpsec);
-  int32_t     kdel = delayframes * framesize;
-  int32_t     mdel = (int32_t) (*p->maxdel * p->frpsec) * framesize;
-  float   *fin = (float *) p->fin->frame.auxp;
-  float   *fout = (float *) p->fout->frame.auxp;
-  float   *delay = (float *) p->delframes.auxp;
+  float *fin = (float *)p->fin->frame.auxp;
+  float *fout = (float *)p->fout->frame.auxp;
+  float *delay = (float *)p->delframes.auxp;
 
-  if (UNLIKELY(fout == NULL || delay == NULL)) goto err1;
+  if (UNLIKELY(fout == NULL || delay == NULL))
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("pvsblur: not initialised"));
 
-  if (p->fin->sliding) {
-    uint32_t offset = p->h.insdshead->ksmps_offset;
-    uint32_t n, nsmps = CS_KSMPS;
-    int32_t NB = p->fin->NB;
-    kdel = kdel >= 0 ? (kdel < mdel ? kdel : mdel - framesize) : 0;
-    for (n=0; n<offset; n++) {
-      CMPLX   *fout = (CMPLX *) p->fout->frame.auxp +NB*n;
-      for (i = 0; i < NB; i++) fout[i].re = fout[i].im = FL(0.0);
-    }
-    for (n=offset; n<nsmps; n++) {
-      CMPLX   *fin = (CMPLX *) p->fin->frame.auxp +NB*n;
-      CMPLX   *fout = (CMPLX *) p->fout->frame.auxp +NB*n;
-      CMPLX   *delay = (CMPLX *) p->delframes.auxp +NB*n;
-
-      for (i = 0; i < NB; i++) {
-        delay[countr + i] = fin[i];
-        if (kdel) {
-          if ((first = countr - kdel) < 0)
-            first += mdel;
-
-          for (j = first; j != countr; j = (j + framesize) % mdel) {
-            amp += delay[j + i].re;
-            freq += delay[j + i].im;
-          }
-
-          fout[i].re = (MYFLT) (amp / delayframes);
-          fout[i].im = (MYFLT) (freq / delayframes);
-          amp = freq = FL(0.0);
-        }
-        else {
-          fout[i] = fin[i];
-        }
-      }
-    }
-    countr += (N + 2);
-    p->count = countr < mdel ? countr : 0;
-    return OK;
-  }
   if (p->lastframe < p->fin->framecount) {
+    int32_t i, first, delayframes, framesize = p->fout->N + 2;
+    int32_t capacity = p->maxframes > 0 ? p->maxframes : 1;
+    double frames = (double)*p->kdel * p->frpsec;
+    float *current = delay + (size_t)p->count * framesize;
 
-    kdel = kdel >= 0 ? (kdel < mdel ? kdel : mdel - framesize) : 0;
+    frames = frames < 0.0 ? 0.0 :
+      (frames > p->maxframes ? p->maxframes : frames);
+    if (UNLIKELY(!(frames >= 0.0)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("pvsblur: invalid blur time"));
+    delayframes = (int32_t)frames;
+    first = p->count - delayframes;
+    if (first < 0)
+      first += capacity;
 
-    for (i = 0; i < N + 2; i += 2) {
-
-      delay[countr + i] = fin[i];
-      delay[countr + i + 1] = fin[i + 1];
-
-      if (kdel) {
-
-        if ((first = countr - kdel) < 0)
-          first += mdel;
-
-        for (j = first; j != countr; j = (j + framesize) % mdel) {
-          amp += delay[j + i];
-          freq += delay[j + i + 1];
+    for (i = 0; i < framesize; i += 2) {
+      double amp = fin[i], freq = fin[i + 1];
+      if (delayframes > 0) {
+        int32_t j, frame = first;
+        amp = freq = 0.0;
+        for (j = 0; j < delayframes; j++) {
+          const float *past = delay + (size_t)frame * framesize + i;
+          amp += past[0];
+          freq += past[1];
+          if (++frame == capacity)
+            frame = 0;
         }
-
-        fout[i] = (float) (amp / delayframes);
-        fout[i + 1] = (float) (freq / delayframes);
-        amp = freq = 0.;
+        amp /= delayframes;
+        freq /= delayframes;
       }
-      else {
-        fout[i] = fin[i];
-        fout[i + 1] = fin[i + 1];
-      }
+      /* At the maximum window, this slot still holds the oldest frame.
+         Read it before replacing it with the current input. */
+      current[i] = fin[i];
+      current[i + 1] = fin[i + 1];
+      fout[i] = (float)amp;
+      fout[i + 1] = (float)freq;
     }
-
     p->fout->framecount = p->lastframe = p->fin->framecount;
-    countr += (N + 2);
-    p->count = countr < mdel ? countr : 0;
+    if (++p->count == capacity)
+      p->count = 0;
   }
-
   return OK;
- err1:
-  return csound->PerfError(csound, &(p->h),
-                           "%s", Str("pvsblur: not initialised"));
 }
 
 /* pvstencil  */

--- a/Opcodes/pvsbasic.h
+++ b/Opcodes/pvsbasic.h
@@ -197,8 +197,8 @@ typedef struct _pvsblur {
     MYFLT   *kdel;
     MYFLT   *maxdel;
     AUXCH   delframes;
-    MYFLT   frpsec;
-    int32   count;
+    double  frpsec;
+    int32_t count, maxframes;
     uint32  lastframe;
 } PVSBLUR;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -591,6 +591,8 @@ def runTest():
         ["test_sum_product_input_reuse.csd", "sum/product input reuse and inactive output"],
         ["test_oversample.csd", "test oversampling in new-style UDO"],
         ["test_pvs_np2.csd", "test pvsanal/synth with np2 size"],
+        ["test_pvsblur_window.csd", "pvsblur delay window, startup, and reset"],
+        ["test_pvsblur_invalid_parameters.csd", "reject invalid pvsblur parameters", 1],
         ["test_trfilter_frequency_bounds.csd", "test trfilter frequency bounds"],
         [
             "test_pvsadsyn_last_bin.csd",

--- a/tests/commandline/test_pvsblur_invalid_parameters.csd
+++ b/tests/commandline/test_pvsblur_invalid_parameters.csd
@@ -1,0 +1,38 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+instr 1
+  fInput pvsosc .5, 512, 4, 128, 32
+  fOutput pvsblur fInput, 0, p4
+endin
+instr 2
+  aInput = .5
+  fInput pvsanal aInput, 64, 1, 64, 1
+  fOutput pvsblur fInput, .01, .1
+endin
+instr 3
+  kInput[] init 65
+  fInput tab2pvs kInput, 32
+  fOutput pvsblur fInput, .01, .1
+endin
+instr 4
+  fInput pvsinit 128, 32, 128, 1, 2
+  fOutput pvsblur fInput, .01, .1
+endin
+</CsInstruments>
+<CsScore>
+; Five init errors: negative/oversized delay, sliding, odd size, bad format.
+i 1 0 .01 -1
+i 1 0 .01 1e30
+i 2 0 .01
+i 3 0 .01
+i 4 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsblur_window.csd
+++ b/tests/commandline/test_pvsblur_window.csd
@@ -1,0 +1,87 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kInput[] init 130
+  kOutput[] init 130
+  ; A ramp gives a closed-form mean for any window, without a reference ring.
+  kInput[16] = kCycle
+  kInput[17] = 512 + 16 * kCycle
+  fInput tab2pvs kInput, 32
+  kRequested = (p4 == -99 ? (kCycle % 4 < 2 ? 4 : 1) : p4)
+  kDelay = kRequested / 256
+  if kCycle == p6 then
+    reinit BLUR
+  endif
+BLUR:
+  iMaximum = (p6 > 0 && i(kCycle) >= p6 && p7 > 0 ? p7 : p5)
+  fOutput pvsblur fInput, kDelay, iMaximum / 256
+  rireturn
+  kFrame pvs2tab kOutput, fOutput
+  kMaximum = iMaximum
+  kWindow = int(max(0, min(kRequested, int(kMaximum))))
+  if kWindow == 0 then
+    kAmp = kCycle
+    kFreq = 512 + 16 * kCycle
+  else
+    kStart = (p6 > 0 && kCycle >= p6 ? p6 : 1)
+    kLow = max(kStart, kCycle - kWindow)
+    kHigh = kCycle - 1
+    kSum = (kHigh >= kLow ? (kHigh * (kHigh + 1) - kLow * (kLow - 1)) / 2 : 0)
+    kAmp = kSum / kWindow
+    ; Unfilled history has zero amplitude and the bin's centre frequency.
+    kFreq = 512 + 16 * kAmp
+  endif
+  if abs(kOutput[16] - kAmp) > .00001 || abs(kOutput[17] - kFreq) > .0001 then
+    printks "pvsblur request %g maximum %g cycle %g: amp %g/%g, freq %g/%g\n", 0, p4, kMaximum, kCycle, kOutput[16], kAmp, kOutput[17], kFreq
+    exitnowk -1
+  endif
+  if kFrame != kCycle then
+    printks "pvsblur missed an input frame\n", 0
+    exitnowk -1
+  endif
+  if kCycle == 32 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 16 then
+    prints "not all pvsblur window checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Requested window, maximum window (in frames), reinit block, new maximum.
+i 1 0 .125 0 4 0
+i 1 0 .125 .5 4 0
+i 1 0 .125 1 4 0
+i 1 0 .125 3 4 0
+i 1 0 .125 4 4 0
+i 1 0 .125 10 4 0
+i 1 0 .125 1e30 4 0
+i 1 0 .125 -1 4 0
+i 1 0 .125 -99 4 0
+i 1 0 .125 1 1 0
+i 1 0 .125 5 0 0
+i 1 0 .125 1 .5 0
+i 1 0 .125 4 4 17
+i 1 0 .125 4 1 17 4
+i 1 0 .125 4 4 17 1
+; Reuse an instance after its earlier note ends.
+i 1 .25 .125 4 4 0
+i 99 .4 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsblur` shortened a request at the maximum delay by one frame but still divided by the requested count, giving the wrong average.

- Average the full requested window and read the oldest frame before replacing it.
- Clamp blur times before integer conversion, check allocation sizes, and allow zero or sub-frame maximum delays to pass through the input.
- Seed delay history with the correct bin frequencies (or zero phases), and reset it on reinitialization.
- Stop initialization immediately for unsupported sliding input and reject invalid frame sizes or formats.
