### PR TITLE
fix: validate audio buffer indices before conversion

### DIFF
--- a/Opcodes/vaops.c
+++ b/Opcodes/vaops.c
@@ -28,8 +28,6 @@
 
 #include "interlocks.h"
 
-#define MYFLOOR(x) (x >= FL(0.0) ? (int32)x : (int32)((double)x - 0.99999999))
-
 typedef struct {
         OPDS    h;
         MYFLT   *kout, *kindx, *avar;
@@ -53,71 +51,74 @@ typedef struct {
 
 static int32_t vaget(CSOUND *csound, VA_GET *p)
 {
-    int32 ndx = (int32) MYFLOOR((double)*p->kindx);
+    double index = *p->kindx;
+    uint32_t ndx;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    if(LIKELY(ndx >= 0 && ndx < (int32) CS_KSMPS)) {
-    if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+    if (UNLIKELY(!(index >= 0.0 && index < (double)CS_KSMPS)))
+      return csound->PerfError(csound, &(p->h),
+                              Str("Out of range in vaget.k (%g)"), index);
+    /* A checked nonnegative index truncates to the same sample as floor. */
+    ndx = (uint32_t)index;
+    if (UNLIKELY(ndx < offset || ndx >= CS_KSMPS-early))
+      csound->Warning(csound, "index %u outside sample-accurate bounds [%u, %u)",
                       ndx, offset, CS_KSMPS-early);
     *p->kout = p->avar[ndx];
     return OK;
-    } else
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaget.k (%d)"), ndx);
-
 }
 
 static int32_t vaset(CSOUND *csound, VA_SET *p)
 {
-    int32 ndx = (int32) MYFLOOR((double)*p->kindx);
+    double index = *p->kindx;
+    uint32_t ndx;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    if(LIKELY(ndx >= 0 && ndx < (int32) CS_KSMPS)) {
-    if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+    if (UNLIKELY(!(index >= 0.0 && index < (double)CS_KSMPS)))
+      return csound->PerfError(csound, &(p->h),
+                              Str("Out of range in vaset.k (%g)"), index);
+    ndx = (uint32_t)index;
+    if (UNLIKELY(ndx < offset || ndx >= CS_KSMPS-early))
+      csound->Warning(csound, "index %u outside sample-accurate bounds [%u, %u)",
                       ndx, offset, CS_KSMPS-early);
-     p->avar[ndx] = *p->kval;
-     return OK;
-    }
-    else return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vaset.k (%d)"), ndx);
+    p->avar[ndx] = *p->kval;
+    return OK;
 }
 
 
 static int32_t vasigget(CSOUND *csound, VASIG_GET *p)
 {
-    int32 ndx = (int32) MYFLOOR((double)*p->kindx);
+    double index = *p->kindx;
+    uint32_t ndx;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
 
-    if(LIKELY(ndx >= 0 && ndx < (int32) CS_KSMPS)) {
-    if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+    if (UNLIKELY(!(index >= 0.0 && index < (double)CS_KSMPS)))
+      return csound->PerfError(csound, &(p->h),
+                              Str("Out of range in vasigget.k (%g)"), index);
+    ndx = (uint32_t)index;
+    if (UNLIKELY(ndx < offset || ndx >= CS_KSMPS-early))
+      csound->Warning(csound, "index %u outside sample-accurate bounds [%u, %u)",
                       ndx, offset, CS_KSMPS-early);
     *p->kout = p->avar[ndx];
     return OK;
-    } else
-      return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vasigget.k (%d)"), ndx);
 }
 
 static int32_t vasigset(CSOUND *csound, VASIG_SET *p)
 {
-    int32 ndx = (int32) MYFLOOR((double)*p->kindx);
+    double index = *p->kindx;
+    uint32_t ndx;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
 
-    if(LIKELY(ndx >= 0 && ndx < (int32) CS_KSMPS)) {
-    if (UNLIKELY(ndx<(int32)offset || ndx>=(int32)(CS_KSMPS-early)))
-      csound->Warning(csound, "index %d outside sample-accurate bounds (%d, %d]",
+    if (UNLIKELY(!(index >= 0.0 && index < (double)CS_KSMPS)))
+      return csound->PerfError(csound, &(p->h),
+                              Str("Out of range in vasigset.k (%g)"), index);
+    ndx = (uint32_t)index;
+    if (UNLIKELY(ndx < offset || ndx >= CS_KSMPS-early))
+      csound->Warning(csound, "index %u outside sample-accurate bounds [%u, %u)",
                       ndx, offset, CS_KSMPS-early);
-     p->avar[ndx] = *p->kval;
-     return OK;
-    }
-    else return csound->PerfError(csound, &(p->h),
-                               Str("Out of range in vasigset.k (%d)"), ndx);
-
+    p->avar[ndx] = *p->kval;
+    return OK;
 }
 
 #define S(x)    sizeof(x)

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -749,6 +749,8 @@ def runTest():
         ["test_karrays_udo.csd", "UDO with k[] arg"],
         ["test_vector_table_correctness.csd", "vector table indexing"],
         ["test_vector_table_invalid_index.csd", "reject invalid vector table index", 1],
+        ["test_vaops_indices.csd", "test audio buffer index reads and writes"],
+        ["test_vaops_invalid_indices.csd", "reject invalid audio buffer indices", 1],
         ["test_arrays_addition.csd", "test array arithmetic (i.e. k[] + k[]"],
         ["test_pitch_conversion_arrays.csd", "pitch conversion arrays update each control cycle"],
         ["test_cps_table_pitch.csd", "tuning-table pitch endpoints and negative pitches"],

--- a/tests/commandline/test_vaops_indices.csd
+++ b/tests/commandline/test_vaops_indices.csd
@@ -1,0 +1,90 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  aBuffer = 0
+  kCycle init 0
+  kCycle += 1
+  kIndex init p4
+  kValue = kCycle * .25
+  vaset kValue, kIndex, aBuffer
+  kRead = aBuffer[kIndex]
+  if kRead != kValue then
+    printks "audio buffer indexing did not read the sample written by vaset\n", 0
+    exitnowk -1
+  endif
+  aBuffer[kIndex] = -kValue
+  kRead vaget kIndex, aBuffer
+  if kRead != -kValue then
+    printks "vaget did not read the sample written by audio buffer indexing\n", 0
+    exitnowk -1
+  endif
+  ; In a full block, the write must change only floor(kIndex).
+  if p5 == 0 then
+    kSample = 0
+    while kSample < ksmps do
+      kRead vaget kSample, aBuffer
+      kExpected = (kSample == int(kIndex) ? -kValue : 0)
+      if kRead != kExpected then
+        printks "audio buffer write changed the wrong sample\n", 0
+        exitnowk -1
+      endif
+      kSample += 1
+    od
+  endif
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  setksmps 1
+  aBuffer = 0
+  kIndex init .75
+  vaset .5, kIndex, aBuffer
+  kRead = aBuffer[kIndex]
+  if kRead != .5 then
+    exitnowk -1
+  endif
+  aBuffer[kIndex] = .25
+  kRead vaget kIndex, aBuffer
+  if kRead != .25 then
+    exitnowk -1
+  endif
+  kCycle timeinstk
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 10 then
+    prints "not all audio buffer index checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03125 0 0
+i 1 0 .03125 .75 0
+i 1 0 .03125 1 0
+i 1 0 .03125 1.75 0
+i 1 0 .03125 31 0
+i 1 0 .03125 31.75 0
+i 1 .0006103515625 .0130615234375 7.75 1
+; Inactive samples remain accessible, with a warning at the note boundaries.
+i 1 .0006103515625 .0130615234375 0 1
+i 1 .0006103515625 .0130615234375 31.75 1
+i 2 0 .03125
+i 99 .05 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_vaops_invalid_indices.csd
+++ b/tests/commandline/test_vaops_invalid_indices.csd
@@ -1,0 +1,55 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+instr 1
+  aBuffer = 0
+  kIndex init p4
+  kRead vaget kIndex, aBuffer
+endin
+instr 2
+  aBuffer = 0
+  kIndex init p4
+  vaset .5, kIndex, aBuffer
+endin
+instr 3
+  aBuffer = 0
+  kIndex init p4
+  kRead = aBuffer[kIndex]
+endin
+instr 4
+  aBuffer = 0
+  kIndex init p4
+  aBuffer[kIndex] = .5
+endin
+</CsInstruments>
+<CsScore>
+; Each form must reject these five indices before integer conversion.
+i 1 0 .01 -1e-10
+i 1 0 .01 -1
+i 1 0 .01 32
+i 1 0 .01 1e30
+i 1 0 .01 -1e30
+i 2 0 .01 -1e-10
+i 2 0 .01 -1
+i 2 0 .01 32
+i 2 0 .01 1e30
+i 2 0 .01 -1e30
+i 3 0 .01 -1e-10
+i 3 0 .01 -1
+i 3 0 .01 32
+i 3 0 .01 1e30
+i 3 0 .01 -1e30
+i 4 0 .01 -1e-10
+i 4 0 .01 -1
+i 4 0 .01 32
+i 4 0 .01 1e30
+i 4 0 .01 -1e30
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`vaget`, `vaset`, and audio-buffer indexing converted indices to integers before checking their range. Large or non-finite values could cause undefined behavior during conversion, and the old floor approximation could accept tiny negative indices as zero.

Check `0 <= index < ksmps` before conversion. Valid fractional indices still select the same sample, without a floor call or separate finite-value checks.

Keep warning-only access to samples outside a note's active interval but inside its buffer. Correct the warning to show the interval as `[start, end)`.
