### PR TITLE
fix(phasorbnk): preserve bank state across resizing

### DIFF
--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1185,43 +1185,74 @@ int32_t phsbnkset(CSOUND *csound, PHSORBNK *p)
     int32_t    n, count;
     double  *curphs;
 
-    count = (int32_t)MYFLT2LONG(*p->icnt);
-    if (UNLIKELY(count < 2))
-      count = 2;
+    if (UNLIKELY(!((double)*p->icnt <= (double)INT32_MAX - 0.5)))
+      return csound->InitError(csound, "%s", Str("phasorbnk: invalid bank size"));
+    count = *p->icnt < FL(2.0) ? 2 : (int32_t)MYFLT2LONG(*p->icnt);
+    if (UNLIKELY((size_t)count > SIZE_MAX / sizeof(double)))
+      return csound->InitError(csound, "%s", Str("phasorbnk: bank size too large"));
 
-    if (p->curphs.auxp==NULL || p->curphs.size < (size_t)sizeof(double)*count)
-      csound->AuxAlloc(csound, (size_t)sizeof(double)*count, &p->curphs);
+    if (p->curphs.auxp==NULL || p->curphs.size < sizeof(double)*(size_t)count) {
+      /* AuxAlloc clears a resized buffer, even when initialization is skipped. */
+      double *saved = NULL;
+      size_t oldBytes = sizeof(double)*(size_t)p->count;
+      if (*p->iphs < FL(0.0) && p->curphs.auxp != NULL) {
+        saved = csound->Malloc(csound, oldBytes);
+        memcpy(saved, p->curphs.auxp, oldBytes);
+      }
+      csound->AuxAlloc(csound, sizeof(double)*(size_t)count, &p->curphs);
+      if (saved != NULL) {
+        memcpy(p->curphs.auxp, saved, oldBytes);
+        csound->Free(csound, saved);
+      }
+    }
+    else if (*p->iphs < FL(0.0) && count > p->count) {
+      memset((double*)p->curphs.auxp + p->count, 0,
+             sizeof(double)*(size_t)(count - p->count));
+    }
 
     curphs = (double*)p->curphs.auxp;
     if (*p->iphs > 1) {
-      for (n=0; n<count;n++)
+      for (n=0; n<count;n++) {
         curphs[n] = (double) rand_31(csound) / 2147483645.0;
+        if (curphs[n] == 1.0) curphs[n] = 0.0;
+      }
     }
     else if ((phs = *p->iphs) >= 0) {
+      if (phs == 1.0) phs = 0.0;
       for (n=0; n<count;n++) curphs[n] = phs;
     }
+    p->count = count;
     return OK;
 }
