### PR TITLE
fix: correct framebuffer history and sample boundaries

### DIFF
--- a/Opcodes/framebuffer.c
+++ b/Opcodes/framebuffer.c
@@ -30,6 +30,7 @@
 #endif
 
 #include "interlocks.h"
+#include "arrays.h"
 
     typedef struct OLABuffer {
 
@@ -87,7 +88,7 @@
     int32_t Framebuffer_process(CSOUND *csound, Framebuffer *self);
 
 ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument);
-void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self);
+int32_t Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self);
 
 int32_t OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self);
 
@@ -245,28 +246,42 @@ int32_t OLABuffer_checkArgumentSanity(CSOUND *csound, OLABuffer *self)
 
 int32_t Framebuffer_initialise(CSOUND *csound, Framebuffer *self)
 {
+    double size;
+    if (UNLIKELY(self->INOCOUNT != 2 || self->OUTOCOUNT != 1))
+      return csound->InitError(csound, "%s",
+                              Str("framebuffer: expected two inputs and one output"));
     self->inputType = Framebuffer_getArgumentType(csound, self->inputArgument);
     self->outputType = Framebuffer_getArgumentType(csound, self->outputArgument);
-    self->elementCount = *self->sizeArgument;
+    if (UNLIKELY(Framebuffer_getArgumentType(csound, self->sizeArgument) != IRATE_VAR))
+      return csound->InitError(csound, "%s", Str("framebuffer: size must be i-rate"));
     self->ksmps = self->h.insdshead->ksmps;
+    size = *self->sizeArgument;
+    if (UNLIKELY(!(size >= self->ksmps && size < (double)INT32_MAX + 1.0)))
+      return csound->InitError(csound, "%s",
+                              Str("framebuffer: size must be at least ksmps and fit in int32"));
+    self->elementCount = (int32_t)size;
+    if (UNLIKELY((size_t)self->elementCount > SIZE_MAX / sizeof(MYFLT)))
+      return csound->InitError(csound, "%s", Str("framebuffer: size is too large"));
 
-    Framebuffer_checkArgumentSanity(csound, self);
+    if (UNLIKELY(Framebuffer_checkArgumentSanity(csound, self) != OK))
+      return NOTOK;
 
     csound->AuxAlloc(csound, self->elementCount * sizeof(MYFLT),
                      &self->bufferMemory);
     self->buffer = self->bufferMemory.auxp;
+    self->writeIndex = 0;
 
     if (self->outputType == KRATE_ARRAY) {
 
         ARRAYDAT *array = (ARRAYDAT *) self->outputArgument;
-        array->sizes = csound->Calloc(csound, sizeof(int32_t));
-        array->sizes[0] = self->elementCount;
-        array->dimensions = 1;
-        CS_VARIABLE *var = csoundCreateVariableForType(
-          csound, array->arrayType, NULL, self->h.insdshead);
-        array->arrayMemberSize = var->memBlockSize;
-        array->data = csound->Calloc(csound,
-                                     var->memBlockSize * self->elementCount);
+        if (UNLIKELY(array->dimensions > 1))
+          return csound->InitError(csound, "%s",
+                                  Str("framebuffer: output array must be one dimensional"));
+        if (UNLIKELY(tabinit(csound, array, self->elementCount,
+                            self->h.insdshead) != OK))
+          return csound->InitError(csound, "%s",
+                                  Str("framebuffer: cannot initialise output array"));
+        memset(array->data, 0, (size_t)self->elementCount * sizeof(MYFLT));
     }
 
     return OK;
@@ -276,12 +291,15 @@ void Framebuffer_writeBuffer(CSOUND *csound, Framebuffer *self,
                              MYFLT *inputSamples, int32_t inputSamplesCount)
 {
      IGN(csound);
-    if (self->writeIndex + inputSamplesCount <= self->elementCount) {
+    if (inputSamplesCount == 0)
+        return;
+    if (inputSamplesCount <= self->elementCount - self->writeIndex) {
 
         memcpy(&self->buffer[self->writeIndex], inputSamples,
                sizeof(MYFLT) * inputSamplesCount);
-        self->writeIndex += self->ksmps;
-        self->writeIndex %= self->elementCount;
+        self->writeIndex += inputSamplesCount;
+        if (self->writeIndex == self->elementCount)
+            self->writeIndex = 0;
     }
     else {
 
@@ -299,7 +317,7 @@ void Framebuffer_readBuffer(CSOUND *csound, Framebuffer *self,
                             MYFLT *outputSamples, int32_t outputSamplesCount)
 {
      IGN(csound);
-    if (self->writeIndex + outputSamplesCount < self->elementCount) {
+    if (outputSamplesCount <= self->elementCount - self->writeIndex) {
 
         memcpy(outputSamples, &self->buffer[self->writeIndex],
                sizeof(MYFLT) * outputSamplesCount);
@@ -315,19 +333,41 @@ void Framebuffer_readBuffer(CSOUND *csound, Framebuffer *self,
     }
 }
 
-void Framebuffer_processAudioInFrameOut(CSOUND *csound, Framebuffer *self)
+static int32_t Framebuffer_processAudioInFrameOut(CSOUND *csound, Framebuffer *self)
 {
-    Framebuffer_writeBuffer(csound, self, self->inputArgument, self->ksmps);
+    uint32_t offset = self->h.insdshead->ksmps_offset;
+    uint32_t end = self->ksmps - self->h.insdshead->ksmps_no_end;
     ARRAYDAT *array = (ARRAYDAT *)self->outputArgument;
-    Framebuffer_readBuffer(csound, self, array->data, array->sizes[0]);
+    if (UNLIKELY(array->dimensions != 1))
+        return csound->PerfError(csound, &self->h, "%s",
+                                Str("framebuffer: output array must be one dimensional"));
+    if (UNLIKELY(tabcheck(csound, array, self->elementCount, &self->h) != OK))
+        return NOTOK;
+    Framebuffer_writeBuffer(csound, self, self->inputArgument + offset, end - offset);
+    Framebuffer_readBuffer(csound, self, array->data, self->elementCount);
+    return OK;
 }
 
 
-void Framebuffer_processFrameInAudioOut(CSOUND *csound, Framebuffer *self)
+static int32_t Framebuffer_processFrameInAudioOut(CSOUND *csound, Framebuffer *self)
 {
+    uint32_t offset = self->h.insdshead->ksmps_offset;
+    uint32_t early = self->h.insdshead->ksmps_no_end;
+    uint32_t end = self->ksmps - early;
     ARRAYDAT *array = (ARRAYDAT *)self->inputArgument;
+    if (UNLIKELY(array->dimensions != 1 || array->data == NULL ||
+                 array->sizes[0] <= 0 || array->sizes[0] > self->elementCount))
+        return csound->PerfError(csound, &self->h, "%s",
+                                Str("framebuffer: invalid input array size"));
+    if (UNLIKELY(offset))
+        memset(self->outputArgument, 0, offset * sizeof(MYFLT));
+    if (UNLIKELY(early))
+        memset(self->outputArgument + end, 0, early * sizeof(MYFLT));
+    if (end == offset)
+        return OK;
     Framebuffer_writeBuffer(csound, self, array->data, array->sizes[0]);
-    Framebuffer_readBuffer(csound, self, self->outputArgument, self->ksmps);
+    Framebuffer_readBuffer(csound, self, self->outputArgument + offset, end - offset);
+    return OK;
 }
 
 int32_t Framebuffer_process(CSOUND *csound, Framebuffer *self)
@@ -335,63 +375,58 @@ int32_t Framebuffer_process(CSOUND *csound, Framebuffer *self)
     if (self->inputType == KRATE_ARRAY) {
 
 
-        Framebuffer_processFrameInAudioOut(csound, self);
+        return Framebuffer_processFrameInAudioOut(csound, self);
     }
     else if (self->inputType == ARATE_VAR) {
 
-        Framebuffer_processAudioInFrameOut(csound, self);
+        return Framebuffer_processAudioInFrameOut(csound, self);
     }
 
 
     return OK;
 }
 
-void Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self)
+int32_t Framebuffer_checkArgumentSanity(CSOUND *csound, Framebuffer *self)
 {
-  if (UNLIKELY((uint32_t)self->elementCount < self->h.insdshead->ksmps)) {
-
-      csound->Die(csound, "%s", Str("framebuffer: Error, specified element "
-                              "count less than ksmps value, Exiting"));
-    }
-
     if (self->inputType == ARATE_VAR) {
 
       if (UNLIKELY(self->outputType != KRATE_ARRAY)) {
 
-          csound->Die(csound, "%s", Str("framebuffer: Error, only k-rate arrays "
-                                  "allowed for a-rate var inputs, Exiting"));
+          return csound->InitError(csound, "%s", Str("framebuffer: Error, only k-rate arrays "
+                                  "allowed for a-rate var inputs"));
         }
     }
     else if (LIKELY(self->inputType == KRATE_ARRAY)) {
 
       if (UNLIKELY(self->outputType != ARATE_VAR)) {
 
-          csound->Die(csound, "%s", Str("framebuffer: Error, only a-rate vars "
-                                  "allowed for k-rate array inputs, Exiting"));
+          return csound->InitError(csound, "%s", Str("framebuffer: Error, only a-rate vars "
+                                  "allowed for k-rate array inputs"));
         }
 
         ARRAYDAT *array = (ARRAYDAT *) self->inputArgument;
 
         if (UNLIKELY(array->dimensions != 1)) {
 
-          csound->Die(csound, "%s", Str("framebuffer: Error, k-rate array input "
-                                  "must be one dimensional, Exiting"));
+          return csound->InitError(csound, "%s", Str("framebuffer: Error, k-rate array input "
+                                  "must be one dimensional"));
         }
 
-        if (UNLIKELY(array->sizes[0] > self->elementCount)) {
+        if (UNLIKELY(array->data == NULL || array->sizes[0] <= 0 ||
+                     array->sizes[0] > self->elementCount)) {
 
-          csound->Die(csound, "%s", Str("framebuffer: Error, k-rate array input "
-                                  "element count must be less than\nor equal "
-                                  "to specified framebuffer size, Exiting"));
+          return csound->InitError(csound, "%s", Str("framebuffer: input array size "
+                                  "must be positive and no greater than buffer size"));
         }
     }
     else {
 
-      csound->Die(csound,
+      return csound->InitError(csound,
                   "%s", Str("framebuffer: Error, only a-rate var input with k-rate "
                       "array output or k-rate\narray input with a-rate var "
-                      "output are valid arguments, Exiting"));
+                      "output are valid arguments"));
     }
+    return OK;
 }
 
 ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument)
@@ -412,7 +447,8 @@ ArgumentType Framebuffer_getArgumentType(CSOUND *csound, MYFLT *argument)
 
         argumentType = KRATE_VAR;
     }
-    else if (strcmp("i", type) == 0) {
+    else if (strcmp("i", type) == 0 || strcmp("c", type) == 0 ||
+             strcmp("p", type) == 0) {
 
         argumentType = IRATE_VAR;
     }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -964,6 +964,8 @@ def runTest():
         ],
         ["test_flanger_invalid_delay.csd", "reject non-finite flanger delay", 1],
         ["test_vdelay_buffers.csd", "test short and wrapped variable delays"],
+        ["test_framebuffer_state.csd", "test framebuffer history and sample boundaries"],
+        ["test_framebuffer_invalid_size.csd", "reject invalid framebuffer sizes", 1],
         ["test_vdelay_reinit.csd", "test variable delay state across reinit"],
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],

--- a/tests/commandline/test_framebuffer_invalid_size.csd
+++ b/tests/commandline/test_framebuffer_invalid_size.csd
@@ -1,0 +1,48 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+instr 1
+  aInput = 1
+  kFrame[] framebuffer aInput, p4
+endin
+instr 2
+  kFrame[] init 65
+  aOutput framebuffer kFrame, 64
+endin
+instr 3
+  kFrame[][] init 8, 8
+  aOutput framebuffer kFrame, 64
+endin
+instr 4
+  kLength init 32
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 2 then
+    kLength = p4
+    reinit ARRAY
+  endif
+ARRAY:
+  kFrame[] init i(kLength)
+  rireturn
+  aOutput framebuffer kFrame, 64
+endin
+</CsInstruments>
+<CsScore>
+; Five init errors, without terminating the engine at the first one.
+i 1 0 .01 -1
+i 1 0 .01 31
+i 1 0 .01 1e30
+i 2 0 .01
+i 3 0 .01
+; Two performance errors after a valid first block.
+i 4 0 .01 0
+i 4 0 .01 65
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_framebuffer_state.csd
+++ b/tests/commandline/test_framebuffer_state.csd
@@ -1,0 +1,123 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  iOffset = int(p2 * sr) % ksmps
+  iSamples = int(p3 * sr)
+  kCycle init 0
+  kProcessed init 0
+  kFirst init 1
+  kSize init p4
+  kCycle += 1
+  kOffset = (kCycle == 1 ? iOffset : 0)
+  kActive = min(ksmps - kOffset, iSamples - kProcessed)
+  aPhase phasor 1
+  aInput = aPhase * sr + 1
+  if kCycle == p6 then
+    kSize = p5
+    kFirst = kProcessed + 1
+    reinit BUFFER
+  endif
+BUFFER:
+  kFrame[] framebuffer aInput, i(kSize)
+  rireturn
+  kProcessed += kActive
+  kLength lenarray kFrame
+  if kLength != kSize then
+    printks "framebuffer cycle %g output size %g expected %g\n", 0, kCycle, kLength, kSize
+    exitnowk -1
+  endif
+  kIndex = 0
+  while kIndex < kSize do
+    kValue = kProcessed - kSize + kIndex + 1
+    kExpected = (kValue >= kFirst ? kValue : 0)
+    if abs(kFrame[kIndex] - kExpected) > .00001 then
+      printks "audio-to-frame cycle %g index %g: %g expected %g\n", 0, kCycle, kIndex, kFrame[kIndex], kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  iOffset = int(p2 * sr) % ksmps
+  iSamples = int(p3 * sr)
+  kCycle init 0
+  kProcessed init 0
+  kFirst init 1
+  kSize init p4
+  kFrame[] init p5
+  kCycle += 1
+  kOffset = (kCycle == 1 ? iOffset : 0)
+  kActive = min(ksmps - kOffset, iSamples - kProcessed)
+  kProcessed += kActive
+  kIndex = 0
+  while kIndex < p5 do
+    kFrame[kIndex] = (kCycle - 1) * p5 + kIndex + 1
+    kIndex += 1
+  od
+  if kCycle == p7 then
+    kSize = p6
+    kFirst = (kCycle - 1) * p5 + 1
+    reinit BUFFER
+  endif
+BUFFER:
+  aOutput framebuffer kFrame, i(kSize)
+  rireturn
+  kIndex = 0
+  while kIndex < ksmps do
+    kValue = kCycle * p5 - kSize + kIndex - kOffset + 1
+    kExpected = (kIndex >= kOffset && kIndex < kOffset + kActive && kValue >= kFirst ? kValue : 0)
+    kActual vaget kIndex, aOutput
+    if kActual != kExpected then
+      printks "frame-to-audio cycle %g sample %g: %g expected %g\n", 0, kCycle, kIndex, kActual, kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kCycle == 1 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 15 then
+    prints "not all framebuffer checks ran\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Audio input: size, new size, reset cycle.
+i 1 0 .0625 32 0 0
+i 1 0 .0625 47 0 0
+i 1 0 .0625 96 48 3
+i 1 0 .0625 48 96 3
+i 1 .0006103515625 .0130615234375 47 0 0
+i 1 .0006103515625 .0013427734375 32 0 0
+; Array input: size, frame length, new size, reset cycle.
+i 2 0 .0625 64 64 0 0
+i 2 0 .0625 47 17 0 0
+i 2 0 .0625 96 32 48 3
+i 2 0 .0625 48 32 96 3
+i 2 0 .0625 32 3 0 0
+i 2 .0006103515625 .0130615234375 64 64 0 0
+i 2 .0006103515625 .0013427734375 64 64 0 0
+; Reuse instances after their first notes end.
+i 1 .125 .0625 47 0 0
+i 2 .125 .0625 47 17 0 0
+i 99 .2 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`framebuffer` advanced its write position by `ksmps` even when it wrote a different number of samples, breaking history for array inputs and partial blocks.

- Advance by the actual write count, use wrap checks that avoid integer overflow, and reset the write position on initialization.
- Consume only active audio samples and clear inactive output samples at note boundaries.
- Use Csound's array allocation helpers so reinitialization reuses output storage without leaking it, and check output capacity before writing.
- Validate sizes before integer conversion and reject invalid array dimensions or lengths, including input arrays resized during performance. Report initialization errors instead of terminating the engine.
