### PR TITLE
fix: honor ftconv impulse length and partition layout

### DIFF
--- a/Opcodes/ftconv.c
+++ b/Opcodes/ftconv.c
@@ -112,19 +112,6 @@ static void multiply_fft_buffers(MYFLT *outBuf, MYFLT *ringBuf,
     } while (--nPartitions);
 }
 
-static inline int32_t buf_bytes_alloc(int32_t nChannels,
-                                      int32_t partSize, int32_t nPartitions)
-{
-    int32_t nSmps;
-
-    nSmps = (partSize << 1);                                /* tmpBuf     */
-    nSmps += ((partSize << 1) * nPartitions);               /* ringBuf    */
-    nSmps += ((partSize << 1) * nChannels * nPartitions);   /* IR_Data    */
-    nSmps += ((partSize << 1) * nChannels);                 /* outBuffers */
-
-    return ((int32_t) sizeof(MYFLT) * nSmps);
-}
-
 static void set_buf_pointers(FTCONV *p,
                              int32_t nChannels, int32_t partSize,
                              int32_t nPartitions)
@@ -149,99 +136,87 @@ static void set_buf_pointers(FTCONV *p,
 
 static int32_t ftconv_init(CSOUND *csound, FTCONV *p)
 {
-    FUNC    *ftp;
-    int32_t     i, j, k, n, nBytes, skipSamples;
-    //MYFLT   FFTscale;
+    FUNC *ftp;
+    int32_t i, j, k, n;
+    int32_t nChannels = (int32_t) p->OUTOCOUNT;
+    double part = nearbyint((double) *p->iPartLen);
+    double skip = nearbyint((double) *p->iSkipSamples);
+    double length = nearbyint((double) *p->iTotLen);
 
-    /* check parameters */
-    p->nChannels = (int32_t) p->OUTOCOUNT;
-    if (UNLIKELY(p->nChannels < 1 || p->nChannels > FTCONV_MAXCHN)) {
+    if (UNLIKELY(nChannels < 1 || nChannels > FTCONV_MAXCHN))
       return csound->InitError(csound, "%s", Str("ftconv: invalid number of channels"));
-    }
-    /* partition length */
-    p->partSize = MYFLT2LRND(*(p->iPartLen));
-    if (UNLIKELY(p->partSize < 4 || (p->partSize & (p->partSize - 1)) != 0)) {
-      return csound->InitError(csound, "%s", Str("ftconv: invalid impulse response "
-                                           "partition length"));
-    }
+    if (UNLIKELY(!(part >= 4 && part <= INT32_MAX / 2)))
+      return csound->InitError(csound, "%s",
+                              Str("ftconv: invalid impulse response partition length"));
+    int32_t partSize = (int32_t) part;
+    if (UNLIKELY((partSize & (partSize - 1)) != 0))
+      return csound->InitError(csound, "%s",
+                              Str("ftconv: invalid impulse response partition length"));
+    if (UNLIKELY(!(skip >= INT32_MIN && skip <= INT32_MAX &&
+                   length >= INT32_MIN && length <= INT32_MAX)))
+      return csound->InitError(csound, "%s", Str("ftconv: invalid impulse response range"));
     ftp = csound->FTFind(csound, p->iFTNum);
     if (UNLIKELY(ftp == NULL))
-      return NOTOK; /* ftfind should already have printed the error message */
-    /* calculate total length / number of partitions */
-    n = (int32_t) ftp->flen / p->nChannels;
-    skipSamples = MYFLT2LRND(*(p->iSkipSamples));
-    n -= skipSamples;
-    if (MYFLT2LRND(*(p->iTotLen)) > 0 && n > MYFLT2LRND(*(p->iTotLen)))
-      n = MYFLT2LRND(*(p->iTotLen));
-    if (UNLIKELY(n <= 0)) {
-      return csound->InitError(csound,
-                               "%s", Str("ftconv: invalid length, or insufficient"
-                                   " IR data for convolution"));
-    }
-    p->nPartitions = (n + (p->partSize - 1)) / p->partSize;
-    /* calculate the amount of aux space to allocate (in bytes) */
-    nBytes = buf_bytes_alloc(p->nChannels, p->partSize, p->nPartitions);
-    if (nBytes != (int32_t) p->auxData.size)
-      csound->AuxAlloc(csound, (int32) nBytes, &(p->auxData));
-    else if (p->initDone > 0 && *(p->iSkipInit) != FL(0.0))
-      return OK;    /* skip initialisation if requested */
-    /* if skipping samples: check for possible truncation of IR */
-    /*
-      if (skipSamples > 0 && (parm->msglevel & WARNMSG)) {
-      n = skipSamples * p->nChannels;
-      if (n > (int32_t) ftp->flen)
-        n = (int32_t) ftp->flen;
-      for (i = 0; i < n; i++) {
-        if (UNLIKELY(ftp->ftable[i] != FL(0.0))) {
-          csound->Warning(csound,
-                          "%s", Str("ftconv: skipped non-zero samples, "
-                              "impulse response may be truncated\n"));
-          break;
-        }
-      }
-      }*/
-    /* initialise buffer pointers */
-    set_buf_pointers(p, p->nChannels, p->partSize, p->nPartitions);
-    /* clear ring buffer to zero */
-    n = (p->partSize << 1) * p->nPartitions;
-    memset(p->ringBuf, 0, n*sizeof(MYFLT));
-    /* for (i = 0; i < n; i++) */
-    /*   p->ringBuf[i] = FL(0.0); */
-    /* initialise buffer index */
+      return NOTOK;
+
+    int64_t tableFrames = ftp->flen / nChannels;
+    int64_t skipSamples = (int64_t) skip;
+    int64_t irLength = tableFrames - skipSamples;
+    if (length > 0 && irLength > (int64_t) length)
+      irLength = (int64_t) length;
+    if (UNLIKELY(irLength <= 0 || irLength > INT32_MAX))
+      return csound->InitError(csound, "%s",
+                              Str("ftconv: invalid length, or insufficient IR data for convolution"));
+    int32_t nPartitions = (int32_t) ((irLength - 1) / partSize + 1);
+    /* FFT and ring-buffer indices use signed 32-bit sample counts. */
+    if (UNLIKELY(nPartitions > INT32_MAX / (partSize * 2)))
+      return csound->InitError(csound, "%s", Str("ftconv: impulse response too large"));
+    uint64_t nSamples = (uint64_t) (partSize * 2) *
+                       (nChannels + 1) * ((uint64_t) nPartitions + 1);
+    if (UNLIKELY(nSamples > SIZE_MAX / sizeof(MYFLT)))
+      return csound->InitError(csound, "%s", Str("ftconv: impulse response too large"));
+    size_t nBytes = (size_t) nSamples * sizeof(MYFLT);
+
+    /* Equal allocation sizes do not imply equal partition layouts. */
+    if (p->initDone > 0 && *p->iSkipInit != FL(0) &&
+        p->nChannels == nChannels && p->partSize == partSize &&
+        p->nPartitions == nPartitions)
+      return OK;
+    p->initDone = 0;
+    p->nChannels = nChannels;
+    p->partSize = partSize;
+    p->nPartitions = nPartitions;
+    if (p->auxData.auxp == NULL || nBytes != p->auxData.size)
+      csound->AuxAlloc(csound, nBytes, &p->auxData);
+    set_buf_pointers(p, nChannels, partSize, nPartitions);
+    n = (partSize * 2) * nPartitions;
+    memset(p->ringBuf, 0, (size_t) n * sizeof(MYFLT));
     p->cnt = 0;
     p->rbCnt = 0;
-    /* calculate FFT of impulse response partitions, in reverse order */
-    /* also apply FFT amplitude scale here */
-    //FFTscale = csound->GetInverseRealFFTScale(csound, (p->partSize << 1));
-    p->fwdsetup = csound->RealFFTSetup(csound,(p->partSize << 1), FFT_FWD);
-    p->invsetup = csound->RealFFTSetup(csound,(p->partSize << 1), FFT_INV);
-    for (j = 0; j < p->nChannels; j++) {
-      i = (skipSamples * p->nChannels) + j;           /* table read position */
-      n = (p->partSize << 1) * (p->nPartitions - 1);  /* IR write position */
+    p->fwdsetup = csound->RealFFTSetup(csound, partSize * 2, FFT_FWD);
+    p->invsetup = csound->RealFFTSetup(csound, partSize * 2, FFT_INV);
+    /* Store IR partitions in reverse order, padding beyond the requested end. */
+    for (j = 0; j < nChannels; j++) {
+      int64_t frame = skipSamples;
+      int64_t endFrame = skipSamples + irLength;
+      n = (partSize * 2) * (nPartitions - 1);
       do {
-        for (k = 0; k < p->partSize; k++) {
-          if (i >= 0 && i < (int32_t) ftp->flen)
-            p->IR_Data[j][n + k] = ftp->ftable[i];// * FFTscale;
+        for (k = 0; k < partSize; k++, frame++) {
+          if (frame >= 0 && frame < tableFrames && frame < endFrame)
+            p->IR_Data[j][n + k] = ftp->ftable[frame * nChannels + j];
           else
             p->IR_Data[j][n + k] = FL(0.0);
-          i += p->nChannels;
         }
-        /* pad second half of IR to zero */
-        for (k = p->partSize; k < (p->partSize << 1); k++)
+        for (k = partSize; k < partSize * 2; k++)
           p->IR_Data[j][n + k] = FL(0.0);
-        /* calculate FFT */
-        csound->RealFFT(csound, p->fwdsetup, &(p->IR_Data[j][n]));
-        n -= (p->partSize << 1);
+        csound->RealFFT(csound, p->fwdsetup, &p->IR_Data[j][n]);
+        n -= partSize * 2;
       } while (n >= 0);
     }
-    /* clear output buffers to zero */
-    /*memset(p->outBuffers, 0, p->nChannels*(p->partSize << 1)*sizeof(MYFLT));*/
-    for (j = 0; j < p->nChannels; j++) {
-      for (i = 0; i < (p->partSize << 1); i++)
+    for (j = 0; j < nChannels; j++)
+      for (i = 0; i < partSize * 2; i++)
         p->outBuffers[j][i] = FL(0.0);
-    }
     p->initDone = 1;
-
     return OK;
 }
 
@@ -317,4 +292,3 @@ int32_t ftconv_init_(CSOUND *csound)
                                 (int32_t (*)(CSOUND *, void *)) ftconv_perf,
                                 NULL);
 }
-

--- a/Opcodes/ftconv.c
+++ b/Opcodes/ftconv.c
@@ -169,9 +169,9 @@ static int32_t ftconv_init(CSOUND *csound, FTCONV *p)
                               Str("ftconv: invalid length, or insufficient IR data for convolution"));
     int32_t nPartitions = (int32_t) ((irLength - 1) / partSize + 1);
     /* FFT and ring-buffer indices use signed 32-bit sample counts. */
