### PR TITLE
fix: correct PVS buffer spectrum and circular reads

### DIFF
--- a/Opcodes/pvsbuffer.c
+++ b/Opcodes/pvsbuffer.c
@@ -52,6 +52,18 @@ static int32_t pvsbufferset(CSOUND *csound, PVSBUFFER *p)
 
     if (UNLIKELY(p->fin->sliding))
       return csound->InitError(csound, "%s", Str("SDFT case not implemented yet"));
+    N = p->fin->N;
+    hop = p->fin->overlap;
+    if (UNLIKELY(N < 2 || N > INT32_MAX - 2 || (N & 1) || hop <= 0 ||
+                 (uint64_t) N + 2 > SIZE_MAX / sizeof(float)))
+      return csound->InitError(csound, "%s", Str("pvsbuffer: invalid frame size"));
+    double frames = (double) *p->len * CS_ESR / hop;
+    size_t frameBytes = ((size_t) N + 2) * sizeof(float);
+    if (UNLIKELY(!(frames >= 1 && frames <= UINT32_MAX &&
+                   frames <= SIZE_MAX / frameBytes)))
+      return csound->InitError(csound, "%s", Str("pvsbuffer: invalid buffer length"));
+    p->nframes = (uint32_t) frames;
+    size_t bytes = frameBytes * p->nframes;
     if (p->handmem.auxp == NULL)
       csound->AuxAlloc(csound, sizeof(FSIG_HANDLE), &p->handmem);
     p->handle = (FSIG_HANDLE *) p->handmem.auxp;
@@ -61,12 +73,12 @@ static int32_t pvsbufferset(CSOUND *csound, PVSBUFFER *p)
     p->handle->header.wintype = p->fin->wintype;
     p->handle->header.format  = p->fin->format;
     p->handle->header.framecount = p->fin->framecount;
-    p->nframes = p->handle->frames = (*p->len) * CS_ESR/hop;
+    p->handle->frames = p->nframes;
     if (p->buffer.auxp == NULL ||
-        p->buffer.size < sizeof(float) * (N + 2) * p->nframes)
-      csound->AuxAlloc(csound, (N + 2) * sizeof(float) * p->nframes, &p->buffer);
+        p->buffer.size < bytes)
+      csound->AuxAlloc(csound, bytes, &p->buffer);
     else
-      memset(p->buffer.auxp, 0, (N + 2) * sizeof(float) * p->nframes);
+      memset(p->buffer.auxp, 0, bytes);
 
     p->handle->header.frame.auxp = p->buffer.auxp;
     p->handle->header.frame.size = p->buffer.size;
