### PR TITLE
fix(pvoc): add opt-in analysis-rate file timing

### DIFF
--- a/Opcodes/pvadd.c
+++ b/Opcodes/pvadd.c
@@ -249,7 +249,7 @@ static int32_t pvx_loadfile(CSOUND *csound, const char *fname, PVADD *p)
     p->maxFr    = pp.nframes - 1;
     p->asr      = pp.srate;
     /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-    p->frPrtim = CS_ESR / (MYFLT) pp.overlap;
+    p->frPrtim = p->asr / (MYFLT) pp.overlap;
     return OK;
 }
 

--- a/Opcodes/pvadd.c
+++ b/Opcodes/pvadd.c
@@ -249,7 +249,7 @@ static int32_t pvx_loadfile(CSOUND *csound, const char *fname, PVADD *p)
     p->maxFr    = pp.nframes - 1;
     p->asr      = pp.srate;
     /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-    p->frPrtim = p->asr / (MYFLT) pp.overlap;
+    p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR) / (MYFLT) pp.overlap;
     return OK;
 }
 

--- a/Opcodes/pvadd.h
+++ b/Opcodes/pvadd.h
@@ -34,7 +34,7 @@
 typedef struct {
     OPDS    h;
     MYFLT   *rslt, *ktimpnt, *kfmod, *ifilno, *ifn, *ibins;
-    MYFLT   *ibinoffset, *ibinincr, *imode, *ifreqlim, *igatefun;
+    MYFLT   *ibinoffset, *ibinincr, *imode, *ifreqlim, *igatefun, *ifiletime;
     FUNC    *ftp, *AmpGateFunc;
     AUXCH   auxch;
     MYFLT   *oscphase, *buf, PvMaxAmp;

--- a/Opcodes/pvinterp.c
+++ b/Opcodes/pvinterp.c
@@ -93,7 +93,7 @@ int32_t pvbufreadset_(CSOUND *csound, PVBUFREAD *p, int32_t stringname)
   p->frPtr = (float*) pp.data;
   p->maxFr = pp.nframes - 1;
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
-  p->frPrtim = p->asr / (MYFLT) frInc;
+  p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR) / (MYFLT) frInc;
   p->prFlg = 1;       /* true */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);
@@ -209,7 +209,7 @@ int32_t pvinterpset_(CSOUND *csound, PVINTERP *p, int32_t stringname)
   /* highest possible frame index */
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = p->asr / (MYFLT) frInc;
+  p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR) / (MYFLT) frInc;
   /* factor by which to mulitply 'real' time index to get frame index */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);
@@ -401,7 +401,7 @@ int32_t pvcrossset_(CSOUND *csound, PVCROSS *p, int32_t stringname)
   /* highest possible frame index */
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = p->asr / (MYFLT) frInc;
+  p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR) / (MYFLT) frInc;
   /* factor by which to mulitply 'real' time index to get frame index */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);

--- a/Opcodes/pvinterp.c
+++ b/Opcodes/pvinterp.c
@@ -93,7 +93,7 @@ int32_t pvbufreadset_(CSOUND *csound, PVBUFREAD *p, int32_t stringname)
   p->frPtr = (float*) pp.data;
   p->maxFr = pp.nframes - 1;
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
-  p->frPrtim = CS_ESR / (MYFLT) frInc;
+  p->frPrtim = p->asr / (MYFLT) frInc;
   p->prFlg = 1;       /* true */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);
@@ -209,7 +209,7 @@ int32_t pvinterpset_(CSOUND *csound, PVINTERP *p, int32_t stringname)
   /* highest possible frame index */
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = CS_ESR / (MYFLT) frInc;
+  p->frPrtim = p->asr / (MYFLT) frInc;
   /* factor by which to mulitply 'real' time index to get frame index */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);
