### PR TITLE
fix: correct unwrap input and phase history

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -1077,36 +1077,60 @@ static int32_t shiftout_perf(CSOUND *csound, FFT *p) {
 }
 
 
-static int32_t unwrap_set(CSOUND *csound, FFT *p) {
+typedef struct {
+  OPDS h;
+  ARRAYDAT *out, *in;
+  MYFLT *mode;
+  AUXCH mem;
+  int32_t size, unwrap;
+} UNWRAP;
+
+static int32_t unwrap_set(CSOUND *csound, UNWRAP *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
+  if (UNLIKELY(p->in->dimensions != 1 || p->out->dimensions > 1))
+    return csound->InitError(csound, "%s",
+                            Str("unwrap: expected one-dimensional arrays"));
+  if (UNLIKELY(*p->mode != FL(0) && *p->mode != FL(1)))
+    return csound->InitError(csound, "%s", Str("unwrap: mode must be 0 or 1"));
   int32_t N = p->in->sizes[0];
   if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
     return csound_array_init_resize_error(csound);
-  if(*((MYFLT *)p->in2) != FL(0)) {
-    csound->AuxAlloc(csound, N*sizeof(float), &p->mem);
-    memset(p->mem.auxp, 0, N*sizeof(float));
+  p->size = N;
+  p->unwrap = *p->mode == FL(1);
+  if (p->unwrap && N > 0) {
+    csound->AuxAlloc(csound, (size_t) N*sizeof(MYFLT), &p->mem);
   }
   return OK;
 }
 
-
-static int32_t unwrap(CSOUND *csound, FFT *p) {
-  if(p->in->sizes == NULL)
-    return csound->InitError(csound, "array not initialised\n");;
-  int32_t i,siz = p->in->sizes[0];
-  int32_t mode = (int32_t) *((MYFLT *)p->in2);
-  MYFLT *phs = p->out->data;
-  if(mode == 0) { // wrap
-  for (i=0; i < siz; i++) {
-    while (phs[i] >= PI) phs[i] -= TWOPI;
-    while (phs[i] < -PI) phs[i] += TWOPI;
+/* Reduce large phase jumps in one step, keeping the interval [-pi, pi). */
+static inline double unwrap_phase(double phase) {
+  if (phase >= PI || phase < -PI) {
+    phase = fmod(phase, TWOPI);
+    if (phase >= PI) phase -= TWOPI;
+    else if (phase < -PI) phase += TWOPI;
   }
-  } else {  // unwrap
+  return phase;
+}
+
+static int32_t unwrap(CSOUND *csound, UNWRAP *p) {
+  if (UNLIKELY(p->in->sizes == NULL || p->in->dimensions != 1 ||
+               p->in->sizes[0] != p->size || p->out->dimensions != 1))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("unwrap: array shape changed"));
+  if (UNLIKELY(tabcheck(csound, p->out, p->size, &p->h) != OK))
+    return NOTOK;
+  int32_t i;
+  MYFLT *in = p->in->data;
+  MYFLT *phs = p->out->data;
+  if (!p->unwrap) {
+    for (i=0; i < p->size; i++)
+      phs[i] = (MYFLT) unwrap_phase(in[i]);
+  } else {
     MYFLT *ophs = (MYFLT *) p->mem.auxp;
-    for (i=0; i < siz; i++) {
-      while (ophs[i] - phs[i] >= PI) phs[i] -= 2*PI;
-      while (ophs[i] - phs[i] < -PI) phs[i] += 2*PI;
+    for (i=0; i < p->size; i++) {
+      phs[i] = (MYFLT) (ophs[i] + unwrap_phase((double) in[i] - ophs[i]));
       ophs[i] = phs[i];
     }
   }
@@ -1484,7 +1508,7 @@ static OENTRY arrayvars_localops[] =
      (SUBR) shiftin_init, (SUBR) shiftin_perf},
     {"shiftout", sizeof(FFT), 0, "a","k[]o",
      (SUBR) shiftout_init, (SUBR) shiftout_perf},
-    {"unwrap", sizeof(FFT), 0, "k[]","k[]o",
+    {"unwrap", sizeof(UNWRAP), 0, "k[]","k[]o",
      (SUBR) unwrap_set, (SUBR) unwrap},
     {"dct", sizeof(FFT), 0, "k[]","k[]",
      (SUBR) init_dct, (SUBR) kdct, NULL},

--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -1104,16 +1104,6 @@ static int32_t unwrap_set(CSOUND *csound, UNWRAP *p) {
   return OK;
 }
 
-/* Reduce large phase jumps in one step, keeping the interval [-pi, pi). */
-static inline double unwrap_phase(double phase) {
-  if (phase >= PI || phase < -PI) {
-    phase = fmod(phase, TWOPI);
-    if (phase >= PI) phase -= TWOPI;
-    else if (phase < -PI) phase += TWOPI;
-  }
-  return phase;
-}
-
 static int32_t unwrap(CSOUND *csound, UNWRAP *p) {
   if (UNLIKELY(p->in->sizes == NULL || p->in->dimensions != 1 ||
                p->in->sizes[0] != p->size || p->out->dimensions != 1))
@@ -1125,12 +1115,18 @@ static int32_t unwrap(CSOUND *csound, UNWRAP *p) {
   MYFLT *in = p->in->data;
   MYFLT *phs = p->out->data;
   if (!p->unwrap) {
-    for (i=0; i < p->size; i++)
-      phs[i] = (MYFLT) unwrap_phase(in[i]);
+    for (i=0; i < p->size; i++) {
+      phs[i] = in[i];
+      while (phs[i] >= PI) phs[i] -= TWOPI;
+      while (phs[i] < -PI) phs[i] += TWOPI;
+    }
   } else {
     MYFLT *ophs = (MYFLT *) p->mem.auxp;
     for (i=0; i < p->size; i++) {
-      phs[i] = (MYFLT) (ophs[i] + unwrap_phase((double) in[i] - ophs[i]));
+      double phase = (double) in[i] - ophs[i];
+      while (phase >= PI) phase -= TWOPI;
+      while (phase < -PI) phase += TWOPI;
+      phs[i] = (MYFLT) (ophs[i] + phase);
       ophs[i] = phs[i];
     }
   }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -664,6 +664,8 @@ def runTest():
         ["test_rspline_invalid_rate.csd", "reject invalid rspline rates", 1],
         ["test_oscil1i.csd", "oscil1i interpolates scans and holds their endpoints"],
         ["test_trigphasor_range.csd", "trigphasor starts, wraps, and resets within its range"],
+        ["test_unwrap_state.csd", "unwrap input and phase history"],
+        ["test_unwrap_invalid_mode.csd", "unwrap rejects invalid modes", 1],
         ["test_squinewave_state.csd", "squinewave sample offsets and phase reset"],
         ["test_sndwarp_bounds.csd", "sndwarp and sndwarpst bound sample indexes and handle zero time scale"],
         ["test_wterrain2_phase.csd", "wterrain2 phase stability and direction changes"],

--- a/tests/commandline/test_unwrap_invalid_mode.csd
+++ b/tests/commandline/test_unwrap_invalid_mode.csd
@@ -1,0 +1,21 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+instr 1
+  kInput[] fillarray 1, 2, 3
+  kOutput[] unwrap kInput, p4
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 -1
+i 1 0 .01 .5
+i 1 0 .01 2
+i 1 0 .01 1e20
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_unwrap_state.csd
+++ b/tests/commandline/test_unwrap_state.csd
@@ -1,0 +1,117 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kInput[] fillarray 1, 4, -4, 0, 24*$M_PI+.25, -24*$M_PI-.25, 1e20, -1e20
+  kExpected[] fillarray 1, 4-2*$M_PI, -4+2*$M_PI, 0, .25, -.25
+  kCopy[] init 8
+  kIndex = 0
+  while kIndex < 8 do
+    kCopy[kIndex] = kInput[kIndex]
+    kIndex += 1
+  od
+  kOutput[] unwrap kInput
+  kCopy unwrap kCopy
+  kIndex = 0
+  while kIndex < 8 do
+    if kOutput[kIndex] != kCopy[kIndex] || !(abs(kOutput[kIndex]) <= $M_PI) then
+      printks "unwrap: separate and in-place outputs differ at %g\n", 0, kIndex
+      exitnowk -1
+    endif
+    if kIndex < 6 then
+      if !(abs(kOutput[kIndex]-kExpected[kIndex]) <= .00002) then
+        printks "unwrap: wrong wrapped phase at %g: %g\n", 0, kIndex, kOutput[kIndex]
+        exitnowk -1
+      endif
+    endif
+    kIndex += 1
+  od
+  if kInput[1] != 4 || kInput[2] != -4 then
+    printks "unwrap changed its separate input\n", 0
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 2
+  kInput[] init 8
+  kCopy[] init 8
+  kCycle init 0
+  kAge init 0
+  if kCycle == 10 then
+    kAge = 0
+    reinit PHASES
+  endif
+  kIndex = 0
+  while kIndex < 8 do
+    kStep = (kIndex+1)*.3
+    if kIndex % 2 == 0 then
+      kStep = -kStep
+    endif
+    kPhase = kAge*kStep
+    kInput[kIndex] = kPhase - 2*$M_PI*floor((kPhase+$M_PI)/(2*$M_PI))
+    kCopy[kIndex] = kInput[kIndex]
+    kIndex += 1
+  od
+PHASES:
+  kOutput[] unwrap kInput, 1
+  kCopy unwrap kCopy, 1
+  rireturn
+  kIndex = 0
+  while kIndex < 8 do
+    kStep = (kIndex+1)*.3
+    if kIndex % 2 == 0 then
+      kStep = -kStep
+    endif
+    kExpected = kAge*kStep
+    if !(abs(kOutput[kIndex]-kExpected) <= .0001 && abs(kCopy[kIndex]-kExpected) <= .0001) then
+      printks "unwrap: cycle %g index %g got %g / %g, expected %g\n", 0, kCycle, kIndex, kOutput[kIndex], kCopy[kIndex], kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kAge += 1
+  kCycle += 1
+  if kCycle == 20 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 3
+  kInput[] init 0
+  kWrapped[] unwrap kInput
+  kUnwrapped[] unwrap kInput, 1
+  if lenarray(kWrapped) != 0 || lenarray(kUnwrapped) != 0 then
+    printks "unwrap changed an empty array's length\n", 0
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 99
+  if i(gkChecks) != 4 then
+    prints "unwrap checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .1
+i 2 .1 .1
+i 2 .3 .1
+i 3 0 .1
+i 99 .5 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_unwrap_state.csd
+++ b/tests/commandline/test_unwrap_state.csd
@@ -10,7 +10,7 @@ nchnls = 1
 gkChecks init 0
 
 instr 1
-  kInput[] fillarray 1, 4, -4, 0, 24*$M_PI+.25, -24*$M_PI-.25, 1e20, -1e20
+  kInput[] fillarray 1, 4, -4, 0, 24*$M_PI+.25, -24*$M_PI-.25, 32*$M_PI, -32*$M_PI
   kExpected[] fillarray 1, 4-2*$M_PI, -4+2*$M_PI, 0, .25, -.25
   kCopy[] init 8
   kIndex = 0


### PR DESCRIPTION
`unwrap` processed the output array without first reading its input, so a separate output could contain zeros or stale phases. Read the input directly while preserving in-place use.

- Allocate phase history as `MYFLT`, matching how it is accessed. The old float-sized allocation was too small in double builds.
- Unwrap each phase relative to its previous output with the correct correction direction, and reset history on initialization.
- Keep the arithmetic wrap/unwrap loops and the default `[-pi, pi)` interval, without a phase helper or remainder calls.
- Use a dedicated opcode struct, validate the mode, and reject array shape changes before accessing history.