@@ -99,12 +111,17 @@ static int32_t pvsbufferset(CSOUND *csound, PVSBUFFER *p)
 
 static int32_t pvsbufferproc(CSOUND *csound, PVSBUFFER *p)
 {
+    if (UNLIKELY(p->fin->N != p->handle->header.N ||
+                 p->fin->overlap != p->handle->header.overlap ||
+                 p->fin->format != p->handle->header.format || p->fin->sliding))
+      return csound->PerfError(csound, &p->h, "%s",
+                              Str("pvsbuffer: input format changed"));
      float *fin = p->fin->frame.auxp;
 
     if (p->lastframe < p->fin->framecount) {
       int32 framesize = p->fin->N + 2, i;
       float *fout = (float *) p->buffer.auxp;
-      fout += framesize*p->cframes;
+      fout += (size_t) framesize*p->cframes;
       for (i=0;i < framesize; i+=2) {
         fout[i] = fin[i];
         fout[i+1] = fin[i+1];
@@ -128,200 +145,146 @@ typedef struct {
   MYFLT *strt;
   MYFLT *end;
   MYFLT *clear;
-  MYFLT iclear, optr;
+  MYFLT optr;
   FSIG_HANDLE *handle;
   uint32_t scnt;
 } PVSBUFFERREAD;
 
+static FSIG_HANDLE *pvsbuffer_handle(CSOUND *csound, MYFLT number)
+{
+    char varname[32];
+    if (!((double) number >= 0 && (double) number <= INT32_MAX))
+      return NULL;
+    snprintf(varname, sizeof(varname), "::buffer%d", (int32_t) number);
+    FSIG_HANDLE **handle = (FSIG_HANDLE **)
+      csound->QueryGlobalVariable(csound, varname);
+    return handle != NULL ? *handle : NULL;
+}
+
+/* Normalize frame positions in bounded time, including one-frame buffers. */
+static inline double pvsbuffer_position(double pos, uint32_t frames)
+{
+    if (pos >= 0 && pos < frames) return pos;
+    pos = fmod(pos, frames);
+    if (pos < 0) pos += frames;
+    if (pos >= frames) pos = 0;
+    return pos;
+}
+
 static int32_t pvsbufreadset(CSOUND *csound, PVSBUFFERREAD *p)
 {
-    int32_t N;
-    FSIG_HANDLE *handle=NULL, **phandle;
-    char varname[32];
-
-    snprintf(varname, 32, "::buffer%d", (int32_t)(*p->hptr));
-    /* csound->Message(csound, "%s:\n", varname); */
-    phandle = (FSIG_HANDLE **) csound->QueryGlobalVariable(csound,varname);
-    if (phandle == NULL)
-      return csound->InitError(csound,
-                               "%s", Str("error... could not read handle from "
-                                   "global variable\n"));
+    FSIG_HANDLE *handle = pvsbuffer_handle(csound, *p->hptr);
+    if (UNLIKELY(handle == NULL))
+      return csound->InitError(csound, "%s", Str("Invalid buffer handle"));
+    int32_t N = handle->header.N;
+    p->fout->N = N;
+    p->fout->overlap = handle->header.overlap;
+    p->fout->winsize = handle->header.winsize;
+    p->fout->wintype = handle->header.wintype;
+    p->fout->format = handle->header.format;
+    p->fout->framecount = 1;
+    size_t bytes = ((size_t) N + 2) * sizeof(float);
+    if (p->fout->frame.auxp == NULL || p->fout->frame.size < bytes)
+      csound->AuxAlloc(csound, bytes, &p->fout->frame);
     else
-      handle = *phandle;
-    p->optr = *p->hptr;
-
-    if (handle != NULL) {
-      p->fout->N = N = handle->header.N;
-      p->fout->overlap = handle->header.overlap;
-      p->fout->winsize = handle->header.winsize;
-      p->fout->wintype = handle->header.wintype;
-      p->fout->format  = handle->header.format;
-      p->fout->framecount = 1;
-    }
-    else {
-      p->fout->N = N = 1024;
-      p->fout->overlap = 256;
-      p->fout->winsize = 1024;
-      p->fout->wintype = 1;
-      p->fout->format  = PVS_AMP_FREQ;
-      p->fout->framecount = 1;
-    }
-
-    if (p->fout->frame.auxp == NULL ||
-         p->fout->frame.size < sizeof(float) * (N + 2))
-          csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
-
+      memset(p->fout->frame.auxp, 0, bytes);
     p->fout->sliding = 0;
     p->scnt = p->fout->overlap;
     p->handle = handle;
+    p->optr = *p->hptr;
     return OK;
 }
 
- static int32_t pvsbufreadproc(CSOUND *csound, PVSBUFFERREAD *p){
-
-    uint32_t posi, frames;
-    MYFLT pos, sr = CS_ESR, frac;
-    FSIG_HANDLE *handle =  p->handle, **phandle;
-    float *fout, *buffer;
-    int32_t strt = *p->strt, end = *p->end, i, N;
-    uint32_t overlap;
-    p->iclear = *p->clear;
-
-   if (*p->hptr != p->optr) {
-     char varname[32];
-     snprintf(varname, 32, "::buffer%d", (int32_t)(*p->hptr));
-     phandle = (FSIG_HANDLE **) csound->QueryGlobalVariable(csound,varname);
-     if (phandle == NULL)
-       csound->PerfError(csound, &(p->h),
-                         "%s", Str("error... could not read handle "
-                             "from global variable\n"));
-     else
-       handle = *phandle;
-   }
-
-   if (handle == NULL) goto err1;
-
-   fout = (float *) p->fout->frame.auxp,
-     buffer = handle->data;
-   N = p->fout->N;
-   overlap = p->fout->overlap;
-
-   if (p->scnt >= overlap){
-     float *frame1, *frame2;
-     strt /= (sr/N);
-     end /= (sr/N);
-     strt = (int32_t)(strt < 0 ? 0 : strt > N/2 ? N/2 : strt);
-     end = (int32_t)(end <= strt ? N/2 + 2 : end > N/2 + 2 ? N/2 + 2 : end);
-     frames = handle->frames-1;
-     pos = *p->ktime*(sr/overlap);
-
-     if (p->iclear) memset(fout, 0, sizeof(float)*(N+2));
-     while (pos >= frames) pos -= frames;
-     while (pos < 0) pos += frames;
-     posi = (int32_t) pos;
-     if (N == handle->header.N &&
-         overlap == (uint32_t)handle->header.overlap){
-       frame1 = buffer + (N + 2) * posi;
-       frame2 = buffer + (N + 2)*(posi != frames-1 ? posi+1 : 0);
-       frac = pos - posi;
-
-       for (i=strt; i < end; i+=2){
-         fout[i] = frame1[i] + frac*(frame2[i] - frame1[i]);
-         fout[i+1] = frame1[i+1] + frac*(frame2[i+1] - frame1[i+1]);
-       }
-     }
-     else
-       for (i=0; i < N+2; i+=2){
-         fout[i] = 0.0f;
-         fout[i+1] = 0.0f;
-       }
-     p->scnt -= overlap;
-     p->fout->framecount++;
-   }
-   p->scnt += CS_KSMPS;
-
-   return OK;
- err1:
-   return csound->PerfError(csound, &(p->h),
-                             "%s", Str("Invalid buffer handle"));
-  }
-
-
-static int32_t pvsbufreadproc2(CSOUND *csound, PVSBUFFERREAD *p)
+static int32_t pvsbufread_handle(CSOUND *csound, PVSBUFFERREAD *p)
 {
-    uint32_t posi, frames;
-    MYFLT pos, sr = CS_ESR;
-    FSIG_HANDLE *handle =  p->handle, **phandle;
-    MYFLT    frac, *tab1, *tab2, *tab;
-    FUNC     *ftab;
-    float    *fout, *buffer;
-    uint32_t overlap, i;
-    int32_t      N;
-
-    if (*p->hptr != p->optr){
-      char varname[32];
-      snprintf(varname, 32, "::buffer%d", (int32_t)(*p->hptr));
-      phandle = (FSIG_HANDLE **) csound->QueryGlobalVariable(csound,varname);
-      if (phandle == NULL)
-        csound->PerfError(csound, &(p->h),
-                          "%s", Str("error... could not read handle from "
-                              "global variable\n"));
-      else
-        handle = *phandle;
+    if (*p->hptr != p->optr) {
+      FSIG_HANDLE *handle = pvsbuffer_handle(csound, *p->hptr);
+      if (UNLIKELY(handle == NULL))
+        return csound->PerfError(csound, &p->h, "%s", Str("Invalid buffer handle"));
+      p->handle = handle;
+      p->optr = *p->hptr;
     }
+    return OK;
+}
 
-    if (UNLIKELY(handle == NULL)) goto err1;
-    fout = (float *) p->fout->frame.auxp,
-    buffer = handle->data;
-    N = p->fout->N;
-    overlap = p->fout->overlap;
+static int32_t pvsbufreadproc(CSOUND *csound, PVSBUFFERREAD *p)
+{
+    if (UNLIKELY(pvsbufread_handle(csound, p) != OK)) return NOTOK;
+    FSIG_HANDLE *handle = p->handle;
+    int32_t N = p->fout->N;
+    uint32_t overlap = p->fout->overlap;
+    float *fout = (float *) p->fout->frame.auxp;
     if (p->scnt >= overlap) {
-      float *frame1, *frame2;
-      frames = handle->frames-1;
-      ftab = csound->FTFind(csound, p->strt);
-      if (UNLIKELY((int32_t)ftab->flen < N/2+1))
-        csound->PerfError(csound, &(p->h),
-                          Str("table length too small: needed %d, got %d\n"),
-                          N/2+1, ftab->flen);
-      tab = tab1 = ftab->ftable;
-      ftab = csound->FTFind(csound, p->end);
-      if (UNLIKELY((int32_t)ftab->flen < N/2+1))
-        csound->PerfError(csound, &(p->h),
-                          Str("table length too small: needed %d, got %d\n"),
-                          N/2+1, ftab->flen);
-      tab2 = ftab->ftable;
-      for (i=0; i < (uint32_t)N+2; i++){
-        pos = (*p->ktime - tab[i/2])*(sr/overlap);
-           while(pos >= frames) {
-             pos -= frames;
-           }
-           while(pos < 0){
-             pos += frames;
-           }
-           posi = (int32_t) pos;
-        if (N == handle->header.N &&
-            overlap == (uint32_t)handle->header.overlap) {
-           frame1 = buffer + (N + 2) * posi;
-           frame2 = buffer + (N + 2)*(posi != frames-1 ? posi+1 : 0);
-           frac = pos - posi;
-           fout[i] = frame1[i] + frac*(frame2[i] - frame1[i]);
-        } else
-          fout[i] = 0.0f;
-        if (tab == tab1) tab = tab2;
-          else tab = tab1;
+      if (N == handle->header.N && overlap == (uint32_t) handle->header.overlap &&
+          p->fout->format == handle->header.format) {
+        double lo = (double) *p->strt * N / CS_ESR;
+        double hi = (double) *p->end * N / CS_ESR;
+        int32_t first = !(lo > 0) ? 0 : (lo >= N/2 ? N/2 : (int32_t) lo);
+        int32_t last = !(hi > first) || hi >= N/2 ? N/2 : (int32_t) hi;
+        double pos = pvsbuffer_position((double) *p->ktime * CS_ESR / overlap,
+                                       handle->frames);
+        if (UNLIKELY(!(pos >= 0)))
+          return csound->PerfError(csound, &p->h, "%s", Str("Invalid buffer position"));
+        uint32_t index = (uint32_t) pos;
+        uint32_t next = index + 1 == handle->frames ? 0 : index + 1;
+        float *frame1 = handle->data + ((size_t) N + 2) * index;
+        float *frame2 = handle->data + ((size_t) N + 2) * next;
+        MYFLT frac = pos - index;
+        if (*p->clear != FL(0)) memset(fout, 0, ((size_t) N + 2) * sizeof(float));
+        /* Each bin contains an amplitude and a frequency (or phase). */
+        for (int32_t i = first * 2; i <= last * 2; i += 2) {
+          fout[i] = frame1[i] + frac * (frame2[i] - frame1[i]);
+          fout[i+1] = frame1[i+1] + frac * (frame2[i+1] - frame1[i+1]);
+        }
+      } else {
+        memset(fout, 0, ((size_t) N + 2) * sizeof(float));
       }
       p->scnt -= overlap;
       p->fout->framecount++;
     }
     p->scnt += CS_KSMPS;
     return OK;
- err1:
-    return csound->PerfError(csound, &(p->h),
-                             "%s", Str("Invalid buffer handle"));
-  }
+}
 
-
-
+static int32_t pvsbufreadproc2(CSOUND *csound, PVSBUFFERREAD *p)
+{
+    if (UNLIKELY(pvsbufread_handle(csound, p) != OK)) return NOTOK;
+    FSIG_HANDLE *handle = p->handle;
+    int32_t N = p->fout->N;
+    uint32_t overlap = p->fout->overlap;
+    float *fout = (float *) p->fout->frame.auxp;
+    if (p->scnt >= overlap) {
+      FUNC *ftab1 = csound->FTFind(csound, p->strt);
+      if (UNLIKELY(ftab1 == NULL)) return NOTOK;
+      FUNC *ftab2 = csound->FTFind(csound, p->end);
+      if (UNLIKELY(ftab2 == NULL)) return NOTOK;
+      if (UNLIKELY(ftab1->flen < (uint32_t) N/2+1 ||
+                   ftab2->flen < (uint32_t) N/2+1))
+        return csound->PerfError(csound, &p->h, "%s", Str("pvsbufread2: delay table too short"));
+      if (N == handle->header.N && overlap == (uint32_t) handle->header.overlap &&
+          p->fout->format == handle->header.format) {
+        for (int32_t i = 0; i < N+2; i++) {
+          MYFLT *tab = (i & 1) ? ftab2->ftable : ftab1->ftable;
+          double pos = pvsbuffer_position(((double) *p->ktime - tab[i/2]) *
+                                         CS_ESR / overlap, handle->frames);
+          if (UNLIKELY(!(pos >= 0)))
+            return csound->PerfError(csound, &p->h, "%s", Str("Invalid buffer position"));
+          uint32_t index = (uint32_t) pos;
+          uint32_t next = index + 1 == handle->frames ? 0 : index + 1;
+          float *frame1 = handle->data + ((size_t) N + 2) * index;
+          float *frame2 = handle->data + ((size_t) N + 2) * next;
+          MYFLT frac = pos - index;
+          fout[i] = frame1[i] + frac * (frame2[i] - frame1[i]);
+        }
+      } else {
+        memset(fout, 0, ((size_t) N + 2) * sizeof(float));
+      }
+      p->scnt -= overlap;
+      p->fout->framecount++;
+    }
+    p->scnt += CS_KSMPS;
+    return OK;
+}
 
 #define S(x)    sizeof(x)
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -874,6 +874,8 @@ def runTest():
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
+        ["test_pvsbufread_frames.csd", "PVS buffer spectrum and circular reads"],
+        ["test_pvsbuffer_invalid_inputs.csd", "PVS buffers reject invalid inputs", 1],
         ["test_sa.csd", "test sample accurate mode"],
         ["test_diode_ladder_saturation.csd", "diode_ladder saturation and filter history"],
         ["test_pareq_initial_state.csd", "pareq first skip, reset, and preserved state"],

--- a/tests/commandline/test_pvsbuffer_invalid_inputs.csd
+++ b/tests/commandline/test_pvsbuffer_invalid_inputs.csd
@@ -1,0 +1,51 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+giShort ftgen 0, 0, 16, -2, 0
+giValid ftgen 0, 0, -33, -2, 0
+instr 1
+  aInput = 0
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, p4
+endin
+instr 2
+  fRead pvsbufread 0, p4
+endin
+instr 3
+  aInput = 0
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, .125
+  fRead pvsbufread2 kTime, iBuffer, (p4 == 0 ? giShort : giValid), (p4 == 0 ? giValid : giShort)
+endin
+instr 4, 5
+  aInput = 0
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, .125
+  kHandle init iBuffer
+  if p1 == 4 then
+    fRead pvsbufread kTime, kHandle
+  else
+    fRead pvsbufread2 kTime, kHandle, giValid, giValid
+  endif
+  kHandle = -1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0
+i 1 0 .01 -.1
+i 1 0 .01 .0001
+i 1 0 .01 1e20
+i 2 0 .01 -1
+i 2 0 .01 1e20
+i 3 .1 .01 0
+i 3 .1 .01 1
+i 4 .2 .01
+i 5 .2 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsbufread_frames.csd
+++ b/tests/commandline/test_pvsbufread_frames.csd
@@ -1,0 +1,163 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giZero ftgen 0, 0, -33, -2, 0
+giQuarter ftgen 0, 0, -33, -7, 1/2048, 33, 1/2048
+gkChecks init 0
+
+; Reading the current write position must return the complete source frame.
+instr 1
+  kSource[] init 66
+  kRead[] init 66
+  kRead2[] init 66
+  kCycle init 0
+  aRamp phasor 137
+  aTone oscili .2, 3072
+  aInput = aTone+.01*(kCycle+1)*aRamp
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, p4/512
+  kTime += p5*p4/512
+  fRead pvsbufread kTime, iBuffer, p6*128, p7*128, 1
+  fRead2 pvsbufread2 kTime, iBuffer, giZero, giZero
+  kFrame pvs2tab kSource, fInput
+  kFrame pvs2tab kRead, fRead
+  kFrame pvs2tab kRead2, fRead2
+  kIndex = 0
+  while kIndex < 66 do
+    kBin = int(kIndex/2)
+    kExpected = 0
+    if kBin >= p6 && (p7 <= p6 || kBin <= p7) then
+      kExpected = kSource[kIndex]
+    endif
+    if !(abs(kRead[kIndex]-kExpected) <= .001 && abs(kRead2[kIndex]-kSource[kIndex]) <= .001) then
+      printks "pvsbufread frames %g cycle %g index %g: got %g / %g, expected %g / %g\n", 0, p4, kCycle, kIndex, kRead[kIndex], kRead2[kIndex], kExpected, kSource[kIndex]
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; Interpolate between the last frame and the first, including negative times.
+instr 2
+  kSource[] init 66
+  kFirst[] init 66
+  kLast[] init 66
+  kRead[] init 66
+  kRead2[] init 66
+  kCycle init 0
+  aRamp phasor 137
+  aInput = .01*(kCycle+1)*aRamp
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, 2/512
+  kFrame pvs2tab kSource, fInput
+  kIndex = 0
+  while kIndex < 66 do
+    if kTime == 0 then
+      kFirst[kIndex] = kSource[kIndex]
+    else
+      kLast[kIndex] = kSource[kIndex]
+    endif
+    kIndex += 1
+  od
+  fRead pvsbufread p4/512, iBuffer
+  fRead2 pvsbufread2 p4/512, iBuffer, giZero, giQuarter
+  kFrame pvs2tab kRead, fRead
+  kFrame pvs2tab kRead2, fRead2
+  kIndex = 0
+  while kIndex < 66 do
+    kExpected = .75*kLast[kIndex]+.25*kFirst[kIndex]
+    if kIndex % 2 == 0 then
+      kExpected2 = kExpected
+    else
+      kExpected2 = kLast[kIndex]
+    endif
+    if !(abs(kRead[kIndex]-kExpected) <= .001 && abs(kRead2[kIndex]-kExpected2) <= .001) then
+      printks "pvsbufread wrap cycle %g index %g: got %g / %g, expected %g / %g\n", 0, kCycle, kIndex, kRead[kIndex], kRead2[kIndex], kExpected, kExpected2
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 3
+  kSourceA[] init 66
+  kSourceB[] init p4+2
+  kRead[] init 66
+  kRead2[] init 66
+  kCycle init 0
+  aInput oscili .2, 3072
+  fA pvsanal aInput, 64, 16, 64, 1
+  fB pvsanal aInput*2, p4, p5, p4, 1
+  iA, kTimeA pvsbuffer fA, 2/512
+  iB, kTimeB pvsbuffer fB, 2/512
+  kHandle init iA
+  kUseB = (kCycle % 4 >= 2 ? 1 : 0)
+  kHandle = (kUseB == 1 ? iB : iA)
+  fRead pvsbufread kTimeA, kHandle
+  fRead2 pvsbufread2 kTimeA, kHandle, giZero, giZero
+  kFrame pvs2tab kSourceA, fA
+  kFrame pvs2tab kSourceB, fB
+  kFrame pvs2tab kRead, fRead
+  kFrame pvs2tab kRead2, fRead2
+  kIndex = 0
+  while kIndex < 66 do
+    kExpected = (kUseB == 1 ? kSourceB[kIndex] : kSourceA[kIndex])
+    if kUseB == 1 && (p4 != 64 || p5 != 16) then
+      kExpected = 0
+    endif
+    if !(abs(kRead[kIndex]-kExpected) <= .001 && abs(kRead2[kIndex]-kExpected) <= .001) then
+      printks "pvsbufread handle switch failed\n", 0
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 14 then
+    prints "pvsbufread checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Frame count, number of complete wraps, first and last bins.
+i 1 0 .125 1 0 0 0
+i 1 0 .125 2 0 0 0
+i 1 0 .125 3 0 0 0
+i 1 0 .125 3 5 0 0
+i 1 0 .125 3 -5 0 0
+i 1 0 .125 1 1e20 0 0
+i 1 0 .125 1 -1e20 0 0
+i 1 0 .125 3 0 23 25
+i 1 0 .125 3 0 32 32
+i 2 .25 .125 1.25
+i 2 .25 .125 -.75
+i 3 .5 .125 64 16
+i 3 .5 .125 128 16
+i 3 .5 .125 64 32
+i 99 .75 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsbufread` treats bin numbers as float offsets, so it reads the wrong frequency range and omits the upper spectrum. Read complete amplitude/frequency pairs through the selected final bin, including Nyquist.

Both readers wrap over `frames - 1`, dropping the last stored frame and looping forever for a one-frame buffer. Wrap over the full buffer and interpolate from the last frame back to the first, with bounded handling of negative and large time positions.

Reject invalid buffer lengths and handles, and stop on missing or short delay tables before reading them. Reset reused output frames and cache handle changes to avoid repeated lookups.
