### PR TITLE
fix: bound window offsets and array access

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -583,41 +583,54 @@ static int32_t ctor_i(CSOUND *csound, FFT *p) {
 static int32_t init_window(CSOUND *csound, FFT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
+  if (UNLIKELY(p->in->dimensions != 1 || p->out->dimensions > 1))
+    return csound->InitError(csound, "%s",
+                            Str("window: expected one-dimensional arrays"));
+  if (UNLIKELY(*p->f != FL(0) && *p->f != FL(1)))
+    return csound->InitError(csound, "%s", Str("window: type must be 0 or 1"));
   int32_t   N = p->in->sizes[0];
-  int32_t   i,type = (int32_t) *p->f;
+  int32_t   i;
   MYFLT *w;
   if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
     return csound_array_init_resize_error(csound);
-  if (p->mem.auxp == 0 || p->mem.size < N*sizeof(MYFLT))
-    csound->AuxAlloc(csound, N*sizeof(MYFLT), &p->mem);
+  p->n = N;
+  if (N > 0 && (p->mem.auxp == 0 || p->mem.size < (size_t) N*sizeof(MYFLT)))
+    csound->AuxAlloc(csound, (size_t) N*sizeof(MYFLT), &p->mem);
   w = (MYFLT *) p->mem.auxp;
-  switch(type) {
-  case 0:
+  if (*p->f == FL(0)) {
     for (i=0; i<N; i++) w[i] = 0.54 - 0.46*cos(i*TWOPI/N);
-    break;
-  case 1:
-  default:
+  } else {
     for (i = 0; i < N; i++)
       w[i] = 0.5 - 0.5*cos(i*TWOPI/N);
-    //for (i = 0; i < N/2; i++)
-    //w[i+N/2] = w[N/2-i-1];
   }
   return OK;
 }
 
 static int32_t perf_window(CSOUND *csound, FFT *p) {
-  IGN(csound);
-  int32_t i,end = p->out->sizes[0], off = *((MYFLT *)p->in2);
+  int32_t i, end = p->n, off;
+  double offset = *((MYFLT *)p->in2);
+  if (UNLIKELY(p->in->sizes == NULL || p->in->dimensions != 1 ||
+               p->in->sizes[0] != end || p->out->dimensions != 1))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("window: array shape changed"));
+  if (UNLIKELY(tabcheck(csound, p->out, end, &p->h) != OK))
+    return NOTOK;
+  if (UNLIKELY(offset < 0 || !isfinite(offset)))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("window: offset must be finite and non-negative"));
+  if (end == 0) return OK;
+  /* Reduce before converting to an index; offsets may span many windows. */
+  if (offset >= end) offset = fmod(offset, end);
+  off = (int32_t) offset;
+  if (off) off = end - off;
   MYFLT *in, *out, *w;
   in = p->in->data;
   out = p->out->data;
   w = (MYFLT *) p->mem.auxp;
-  /*while (off < 0) off += end;
-    for (i=0;i<end;i++)
-    out[(i+off)%end] = in[i]*w[i];*/
-  if(off) off = end - off;
-  for(i=0;i<end;i++)
-    out[i] = in[i]*w[(i+off)%end];
+  for(i=0;i<end;i++) {
+    out[i] = in[i]*w[off];
+    if (++off == end) off = 0;
+  }
   return OK;
 
 }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -852,6 +852,8 @@ def runTest():
         ["test_create_init_perf_delete.csd", "testing new instance opcodes"],
         ["test_complex_numbers.csd", "testing complex number operations"],
         ["test_rfft.csd", "testing real-to-complex and complex-to-real fft"],
