### PR TITLE
Fix pvsfilter gain and note boundaries in sliding-DFT mode

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -1493,26 +1493,24 @@ static int32_t pvsmix(CSOUND *csound, PVSMIX *p)
 static int32_t pvsfilterset(CSOUND *csound, PVSFILTER *p)
 {
   int32    N = p->fin->N;
+  size_t bytes = ((size_t)N + 2) * sizeof(float);
 
   if (UNLIKELY(p->fin == p->fout || p->fil == p->fout))
     csound->Warning(csound, "%s", Str("Unsafe to have same fsig as in and out"));
-  if (UNLIKELY(!((p->fout->format == PVS_AMP_FREQ) ||
-                 (p->fout->format == PVS_AMP_PHASE))))
+  if (UNLIKELY(!((p->fin->format == PVS_AMP_FREQ) ||
+                 (p->fin->format == PVS_AMP_PHASE))))
     return csound->InitError(csound, "%s", Str("pvsfilter: signal format "
                                          "must be amp-phase or amp-freq."));
   p->fout->sliding = 0;
   if (p->fin->sliding) {
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(MYFLT) * CS_KSMPS * (N + 2))
-      csound->AuxAlloc(csound, sizeof(MYFLT) * CS_KSMPS * (N + 2),
-                       &p->fout->frame);
+    bytes = sizeof(MYFLT) * CS_KSMPS * ((size_t)N + 2);
     p->fout->NB = p->fin->NB;
     p->fout->sliding = 1;
   }
+  if (p->fout->frame.auxp == NULL || p->fout->frame.size < bytes)
+    csound->AuxAlloc(csound, bytes, &p->fout->frame);
   else
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(float) * (N + 2))
-      csound->AuxAlloc(csound, sizeof(float) * (N + 2), &p->fout->frame);
+    memset(p->fout->frame.auxp, 0, bytes);
   p->fout->N = N;
   p->fout->overlap = p->fin->overlap;
   p->fout->winsize = p->fin->winsize;