-    if (UNLIKELY(nPartitions > INT32_MAX / (partSize * 2)))
+    if (UNLIKELY(nPartitions > INT32_MAX / (partSize << 1)))
       return csound->InitError(csound, "%s", Str("ftconv: impulse response too large"));
-    uint64_t nSamples = (uint64_t) (partSize * 2) *
+    uint64_t nSamples = (uint64_t) (partSize << 1) *
                        (nChannels + 1) * ((uint64_t) nPartitions + 1);
     if (UNLIKELY(nSamples > SIZE_MAX / sizeof(MYFLT)))
       return csound->InitError(csound, "%s", Str("ftconv: impulse response too large"));
@@ -189,17 +189,17 @@ static int32_t ftconv_init(CSOUND *csound, FTCONV *p)
     if (p->auxData.auxp == NULL || nBytes != p->auxData.size)
       csound->AuxAlloc(csound, nBytes, &p->auxData);
     set_buf_pointers(p, nChannels, partSize, nPartitions);
-    n = (partSize * 2) * nPartitions;
+    n = (partSize << 1) * nPartitions;
     memset(p->ringBuf, 0, (size_t) n * sizeof(MYFLT));
     p->cnt = 0;
     p->rbCnt = 0;
-    p->fwdsetup = csound->RealFFTSetup(csound, partSize * 2, FFT_FWD);
-    p->invsetup = csound->RealFFTSetup(csound, partSize * 2, FFT_INV);
+    p->fwdsetup = csound->RealFFTSetup(csound, (partSize << 1), FFT_FWD);
+    p->invsetup = csound->RealFFTSetup(csound, (partSize << 1), FFT_INV);
     /* Store IR partitions in reverse order, padding beyond the requested end. */
     for (j = 0; j < nChannels; j++) {
       int64_t frame = skipSamples;
       int64_t endFrame = skipSamples + irLength;
-      n = (partSize * 2) * (nPartitions - 1);
+      n = (partSize << 1) * (nPartitions - 1);
       do {
         for (k = 0; k < partSize; k++, frame++) {
           if (frame >= 0 && frame < tableFrames && frame < endFrame)
@@ -207,14 +207,14 @@ static int32_t ftconv_init(CSOUND *csound, FTCONV *p)
           else
             p->IR_Data[j][n + k] = FL(0.0);
         }
-        for (k = partSize; k < partSize * 2; k++)
+        for (k = partSize; k < (partSize << 1); k++)
           p->IR_Data[j][n + k] = FL(0.0);
         csound->RealFFT(csound, p->fwdsetup, &p->IR_Data[j][n]);
-        n -= partSize * 2;
+        n -= (partSize << 1);
       } while (n >= 0);
     }
     for (j = 0; j < nChannels; j++)