+        ["test_window_offsets.csd", "window offsets and array reinitialization"],
+        ["test_window_invalid_inputs.csd", "window rejects invalid inputs", 1],
         ["test_quadrature_osc.csd", "testing quadrature oscillator"],
         [
             "test_schedule_named_instance.csd",

--- a/tests/commandline/test_window_invalid_inputs.csd
+++ b/tests/commandline/test_window_invalid_inputs.csd
@@ -1,0 +1,57 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+
+instr 1
+  kInput[] init 8
+  kOutput[] window kInput, p4, p5
+endin
+
+instr 2
+  kInput[][] init 2, 4
+  kOutput[] window kInput
+endin
+
+; The input changes length without reinitializing the window.
+instr 3
+  kCycle init 0
+  kLength init 8
+  if kCycle == 1 then
+    kLength = p4
+    reinit INPUT
+  endif
+INPUT:
+  kInput[] init i(kLength)
+  rireturn
+  kOutput[] window kInput
+  kCycle += 1
+endin
+
+instr 4
+  kInput[] init 8
+  kOffset = exp(1000)
+  if p4 != 0 then
+    kOffset = kOffset-kOffset
+  endif
+  kOutput[] window kInput, kOffset
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 -1 1
+i 1 0 .01 0 -1
+i 1 0 .01 0 .5
+i 1 0 .01 0 2
+i 1 0 .01 0 1e20
+i 2 0 .01
+i 3 .1 .02 3
+i 3 .1 .02 13
+i 4 .2 .01 0
+i 4 .2 .01 1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_window_offsets.csd
+++ b/tests/commandline/test_window_offsets.csd
@@ -1,0 +1,161 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kInput[] init 8
+  kCopy[] init 8
+  kCycle init 0
+  kIndex = 0
+  while kIndex < 8 do
+    kInput[kIndex] = kIndex+1
+    kCopy[kIndex] = kInput[kIndex]
+    kIndex += 1
+  od
+  kOffset = p5
+  kShift = p6
+  if p5 < 1e15 then
+    kOffset += kCycle*9
+    kShift = (p6+kCycle) % 8
+  endif
+  kOutput[] window kInput, kOffset, p4
+  kCopy window kCopy, kOffset, p4
+  kIndex = 0
+  while kIndex < 8 do
+    kPhase = (kIndex-kShift)*2*$M_PI/8
+    if p4 == 0 then
+      kWeight = .54-.46*cos(kPhase)
+    else
+      kWeight = .5-.5*cos(kPhase)
+    endif
+    kExpected = (kIndex+1)*kWeight
+    if !(abs(kOutput[kIndex]-kExpected) <= .00001 && abs(kCopy[kIndex]-kExpected) <= .00001) then
+      printks "window type %g offset %g index %g: got %g / %g, expected %g\n", 0, p4, kOffset, kIndex, kOutput[kIndex], kCopy[kIndex], kExpected
+      exitnowk -1
+    endif
+    if kInput[kIndex] != kIndex+1 then
+      printks "window changed its separate input\n", 0
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 16 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; Rebuild the coefficients and output when reinit changes the input length.
+instr 2
+  kCycle init 0
+  kLength init 8
+  if kCycle == 2 then
+    kLength = 3
+    reinit WINDOW
+  elseif kCycle == 4 then
+    kLength = 13
+    reinit WINDOW
+  endif
+WINDOW:
+  kInput[] init i(kLength)
+  kCopy[] init i(kLength)
+  kIndex = 0
+  while kIndex < kLength do
+    kInput[kIndex] = kIndex+1
+    kCopy[kIndex] = kInput[kIndex]
+    kIndex += 1
+  od
+  kOutput[] window kInput, 4, p4
+  kCopy window kCopy, 4, p4
+  rireturn
+  kSize lenarray kOutput
+  if kSize != kLength then
+    printks "window retained its old output length\n", 0
+    exitnowk -1
+  endif
+  kIndex = 0
+  while kIndex < kLength do
+    kPhase = (kIndex-4)*2*$M_PI/kLength
+    if p4 == 0 then
+      kWeight = .54-.46*cos(kPhase)
+    else
+      kWeight = .5-.5*cos(kPhase)
+    endif
+    kExpected = (kIndex+1)*kWeight
+    if !(abs(kOutput[kIndex]-kExpected) <= .00002 && abs(kCopy[kIndex]-kExpected) <= .00002) then
+      printks "window reinit type %g length %g index %g: got %g / %g, expected %g\n", 0, p4, kLength, kIndex, kOutput[kIndex], kCopy[kIndex], kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 8 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 3
+  kInput[] init 1
+  kInput[0] = 1
+  kHamming[] window kInput, 1e20, 0
+  kHann[] window kInput
+  if !(abs(kHamming[0]-.08) <= .000001 && kHann[0] == 0) then
+    printks "window failed for a single element\n", 0
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 4
+  kInput[] init 0
+  kHamming[] window kInput, 1e20, 0
+  kHann[] window kInput
+  if lenarray(kHamming) != 0 || lenarray(kHann) != 0 then
+    printks "window changed an empty array's length\n", 0
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 99
+  if i(gkChecks) != 18 then
+    prints "window checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; type, offset, equivalent integer offset
+i 1 0 .1 0 0 0
+i 1 0 .1 1 0 0
+i 1 0 .1 0 1.75 1
+i 1 0 .1 1 1.75 1
+i 1 0 .1 0 8 0
+i 1 0 .1 1 8 0
+i 1 0 .1 0 17.75 1
+i 1 0 .1 1 17.75 1
+i 1 0 .1 0 1e20 0
+i 1 0 .1 1 1e20 0
+i 1 0 .1 0 7.75 7
+i 1 0 .1 1 7.75 7
+i 2 .1 .1 0
+i 2 .1 .1 1
+i 2 .3 .1 0
+i 2 .3 .1 1
+i 3 .4 .01
+i 4 .4 .01
+i 99 .5 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`window` converted offsets to integers before reducing them and could produce negative coefficient indices for offsets beyond the array length.

- Reduce finite, nonnegative offsets modulo the window length before conversion, preserving fractional-offset truncation. Advance the coefficient index with a comparison instead of per-element modulo.
- Reject negative or non-finite offsets and unsupported window types.
- Track the coefficient array's initialized length, reject input shape changes until reinitialization, and check output capacity before writing.
- Handle empty arrays without offset reduction or coefficient allocation, and rebuild coefficients when reinitialization changes the length.
