### PR TITLE
Fix scantable phase wrapping and circular table updates

### DIFF
--- a/Opcodes/wave-terrain.c
+++ b/Opcodes/wave-terrain.c
@@ -211,7 +211,9 @@ static int32_t scantinit(CSOUND *csound, SCANTABLE *p)
     p->fdamp  = fdamp;
     p->fvel   = fvel;
 
-    p->size = (MYFLT)fpoint->flen;
+    if (UNLIKELY(fpoint->flen == 0))
+      return csound->InitError(csound, "%s", Str("Scantable: tables must not be empty"));
+    p->size = fpoint->flen;
 
     /* ALLOCATE SPACE FOR NEW POINTS AND VELOCITIES */
     csound->AuxAlloc(csound, fpoint->flen * sizeof(MYFLT), &p->newloca);
@@ -233,7 +235,7 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t i, nsmps = CS_KSMPS;
     MYFLT force, fc1, fc2;
-    int32_t next, last;
+    uint32_t next, last;
 
     /* DECLARE */
     FUNC *fpoint = p->fpoint;
@@ -241,10 +243,18 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
     FUNC *fstiff = p->fstiff;
     FUNC *fdamp  = p->fdamp;
     FUNC *fvel   = p->fvel;
-    MYFLT inc    = p->size * *(p->kpch) * CS_ONEDSR;
+    double pitch = *p->kpch, inc;
     MYFLT amp    = *(p->kamp);
-    MYFLT pos    = p->pos;
+    double pos   = p->pos;
     MYFLT *aout  = p->aout;