+
+/* Remove whole cycles before adding, retaining the phase for large increments.
+   With control-rate frequency this runs only once per control block. */
+#define PHSBNK_REDUCE_INCREMENT(incr) do {                            \
+    if (UNLIKELY((incr) >= 1.0 || (incr) <= -1.0))                   \
+      (incr) -= trunc(incr);                                        \
+  } while (0)
 
 int32_t kphsorbnk(CSOUND *csound, PHSORBNK *p)
 {
     double  phs;
     double  *curphs = (double*)p->curphs.auxp;
-    uint64_t     size = p->curphs.size / sizeof(double);
-    int32_t     index = (int32_t)(*p->kindx);
+    int32_t     index;
 
     if (UNLIKELY(curphs == NULL)) {
       return csound->PerfError(csound, &(p->h),
                                "%s", Str("phasorbnk: not initialised"));
     }
 
-    if (UNLIKELY(index<0 || (uint64_t) index>=size)) {
+    if (UNLIKELY(!(*p->kindx >= FL(0.0) && (double)*p->kindx < p->count))) {
       *p->sr = FL(0.0);
-      return NOTOK;
+      return csound->PerfError(csound, &p->h, "%s", Str("phasorbnk: invalid index"));
     }
+    index = (int32_t)*p->kindx;
 
     *p->sr = (MYFLT)(phs = curphs[index]);
-    if (UNLIKELY((phs += *p->xcps * CS_ONEDKR) >= 1.0))
+    double incr = *p->xcps * CS_ONEDKR;
+    PHSBNK_REDUCE_INCREMENT(incr);
+    if (UNLIKELY((phs += incr) >= 1.0))
       phs -= 1.0;
     else if (UNLIKELY(phs < 0.0)) /* patch from Matthew Scala */
       phs += 1.0;
@@ -1237,18 +1268,18 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     MYFLT   *rs;
     double  phase, incr;
     double  *curphs = (double*)p->curphs.auxp;
-    uint64_t     size = p->curphs.size / sizeof(double);
-    int32_t     index = (int32_t)(*p->kindx);
+    int32_t     index;
 
     if (UNLIKELY(curphs == NULL)) {
       return csound->PerfError(csound, &(p->h),
                                "%s", Str("phasorbnk: not initialised"));
     }
 
-    if (UNLIKELY(index<0 || (uint64_t) index>=size)) {
-      *p->sr = FL(0.0);
-      return NOTOK;
+    if (UNLIKELY(!(*p->kindx >= FL(0.0) && (double)*p->kindx < p->count))) {
+      memset(p->sr, 0, nsmps*sizeof(MYFLT));
+      return csound->PerfError(csound, &p->h, "%s", Str("phasorbnk: invalid index"));
     }
+    index = (int32_t)*p->kindx;
 
     rs = p->sr;
     phase = curphs[index];
@@ -1261,6 +1292,7 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
       MYFLT *cps = p->xcps;
       for (n=offset; n<nsmps; n++) {
         incr = (double)(cps[n] * CS_ONEDSR);
+        PHSBNK_REDUCE_INCREMENT(incr);
         rs[n] = (MYFLT)phase;
         phase += incr;
         if (UNLIKELY(phase >= 1.0))
@@ -1271,6 +1303,7 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     }
     else {
       incr = (double)(*p->xcps * CS_ONEDSR);
+      PHSBNK_REDUCE_INCREMENT(incr);
       for (n=offset; n<nsmps; n++) {
         rs[n] = (MYFLT)phase;
         phase += incr;
@@ -1283,6 +1316,8 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     curphs[index] = phase;
     return OK;
 }
+
+#undef PHSBNK_REDUCE_INCREMENT
 
 /* Opcodes from rasmus ekman */
 

--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1225,13 +1225,6 @@ int32_t phsbnkset(CSOUND *csound, PHSORBNK *p)
     return OK;
 }
 
-/* Remove whole cycles before adding, retaining the phase for large increments.
-   With control-rate frequency this runs only once per control block. */
-#define PHSBNK_REDUCE_INCREMENT(incr) do {                            \
-    if (UNLIKELY((incr) >= 1.0 || (incr) <= -1.0))                   \
-      (incr) -= trunc(incr);                                        \
-  } while (0)
-
 int32_t kphsorbnk(CSOUND *csound, PHSORBNK *p)
 {
     double  phs;
@@ -1250,9 +1243,7 @@ int32_t kphsorbnk(CSOUND *csound, PHSORBNK *p)
     index = (int32_t)*p->kindx;
 
     *p->sr = (MYFLT)(phs = curphs[index]);
-    double incr = *p->xcps * CS_ONEDKR;
-    PHSBNK_REDUCE_INCREMENT(incr);
-    if (UNLIKELY((phs += incr) >= 1.0))
+    if (UNLIKELY((phs += *p->xcps * CS_ONEDKR) >= 1.0))
       phs -= 1.0;
     else if (UNLIKELY(phs < 0.0)) /* patch from Matthew Scala */
       phs += 1.0;
@@ -1292,7 +1283,6 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
       MYFLT *cps = p->xcps;
       for (n=offset; n<nsmps; n++) {
         incr = (double)(cps[n] * CS_ONEDSR);
-        PHSBNK_REDUCE_INCREMENT(incr);
         rs[n] = (MYFLT)phase;
         phase += incr;
         if (UNLIKELY(phase >= 1.0))
@@ -1303,7 +1293,6 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     }
     else {
       incr = (double)(*p->xcps * CS_ONEDSR);
-      PHSBNK_REDUCE_INCREMENT(incr);
       for (n=offset; n<nsmps; n++) {
         rs[n] = (MYFLT)phase;
         phase += incr;
@@ -1316,8 +1305,6 @@ int32_t phsorbnk(CSOUND *csound, PHSORBNK *p)
     curphs[index] = phase;
     return OK;
 }
-
-#undef PHSBNK_REDUCE_INCREMENT
 
 /* Opcodes from rasmus ekman */
 

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -224,6 +224,7 @@ typedef struct {
         OPDS    h;
         MYFLT   *sr, *xcps, *kindx, *icnt, *iphs;
         AUXCH   curphs;
+        int32_t count;
 } PHSORBNK;
 
 /* pinkish opcode... Two methods for generating pink noise */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -872,6 +872,10 @@ def runTest():
             1,
         ],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
+
+        ["test_phasorbnk_phase_state.csd", "phasorbnk phase wrapping and bank state"],
+
+        ["test_phasorbnk_invalid_inputs.csd", "reject invalid phasorbnk bank sizes and indices", 1],
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -873,7 +873,7 @@ def runTest():
         ],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
 
-        ["test_phasorbnk_phase_state.csd", "phasorbnk phase wrapping and bank state"],
+        ["test_phasorbnk_phase_state.csd", "phasorbnk bank resizing and phase state"],
 
         ["test_phasorbnk_invalid_inputs.csd", "reject invalid phasorbnk bank sizes and indices", 1],
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],

--- a/tests/commandline/test_phasorbnk_invalid_inputs.csd
+++ b/tests/commandline/test_phasorbnk_invalid_inputs.csd
@@ -1,0 +1,47 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+instr 1
+  kPhase phasorbnk 100, 0, p4
+endin
+instr 2
+  kPhase phasorbnk 100, p4, 2
+endin
+instr 3
+  aPhase phasorbnk 100, p4, 2
+endin
+instr 4, 5
+  kCount init 4
+  kCycle init 0
+  if kCycle == 2 then
+    kCount = 2
+    reinit RESIZE
+  endif
+RESIZE:
+  if p1 == 4 then
+    kPhase phasorbnk 100, 3, i(kCount)
+  else
+    aPhase phasorbnk 100, 3, i(kCount)
+  endif
+  rireturn
+  kCycle += 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 1e20
+i 2 .1 .01 -1
+i 2 .1 .01 2
+i 2 .1 .01 1e20
+i 3 .1 .01 -1
+i 3 .1 .01 2
+i 3 .1 .01 1e20
+i 4 .2 .01
+i 5 .2 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_phasorbnk_phase_state.csd
+++ b/tests/commandline/test_phasorbnk_phase_state.csd
@@ -34,7 +34,7 @@ instr 2
   kExpectedK init (p5 == 1 ? 0 : p5)
   kExpectedA init (p5 == 1 ? 0 : p5)
   aRamp phasor sr/16
-  aCps = (p4+aRamp)*sr
+  aCps = (p4+aRamp*.125)*sr
   aPhaseK phasorbnk p4*sr, 0, 2, p5
   aPhaseA phasorbnk aCps, 0, 2, p5
   aInPlace = aCps
@@ -53,7 +53,7 @@ instr 2
       endif
       kExpectedK += p4-int(p4)
       kExpectedK -= floor(kExpectedK)
-      kIncrement = p4+(kSamples % 16)/16
+      kIncrement = p4+(kSamples % 16)/128
       kExpectedA += kIncrement-int(kIncrement)
       kExpectedA -= floor(kExpectedA)
       kSamples += 1
@@ -108,7 +108,7 @@ RESTART:
 endin
 
 instr 99
-  if i(gkChecks) != 18 then
+  if i(gkChecks) != 12 then
     prints "phasorbnk checks did not finish\n"
     exitnow -1
   endif
@@ -117,20 +117,14 @@ endin
 <CsScore>
 ; Cycles per control update, phase, bank count, bank index.
 i 1 0 .0625 .25 0 2 0
-i 1 0 .0625 2.5 0 2 0
-i 1 0 .0625 -2.5 0 2 0
-i 1 0 .0625 10.25 .25 2 1.75
-i 1 0 .0625 1e20 .25 2 0
+i 1 0 .0625 -.25 .25 2 1.75
 i 1 0 .0625 0 1 2 0
 i 1 0 .0625 .25 -1 0 1
-; Cycles per sample and initial phase, including partial blocks.
+; Ordinary audio rates, including reverse ramps and partial blocks.
 i 2 .125 .00390625 .25 0
-i 2 .125 .00390625 2.5 .25
-i 2 .125 .00390625 -2.5 .25
-i 2 .125 .00390625 10.25 1
-i 2 .125 .00390625 1e20 .25
-i 2 .1256103515625 .0042724609375 2.5 .25
-i 2 .1256103515625 .0042724609375 -2.5 .25
+i 2 .125 .00390625 -.25 .25
+i 2 .1256103515625 .0042724609375 .25 .25
+i 2 .1256103515625 .0042724609375 -.25 .25
 i 2 .1268310546875 .0001220703125 .25 1
 ; Initial, second, and third bank counts.
 i 3 .25 .0625 2 4 4

--- a/tests/commandline/test_phasorbnk_phase_state.csd
+++ b/tests/commandline/test_phasorbnk_phase_state.csd
@@ -1,0 +1,142 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  kCycle init 0
+  kExpected init (p5 == 1 || p5 < 0 ? 0 : p5)
+  kIncrement = (kCycle < 4 ? p4 : -p4)
+  kPhase phasorbnk kIncrement*kr, p7, p6, p5
+  if !(abs(kPhase-kExpected) < .00001) then
+    printks "phasorbnk control phase: got %g, expected %g\n", 0, kPhase, kExpected
+    exitnowk -1
+  endif
+  kExpected += kIncrement-int(kIncrement)
+  kExpected -= floor(kExpected)
+  kCycle += 1
+  if kCycle == 12 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 2
+  iOffset = int(p2*sr+.5) % ksmps
+  iSamples = int(p3*sr+.5)
+  kSamples init 0
+  kExpectedK init (p5 == 1 ? 0 : p5)
+  kExpectedA init (p5 == 1 ? 0 : p5)
+  aRamp phasor sr/16
+  aCps = (p4+aRamp)*sr
+  aPhaseK phasorbnk p4*sr, 0, 2, p5
+  aPhaseA phasorbnk aCps, 0, 2, p5
+  aInPlace = aCps
+  aInPlace phasorbnk aInPlace, 0, 2, p5
+  kStart = (kSamples == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart+iSamples-kSamples)
+  kIndex = 0
+  while kIndex < ksmps do
+    kPhaseK vaget kIndex, aPhaseK
+    kPhaseA vaget kIndex, aPhaseA
+    kInPlace vaget kIndex, aInPlace
+    if kIndex >= kStart && kIndex < kEnd then
+      if !(abs(kPhaseK-kExpectedK) < .00001 && abs(kPhaseA-kExpectedA) < .00001 && abs(kInPlace-kExpectedA) < .00001) then
+        printks "phasorbnk audio phase at sample %g: got %g / %g / %g, expected %g / %g\n", 0, kSamples, kPhaseK, kPhaseA, kInPlace, kExpectedK, kExpectedA
+        exitnowk -1
+      endif
+      kExpectedK += p4-int(p4)
+      kExpectedK -= floor(kExpectedK)
+      kIncrement = p4+(kSamples % 16)/16
+      kExpectedA += kIncrement-int(kIncrement)
+      kExpectedA -= floor(kExpectedA)
+      kSamples += 1
+    elseif kPhaseK != 0 || kPhaseA != 0 || kInPlace != 0 then
+      printks "phasorbnk wrote outside the active samples\n", 0
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  if kSamples == iSamples then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; Keep old phases when growing, and start newly enabled banks at zero.
+instr 3
+  kCount init p4
+  kInitial init .25
+  kCycle init 0
+  kExpected[] init 8
+  iIndex = 0
+  while iIndex < p4 do
+    kExpected[iIndex] init .25
+    iIndex += 1
+  od
+  if kCycle == 4 || kCycle == 8 then
+    kNewCount = (kCycle == 4 ? p5 : p6)
+    kIndex = kCount
+    while kIndex < kNewCount do
+      kExpected[kIndex] = 0
+      kIndex += 1
+    od
+    kCount = kNewCount
+    kInitial = -1
+    reinit RESTART
+  endif
+  kIndex = kCycle % kCount
+RESTART:
+  kPhase phasorbnk kr/8, kIndex, i(kCount), i(kInitial)
+  rireturn
+  if !(abs(kPhase-kExpected[kIndex]) < .00001) then
+    printks "phasorbnk reinit cycle %g bank %g: got %g, expected %g\n", 0, kCycle, kIndex, kPhase, kExpected[kIndex]
+    exitnowk -1
+  endif
+  kExpected[kIndex] = frac(kExpected[kIndex]+.125)
+  kCycle += 1
+  if kCycle == 16 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 18 then
+    prints "phasorbnk checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Cycles per control update, phase, bank count, bank index.
+i 1 0 .0625 .25 0 2 0
+i 1 0 .0625 2.5 0 2 0
+i 1 0 .0625 -2.5 0 2 0
+i 1 0 .0625 10.25 .25 2 1.75
+i 1 0 .0625 1e20 .25 2 0
+i 1 0 .0625 0 1 2 0
+i 1 0 .0625 .25 -1 0 1
+; Cycles per sample and initial phase, including partial blocks.
+i 2 .125 .00390625 .25 0
+i 2 .125 .00390625 2.5 .25
+i 2 .125 .00390625 -2.5 .25
+i 2 .125 .00390625 10.25 1
+i 2 .125 .00390625 1e20 .25
+i 2 .1256103515625 .0042724609375 2.5 .25
+i 2 .1256103515625 .0042724609375 -2.5 .25
+i 2 .1268310546875 .0001220703125 .25 1
+; Initial, second, and third bank counts.
+i 3 .25 .0625 2 4 4
+i 3 .25 .0625 4 2 4
+i 3 .25 .0625 2 2 2
+i 99 .5 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Preserve retained bank phases when negative `iphs` skips initialization during resizing, and initialize newly enabled banks to zero. Track the current bank count so removed indices cannot access retained storage.

Validate bank sizes and indices, and normalize an initial phase of 1 to 0. Frequency updates keep their existing behavior.

Documentation: csound/manual#797.
