### PR TITLE
Fix pvsinit frame initialization in FFT and sliding-DFT modes

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -126,46 +126,66 @@ static int32_t pvsgain(CSOUND *csound, PVSGAIN *p)
 
 static int32_t pvsinit(CSOUND *csound, PVSINI *p)
 {
-  int32_t     i;
-  uint32_t offset = p->h.insdshead->ksmps_offset;
-  uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t n, nsmps = CS_KSMPS;
-  float   *bframe;
-  int32    N = (int32) *p->framesize;
+  double size = *p->framesize;
+  double overlap = *p->olap, winsize = *p->winsize;
+  int32_t N, i;
+  size_t bytes, samples;
+  MYFLT binsize;
+
+  if (UNLIKELY(!(size >= 2.0 && size <= INT32_MAX - 2)))
+    return csound->InitError(csound, "%s", Str("pvsinit: invalid frame size"));
+  N = (int32_t)size;
+  if (UNLIKELY(N & 1))
+    return csound->InitError(csound, "%s", Str("pvsinit: frame size must be even"));
+  if (overlap == 0.0)
+    overlap = N / 4;
+  if (winsize == 0.0)
+    winsize = N;
+  if (UNLIKELY(!(overlap >= 1.0 && overlap <= INT32_MAX &&
+                 winsize >= 1.0 && winsize <= INT32_MAX)))
+    return csound->InitError(csound, "%s",
+                             Str("pvsinit: invalid overlap or window size"));
+  if (UNLIKELY(!(*p->wintype >= INT32_MIN && *p->wintype <= (double)INT32_MAX)))
+    return csound->InitError(csound, "%s", Str("pvsinit: invalid window type"));
+  if (UNLIKELY(*p->format != PVS_AMP_FREQ &&
+               *p->format != PVS_AMP_PHASE && *p->format != PVS_COMPLEX))
+    return csound->InitError(csound, "%s", Str("pvsinit: unsupported format"));
 
   p->fout->N = N;
-  p->fout->overlap = (int32)(*p->olap ? *p->olap : N/4);
-  p->fout->winsize = (int32)(*p->winsize ? *p->winsize : N);
-  p->fout->wintype = (int32) *p->wintype;
-  p->fout->format = (int32) *p->format;
+  p->fout->NB = N / 2 + 1;
+  p->fout->overlap = (int32_t)overlap;
+  p->fout->winsize = (int32_t)winsize;
+  p->fout->wintype = (int32_t)*p->wintype;
+  p->fout->format = (int32_t)*p->format;
   p->fout->framecount = 1;
-  p->fout->sliding = 0;
-  if (p->fout->overlap < (int32_t)nsmps || p->fout->overlap <=10) {
-    int32_t NB = 1+N/2;
-    MYFLT *bframe;
-    p->fout->NB = NB;
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size * CS_KSMPS < sizeof(float) * (N + 2))
-      csound->AuxAlloc(csound, (N + 2) * nsmps * sizeof(float),
-                       &p->fout->frame);
-    p->fout->sliding = 1;
-    bframe = (MYFLT *) p->fout->frame.auxp;
-    for (n=0; n<nsmps; n++)
-      for (i = 0; i < N + 2; i += 2) {
-        bframe[i+n*NB] = FL(0.0);
-        bframe[i+n*NB + 1] =
-          (n<offset || n>nsmps-early ? FL(0.0) :(i >>1) * N * CS_ONEDSR);
-      }
-  }
-  else {
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(float) * (N + 2)) {
-      csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
+  p->fout->sliding = (p->fout->overlap < (int32_t)CS_KSMPS ||
+                      p->fout->overlap <= 10);
+  samples = p->fout->sliding ? CS_KSMPS : 1;
+  bytes = p->fout->sliding ? sizeof(MYFLT) : sizeof(float);
+  if (UNLIKELY((size_t)N + 2 > SIZE_MAX / bytes / samples))
+    return csound->InitError(csound, "%s", Str("pvsinit: frame size is too large"));
+  bytes *= ((size_t)N + 2) * samples;
+  if (p->fout->frame.auxp == NULL || p->fout->frame.size < bytes)
+    csound->AuxAlloc(csound, bytes, &p->fout->frame);
+  else
+    memset(p->fout->frame.auxp, 0, bytes);
+
+  /* Silent amp/freq frames retain bin frequencies; phase and complex
+     frames start with both components zero. */
+  binsize = CS_ESR / N;
+  if (p->fout->format == PVS_AMP_FREQ) {
+    if (p->fout->sliding) {
+      uint32_t n, offset = p->h.insdshead->ksmps_offset;
+      uint32_t nsmps = CS_KSMPS - p->h.insdshead->ksmps_no_end;
+      CMPLX *bframe = (CMPLX *)p->fout->frame.auxp;
+      for (n = offset; n < nsmps; n++)
+        for (i = 0; i < p->fout->NB; i++)
+          bframe[(size_t)n * p->fout->NB + i].im = i * binsize;
     }
-    bframe = (float *) p->fout->frame.auxp;
-    for (i = 0; i < N + 2; i += 2) {
-      //bframe[i] = 0.0f;
-      bframe[i + 1] = (i >>1) * N * CS_ONEDSR;
+    else {
+      float *bframe = (float *)p->fout->frame.auxp;
+      for (i = 0; i < N + 2; i += 2)
+        bframe[i + 1] = (float)((i / 2) * binsize);
     }
   }
   p->lastframe = 0;

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -27,6 +27,7 @@ if(BUILD_TESTS)
         engine_test.cpp
         io_test.cpp
         osc_blob_test.cpp
+        pvsinit_test.cpp
         paulstretch_test.cpp
         server_test.cpp
         csound_plugin_opcode_test.cpp

--- a/tests/c/pvsinit_test.cpp
+++ b/tests/c/pvsinit_test.cpp
@@ -1,0 +1,140 @@
+#define __BUILDING_LIBCSOUND
+#include "csoundCore.h"
+#include "csdebug.h"
+#include "pstream.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+
+namespace {
+
+class PvsinitTests : public ::testing::Test {
+protected:
+    CSOUND *csound = nullptr;
+
+    void SetUp() override
+    {
+        csound = csoundCreate(nullptr, nullptr);
+        ASSERT_NE(csound, nullptr);
+        csoundCreateMessageBuffer(csound, 0);
+        ASSERT_EQ(csoundSetOption(csound, "-n"), CSOUND_SUCCESS);
+        ASSERT_EQ(csoundSetOption(csound, "--sample-accurate"), CSOUND_SUCCESS);
+        ASSERT_EQ(csoundCompileOrc(csound,
+            "sr = 8192\nksmps = 16\nnchnls = 1\n0dbfs = 1\n"
+            "gfSignal pvsinit 64, 16, 64, 1\n", 0), CSOUND_SUCCESS);
+        ASSERT_EQ(csoundStart(csound), CSOUND_SUCCESS);
+    }
+
+    void TearDown() override { csoundDestroy(csound); }
+
+    PVSDAT *signal()
+    {
+        auto *variables = csoundDebugGetGlobalVariables(csound);
+        PVSDAT *result = nullptr;
+        for (auto *variable = variables; variable; variable = variable->next)
+            if (std::strcmp(variable->name, "gfSignal") == 0)
+                result = static_cast<PVSDAT *>(variable->data);
+        csoundDebugFreeVariables(csound, variables);
+        return result;
+    }
+
+    void checkFrame(int size, bool sliding, int format)
+    {
+        auto *frame = signal();
+        ASSERT_NE(frame, nullptr);
+        ASSERT_NE(frame->frame.auxp, nullptr);
+        ASSERT_EQ(frame->N, size);
+        ASSERT_EQ(frame->NB, size / 2 + 1);
+        ASSERT_EQ(frame->sliding, sliding);
+        ASSERT_EQ(frame->format, format);
+        ASSERT_EQ(frame->framecount, 1u);
+        const size_t samples = sliding ? 16 : 1;
+        const size_t values = samples * (size + 2);
+        ASSERT_GE(frame->frame.size,
+                  values * (sliding ? sizeof(MYFLT) : sizeof(float)));
+        for (size_t sample = 0; sample < samples; ++sample) {
+            for (int bin = 0; bin <= size / 2; ++bin) {
+                const size_t index = sample * (size + 2) + 2 * bin;
+                const double amplitude = sliding
+                    ? static_cast<MYFLT *>(frame->frame.auxp)[index]
+                    : static_cast<float *>(frame->frame.auxp)[index];
+                const double second = sliding
+                    ? static_cast<MYFLT *>(frame->frame.auxp)[index + 1]
+                    : static_cast<float *>(frame->frame.auxp)[index + 1];
+                EXPECT_EQ(amplitude, 0.0) << sample << ":" << bin;
+                EXPECT_EQ(second, format == PVS_AMP_FREQ ? bin * 8192.0 / size : 0.0)
+                    << sample << ":" << bin;
+            }
+        }
+    }
+
+    void seedFrame()
+    {
+        auto *frame = signal();
+        ASSERT_NE(frame, nullptr);
+        ASSERT_NE(frame->frame.auxp, nullptr);
+        // Model a producer leaving nonzero data before the next initialization.
+        if (frame->sliding) {
+            auto *data = static_cast<MYFLT *>(frame->frame.auxp);
+            std::fill(data, data + 16 * (frame->N + 2), FL(0.5));
+        }
+        else {
+            auto *data = static_cast<float *>(frame->frame.auxp);
+            std::fill(data, data + frame->N + 2, 0.5f);
+        }
+    }
+};
+
+TEST_F(PvsinitTests, FreshFrame)
+{
+    checkFrame(64, false, PVS_AMP_FREQ);
+}
+
+TEST_F(PvsinitTests, ReusedFramesAcrossSizesModesAndFormats)
+{
+    struct Configuration { int size, overlap, format; };
+    const Configuration configurations[] = {
+        {64, 16, PVS_AMP_FREQ}, {64, 1, PVS_AMP_FREQ},
+        {128, 1, PVS_AMP_FREQ}, {64, 1, PVS_AMP_FREQ},
+        {64, 16, PVS_AMP_FREQ}, {128, 32, PVS_AMP_PHASE},
+        {64, 16, PVS_COMPLEX}, {64, 1, PVS_AMP_PHASE},
+        {64, 1, PVS_COMPLEX}, {64, 16, PVS_AMP_FREQ}
+    };
+    for (const auto &configuration : configurations) {
+        SCOPED_TRACE(std::to_string(configuration.size) + "/" +
+                     std::to_string(configuration.overlap) + "/" +
+                     std::to_string(configuration.format));
+        ASSERT_NO_FATAL_FAILURE(seedFrame());
+        const auto statement = "gfSignal pvsinit " + std::to_string(configuration.size) +
+            ", " + std::to_string(configuration.overlap) + ", 0, 1, " +
+            std::to_string(configuration.format) + "\n";
+        ASSERT_EQ(csoundCompileOrc(csound, statement.c_str(), 0), CSOUND_SUCCESS);
+        ASSERT_NO_FATAL_FAILURE(checkFrame(configuration.size,
+            configuration.overlap == 1, configuration.format));
+    }
+}
+
+TEST_F(PvsinitTests, SlidingSampleOffset)
+{
+    ASSERT_EQ(csoundCompileOrc(csound,
+        "instr 1\ngfSignal pvsinit 64, 1, 64, 1\nendin\n", 0), CSOUND_SUCCESS);
+    csoundEventString(csound, "i 1 0.0006103515625 0.125", 0);
+    ASSERT_EQ(csoundPerformKsmps(csound), CSOUND_SUCCESS);
+    auto *frame = signal();
+    ASSERT_NE(frame, nullptr);
+    ASSERT_TRUE(frame->sliding);
+    ASSERT_GE(frame->frame.size, 16 * 66 * sizeof(MYFLT));
+    auto *data = static_cast<MYFLT *>(frame->frame.auxp);
+    for (int sample = 0; sample < 16; ++sample)
+        for (int bin = 0; bin < 33; ++bin) {
+            const int index = sample * 66 + 2 * bin;
+            EXPECT_EQ(data[index], FL(0.0));
+            EXPECT_EQ(data[index + 1],
+                      sample >= 5 ? bin * FL(128.0) : FL(0.0))
+                << sample << ":" << bin;
+        }
+}
+
+} // namespace

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -874,6 +874,7 @@ def runTest():
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
+        ["test_pvsinit_invalid_parameters.csd", "reject invalid pvsinit parameters", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
         ["test_shift_array_state.csd", "shiftin and shiftout sample state"],

--- a/tests/commandline/test_pvsinit_invalid_parameters.csd
+++ b/tests/commandline/test_pvsinit_invalid_parameters.csd
@@ -1,0 +1,24 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+instr 1
+  fSignal pvsinit p4, p5, p6, p7, p8
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 0 16 64 1 0
+i 1 0 .01 63 16 64 1 0
+i 1 0 .01 2147483648 16 64 1 0
+i 1 0 .01 64 -1 64 1 0
+i 1 0 .01 64 2147483648 64 1 0
+i 1 0 .01 64 16 -1 1 0
+i 1 0 .01 64 16 64 2147483648 0
+i 1 0 .01 64 16 64 1 3
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsinit` should initialize a silent spectral stream, but reusing an ordinary FFT frame leaves the previous amplitudes in place. This can retain sound from a prior producer.

- Clear reused frames in both FFT and sliding-DFT modes.
- In sliding mode (for example, hop 1 with `ksmps = 16`), allocate a full frame per sample using `MYFLT`, and advance by complete amplitude/frequency pairs. The old allocation used `float` even in double builds, the size check could miss needed growth, and the stride overlapped adjacent frames.
- Set amp/frequency bin centers to `bin * sr / N`. The old formula reversed `sr` and `N`: at `sr = 8192`, `N = 64`, bin 1 held 0.0078125 instead of 128 Hz. Phase and complex formats now start with both components zero.
- Reject invalid dimensions and unsupported formats before integer conversion or allocation. Track frames use a different layout and cannot use this DFT initializer.

All changes run at initialization; audio processing gains no checks or function calls.
