### PR TITLE
Fix pvstencil frequency handling and reused output mode

### DIFF
--- a/Opcodes/pvsbasic.c
+++ b/Opcodes/pvsbasic.c
@@ -2362,6 +2362,12 @@ static int32_t pvstencilset(CSOUND *csound, PVSTENCIL *p)
   uint32_t i;
   int32    chans = N / 2 + 1;
   MYFLT   *ftable;
+  size_t bytes;
+
+  if (UNLIKELY(p->fin->format != PVS_AMP_FREQ &&
+               p->fin->format != PVS_AMP_PHASE))
+    return csound->InitError(csound, "%s", Str("pvstencil: signal format "
+                                         "must be amp-phase or amp-freq."));
 
   p->fout->N = N;
   p->fout->overlap = p->fin->overlap;
@@ -2372,27 +2378,17 @@ static int32_t pvstencilset(CSOUND *csound, PVSTENCIL *p)
   p->lastframe = 0;
 
   p->fout->NB = chans;
-  if (p->fin->sliding) {
-    if (p->fout->frame.auxp == NULL ||
-        p->fout->frame.size < sizeof(MYFLT) * (N + 2) * CS_KSMPS)
-      csound->AuxAlloc(csound, (N + 2) * sizeof(MYFLT) * CS_KSMPS,
-                       &p->fout->frame);
-    p->fout->sliding = 1;
-  }
+  p->fout->sliding = p->fin->sliding;
+  bytes = ((size_t)N + 2) * (p->fin->sliding ?
+          sizeof(MYFLT) * CS_KSMPS : sizeof(float));
+  if (p->fout->frame.auxp == NULL || p->fout->frame.size < bytes)
+    csound->AuxAlloc(csound, bytes, &p->fout->frame);
   else
-    {
-      if (p->fout->frame.auxp == NULL ||
-          p->fout->frame.size < sizeof(float) * (N + 2))
-        csound->AuxAlloc(csound, (N + 2) * sizeof(float), &p->fout->frame);
+    memset(p->fout->frame.auxp, 0, bytes);
 
-      if (UNLIKELY(!((p->fout->format == PVS_AMP_FREQ) ||
-                     (p->fout->format == PVS_AMP_PHASE))))
-        return csound->InitError(csound, "%s", Str("pvstencil: signal format "
-                                             "must be amp-phase or amp-freq."));
-    }
   p->func = csound->FTFind(csound, p->ifn);
-  if (p->func == NULL)
-    return OK;
+  if (UNLIKELY(p->func == NULL))
+    return NOTOK;
 
   if (UNLIKELY(p->func->flen + 1 < (uint32_t)chans))
     return csound->InitError(csound, "%s", Str("pvstencil: ftable needs to equal "
@@ -2422,24 +2418,24 @@ static int32_t pvstencil(CSOUND *csound, PVSTENCIL *p)
     p->fout->wintype = p->fin->wintype;
     ftable = p->func->ftable;
     for (n=0; n<offset; n++) {
-      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + n*NB;
+      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + (size_t)n*NB;
       for (i = 0; i < NB; i++) fout[i].re = fout[i].im = FL(0.0);
     }
     for (n=nsmps-early; n<nsmps; n++) {
-      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + n*NB;
+      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + (size_t)n*NB;
       for (i = 0; i < NB; i++) fout[i].re = fout[i].im = FL(0.0);
     }
     nsmps -= early;
     for (n=offset; n<nsmps; n++) {
-      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + n*NB;
-      CMPLX *fin  = (CMPLX *) p->fin->frame.auxp  + n*NB;
+      CMPLX *fout = (CMPLX *) p->fout->frame.auxp + (size_t)n*NB;
+      CMPLX *fin  = (CMPLX *) p->fin->frame.auxp  + (size_t)n*NB;
       for (i = 0; i < NB; i++) {
         if (fin[i].re > ftable[i] * masklevel)
           fout[i].re = fin[i].re;   /* Just copy */
         else {
           fout[i].re = fin[i].re * g; /* or apply gain */
         }
-        fout[i].im = fin[i].im * g;
+        fout[i].im = fin[i].im;
       }
     }
   }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -881,6 +881,8 @@ def runTest():
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],
         ["test_pvsinit_invalid_parameters.csd", "reject invalid pvsinit parameters", 1],
+        ["test_pvstencil_gain.csd", "pvstencil gain and reused FFT/sliding outputs"],
+        ["test_pvstencil_invalid_inputs.csd", "reject invalid pvstencil inputs", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
         ["test_shift_array_state.csd", "shiftin and shiftout sample state"],

--- a/tests/commandline/test_pvstencil_gain.csd
+++ b/tests/commandline/test_pvstencil_gain.csd
@@ -1,0 +1,59 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+giZero ftgen 1, 0, 64, -2, 0
+giMask ftgen 2, 0, 64, -7, 1000, 64, 1000
+
+instr 1
+  aInput oscili .25, 1024
+  fInput pvsanal aInput, 64, p4, 64, 1
+  fStencil pvstencil fInput, p5, p7, p6
+  fExpected pvsgain fInput, p8
+  aExpected pvsynth fExpected
+  aActual pvsynth fStencil
+  kError max_k abs(aExpected-aActual), 1, 1
+  if !(kError < .00001) then
+    printks "pvstencil hop %g gain %g table %g level %g: error %g\n", 0, p4, p5, p6, p7, kError
+    exitnowk -1
+  endif
+  kCycle init 0
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 12 then
+    prints "pvstencil checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Hop, gain, mask table, mask level, expected amplitude scale.
+; Alternate modes on a reused note instance to check the sliding flag.
+i 1 0 .125 1 .5 1 1 1
+i 1 .25 .125 16 .5 1 1 1
+i 1 .5 .125 1 .5 2 1 .5
+i 1 .75 .125 16 .5 2 1 .5
+i 1 1 .125 1 0 1 1 1
+i 1 1.25 .125 16 0 1 1 1
+i 1 1.5 .125 1 0 2 1 0
+i 1 1.75 .125 1 -2 2 1 2
+i 1 2 .125 1 2 2 0 1
+i 1 2.25 .125 1 1 2 1 1
+i 1 2.5 .125 16 2 2 1 2
+i 1 2.75 .125 1 .5 1 1 1
+i 99 3 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_pvstencil_invalid_inputs.csd
+++ b/tests/commandline/test_pvstencil_invalid_inputs.csd
@@ -1,0 +1,29 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+giShort ftgen 1, 0, 8, -2, 0
+giMask ftgen 2, 0, 64, -2, 0
+instr 1
+  aInput init 0
+  fInput pvsanal aInput, 64, p5, 64, 1
+  fOutput pvstencil fInput, .5, 1, p4
+endin
+instr 2
+  fInput pvsinit 64, 16, 64, 1, 2
+  fOutput pvstencil fInput, .5, 1, giMask
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 999 16
+i 1 0 .01 999 1
+i 1 0 .01 1 16
+i 1 0 .01 1 1
+i 2 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
In sliding-DFT mode (for example, `pvsanal` with hop 1 and `ksmps = 16`), `pvstencil` multiplies every bin's frequency or phase by `kgain`. That changes pitch even when the bin passes the mask and its amplitude stays unchanged. Copy frequency/phase directly, as the standard FFT path already does, and apply gain only to masked amplitudes.

Also reset the output's sliding flag from the input on every initialization. A reused note switching to FFT otherwise labels float FFT data as per-sample sliding frames. Clear reused output frames, apply the format check in both modes, and propagate failure when the mask table is missing.

The bin loop loses a multiplication and gains no function calls or checks.
