### PR TITLE
fix: correct shift array sample and buffer state

### DIFF
--- a/Opcodes/arrays.c
+++ b/Opcodes/arrays.c
@@ -1022,57 +1022,106 @@ static int32_t cols_init_S(CSOUND *csound, FFT *p) {
   return NOTOK;
 }
 
-static int32_t shiftin_init(CSOUND *csound, FFT *p) {
+typedef struct {
+  OPDS h;
+  ARRAYDAT *out;
+  MYFLT *in;
+  uint32_t size, n;
+} SHIFTIN;
 
-  int32_t sizs = CS_KSMPS;
-  if(p->out->sizes[0] < sizs)
-    if (UNLIKELY(tabinit(csound, p->out, sizs, p->h.insdshead) != OK))
-      return csound_array_init_resize_error(csound);
+typedef struct {
+  OPDS h;
+  MYFLT *out;
+  ARRAYDAT *in;
+  MYFLT *offset;
+  uint32_t size, n;
+} SHIFTOUT;
+
+static int32_t shiftin_init(CSOUND *csound, SHIFTIN *p) {
+  int32_t size = CS_KSMPS;
+  if (UNLIKELY(p->out->dimensions > 1))
+    return csound->InitError(csound, "%s",
+                            Str("shiftin: expected a one-dimensional array"));
+  if (p->out->sizes != NULL && p->out->sizes[0] > size)
+    size = p->out->sizes[0];
+  if (UNLIKELY(tabinit(csound, p->out, size, p->h.insdshead) != OK))
+    return csound_array_init_resize_error(csound);
+  p->size = size;
   p->n = 0;
   return OK;
 }
 
-static int32_t shiftin_perf(CSOUND *csound, FFT *p) {
-  IGN(csound);
-  uint32_t  siz =  p->out->sizes[0], n = p->n;
-  MYFLT *in = ((MYFLT *) p->in);
-  if (n + CS_KSMPS < siz) {
-    memcpy(p->out->data+n,in,CS_KSMPS*sizeof(MYFLT));
+static int32_t shiftin_perf(CSOUND *csound, SHIFTIN *p) {
+  if (UNLIKELY(p->out->sizes == NULL || p->out->dimensions != 1 ||
+               p->out->sizes[0] != (int32_t) p->size))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("shiftin: array shape changed"));
+  if (UNLIKELY(tabcheck(csound, p->out, p->size, &p->h) != OK))
+    return NOTOK;
+  uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t count = CS_KSMPS - p->h.insdshead->ksmps_no_end - offset;
+  uint32_t n = p->n, remaining = p->size - n;
+  MYFLT *in = p->in + offset;
+  if (count == 0) return OK;
+  if (count < remaining) {
+    memcpy(p->out->data+n, in, count*sizeof(MYFLT));
+    n += count;
   }
   else {
-    int32_t num = siz - n;
-    memcpy(p->out->data+n,in,num*sizeof(MYFLT));
-    memcpy(p->out->data,in+num,(CS_KSMPS-num)*sizeof(MYFLT));
+    memcpy(p->out->data+n, in, remaining*sizeof(MYFLT));
+    if (count > remaining)
+      memcpy(p->out->data, in+remaining, (count-remaining)*sizeof(MYFLT));
+    n = count - remaining;
   }
-  p->n = (n + CS_KSMPS)%siz;
+  p->n = n;
   return OK;
 }
 
 
-static int32_t shiftout_init(CSOUND *csound, FFT *p) {
+static int32_t shiftout_init(CSOUND *csound, SHIFTOUT *p) {
   if(p->in->sizes == NULL)
     return csound->InitError(csound, "array not initialised\n");
+  if (UNLIKELY(p->in->dimensions != 1))
+    return csound->InitError(csound, "%s",
+                            Str("shiftout: expected a one-dimensional array"));
   int32_t siz = p->in->sizes[0];
-  p->n = ((int32_t)*((MYFLT *)p->in2) % siz);
-  if (UNLIKELY((uint32_t) siz < CS_KSMPS))
+  if (UNLIKELY(siz < (int32_t) CS_KSMPS))
     return csound->InitError(csound, "%s", Str("input array too small\n"));
+  double offset = *p->offset;
+  if (UNLIKELY(!isfinite(offset)))
+    return csound->InitError(csound, "%s",
+                            Str("shiftout: offset must be finite"));
+  offset = fmod(trunc(offset), siz);
+  if (offset < 0) offset += siz;
+  p->n = (uint32_t) offset;
+  p->size = siz;
   return OK;
 }
 
-static int32_t shiftout_perf(CSOUND *csound, FFT *p) {
-  IGN(csound);
-  uint32_t siz =  p->in->sizes[0], n = p->n;
-  MYFLT *out = ((MYFLT *) p->out);
-
-  if (n + CS_KSMPS < siz) {
-    memcpy(out,p->in->data+n,CS_KSMPS*sizeof(MYFLT));
+static int32_t shiftout_perf(CSOUND *csound, SHIFTOUT *p) {
+  if (UNLIKELY(p->in->sizes == NULL || p->in->dimensions != 1 ||
+               p->in->sizes[0] != (int32_t) p->size))
+    return csound->PerfError(csound, &p->h, "%s",
+                            Str("shiftout: array shape changed"));
+  uint32_t offset = p->h.insdshead->ksmps_offset;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
+  uint32_t end = CS_KSMPS - early, count = end - offset;
+  uint32_t n = p->n, remaining = p->size - n;
+  if (offset) memset(p->out, 0, offset*sizeof(MYFLT));
+  if (early) memset(p->out+end, 0, early*sizeof(MYFLT));
+  if (count == 0) return OK;
+  MYFLT *out = p->out + offset;
+  if (count < remaining) {
+    memcpy(out, p->in->data+n, count*sizeof(MYFLT));
+    n += count;
   }
   else {
-    int32_t num = siz - n;
-    memcpy(out,p->in->data+n,num*sizeof(MYFLT));
-    memcpy(out+num,p->in->data,(CS_KSMPS-num)*sizeof(MYFLT));
+    memcpy(out, p->in->data+n, remaining*sizeof(MYFLT));
+    if (count > remaining)
+      memcpy(out+remaining, p->in->data, (count-remaining)*sizeof(MYFLT));
+    n = count - remaining;
   }
-  p->n = (n + CS_KSMPS)%siz;
+  p->n = n;
   return OK;
 }
 
@@ -1480,9 +1529,9 @@ static OENTRY arrayvars_localops[] =
      (SUBR) set_cols_init, (SUBR) set_cols_perf, NULL},
     {"setcol", sizeof(FFT), 0, "S[]","S[]k",
      (SUBR) set_cols_init_S, (SUBR) set_cols_perf_S, NULL},
-    {"shiftin", sizeof(FFT), 0, "k[]","a",
+    {"shiftin", sizeof(SHIFTIN), 0, "k[]","a",
      (SUBR) shiftin_init, (SUBR) shiftin_perf},
-    {"shiftout", sizeof(FFT), 0, "a","k[]o",
+    {"shiftout", sizeof(SHIFTOUT), 0, "a","k[]o",
      (SUBR) shiftout_init, (SUBR) shiftout_perf},
     {"unwrap", sizeof(FFT), 0, "k[]","k[]o",
      (SUBR) unwrap_set, (SUBR) unwrap},

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -874,6 +874,8 @@ def runTest():
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
+        ["test_shift_array_state.csd", "shiftin and shiftout sample state"],
+        ["test_shift_array_invalid_inputs.csd", "shift arrays reject invalid inputs", 1],
         ["test_sa.csd", "test sample accurate mode"],
         ["test_diode_ladder_saturation.csd", "diode_ladder saturation and filter history"],
         ["test_pareq_initial_state.csd", "pareq first skip, reset, and preserved state"],

--- a/tests/commandline/test_shift_array_invalid_inputs.csd
+++ b/tests/commandline/test_shift_array_invalid_inputs.csd
@@ -1,0 +1,67 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+
+instr 1
+  kFrame[] init p4
+  aOutput shiftout kFrame
+endin
+
+instr 2
+  kFrame[][] init 2, 32
+  aOutput shiftout kFrame
+endin
+
+instr 3
+  kFrame[][] init 2, 32
+  aInput = 1
+  kFrame shiftin aInput
+endin
+
+instr 4
+  kFrame[] init 32
+  iOffset = exp(1000)
+  if p4 != 0 then
+    iOffset = iOffset-iOffset
+  endif
+  aOutput shiftout kFrame, iOffset
+endin
+
+instr 5, 6
+  kCycle init 0
+  kSize init 64
+  if kCycle == 1 then
+    kSize = p4
+    reinit RESIZE
+  endif
+RESIZE:
+  kFrame[] init i(kSize)
+  rireturn
+  if p1 == 5 then
+    aOutput shiftout kFrame
+  else
+    aInput = 1
+    kFrame shiftin aInput
+  endif
+  kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0
+i 1 0 .01 31
+i 2 0 .01
+i 3 0 .01
+i 4 0 .01 0
+i 4 0 .01 1
+i 5 .1 .02 32
+i 5 .1 .02 96
+i 6 .1 .02 32
+i 6 .1 .02 96
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_shift_array_state.csd
+++ b/tests/commandline/test_shift_array_state.csd
@@ -1,0 +1,161 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kProcessed init 0
+  kWritten init 0
+  kFirst init 1
+  kSize init p4
+  kCycle += 1
+  kOffset offsetsmps
+  kEarly earlysmps
+  kActive = ksmps-kOffset-kEarly
+  aPhase phasor 1
+  aInput = aPhase*sr+1
+  if kCycle == p6 then
+    kSize = p5
+    kWritten = 0
+    kFirst = kProcessed+1
+    reinit BUFFER
+  endif
+BUFFER:
+  kFrame[] init i(kSize)
+  kFrame shiftin aInput
+  rireturn
+  kWritten += kActive
+  kProcessed += kActive
+  kLength lenarray kFrame
+  if kLength != max(kSize, ksmps) then
+    printks "shiftin output length is wrong\n", 0
+    exitnowk -1
+  endif
+  kIndex = 0
+  while kIndex < kLength do
+    kExpected = 0
+    if kIndex < kWritten then
+      kLast = kIndex+1+floor((kWritten-1-kIndex)/kLength)*kLength
+      kExpected = kFirst+kLast-1
+    endif
+    if !(abs(kFrame[kIndex]-kExpected) <= .00001) then
+      printks "shiftin cycle %g index %g: got %g, expected %g\n", 0, kCycle, kIndex, kFrame[kIndex], kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kProcessed == int(p3*sr) then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  kCycle init 0
+  kProcessed init 0
+  kRead init 0
+  kSize init p4
+  kCycle += 1
+  kOffset offsetsmps
+  kEarly earlysmps
+  kActive = ksmps-kOffset-kEarly
+  if kCycle == p7 then
+    kSize = p6
+    kRead = 0
+    reinit BUFFER
+  endif
+BUFFER:
+  kFrame[] init i(kSize)
+  kIndex = 0
+  while kIndex < kSize do
+    kFrame[kIndex] = kIndex+1
+    kIndex += 1
+  od
+  aOutput shiftout kFrame, p5
+  rireturn
+  kIndex = 0
+  while kIndex < ksmps do
+    kExpected = 0
+    if kIndex >= kOffset && kIndex < ksmps-kEarly then
+      ; p8 is the expected integer offset before wrapping.
+      kPosition = kRead+kIndex-kOffset+p8
+      kExpected = kPosition-floor(kPosition/kSize)*kSize+1
+    endif
+    kActual vaget kIndex, aOutput
+    if kActual != kExpected then
+      printks "shiftout cycle %g sample %g: got %g, expected %g\n", 0, kCycle, kIndex, kActual, kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kRead += kActive
+  kProcessed += kActive
+  if kProcessed == int(p3*sr) then
+    gkChecks += 1
+  endif
+endin
+
+; An output without an explicit array init gets one block of storage.
+instr 3
+  aInput = .25
+  kFrame[] shiftin aInput
+  kLength lenarray kFrame
+  if kLength != ksmps then
+    printks "shiftin allocated %g elements, expected %g\n", 0, kLength, ksmps
+    exitnowk -1
+  endif
+  kIndex = 0
+  while kIndex < kLength do
+    if kFrame[kIndex] != .25 then
+      printks "shiftin allocated output index %g: got %g, expected .25\n", 0, kIndex, kFrame[kIndex]
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  gkChecks += 1
+  turnoff
+endin
+
+instr 99
+  if i(gkChecks) != 22 then
+    prints "shift array checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; shiftin: size, new size, reset cycle.
+i 1 0 .0625 32 0 0
+i 1 0 .0625 47 0 0
+i 1 0 .0625 96 48 3
+i 1 0 .0625 48 96 3
+i 1 0 .0625 3 0 0
+i 1 .0006103515625 .0130615234375 47 0 0
+i 1 .0006103515625 .0013427734375 32 0 0
+; shiftout: size, offset, new size, reset cycle, expected offset.
+i 2 0 .0625 32 0 0 0 0
+i 2 0 .0625 47 46 0 0 46
+i 2 0 .0625 96 100 48 3 100
+i 2 0 .0625 48 -1 96 3 -1
+i 2 0 .0625 47 -1.75 0 0 -1
+i 2 0 .0625 47 -.75 0 0 0
+i 2 0 .0625 47 1.75 0 0 1
+i 2 0 .0625 64 1e20 0 0 0
+i 2 0 .0625 64 -1e20 0 0 0
+i 2 .0006103515625 .0130615234375 47 46 0 0 46
+i 2 .0006103515625 .0013427734375 32 31 0 0 31
+; Reused notes reset their read/write positions.
+i 1 .125 .0625 47 0 0
+i 2 .125 .0625 47 46 0 0 46
+i 3 .25 .01
+i 3 .375 .01
+i 99 .4 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`shiftin` and `shiftout` copied whole blocks and advanced their positions by `ksmps`, even when only part of a block belonged to the note.

- Copy and advance by the active sample count, and clear inactive `shiftout` samples. Wrap positions without modulo and skip empty copies at exact buffer boundaries.
- Allocate an uninitialized `shiftin` output before reading its size, while retaining the minimum length of one block.
- Check `shiftout` array length before reducing the offset. Normalize finite positive or negative offsets before integer conversion, preserving truncation toward zero.
- Use dedicated opcode structs and reject array shape changes until reinitialization so saved positions remain valid.