@@ -1538,24 +1536,30 @@ static int32_t pvsfilter(CSOUND *csound, PVSFILTER *p)
 
   if (p->fin->sliding) {
     int32_t NB = p->fout->NB;
+    int32_t asig = IS_ASIG_ARG(p->kdepth);
     uint32_t offset = p->h.insdshead->ksmps_offset;
+    uint32_t early = p->h.insdshead->ksmps_no_end;
     uint32_t n, nsmps = CS_KSMPS;
     CMPLX *fin, *fout, *fil;
     MYFLT g = *p->gain;
     kdepth = kdepth >= FL(0.0) ? (kdepth <= FL(1.0) ? kdepth*g : g) : FL(0.0);
-    dirgain = (FL(1.0) - kdepth)*g;
-    for (n=0; n<offset; n++) {
-      fout = (CMPLX *)p->fout->frame.auxp + NB*n;
-      for (i = 0; i < NB; i++) fout[i].re = fout[i].im = FL(0.0);
+    /* Both the direct and filtered parts receive the output gain once. */
+    dirgain = g - kdepth;
+    if (UNLIKELY(offset))
+      memset(p->fout->frame.auxp, 0, sizeof(CMPLX)*(size_t)NB*offset);
+    if (UNLIKELY(early)) {
+      nsmps -= early;
+      memset((CMPLX *)p->fout->frame.auxp + (size_t)NB*nsmps, 0,
+             sizeof(CMPLX)*(size_t)NB*early);
     }
     for (n=offset; n<nsmps; n++) {
-      fin = (CMPLX *)p->fin->frame.auxp + NB*n;
-      fout = (CMPLX *)p->fout->frame.auxp + NB*n;
-      fil = (CMPLX *)p->fil->frame.auxp + NB*n;
-      if (IS_ASIG_ARG(p->kdepth)) {
+      fin = (CMPLX *)p->fin->frame.auxp + (size_t)NB*n;
+      fout = (CMPLX *)p->fout->frame.auxp + (size_t)NB*n;
+      fil = (CMPLX *)p->fil->frame.auxp + (size_t)NB*n;
+      if (asig) {
         kdepth = p->kdepth[n] >= FL(0.0) ?
           (p->kdepth[n] <= FL(1.0) ? p->kdepth[n]*g : g) : FL(0.0);
-        dirgain = (FL(1.0) - kdepth)*g;
+        dirgain = g - kdepth;
       }
       for (i = 0; i < NB; i++) {
         fout[i].re = fin[i].re * (dirgain + fil[i].re * kdepth);

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -897,6 +897,8 @@ def runTest():
         ["test_pvsinit_invalid_parameters.csd", "reject invalid pvsinit parameters", 1],
         ["test_pvstencil_gain.csd", "pvstencil gain and reused FFT/sliding outputs"],
         ["test_pvstencil_invalid_inputs.csd", "reject invalid pvstencil inputs", 1],
+        ["test_pvsfilter_gain.csd", "pvsfilter gain and sliding sample range"],
+        ["test_pvsfilter_invalid_format.csd", "reject unsupported pvsfilter input format", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
         ["test_shift_array_state.csd", "shiftin and shiftout sample state"],

--- a/tests/commandline/test_pvsfilter_gain.csd
+++ b/tests/commandline/test_pvsfilter_gain.csd
@@ -1,0 +1,103 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+gfSource pvsinit 64, 16, 64, 1
+gfFiltered pvsinit 64, 16, 64, 1
+
+; Applying the optional gain must equal a separate pvsgain after filtering.
+instr 1, 2
+  kCycle init 0
+  aIn oscili .25, 1024
+  aFilter oscili .5, 1024
+  fIn pvsanal aIn, 64, p6, 64, 1
+  fFilter pvsanal aFilter, 64, p6, 64, 1
+  if p1 == 1 then
+    fUnit pvsfilter fIn, fFilter, p4, 1
+    fActual pvsfilter fIn, fFilter, p4, p5
+  else
+    aRamp phasor 128
+    aDepth = p4+aRamp
+    fUnit pvsfilter fIn, fFilter, aDepth, 1
+    fActual pvsfilter fIn, fFilter, aDepth, p5
+  endif
+  fExpected pvsgain fUnit, p5
+  aExpected pvsynth fExpected
+  aActual pvsynth fActual
+  aError = abs(aExpected-aActual)
+  kError max_k aError, 1, 1
+  if !(kError < .00001) then
+    printks "pvsfilter depth %g gain %g hop %g: error %g\n", 0, p4, p5, p6, kError
+    exitnowk -1
+  endif
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; A shared input remains active beyond the filtering note's sample range.
+instr 10
+  aIn oscili .25, 1024
+  gfSource pvsanal aIn, 64, 1, 64, 1
+endin
+
+instr 11
+  gfFiltered pvsfilter gfSource, gfSource, 0, 1
+endin
+
+instr 12
+  kCentroid pvscent gfFiltered
+  if kCentroid != 0 then
+    printks "pvsfilter left a spectrum outside the active samples: %g\n", 0, kCentroid
+    exitnowk -1
+  endif
+  gkChecks += 1
+  turnoff
+endin
+
+instr 99
+  if i(gkChecks) != 21 then
+    prints "pvsfilter checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Depth, gain, hop. Hop 1 selects sliding DFT; hop 16 uses FFT frames.
+i 1 0 .125 1 2 1
+i 1 0 .125 .25 2 1
+i 1 0 .125 1 .5 1
+i 1 0 .125 1 0 1
+i 1 0 .125 1 -1 1
+i 1 0 .125 1 1 1
+i 1 0 .125 0 2 1
+i 1 0 .125 -1 2 1
+i 1 0 .125 2 2 1
+i 1 0 .125 1 2 16
+i 1 0 .125 .25 2 16
+i 1 0 .125 1 .5 16
+i 1 0 .125 1 0 16
+i 2 .25 .125 0 2 1
+i 2 .25 .125 -.5 .5 1
+i 2 .25 .125 .5 2 1
+i 2 .25 .125 0 0 1
+; Reuse note instances with different gains.
+i 1 .5 .125 1 .5 1
+i 2 .5 .125 0 .5 1
+i 10 .75 .125
+; Start at sample 5, finish at sample 11 of a later block.
+i 11 .7818603515625 .004638671875
+i 12 .7816162109375 .0001220703125
+i 12 .7864990234375 .0001220703125
+i 99 1 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvsfilter_invalid_format.csd
+++ b/tests/commandline/test_pvsfilter_invalid_format.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+instr 1
+  fInput pvsinit 64, 16, 64, 1, 2
+  fOutput pvsfilter fInput, fInput, 1
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsfilter` applies its optional gain incorrectly in sliding-DFT mode (for example, `pvsanal` with hop 1 and `ksmps = 16`). The gain changes the mix between direct and filtered amplitudes instead of scaling the result. At depth 1 and gain 2, it adds an unwanted term of minus twice the input amplitude. Gain 1 hides the error.

Compute the direct share as `gain - depth * gain`, so the output is `input * gain * ((1 - depth) + filter * depth)`. This covers scalar and audio-rate depth. The standard FFT gain calculation stays unchanged, and the bin loop gains no function calls.

Also clear spectra outside the note's active sample range, including its final partial block; clear reused output frames on initialization; and check the input format so unsupported complex spectra cannot pass through the amp/frequency or amp/phase path.