@@ -401,7 +401,7 @@ int32_t pvcrossset_(CSOUND *csound, PVCROSS *p, int32_t stringname)
   /* highest possible frame index */
   p->frPktim = (MYFLT) CS_KSMPS / (MYFLT) frInc;
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = CS_ESR / (MYFLT) frInc;
+  p->frPrtim = p->asr / (MYFLT) frInc;
   /* factor by which to mulitply 'real' time index to get frame index */
   /* amplitude scale for PVOC */
   /* p->scale = (MYFLT) pp.fftsize * ((MYFLT) pp.fftsize / (MYFLT) pp.winsize);

--- a/Opcodes/pvinterp.h
+++ b/Opcodes/pvinterp.h
@@ -26,7 +26,7 @@
 
 typedef struct {
     OPDS    h;
-    MYFLT   *ktimpnt, *ifilno;
+    MYFLT   *ktimpnt, *ifilno, *ifiletime;
     int32   maxFr, frSiz, prFlg;
     /* base Frame (in frameData0) and maximum frame on file, ptr to fr, size */
     MYFLT   frPktim, frPrtim, asr, scale;
@@ -40,7 +40,7 @@ typedef struct {
     OPDS    h;
     MYFLT   *rslt, *ktimpnt, *kfmod, *ifilno,
             *kfreqscale1, *kfreqscale2, *kampscale1, *kampscale2,
-            *kfreqinterp, *kampinterp;
+            *kfreqinterp, *kampinterp, *ifiletime;
     int32   kcnt;
     int32   baseFr, maxFr, frSiz, prFlg, opBpos;
      /* base Frame (in frameData0) and maximum frame on file, ptr to fr, size */
@@ -62,7 +62,7 @@ typedef struct {
 typedef struct {
     OPDS    h;
     MYFLT   *rslt, *ktimpnt, *kfmod, *ifilno,
-            *kampscale1, *kampscale2, *ispecwp;
+            *kampscale1, *kampscale2, *ispecwp, *ifiletime;
     int32   kcnt;
     int32   baseFr, maxFr, frSiz, prFlg, opBpos;
     /* base Frame (in frameData0) and maximum frame on file, ptr to fr, size */

--- a/Opcodes/pvoc.c
+++ b/Opcodes/pvoc.c
@@ -44,23 +44,23 @@ int32_t     pvinterpset_S(CSOUND *, void *);
 
 static OENTRY pvoc_localops[] =
   {
-   { "pvoc",      S(PVOC),      0, "a",  "kkSoooo", pvset_S, pvoc        },
-   { "pvoc.i",      S(PVOC),      0, "a",  "kkioooo", pvset, pvoc        },
+   { "pvoc",      S(PVOC),      0, "a",  "kkSooooo", pvset_S, pvoc        },
+   { "pvoc.i",      S(PVOC),      0, "a",  "kkiooooo", pvset, pvoc        },
 { "tableseg",  S(TABLESEG),  TR, "",   "iim",     tblesegset, ktableseg, NULL  },
 { "ktableseg", S(TABLESEG),  _QQ|TR, "",   "iim",  tblesegset, ktableseg, NULL },
 { "tablexseg", S(TABLESEG),  TW, "",   "iin",     tblesegset, ktablexseg, NULL },
    { "vpvoc",     S(VPVOC),     TR, "a",  "kkSoo",   vpvset_S, vpvoc        },
    { "vpvoc.i",     S(VPVOC),     TR, "a",  "kkioo",   vpvset, vpvoc        },
-{ "pvread",    S(PVREAD),  0,  "kk", "kSi",     pvreadset_S, pvread, NULL      },
-{ "pvread.i",    S(PVREAD),  0,  "kk", "kii",     pvreadset, pvread, NULL      },
-   { "pvcross",   S(PVCROSS), 0,  "a",  "kkSkko",  pvcrossset_S, pvcross    },
-{ "pvbufread", S(PVBUFREAD),0, "",   "kS",      pvbufreadset_S, pvbufread, NULL},
-   { "pvinterp",  S(PVINTERP), 0, "a",  "kkSkkkkkk", pvinterpset_S, pvinterp},
-   { "pvcross.i",   S(PVCROSS), 0,  "a",  "kkikko",  pvcrossset, pvcross    },
-{ "pvbufread.i", S(PVBUFREAD),0, "",   "ki",      pvbufreadset, pvbufread, NULL},
-   { "pvinterp.i",  S(PVINTERP), 0, "a",  "kkikkkkkk", pvinterpset, pvinterp},
-   { "pvadd",     S(PVADD),   0,  "a",  "kkSiiopooo", pvaddset_S, pvadd     },
-   { "pvadd.i",     S(PVADD),   0,  "a",  "kkiiiopooo", pvaddset, pvadd     }
+{ "pvread",    S(PVREAD),  0,  "kk", "kSio",     pvreadset_S, pvread, NULL      },
+{ "pvread.i",    S(PVREAD),  0,  "kk", "kiio",     pvreadset, pvread, NULL      },
+   { "pvcross",   S(PVCROSS), 0,  "a",  "kkSkkoo",  pvcrossset_S, pvcross    },
+{ "pvbufread", S(PVBUFREAD),0, "",   "kSo",      pvbufreadset_S, pvbufread, NULL},
+   { "pvinterp",  S(PVINTERP), 0, "a",  "kkSkkkkkko", pvinterpset_S, pvinterp},
+   { "pvcross.i",   S(PVCROSS), 0,  "a",  "kkikkoo",  pvcrossset, pvcross    },
+{ "pvbufread.i", S(PVBUFREAD),0, "",   "kio",      pvbufreadset, pvbufread, NULL},
+   { "pvinterp.i",  S(PVINTERP), 0, "a",  "kkikkkkkko", pvinterpset, pvinterp},
+   { "pvadd",     S(PVADD),   0,  "a",  "kkSiiopoooo", pvaddset_S, pvadd     },
+   { "pvadd.i",     S(PVADD),   0,  "a",  "kkiiiopoooo", pvaddset, pvadd     }
 };
 
 PVOC_GLOBALS *PVOC_AllocGlobals(CSOUND *csound)

--- a/Opcodes/pvread.c
+++ b/Opcodes/pvread.c
@@ -135,7 +135,7 @@ static int32_t pvocex_loadfile(CSOUND *csound, const char *fname, PVREAD *p)
   p->asr      = pp.srate;
   /* highest possible frame index */
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = CS_ESR / ((MYFLT) pp.overlap);
+  p->frPrtim = p->asr / ((MYFLT) pp.overlap);
   return OK;
 }
 

--- a/Opcodes/pvread.c
+++ b/Opcodes/pvread.c
@@ -135,7 +135,7 @@ static int32_t pvocex_loadfile(CSOUND *csound, const char *fname, PVREAD *p)
   p->asr      = pp.srate;
   /* highest possible frame index */
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = p->asr / ((MYFLT) pp.overlap);
+  p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR) / ((MYFLT) pp.overlap);
   return OK;
 }
 

