### PR TITLE
fix: correct ftmorf interpolation and table bounds

### DIFF
--- a/Opcodes/ugmoss.c
+++ b/Opcodes/ugmoss.c
@@ -861,25 +861,37 @@ static int32_t ftmorfset(CSOUND *csound, FTMORF *p)
 
 static int32_t ftmorf(CSOUND *csound, FTMORF *p)
 {
-    uint32_t j = 0;
-    int32_t i;
+    uint32_t j, i;
+    double ndx = *p->kftndx;
     MYFLT f;
     FUNC *ftp1, *ftp2;
 
-    if (*p->kftndx >= p->ftfn->flen) *p->kftndx = (MYFLT)(p->ftfn->flen - 1);
-    i = (int32_t)*p->kftndx;
-    f = *p->kftndx - i;
-    if (p->ftndx != *p->kftndx && p->ftfn->ftable) {
-      p->ftndx = *p->kftndx;
-      MYFLT tbl1 = *(p->ftfn->ftable + i++);
-      MYFLT tbl2 = *(p->ftfn->ftable + i--);
-      ftp1 = csound->FTFind(csound, &tbl1);
-      ftp2 = csound->FTFind(csound, &tbl2);
-     if(ftp2)
-      do {
-            *(p->resfn->ftable + j) = (*(ftp1->ftable + j) * (1-f)) +
-              (*(ftp2->ftable + j) * f);
-      } while (++j < p->len);
+    /* Clamp locally: the input can also be used by other opcodes. */
+    if (ndx < 0.0)
+      ndx = 0.0;
+    else if (ndx > (double)p->ftfn->flen - 1.0)
+      ndx = (double)p->ftfn->flen - 1.0;
+    else if (UNLIKELY(!(ndx >= 0.0)))
+      return csound->PerfError(csound, &(p->h),
+                              "%s", Str("ftmorf: invalid index"));
+    if (p->ftndx != ndx) {
+      i = (uint32_t)ndx;
+      f = (MYFLT)(ndx - i);
+      ftp1 = csound->FTFind(csound, &p->ftfn->ftable[i]);
+      ftp2 = f != FL(0.0) ?
+        csound->FTFind(csound, &p->ftfn->ftable[i + 1]) : ftp1;
+      /* The table list may have changed since initialisation. */
+      if (UNLIKELY(ftp1 == NULL || ftp2 == NULL))
+        return csound->PerfError(csound, &(p->h),
+                                "%s", Str("ftmorf: source table does not exist"));
+      if (UNLIKELY(ftp1->flen != p->len || ftp2->flen != p->len))
+        return csound->PerfError(csound, &(p->h),
+                                "%s", Str("ftmorf: source table has wrong size"));
+      /* Interpolating readers also need the source tables' guard points. */
+      for (j = 0; j <= p->len; j++)
+        p->resfn->ftable[j] = ftp1->ftable[j] * (FL(1.0) - f) +
+                             ftp2->ftable[j] * f;
+      p->ftndx = (MYFLT)ndx;
     }
     return OK;
 }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -797,6 +797,8 @@ def runTest():
             "test_tablemix_nonpower_source.csd",
             "test tableimix wraps a non-power-of-two source table",
         ],