-      for (i = 0; i < partSize * 2; i++)
+      for (i = 0; i < (partSize << 1); i++)
         p->outBuffers[j][i] = FL(0.0);
     p->initDone = 1;
     return OK;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -851,6 +851,8 @@ def runTest():
         ["test_splice_instance.csd", "test splicing instr order"],
         ["test_create_init_perf_delete.csd", "testing new instance opcodes"],
         ["test_complex_numbers.csd", "testing complex number operations"],
+        ["test_ftconv_impulse_length.csd", "ftconv impulse length and partition state"],
+        ["test_ftconv_invalid_sizes.csd", "ftconv rejects invalid sizes", 1],
         ["test_rfft.csd", "testing real-to-complex and complex-to-real fft"],
         ["test_quadrature_osc.csd", "testing quadrature oscillator"],
         [

--- a/tests/commandline/test_ftconv_impulse_length.csd
+++ b/tests/commandline/test_ftconv_impulse_length.csd
@@ -1,0 +1,135 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1, 2
+  iChannels = p1
+  iIR ftgen 0, 0, 32*iChannels, -2, 0
+  iFrame = 0
+  while iFrame < 32 do
+    tableiw iFrame+1, iFrame*iChannels, iIR
+    if iChannels == 2 then
+      tableiw -(iFrame+1)*.5, iFrame*2+1, iIR
+    endif
+    iFrame += 1
+  od
+  iLength = 32-p5
+  if p6 > 0 then
+    iLength = min(iLength, p6)
+  endif
+  aInput = .1
+  if iChannels == 1 then
+    aLeft ftconv aInput, iIR, p4, p5, p6
+    aRight = -.5*aLeft
+  else
+    aLeft, aRight ftconv aInput, iIR, p4, p5, p6
+  endif
+  kProcessed init 0
+  kOffset offsetsmps
+  kEarly earlysmps
+  kIndex = 0
+  while kIndex < ksmps do
+    kExpected = 0
+    if kIndex >= kOffset && kIndex < ksmps-kEarly then
+      kTime = kProcessed+kIndex-kOffset-p4
+      kTap = 0
+      while kTap < iLength && kTap <= kTime do
+        kSource = p5+kTap
+        if kSource >= 0 && kSource < 32 then
+          kExpected += .1*(kSource+1)
+        endif
+        kTap += 1
+      od
+    endif
+    kLeft vaget kIndex, aLeft
+    kRight vaget kIndex, aRight
+    if !(abs(kLeft-kExpected) <= .0001 && abs(kRight+.5*kExpected) <= .0001) then
+      printks "ftconv channels %g partition %g skip %g length %g sample %g: got %g / %g, expected %g / %g\n", 0, p1, p4, p5, p6, kProcessed+kIndex, kLeft, kRight, kExpected, -.5*kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kProcessed += ksmps-kOffset-kEarly
+  if kProcessed == int(p3*sr) then
+    gkChecks += 1
+  endif
+endin
+
+; Two different stereo partition layouts can require the same byte count.
+instr 3
+  iIR ftgen 0, 0, 128, -7, 1, 128, 1
+  kCycle init 0
+  kAge init 0
+  kPart init p4
+  kLength init p5
+  if kCycle == 3 then
+    kPart = p6
+    kLength = p7
+    if p4 != p6 || p5 != p7 || p8 == 0 then
+      kAge = 0
+    endif
+    reinit CONVOLUTION
+  endif
+  aInput = .1
+CONVOLUTION:
+  aLeft, aRight ftconv aInput, iIR, i(kPart), 0, i(kLength), p8
+  rireturn
+  kIndex = 0
+  while kIndex < ksmps do
+    kExpected = .1*max(0, min(kLength, kAge+kIndex-kPart+1))
+    kLeft vaget kIndex, aLeft
+    kRight vaget kIndex, aRight
+    if !(abs(kLeft-kExpected) <= .00001 && abs(kRight-kExpected) <= .00001) then
+      printks "ftconv reinit cycle %g part %g length %g sample %g: got %g / %g, expected %g\n", 0, kCycle, kPart, kLength, kIndex, kLeft, kRight, kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kAge += ksmps
+  kCycle += 1
+  if kCycle == 8 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 20 then
+    prints "ftconv checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Partition size, skipped frames, impulse length.
+i 1 0 .03125 4 0 5
+i 2 0 .03125 4 0 5
+i 1 0 .03125 8 0 1
+i 1 0 .03125 8 0 8
+i 1 0 .03125 8 3 9
+i 1 0 .03125 16 7 17
+i 1 0 .03125 8 -3 9
+i 1 0 .03125 8 0 0
+i 2 0 .03125 8 0 1
+i 2 0 .03125 8 0 8
+i 2 0 .03125 8 3 9
+i 2 0 .03125 16 7 17
+i 2 0 .03125 8 -3 9
+i 2 0 .03125 8 0 0
+i 1 .0006103515625 .0130615234375 8 3 9
+i 2 .0006103515625 .0130615234375 8 3 9
+; Initial and new partition/length, skip initialization flag.
+i 3 .125 .03125 8 33 16 17 1
+i 3 .125 .03125 16 17 8 33 1
+i 3 .125 .03125 8 33 8 33 1
+i 3 .125 .03125 8 33 8 33 0
+i 99 .25 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_ftconv_invalid_sizes.csd
+++ b/tests/commandline/test_ftconv_invalid_sizes.csd
@@ -1,0 +1,26 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 32
+nchnls = 1
+giIR ftgen 0, 0, 32, -2, 1
+instr 1
+  aInput = 0
+  aOutput ftconv aInput, giIR, p4, p5, p6
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0 0 0
+i 1 0 .01 3 0 0
+i 1 0 .01 6 0 0
+i 1 0 .01 1e20 0 0
+i 1 0 .01 8 1e20 0
+i 1 0 .01 8 0 1e20
+i 1 0 .01 8 32 0
+i 1 0 .01 8 -2147483648 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`ftconv` used the requested impulse length to choose its partition count, but still read later table samples into the last partition. Zero-pad beyond the requested end so those samples no longer affect the output.

- Preserve state on skipped initialization only when channel count, partition size, and partition count match. Different layouts can need the same allocation size and must still rebuild their buffers and FFT setup.
- Check rounded parameters before integer conversion, calculate impulse ranges with wider integers, and bound allocation sizes and signed FFT indices before multiplication.
- Keep negative skip values as leading silence and handle multichannel impulse lengths in sample frames.