--- a/Opcodes/pvread.h
+++ b/Opcodes/pvread.h
@@ -26,7 +26,7 @@
 
 typedef struct {
     OPDS    h;
-    MYFLT   *kfreq, *kamp, *ktimpnt,  *ifilno, *ibin;
+    MYFLT   *kfreq, *kamp, *ktimpnt,  *ifilno, *ibin, *ifiletime;
     int32   kcnt;
     int32   baseFr, maxFr, frSiz, prFlg;
     /* base Frame (in frameData0) and maximum frame on file, ptr to fr, size */

--- a/Opcodes/ugens8.c
+++ b/Opcodes/ugens8.c
@@ -83,7 +83,7 @@ int32_t pvset_(CSOUND *csound, PVOC *p, int32_t stringname)
   p->mems = memsize;
   p->frPktim = ((MYFLT)CS_KSMPS)/((MYFLT) p->frInc);
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = p->asr/((MYFLT) p->frInc);
+  p->frPrtim = (*p->ifiletime != FL(0.0) ? p->asr : CS_ESR)/((MYFLT) p->frInc);
   /* factor by which to mulitply 'real' time index to get frame index */
   size = pvfrsiz(p);          /* size used in def of OPWLEN ? */
   /* 2*incr/OPWLEN scales down for win ovlp, windo'd 1ce (but 2ce?) */

--- a/Opcodes/ugens8.c
+++ b/Opcodes/ugens8.c
@@ -83,7 +83,7 @@ int32_t pvset_(CSOUND *csound, PVOC *p, int32_t stringname)
   p->mems = memsize;
   p->frPktim = ((MYFLT)CS_KSMPS)/((MYFLT) p->frInc);
   /* factor by which to mult expand phase diffs (ratio of samp spacings) */
-  p->frPrtim = CS_ESR/((MYFLT) p->frInc);
+  p->frPrtim = p->asr/((MYFLT) p->frInc);
   /* factor by which to mulitply 'real' time index to get frame index */
   size = pvfrsiz(p);          /* size used in def of OPWLEN ? */
   /* 2*incr/OPWLEN scales down for win ovlp, windo'd 1ce (but 2ce?) */

--- a/Opcodes/ugens8.h
+++ b/Opcodes/ugens8.h
@@ -51,7 +51,7 @@
 typedef struct {
     OPDS    h;
     MYFLT   *rslt, *ktimpnt, *kfmod, *ifilno, *ispecwp, *imode;
-    MYFLT   *ifreqlim, *igatefun;
+    MYFLT   *ifreqlim, *igatefun, *ifiletime;
     int32   mems;
     int32   kcnt, baseFr, maxFr, frSiz, prFlg, opBpos;
     /* RWD 8:2001 for pvocex: need these too */

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -21,6 +21,10 @@ if(Python3_FOUND)
                 "PYTHONPATH=${CMAKE_SOURCE_DIR}/Python")
         endif()
 
+        if(TARGET csound-bin)
+            list(APPEND _pytest_env "CSOUND_TEST_EXECUTABLE=$<TARGET_FILE:csound-bin>")
+        endif()
+
         add_custom_target(pytests
             COMMAND ${CMAKE_COMMAND} -E env ${_pytest_env}
                     ${Python3_EXECUTABLE} -m unittest discover

--- a/tests/python/test_pvoc_file_time.py
+++ b/tests/python/test_pvoc_file_time.py
@@ -1,0 +1,96 @@
+"""PVOC file positions use the analysis rate, not the output sample rate."""
+
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+import unittest
+
+
+def write_pvx(path, positions):
+    """Write valid mono, 128-point amp/frequency frames at 8192 Hz."""
+    fmt = struct.pack("<HHIIHHHHI", 0xFFFE, 1, 8192, 16384, 2, 16, 62, 16, 0)
+    fmt += bytes.fromhex("c2b912836e2ed411a824de5b96c3ab21")
+    fmt += struct.pack("<IIHHHHIIIIff", 1, 32, 0, 0, 1, 1,
+                       65, 128, 32, 520, 256, 0)
+    frames = []
+    for position in positions:
+        frame = [value for bin_number in range(65)
+                 for value in (0, bin_number * 64)]
+        frame[4] = .0625 + position * .03125
+        frame[5] = 256 + position * 64
+        frames.append(struct.pack("<130f", *frame))
+    data = b"".join(frames)
+    chunks = b"fmt " + struct.pack("<I", len(fmt)) + fmt
+    chunks += b"data" + struct.pack("<I", len(data)) + data
+    path.write_bytes(b"RIFF" + struct.pack("<I", len(chunks) + 4) + b"WAVE" + chunks)
+
+
+class PvocFileTimeTests(unittest.TestCase):
+    def test_file_positions_at_different_output_rates(self):
+        default = Path(__file__).resolve().parents[2] / "build" / "csound"
+        executable = os.environ.get("CSOUND_TEST_EXECUTABLE", str(default))
+        if not Path(executable).is_file():
+            self.skipTest("Set CSOUND_TEST_EXECUTABLE to the built csound command")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_pvx(root / "source.pvx", range(8))
+            for rate in (4096, 8192, 16384):
+                for position in (0, 1, 1.5, 3.25, 7, 10):
+                    with self.subTest(rate=rate, position=position):
+                        expected = min(position, 7)
+                        write_pvx(root / "reference.pvx", [expected] * 8)
+                        csd = f"""<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = {rate}
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giSine ftgen 0, 0, 1024, 10, 1
+instr 1
+  kTime = {position / 256}
+  kFreq, kAmp pvread kTime, "source.pvx", 2
+  if abs(kFreq - {256 + expected * 64}) > .001 || abs(kAmp - {.0625 + expected * .03125}) > .00001 then
+    printks "pvread selected the wrong analysis frame\\n", 0
+    exitnowk -1
+  endif
+  aAdd pvadd kTime, 1, "source.pvx", giSine, 1, 2
+  aAddRef pvadd 0, 1, "reference.pvx", giSine, 1, 2
+  aVoc pvoc kTime, 1, "source.pvx"
+  aVocRef pvoc 0, 1, "reference.pvx"
+  pvbufread kTime, "source.pvx"
+  aInterp pvinterp kTime, 1, "source.pvx", 1, 1, 1, 1, .5, .5
+  pvbufread 0, "reference.pvx"
+  aInterpRef pvinterp 0, 1, "reference.pvx", 1, 1, 1, 1, .5, .5
+  pvbufread kTime, "source.pvx"
+  aCross pvcross kTime, 1, "source.pvx", .5, .5
+  pvbufread 0, "reference.pvx"
+  aCrossRef pvcross 0, 1, "reference.pvx", .5, .5
+  aError = abs(aAdd-aAddRef) + abs(aVoc-aVocRef) + abs(aInterp-aInterpRef) + abs(aCross-aCrossRef)
+  kError max_k aError, 1, 1
+  if kError > .0001 then
+    printks "PVOC synthesis selected the wrong analysis frame: %g\\n", 0, kError
+    exitnowk -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03125
+e
+</CsScore>
+</CsoundSynthesizer>
+"""
+                        path = root / "read.csd"
+                        path.write_text(csd)
+                        result = subprocess.run([executable, str(path)], cwd=root,
+                                                capture_output=True, text=True)
+                        self.assertEqual(result.returncode, 0,
+                                         result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_pvoc_file_time.py
+++ b/tests/python/test_pvoc_file_time.py
@@ -1,6 +1,7 @@
-"""PVOC file positions use the analysis rate, not the output sample rate."""
+"""PVOC file time is opt-in; existing calls retain the output-rate timebase."""
 
 import os
+from itertools import product
 from pathlib import Path
 import struct
 import subprocess
@@ -36,11 +37,20 @@ class PvocFileTimeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_pvx(root / "source.pvx", range(8))
+            write_pvx(root / "pvoc.1", range(8))
             for rate in (4096, 8192, 16384):
-                for position in (0, 1, 1.5, 3.25, 7, 10):
-                    with self.subTest(rate=rate, position=position):
-                        expected = min(position, 7)
+                for mode, position, numeric in product(
+                        (None, 0, 1), (0, 1, 1.5, 3.25, 7, 10), (False, True)):
+                    with self.subTest(rate=rate, position=position, mode=mode, numeric=numeric):
+                        expected = min(position if mode else position * rate / 8192, 7)
+                        suffix = "" if mode is None else f", {mode}"
+                        add_suffix = "" if mode is None else f", 1, 0, 0, 0, {mode}"
+                        voc_suffix = "" if mode is None else f", 0, 0, 0, 0, {mode}"
+                        cross_suffix = "" if mode is None else f", 0, {mode}"
                         write_pvx(root / "reference.pvx", [expected] * 8)
+                        write_pvx(root / "pvoc.2", [expected] * 8)
+                        source_name = "1" if numeric else '"source.pvx"'
+                        reference_name = "2" if numeric else '"reference.pvx"'
                         csd = f"""<CsoundSynthesizer>
 <CsOptions>
 -n -d -m0
@@ -53,23 +63,23 @@ nchnls = 1
 giSine ftgen 0, 0, 1024, 10, 1
 instr 1
   kTime = {position / 256}
-  kFreq, kAmp pvread kTime, "source.pvx", 2
+  kFreq, kAmp pvread kTime, {source_name}, 2{suffix}
   if abs(kFreq - {256 + expected * 64}) > .001 || abs(kAmp - {.0625 + expected * .03125}) > .00001 then
     printks "pvread selected the wrong analysis frame\\n", 0
     exitnowk -1
   endif
-  aAdd pvadd kTime, 1, "source.pvx", giSine, 1, 2
-  aAddRef pvadd 0, 1, "reference.pvx", giSine, 1, 2
-  aVoc pvoc kTime, 1, "source.pvx"
-  aVocRef pvoc 0, 1, "reference.pvx"
-  pvbufread kTime, "source.pvx"
-  aInterp pvinterp kTime, 1, "source.pvx", 1, 1, 1, 1, .5, .5
-  pvbufread 0, "reference.pvx"
-  aInterpRef pvinterp 0, 1, "reference.pvx", 1, 1, 1, 1, .5, .5
-  pvbufread kTime, "source.pvx"
-  aCross pvcross kTime, 1, "source.pvx", .5, .5
-  pvbufread 0, "reference.pvx"
-  aCrossRef pvcross 0, 1, "reference.pvx", .5, .5
+  aAdd pvadd kTime, 1, {source_name}, giSine, 1, 2{add_suffix}
+  aAddRef pvadd 0, 1, {reference_name}, giSine, 1, 2{add_suffix}
+  aVoc pvoc kTime, 1, {source_name}{voc_suffix}
+  aVocRef pvoc 0, 1, {reference_name}{voc_suffix}
+  pvbufread kTime, {source_name}{suffix}
+  aInterp pvinterp kTime, 1, {source_name}, 1, 1, 1, 1, .5, .5{suffix}
+  pvbufread 0, {reference_name}{suffix}
+  aInterpRef pvinterp 0, 1, {reference_name}, 1, 1, 1, 1, .5, .5{suffix}
+  pvbufread kTime, {source_name}{suffix}
+  aCross pvcross kTime, 1, {source_name}, .5, .5{cross_suffix}
+  pvbufread 0, {reference_name}{suffix}
+  aCrossRef pvcross 0, 1, {reference_name}, .5, .5{cross_suffix}
   aError = abs(aAdd-aAddRef) + abs(aVoc-aVocRef) + abs(aInterp-aInterpRef) + abs(aCross-aCrossRef)
   kError max_k aError, 1, 1
   if kError > .0001 then
@@ -86,7 +96,7 @@ e
 """
                         path = root / "read.csd"
                         path.write_text(csd)
-                        result = subprocess.run([executable, str(path)], cwd=root,
+                        result = subprocess.run([executable, path.name], cwd=root,
                                                 capture_output=True, text=True)
                         self.assertEqual(result.returncode, 0,
                                          result.stdout + result.stderr)


### PR DESCRIPTION
Add a trailing optional `ifiletime` argument to `pvoc`, `pvadd`, `pvread`, `pvbufread`, `pvinterp`, and `pvcross`, for both string and numeric filenames.

The default, 0, preserves the output-rate time mapping used by existing scores. Set it to 1 to convert the time pointer using the analysis file’s sample rate, so it addresses seconds in the source recording when input and output rates differ.

Documentation: csound/manual#797.
