### PR TITLE
fix: use bounded delays for variable comb feedback

### DIFF
--- a/Opcodes/ugmoss.c
+++ b/Opcodes/ugmoss.c
@@ -661,50 +661,57 @@ static int32_t not_a(CSOUND *csound, AOP *p)
 
 static int32_t vcombset(CSOUND *csound, VCOMB *p)
 {
-    int32_t        lpsiz, nbytes;
-
-    if (*p->insmps != FL(0.0)) {
-      if (UNLIKELY((lpsiz = MYFLT2LONG(*p->imaxlpt)) <= 0)) {
-        return csound->InitError(csound, "%s", Str("illegal loop time"));
-      }
-    }
-    else if (UNLIKELY((lpsiz = (int32)(*p->imaxlpt * CS_ESR)) <= 0)) {
+    MYFLT samples = *p->insmps != FL(0) ? *p->imaxlpt : *p->imaxlpt * CS_ESR;
+    if (UNLIKELY(!((double) samples >= 1.0 &&
+                   (double) samples <= INT32_MAX &&
+                   (double) samples <= SIZE_MAX / sizeof(MYFLT)))) {
       return csound->InitError(csound, "%s", Str("illegal loop time"));
     }
-    nbytes = lpsiz * sizeof(MYFLT);
-    if (p->auxch.auxp == NULL || nbytes != (int32_t)p->auxch.size) {
-      csound->AuxAlloc(csound, (size_t)nbytes, &p->auxch);
+    uint32_t lpsiz = (uint32_t) samples;
+    size_t nbytes = (size_t) lpsiz * sizeof(MYFLT);
+    if (p->auxch.auxp == NULL || nbytes != p->auxch.size) {
+      csound->AuxAlloc(csound, nbytes, &p->auxch);
       p->pntr = (MYFLT *) p->auxch.auxp;
       if (UNLIKELY(p->pntr==NULL)) {
         return csound->InitError(csound, "%s", Str("could not allocate memory"));
       }
     }
     else if (!(*p->istor)) {
-      int32_t *fp = (int32_t *) p->auxch.auxp;
-      p->pntr = (MYFLT *) fp;
+      p->pntr = (MYFLT *) p->auxch.auxp;
       memset(p->pntr, 0, nbytes);
-      /* do   /\* Seems to assume sizeof(int32)=sizeof(MYFLT) *\/ */
-      /*   *fp++ = 0; */
-      /* while (--lpsiz); */
     }
     p->rvt = FL(0.0);
-    p->lpt = FL(0.0);
+    p->lpt = 0;
     p->g   = FL(0.0);
     p->lpta = IS_ASIG_ARG(p->xlpt) ? 1 : 0;
-    if (*p->insmps == 0) p->maxlpt = *p->imaxlpt * CS_ESR;
-    else p->maxlpt = *p->imaxlpt;
+    p->maxlpt = lpsiz;
     return OK;
 }
+
+/* Feedback requires at least one sample of delay. Bound before conversion. */
+#define VCOMB_DELAY(value, scale, maximum, result) do {                   \
+    MYFLT delaySamples = (value) * (scale);                              \
+    (result) = !(delaySamples >= FL(1)) ? 1 :                             \
+      ((double) delaySamples >= (maximum) ? (maximum) :                   \
+       (uint32_t) delaySamples);                                        \
+  } while (0)
+
+/* Wrap an integer index without first forming a pointer before the array. */
+#define VCOMB_READ(write, start, size, delay, read) do {                   \
+    uint32_t writeIndex = (uint32_t) ((write) - (start));                 \
+    (read) = (start) + (writeIndex >= (delay) ? writeIndex - (delay) :     \
+                       (size) - ((delay) - writeIndex));                \
+  } while (0)
 
 static int32_t vcomb(CSOUND *csound, VCOMB *p)
 {
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t    n, nsmps = CS_KSMPS;
-    uint32_t      xlpt, maxlpt = (uint32)p->maxlpt;
+    uint32_t      xlpt, maxlpt = p->maxlpt;
     MYFLT       *ar, *asig, *rp, *endp, *startp, *wp, *lpt;
     MYFLT       g = p->g;
-    MYFLT timeScale = *p->insmps != 0 ? CS_ONEDSR : FL(1.0);
+    MYFLT sampleScale = *p->insmps != 0 ? FL(1.0) : CS_ESR;
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1;
     ar = p->ar;
@@ -720,29 +727,27 @@ static int32_t vcomb(CSOUND *csound, VCOMB *p)
     if (p->lpta) {                               /* if xlpt is a-rate */
       lpt = p->xlpt + offset;
       for (n=offset; n<nsmps; n++) {
-        xlpt = (uint32)((*p->insmps != 0) ? *lpt : *lpt * CS_ESR);
-        if (xlpt > maxlpt) xlpt = maxlpt;
-        if ((rp = wp - xlpt) < startp) rp += maxlpt;
-        if ((p->rvt != *p->krvt) || (p->lpt != *lpt)) {
-          p->rvt = *p->krvt, p->lpt = *lpt;
-          g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
+        VCOMB_DELAY(*lpt, sampleScale, maxlpt, xlpt);
+        VCOMB_READ(wp, startp, maxlpt, xlpt, rp);
+        if ((p->rvt != *p->krvt) || (p->lpt != xlpt)) {
+          p->rvt = *p->krvt, p->lpt = xlpt;
+          g = p->g = p->rvt == FL(0) ? FL(0) :
+            POWER(FL(0.001), (p->lpt * CS_ONEDSR / p->rvt));
         }
         lpt++;
         MYFLT output = *rp++;
         *wp++ = (output * g) + asig[n];
         ar[n] = output;
         if (wp >= endp) wp = startp;
-        //if (rp >= endp) rp = startp;
       }
     }
     else {                                       /* if xlpt is k-rate */
-      xlpt = (uint32) ((*p->insmps != 0) ? *p->xlpt
-                                                  : *p->xlpt * CS_ESR);
-      if (xlpt > maxlpt) xlpt = maxlpt;
-      if ((rp = wp - xlpt) < startp) rp += maxlpt;
-      if ((p->rvt != *p->krvt) || (p->lpt != *p->xlpt)) {
-        p->rvt = *p->krvt, p->lpt = *p->xlpt;
-        g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
+      VCOMB_DELAY(*p->xlpt, sampleScale, maxlpt, xlpt);
+      VCOMB_READ(wp, startp, maxlpt, xlpt, rp);
+      if ((p->rvt != *p->krvt) || (p->lpt != xlpt)) {
+        p->rvt = *p->krvt, p->lpt = xlpt;
+        g = p->g = p->rvt == FL(0) ? FL(0) :
+            POWER(FL(0.001), (p->lpt * CS_ONEDSR / p->rvt));
       }
       for (n=offset; n<nsmps; n++) {
         MYFLT output = *rp++;
@@ -764,10 +769,10 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
-    uint32_t xlpt, maxlpt = (uint32)p->maxlpt;
+    uint32_t xlpt, maxlpt = p->maxlpt;
     MYFLT       *ar, *asig, *rp, *startp, *endp, *wp, *lpt;
     MYFLT       y, z, g = p->g;
-    MYFLT timeScale = *p->insmps != 0 ? CS_ONEDSR : FL(1.0);
+    MYFLT sampleScale = *p->insmps != 0 ? FL(1.0) : CS_ESR;
 
     if (UNLIKELY(p->auxch.auxp==NULL)) goto err1;
     ar = p->ar;
@@ -783,28 +788,26 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
     if (p->lpta) {                                      /* if xlpt is a-rate */
       lpt = p->xlpt;
       for (n=offset; n<nsmps; n++) {
-        xlpt = (uint32)((*p->insmps != 0) ? lpt[n] : lpt[n] * CS_ESR);
-        if (xlpt > maxlpt) xlpt = maxlpt;
-        if ((rp = wp - xlpt) < startp) rp += maxlpt;
-        if ((p->rvt != *p->krvt) || (p->lpt != lpt[n])) {
-          p->rvt = *p->krvt, p->lpt = lpt[n];
-          g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
+        VCOMB_DELAY(lpt[n], sampleScale, maxlpt, xlpt);
+        VCOMB_READ(wp, startp, maxlpt, xlpt, rp);
+        if ((p->rvt != *p->krvt) || (p->lpt != xlpt)) {
+          p->rvt = *p->krvt, p->lpt = xlpt;
+          g = p->g = p->rvt == FL(0) ? FL(0) :
+            POWER(FL(0.001), (p->lpt * CS_ONEDSR / p->rvt));
         }
         y = *rp++;
         *wp++ = z = y * g + asig[n];
         ar[n] = y - g * z;
         if (wp >= endp) wp = startp;
-        //if (rp >= endp) rp = startp;
       }
     }
     else {                                              /* if xlpt is k-rate */
-      xlpt = (uint32) ((*p->insmps != 0) ? *p->xlpt
-                                         : *p->xlpt * CS_ESR);
-      if (xlpt > maxlpt) xlpt = maxlpt;
-      if ((rp = wp - xlpt) < startp) rp += maxlpt;
-      if ((p->rvt != *p->krvt) || (p->lpt != *p->xlpt)) {
-        p->rvt = *p->krvt, p->lpt = *p->xlpt;
-        g = p->g = POWER(FL(0.001), (p->lpt * timeScale / p->rvt));
+      VCOMB_DELAY(*p->xlpt, sampleScale, maxlpt, xlpt);
+      VCOMB_READ(wp, startp, maxlpt, xlpt, rp);
+      if ((p->rvt != *p->krvt) || (p->lpt != xlpt)) {
+        p->rvt = *p->krvt, p->lpt = xlpt;
+        g = p->g = p->rvt == FL(0) ? FL(0) :
+            POWER(FL(0.001), (p->lpt * CS_ONEDSR / p->rvt));
       }
       for (n=offset; n<nsmps; n++) {
         y = *rp++;
@@ -820,6 +823,9 @@ static int32_t valpass(CSOUND *csound, VCOMB *p)
     return csound->PerfError(csound, &(p->h),
                              "%s", Str("valpass: not initialised"));
 }
+
+#undef VCOMB_DELAY
+#undef VCOMB_READ
 
 static int32_t ftmorfset(CSOUND *csound, FTMORF *p)
 {

--- a/Opcodes/ugmoss.h
+++ b/Opcodes/ugmoss.h
@@ -36,7 +36,8 @@ typedef struct {
 typedef struct {
   OPDS                  h;
   MYFLT                 *ar, *asig, *krvt, *xlpt, *imaxlpt, *istor, *insmps;
-  MYFLT                 g, rvt, lpt, *pntr, maxlpt;
+  MYFLT                 g, rvt, *pntr;
+  uint32_t              lpt, maxlpt;
   AUXCH                 auxch;
   int16                 lpta;
 } VCOMB;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -969,6 +969,8 @@ def runTest():
         ["test_flanger_invalid_delay.csd", "reject non-finite flanger delay", 1],
         ["test_vdelay_buffers.csd", "test short and wrapped variable delays"],
         ["test_vdelay_reinit.csd", "test variable delay state across reinit"],
+        ["test_vcomb_delay_feedback.csd", "variable comb delay and feedback"],
+        ["test_vcomb_invalid_size.csd", "variable comb rejects invalid sizes", 1],
         ["test_vdelay_invalid_maximum.csd", "reject invalid maximum delay", 1],
         ["test_vdelay_invalid_delay.csd", "reject non-finite delay", 1],
         ["test_comb_units.csd", "comb family delay units, rate handling and partial blocks"],

--- a/tests/commandline/test_vcomb_delay_feedback.csd
+++ b/tests/commandline/test_vcomb_delay_feedback.csd
@@ -1,0 +1,165 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Reference, aa, aaki
+  setksmps 1
+  aInput, aDelay, kRvt, iMaximum xin
+  iSize = int(iMaximum)
+  kComb[] init iSize
+  kAll[] init iSize
+  kWrite init 0
+  kInput downsamp aInput
+  kRequested downsamp aDelay
+  if kRequested < 1 then
+    kDelay = 1
+  elseif kRequested >= iSize then
+    kDelay = iSize
+  else
+    kDelay = int(kRequested)
+  endif
+  kRead = (kWrite-kDelay+iSize) % iSize
+  if kRvt == 0 then
+    kGain = 0
+  else
+    kGain = .001^(kDelay/(sr*kRvt))
+  endif
+  kCombOut = kComb[kRead]
+  kAllRead = kAll[kRead]
+  kComb[kWrite] = kInput+kGain*kCombOut
+  kAll[kWrite] = kInput+kGain*kAllRead
+  kAllOut = kAllRead-kGain*kAll[kWrite]
+  kWrite = (kWrite+1) % iSize
+  aComb = kCombOut
+  aAll = kAllOut
+  xout aComb, aAll
+endop
+
+instr 1
+  kCycle init 0
+  kProcessed init 0
+  kMaximum init p5
+  kCycle += 1
+  kRvt = (p9 != 0 ? 0 : (kCycle < 7 ? .01 : .02))
+  kDelay = p6
+  aPhase phasor 1193
+  aInput = .05+.1*aPhase
+  aDelay = kDelay+p7*(aPhase*32-8)
+  aFixedDelay = kDelay
+  if p4 == 0 then
+    kLoop = kDelay/sr
+    aLoop = aDelay/sr
+  else
+    kLoop = kDelay
+    aLoop = aDelay
+  endif
+  if p8 > 0 && kCycle == 5 then
+    kMaximum = p8
+    reinit FILTERS
+  endif
+FILTERS:
+  iMaximum = i(kMaximum)
+  iLimit = (p4 == 0 ? iMaximum/sr : iMaximum)
+  aRefComb, aRefAll Reference aInput, aFixedDelay, kRvt, iMaximum
+  aRefCombAudio, aRefAllAudio Reference aInput, aDelay, kRvt, iMaximum
+  aComb vcomb aInput, kRvt, kLoop, iLimit, 0, p4
+  aAll valpass aInput, kRvt, kLoop, iLimit, 0, p4
+  aCombAudio vcomb aInput, kRvt, aLoop, iLimit, 0, p4
+  aAllAudio valpass aInput, kRvt, aLoop, iLimit, 0, p4
+  aCopy = aInput
+  aCopy vcomb aCopy, kRvt, aLoop, iLimit, 0, p4
+  rireturn
+  kIndex = 0
+  while kIndex < ksmps do
+    kComb vaget kIndex, aComb
+    kAll vaget kIndex, aAll
+    kCombAudio vaget kIndex, aCombAudio
+    kAllAudio vaget kIndex, aAllAudio
+    kCopy vaget kIndex, aCopy
+    kRefComb vaget kIndex, aRefComb
+    kRefAll vaget kIndex, aRefAll
+    kRefCombAudio vaget kIndex, aRefCombAudio
+    kRefAllAudio vaget kIndex, aRefAllAudio
+    kError = abs(kComb-kRefComb)+abs(kAll-kRefAll)
+    kError += abs(kCombAudio-kRefCombAudio)+abs(kAllAudio-kRefAllAudio)+abs(kCopy-kRefCombAudio)
+    if !(kError <= .00005) then
+      printks "vcomb/valpass units %g delay %g cycle %g sample %g error %g\n", 0, p4, p6, kCycle, kIndex, kError
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kOffset offsetsmps
+  kEarly earlysmps
+  kProcessed += ksmps-kOffset-kEarly
+  if kProcessed == int(p3*sr) then
+    gkChecks += 1
+  endif
+endin
+
+; Skipping initialization with the same size must retain delay history.
+instr 2
+  kCycle init 0
+  aInput oscili .1, 437
+  aDelay = 20
+  aRefComb, aRefAll Reference aInput, aDelay, .01, 8
+  if kCycle == 5 then
+    reinit FILTERS
+  endif
+FILTERS:
+  aComb vcomb aInput, .01, 20, 8, 1, 1
+  aAll valpass aInput, .01, 20, 8, 1, 1
+  rireturn
+  aError = abs(aComb-aRefComb)+abs(aAll-aRefAll)
+  kError max_k aError, 1, 1
+  if !(kError <= .00001) then
+    printks "vcomb/valpass lost history on skipped init\n", 0
+    exitnowk -1
+  endif
+  kCycle += 1
+  if kCycle == 16 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 22 then
+    prints "vcomb/valpass checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Units, maximum in samples, requested samples, modulation, new maximum, zero rvt.
+i 1 0 .0625 0 8.75 4.75 0 0 0
+i 1 0 .0625 1 8.75 4.75 0 0 0
+i 1 0 .0625 0 8 20 0 0 0
+i 1 0 .0625 1 8 20 0 0 0
+i 1 0 .0625 0 8 0 0 0 0
+i 1 0 .0625 1 8 0 0 0 0
+i 1 0 .0625 0 8 -3 0 0 0
+i 1 0 .0625 1 8 -3 0 0 0
+i 1 0 .0625 0 8 1e20 0 0 0
+i 1 0 .0625 1 8 -1e20 0 0 0
+i 1 0 .0625 0 8 4 1 0 0
+i 1 0 .0625 1 8 4 1 0 0
+i 1 0 .0625 1 1 20 0 0 0
+i 1 0 .0625 1 8 20 0 0 1
+i 1 0 .0625 0 8 4 1 0 1
+i 1 0 .0625 1 8 4 1 0 1
+i 1 0 .0625 0 16 20 1 8 0
+i 1 0 .0625 1 8 20 1 16 0
+i 1 .0006103515625 .0130615234375 0 8 20 1 0 0
+i 1 .0006103515625 .0013427734375 1 8 4 1 0 0
+i 1 .125 .0625 1 8 20 0 0 0
+i 2 .25 .0625
+i 99 .375 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_vcomb_invalid_size.csd
+++ b/tests/commandline/test_vcomb_invalid_size.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+instr 1
+  aInput = 0
+  aOutput vcomb aInput, .1, 1, p4, 0, p5
+endin
+instr 2
+  aInput = 0
+  aOutput valpass aInput, .1, 1, p4, 0, p5
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0 1
+i 1 0 .01 -.1 0
+i 1 0 .01 .5 1
+i 1 0 .01 1e20 0
+i 2 0 .01 0 0
+i 2 0 .01 -1 1
+i 2 0 .01 .5 1
+i 2 0 .01 1e20 1
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`vcomb` and `valpass` used the requested delay to calculate feedback even when their buffer used a shorter, clamped delay. Use the actual whole-sample delay so the decay matches the requested reverberation time.

- Bound delays before integer conversion, with a minimum of one sample, and wrap read indices without forming pointers before the buffer.
- Keep the maximum delay equal to the allocated sample count and validate allocation sizes before conversion.
- Recalculate feedback only when the effective delay or reverberation time changes. Zero reverberation time explicitly disables feedback, avoiding division by zero and a power calculation.

Delay checks and wrapping use macros in the audio loops.
