### PR TITLE
fix: keep dconv buffer arithmetic within bounds

### DIFF
--- a/Opcodes/ugmoss.c
+++ b/Opcodes/ugmoss.c
@@ -37,22 +37,25 @@
 static int32_t dconvset(CSOUND *csound, DCONV *p)
 {
     FUNC *ftp;
+    double len = *p->isize;
+    size_t nbytes;
 
-    p->len = (int32_t)*p->isize;
+    if (UNLIKELY(!(len >= 1.0)))
+      return csound->InitError(csound, "%s", Str("dconv: isize must be at least 1"));
     if (LIKELY((ftp = csound->FTFind(csound,
                                         p->ifn)) != NULL)) {   /* find table */
       p->ftp = ftp;
-      if ((uint32_t)ftp->flen < p->len)
-        p->len = ftp->flen; /* correct len if flen shorter */
+      /* Limit to the table before converting a possibly large request. */
+      p->len = len >= ftp->flen ? ftp->flen : (uint32_t)len;
     }
     else {
       return csound->InitError(csound, "%s", Str("No table for dconv"));
     }
-    if (p->sigbuf.auxp == NULL ||
-        p->sigbuf.size < (uint32_t)(p->len*sizeof(MYFLT)))
-      csound->AuxAlloc(csound, p->len*sizeof(MYFLT), &p->sigbuf);
+    nbytes = (size_t)p->len * sizeof(MYFLT);
+    if (p->sigbuf.auxp == NULL || p->sigbuf.size < nbytes)
+      csound->AuxAlloc(csound, nbytes, &p->sigbuf);
     else
-      memset(p->sigbuf.auxp, '\0', p->len*sizeof(MYFLT));
+      memset(p->sigbuf.auxp, '\0', nbytes);
     p->curp = (MYFLT *)p->sigbuf.auxp;
     return OK;
 }
@@ -60,11 +63,11 @@ static int32_t dconvset(CSOUND *csound, DCONV *p)
 static int32_t dconv(CSOUND *csound, DCONV *p)
 {
     IGN(csound);
-    int32_t i = 0;
+    uint32_t i;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    int32_t len = p->len;
+    uint32_t len = p->len;
     MYFLT *ar, *ain, *ftp, *startp, *endp, *curp;
     MYFLT sum;
 
@@ -88,8 +91,9 @@ static int32_t dconv(CSOUND *csound, DCONV *p)
       curp = startp;                            /* correct the ptr */
       while (i<len)
         sum += (*curp++ * ftp[i++]);            /* finish the convolution */
-      if (--curp < startp)
-        curp += len;                            /* correct for last curp++ */
+      if (curp == startp)
+        curp = endp;
+      --curp;                                  /* stay within the buffer */
       ar[n] = sum;
     }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -963,6 +963,8 @@ def runTest():
             1,
         ],
         ["test_flanger_invalid_delay.csd", "reject non-finite flanger delay", 1],
+        ["test_dconv_history.csd", "test dconv history, reset, and sample bounds"],
+        ["test_dconv_invalid_size.csd", "reject invalid dconv sizes", 1],
         ["test_vdelay_buffers.csd", "test short and wrapped variable delays"],
         ["test_vdelay_reinit.csd", "test variable delay state across reinit"],
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],

--- a/tests/commandline/test_dconv_history.csd
+++ b/tests/commandline/test_dconv_history.csd
@@ -1,0 +1,108 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+giIR ftgen 1, 0, 8, -2, 1, -.5, .25, -.125, .0625, -.03125, .015625, -.0078125
+gkChecks init 0
+
+; An explicit FIR reference avoids duplicating dconv's circular buffer.
+opcode Reference, a, ai
+  aInput, iLength xin
+  a1 delay1 aInput
+  a2 delay1 a1
+  a3 delay1 a2
+  a4 delay1 a3
+  a5 delay1 a4
+  a6 delay1 a5
+  a7 delay1 a6
+  aResult = aInput
+  if iLength >= 2 then
+    aResult -= .5 * a1
+  endif
+  if iLength >= 3 then
+    aResult += .25 * a2
+  endif
+  if iLength >= 4 then
+    aResult -= .125 * a3
+  endif
+  if iLength >= 5 then
+    aResult += .0625 * a4
+  endif
+  if iLength >= 6 then
+    aResult -= .03125 * a5
+  endif
+  if iLength >= 7 then
+    aResult += .015625 * a6
+  endif
+  if iLength >= 8 then
+    aResult -= .0078125 * a7
+  endif
+  xout aResult
+endop
+
+instr 1
+  kCycle init 0
+  kLength init p4
+  kCycle += 1
+  kLength = (p6 > 0 && kCycle >= p6 ? p5 : p4)
+  aInput oscils .5, 311, 0
+  if kCycle == p6 then
+    reinit FILTER
+  endif
+FILTER:
+  iLength = i(kLength)
+  aExpected Reference aInput, int(min(iLength, 8))
+  if p7 == 1 then
+    aInput dconv aInput, iLength, giIR
+    aActual = aInput
+  else
+    aActual dconv aInput, iLength, giIR
+  endif
+  rireturn
+  kSample = 0
+  while kSample < ksmps do
+    kActual vaget kSample, aActual
+    kExpected vaget kSample, aExpected
+    if abs(kActual - kExpected) > .000001 then
+      printks "dconv length %g cycle %g sample %g: %g expected %g\n", 0, kLength, kCycle, kSample, kActual, kExpected
+      exitnowk -1
+    endif
+    kSample += 1
+  od
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 12 then
+    prints "not all dconv checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Initial length, new length, reset cycle, in-place output.
+i 1 0 .0625 1 0 0 0
+i 1 0 .0625 3.75 0 0 0
+i 1 0 .0625 8 0 0 0
+i 1 0 .0625 1e30 0 0 0
+i 1 0 .0625 1 8 4 0
+i 1 0 .0625 8 1 4 0
+i 1 0 .0625 8 8 4 0
+i 1 0 .0625 8 0 0 1
+; Partial first/last blocks, including a note inside a single block.
+i 1 .0006103515625 .0130615234375 3 0 0 0
+i 1 .0006103515625 .0130615234375 3 0 0 1
+i 1 .0006103515625 .0013427734375 8 0 0 0
+; Reuse an instance after its previous note ends.
+i 1 .125 .0625 8 0 0 0
+i 99 .2 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_dconv_invalid_size.csd
+++ b/tests/commandline/test_dconv_invalid_size.csd
@@ -1,0 +1,23 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+giIR ftgen 1, 0, 8, -2, 1
+instr 1
+  aInput = .5
+  aOutput dconv aInput, p4, giIR
+endin
+</CsInstruments>
+<CsScore>
+; All three sizes must fail at init.
+i 1 0 .01 0
+i 1 0 .01 .5
+i 1 0 .01 -1
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`dconv` decremented its history pointer before checking whether it had reached the start. Forming a pointer before the buffer is undefined behavior, even if it is corrected before use. Wrap before decrementing, while preserving the convolution order.

Reject sizes below one sample and clamp large requests to the impulse table length before integer conversion. Compute allocation sizes with `size_t` and keep loop counters consistent with the unsigned buffer length.