+        ["test_ftmorf_tables.csd", "test ftmorf interpolation and index limits"],
+        ["test_ftmorf_changed_tables.csd", "reject invalid changed ftmorf tables", 1],
         [
             "prints_number_no_crash.csd",
             "test prints does not crash when given a number arguments"

--- a/tests/commandline/test_ftmorf_changed_tables.csd
+++ b/tests/commandline/test_ftmorf_changed_tables.csd
@@ -1,0 +1,27 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+giSource ftgen 1, 0, 8, -2, 1
+giShort ftgen 2, 0, 4, -2, 1
+instr 1
+  iList ftgen 0, 0, 2, -2, 1, 1
+  iResult ftgen 0, 0, 8, -2, 0
+  ; Change one entry after ftmorf has checked the original list at init.
+  kTable = p4
+  tablew kTable, p5, iList
+  ftmorf .5, iList, iResult
+endin
+</CsInstruments>
+<CsScore>
+; Two performance errors: a short table in either source position.
+i 1 0 .01 2 0
+i 1 0 .01 2 1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_ftmorf_tables.csd
+++ b/tests/commandline/test_ftmorf_tables.csd
@@ -1,0 +1,112 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+; Explicit guard points differ from the first sample.
+giA ftgen 1, 0, 9, -2, 1, 1, 1, 1, 1, 1, 1, 1, 5
+giB ftgen 2, 0, 9, -2, 3, 3, 3, 3, 3, 3, 3, 3, 7
+giC ftgen 3, 0, 9, -2, 5, 5, 5, 5, 5, 5, 5, 5, 9
+giList ftgen 4, 0, 2, -2, 1, 2
+giSingle ftgen 5, 0, -1, -2, 2
+gkChecks init 0
+
+instr 1
+  iResult ftgen 0, 0, 8, -2, 0
+  kIndex init p4
+  ftmorf kIndex, giList, iResult
+  kMiddle tablei 3.5, iResult
+  kEnd tablei 7.5, iResult
+  kExpected = 1 + 2 * limit(p4, 0, 1)
+  if kIndex != p4 || abs(kMiddle - kExpected) > .00001 || abs(kEnd - kExpected - 2) > .00001 then
+    printks "ftmorf index %g became %g, middle %g end %g expected %g/%g\n", 0, p4, kIndex, kMiddle, kEnd, kExpected, kExpected + 2
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 2
+  iResult ftgen 0, 0, 8, -2, 0
+  kIndex init .5
+  ftmorf kIndex, giSingle, iResult
+  kMiddle tablei 3.5, iResult
+  kEnd tablei 7.5, iResult
+  if kIndex != .5 || kMiddle != 3 || kEnd != 5 then
+    printks "ftmorf failed for a one-entry list\n", 0
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 3
+  iList ftgen 0, 0, 2, -2, 1, 2
+  iResult ftgen 0, 0, 8, -2, 0
+  kCycle init 0
+  kCycle += 1
+  kIndex = (kCycle == 1 ? 0 : .5)
+  kTable = 3
+  if kCycle == 2 then
+    tablew kTable, 0, iList
+  endif
+  ftmorf kIndex, iList, iResult
+  kMiddle tablei 3.5, iResult
+  kEnd tablei 7.5, iResult
+  kExpected = (kCycle == 1 ? 1 : 4)
+  if kMiddle != kExpected || kEnd != kExpected + 2 then
+    printks "ftmorf changed list cycle %g: middle %g end %g expected %g/%g\n", 0, kCycle, kMiddle, kEnd, kExpected, kExpected + 2
+    exitnowk -1
+  endif
+  if kCycle == 2 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 4
+  iList ftgen 0, 0, -3, -2, 1, 2, 3
+  iResult ftgen 0, 0, 8, -2, 0
+  kCycle init 0
+  kCycle += 1
+  kIndex = (kCycle <= 5 ? (kCycle - 1) * .5 : (9 - kCycle) * .5)
+  ftmorf kIndex, iList, iResult
+  kMiddle tablei 3.5, iResult
+  kEnd tablei 7.5, iResult
+  kExpected = 1 + 2 * kIndex
+  if kMiddle != kExpected || kEnd != kExpected + 2 then
+    printks "ftmorf moving index %g: middle %g end %g expected %g/%g\n", 0, kIndex, kMiddle, kEnd, kExpected, kExpected + 2
+    exitnowk -1
+  endif
+  if kCycle == 9 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "not all ftmorf checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 -1
+i 1 0 .01 0
+i 1 0 .01 .5
+i 1 0 .01 1
+i 1 0 .01 1.5
+i 1 0 .01 2
+i 1 0 .01 1e30
+i 2 0 .01
+i 3 0 .02
+i 4 0 .05
+i 99 .06 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix `ftmorf` table selection and output at the ends of the morph range.

- Clamp the index before conversion without changing the caller's control value. Use only the selected table at integer indices, including the last entry and one-entry lists.
- Interpolate the guard point as well as the table contents so interpolating readers get the correct value at the table end.
- Check selected source tables again when the index changes, since the table list can change after initialization. Reject missing or wrong-sized sources before reading them.

Keep the existing behavior of updating the destination only when the morph index changes.