+
+    if (UNLIKELY(!isfinite(pitch)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                              Str("Scantable: frequency must be finite"));
+    /* A whole number of scans per sample leaves the same read position. */
+    if (UNLIKELY(pitch >= CS_ESR || pitch <= -CS_ESR))
+      pitch = fmod(pitch, CS_ESR);
+    inc = p->size * (pitch / CS_ESR);
 
 /* CALCULATE NEW POSITIONS
  *
@@ -254,18 +264,10 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
  * a mass of zero means immovable, so as to allow fixed points
  */
 
-    /* For all except end points  */
-    for (i=0; i!=p->size; i++) {
-
-      /* set up conditions for end-points */
-      last = i - 1;
-      next = i + 1;
-      if (UNLIKELY(i == p->size - 1)) {
-        next = 0;
-      }
-      else if (UNLIKELY(i == 0)) {
-        last = (int32_t)p->size - 1;
-      }
+    for (i=0; i<p->size; i++) {
+      /* Circular neighbors, including a one-point string. */
+      last = i == 0 ? p->size - 1 : i - 1;
+      next = i + 1 == p->size ? 0 : i + 1;
 
       if (UNLIKELY(fmass->ftable[i] == 0)) {
         /* if the mass is zero... */
@@ -293,12 +295,13 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
     for (i=offset; i<nsmps; i++) {
 
       /* NO INTERPOLATION */
-      aout[i] = fpoint->ftable[(int32_t)pos] * amp;
+      aout[i] = fpoint->ftable[(uint32_t)pos] * amp;
 
-      pos += inc /* p->size * *(p->kpch) * CS_ONEDSR */;
-      if (UNLIKELY(pos > p->size)) {
+      pos += inc;
+      if (UNLIKELY(pos < 0.0))
+        pos += p->size;
+      if (UNLIKELY(pos >= p->size))
         pos -= p->size;
-      }
     }
     p->pos = pos;
 
@@ -308,6 +311,8 @@ static int32_t scantPerf(CSOUND *csound, SCANTABLE *p)
      */
     memcpy(fpoint->ftable, p->newloc, p->size*sizeof(MYFLT));
     memcpy(fvel->ftable, p->newvel, p->size*sizeof(MYFLT));
+    fpoint->ftable[p->size] = fpoint->ftable[0];
+    fvel->ftable[p->size] = fvel->ftable[0];
     return OK;
 }
 

--- a/Opcodes/wave-terrain.h
+++ b/Opcodes/wave-terrain.h
@@ -80,9 +80,9 @@ typedef struct {
   AUXCH newloca;
   AUXCH newvela;
   MYFLT *newloc, *newvel;
-  MYFLT size;
+  uint32_t size;
 
-  MYFLT pos;
+  double pos;
   FUNC *fpoint;
   FUNC *fmass;
   FUNC *fstiff;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -920,6 +920,8 @@ def runTest():
         ["test_metro2_timing.csd", "metro2 corrected startup, swing, and bounded phase timing"],
         ["test_metro2_legacy_timing.csd", "metro2 preserves legacy timing by default"],
         ["test_metro2_invalid_parameters.csd", "reject invalid metro2 phase, frequency, and swing", 1],
+        ["test_scantable_phase.csd", "scantable circular phase and table state"],
+        ["test_scantable_invalid_frequency.csd", "reject non-finite scantable frequency", 1],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
 
         ["test_phasorbnk_phase_state.csd", "phasorbnk bank resizing and phase state"],

--- a/tests/commandline/test_scantable_invalid_frequency.csd
+++ b/tests/commandline/test_scantable_invalid_frequency.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+giPosition ftgen 1, 0, 8, -2, 0
+giMass ftgen 2, 0, 8, -7, 1, 8, 1
+giStiff ftgen 3, 0, 8, -2, 0
+giDamp ftgen 4, 0, 8, -7, 1, 8, 1
+giVelocity ftgen 5, 0, 8, -2, 0
+instr 1
+  kValue init p4
+  kPitch = log(kValue)
+  aSignal scantable 1, kPitch, giPosition, giMass, giStiff, giDamp, giVelocity
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01 -1
+i 1 .02 .01 0
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_scantable_phase.csd
+++ b/tests/commandline/test_scantable_phase.csd
@@ -1,0 +1,92 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; With no spring force, equal velocities keep every position equal.
+instr 1
+  iPosition ftgen 0, 0, -p4, -2, 0
+  iMass ftgen 0, 0, -p4, -7, 1, p4, 1
+  iStiff ftgen 0, 0, -p4, -2, 0
+  iDamp ftgen 0, 0, -p4, -7, 1, p4, 1
+  iVelocity ftgen 0, 0, -p4, -7, 1, p4, 1
+  aSignal scantable 1, p5, iPosition, iMass, iStiff, iDamp, iVelocity
+  kCycle init 0
+  kCycle += 1
+  kError max_k abs(aSignal-(kCycle-1)/kr), 1, 1
+  ; Interpolation across the final element uses the guard point.
+  kPosition tablei p4-.5, iPosition
+  kVelocity tablei p4-.5, iVelocity
+  if !(kError < .000001 && abs(kPosition-kCycle/kr) < .000001 && kVelocity == 1) then
+    printks "scantable size %g pitch %g: audio error %g, position %g, velocity %g\n", 0, p4, p5, kError, kPosition, kVelocity
+    exitnowk -1
+  endif
+  if kCycle == 8 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; Fixed points turn the model into a plain table oscillator.
+instr 2
+  iPosition ftgen 0, 0, 8, -7, 0, 8, 1
+  iMass ftgen 0, 0, 8, -2, 0
+  iStiff ftgen 0, 0, 8, -2, 0
+  iDamp ftgen 0, 0, 8, -7, 1, 8, 1
+  iVelocity ftgen 0, 0, 8, -2, 0
+  kCycle init 0
+  kCycle += 1
+  kPitch = (p4 == 0 ? (kCycle == 1 ? 256 : 1e20) : p4)
+  kReferencePitch = (p4 == 0 ? (kCycle == 1 ? 256 : 0) : p5)
+  aSignal scantable 1, kPitch, iPosition, iMass, iStiff, iDamp, iVelocity
+  aPhase phasor kReferencePitch
+  aReference table aPhase, iPosition, 1
+  kError max_k abs(aSignal-aReference), 1, 1
+  if !(kError < .000001) then
+    printks "scantable pitch %g differs from reference %g: %g\n", 0, p4, p5, kError
+    exitnowk -1
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 17 then
+    prints "scantable checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .04 32 256
+i 1 0 .04 7 8192
+i 1 0 .04 1 512
+i 1 0 .04 32 -256
+i 1 0 .04 32 16640
+i 1 0 .04 32 -16640
+i 2 .05 .01 512 512
+i 2 .05 .01 -512 -512
+i 2 .05 .01 8192 0
+i 2 .05 .01 -8192 0
+i 2 .05 .01 16896 512
+i 2 .05 .01 -16896 -512
+; Begin three samples into a block and finish before its end.
+i 2 .0706787109375 .0009765625 512 512
+i 2 .0706787109375 .0009765625 -512 -512
+i 2 .09 .01 1e20 0
+i 2 .09 .01 -1e20 0
+; Whole scans must preserve an already nonzero phase.
+i 2 .10 .01 0 0
+i 99 .12 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`scantable` wraps its cursor only when it is greater than the table length. At the exact endpoint it reads the guard point, which the simulation leaves stale. A uniformly moving string therefore gets a periodic wrong sample.

Keep the cursor in `[0, table length)` in both directions. Reduce whole scans once per control cycle so large frequency steps remain bounded, and retain the phase in double precision. Reject non-finite frequency before converting the cursor to a table index.

Also refresh position and velocity guard points after each update, use an integer table length, and handle a one-point string's circular neighbors correctly. The audio loop adds no function calls; frequency reduction and validation run at control rate.
