### PR TITLE
Fix wgpluck excitation reuse and sample alignment

### DIFF
--- a/Opcodes/pluck.c
+++ b/Opcodes/pluck.c
@@ -201,7 +201,6 @@ static int32_t pluckGetSamps(CSOUND *csound, WGPLUCK* p)
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     len_t n,nsmps=CS_KSMPS;
 /*    int32_t i = 0; */
-    MYFLT *fdbk = p->afdbk;
     /* set the delay element to pickup at */
     len_t pickupSamp=(len_t)(M * *p->pickupPos);
     if (UNLIKELY(pickupSamp<1)) pickupSamp = 1;
@@ -212,6 +211,8 @@ static int32_t pluckGetSamps(CSOUND *csound, WGPLUCK* p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset;n<nsmps;n++) {
+        /* The output may reuse the excitation buffer. */
+        MYFLT excitation = p->afdbk[n];
         ar[n] = guideRailAccess(&p->wg.upperRail,pickupSamp)
                +guideRailAccess(&p->wg.lowerRail,M-pickupSamp);
         yrM = guideRailAccess(&p->wg.upperRail,M-1);/* wave into the nut */
@@ -220,7 +221,7 @@ static int32_t pluckGetSamps(CSOUND *csound, WGPLUCK* p)
         yl0 = guideRailAccess(&p->wg.lowerRail,0);  /* wave into bridge */
         yr0 = -filter3FIR(&p->bridge,yl0);   /* bridge reflection filter */
         yr0 = filterAllpass(&p->wg,yr0);     /* allpass tuning filter */
-        yr0 += *fdbk++;           /* Surely better to inject here */
+        yr0 += excitation;
         guideRailUpdate(&p->wg.upperRail,yr0);    /* update the upper rail*/
         guideRailUpdate(&p->wg.lowerRail,ylM);    /* update the lower rail*/
       }
@@ -261,14 +262,14 @@ static inline int32_t circularBufferCircularBuffer(CSOUND *csound,
 #define guideRailGuideRail(csound,gr,d) circularBufferCircularBuffer(csound, gr,d)
 
 /* ::access -- waveguide rail access routine */
-static MYFLT guideRailAccess(guideRail* gr, len_t pos)
+static inline MYFLT guideRailAccess(guideRail* gr, len_t pos)
 {
-    MYFLT *s = gr->pointer - pos;
-    while (s < gr->data)
-      s += gr->size;
-    while (s > gr->endPoint)
-      s -= gr->size;
-    return *s;
+    len_t index = (gr->pointer - gr->data) - pos;
+    while (index < 0)
+      index += gr->size;
+    while (index >= gr->size)
+      index -= gr->size;
+    return gr->data[index];
 }
 
 /* ::FIR -- direct convolution filter routine */

--- a/Opcodes/wavegde.h
+++ b/Opcodes/wavegde.h
@@ -78,7 +78,7 @@ static MYFLT filter3FIR(filter3*,MYFLT);      /* convolution filter routine */
 typedef circularBuffer guideRail; /* It's just a circular buffer really */
 
 /* guideRail member functions */
-static MYFLT guideRailAccess(guideRail*,len_t);  /* delay line access routine */
+static inline MYFLT guideRailAccess(guideRail*,len_t);  /* delay line access routine */
 static void guideRailUpdate(guideRail*,MYFLT);   /* delay line update routine */
 
 /* waveguide -- abstract base class definition for waveguide classes */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -871,6 +871,7 @@ def runTest():
             "reject managed opcode-object output access",
             1,
         ],
+        ["test_wgpluck_excitation.csd", "wgpluck excitation reuse and partial blocks"],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
         ["test_syncphasor_invalid_phase.csd", "reject invalid syncphasor phase", 1],
         ["test_syncphasor_invalid_frequency.csd", "reject invalid syncphasor frequency", 1],

--- a/tests/commandline/test_wgpluck_excitation.csd
+++ b/tests/commandline/test_wgpluck_excitation.csd
@@ -1,0 +1,58 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; A one-sample block provides a reference for partial-block excitation.
+opcode PluckReference, a, aiik
+  setksmps 1
+  aInput, iFrequency, iAmplitude, kPickup xin
+  aOutput wgpluck iFrequency, iAmplitude, kPickup, .5, 10, 100, aInput
+  xout aOutput
+endop
+
+instr 1
+  aInput oscili .1, 600
+  aReference PluckReference aInput, p4, p5, p6
+  aOutput wgpluck p4, p5, p6, .5, 10, 100, aInput
+  aReuse = aInput
+  aReuse wgpluck p4, p5, p6, .5, 10, 100, aReuse
+  kError max_k abs(aOutput-aReference)+abs(aReuse-aReference), 1, 1
+  if !(kError < .000001) then
+    printks "wgpluck frequency %g amplitude %g pickup %g: excitation error %g\n", 0, p4, p5, p6, kError
+    exitnowk -1
+  endif
+  kFirst init 1
+  if kFirst == 1 then
+    gkChecks += 1
+    kFirst = 0
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 8 then
+    prints "wgpluck checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03 256 0 .5
+i 1 0 .03 440 .2 .5
+i 1 0 .03 256 .2 0
+i 1 0 .03 440 0 1
+; Reuse notes, starting at sample 3 and ending at sample 13 of a block.
+i 1 .0628662109375 .030517578125 256 0 .5
+i 1 .0628662109375 .030517578125 440 .2 .5
+i 1 .0628662109375 .030517578125 256 .2 0
+i 1 .0628662109375 .030517578125 440 0 1
+i 99 .125 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`wgpluck` writes each output sample before reading the excitation sample. When the output reuses the excitation variable, this replaces the input with the string output and can leave an otherwise excited string silent.

Read the excitation at the current sample index before writing the output. This also fixes notes starting partway through a block, where the old excitation pointer started at sample zero.

Wrap rail indices as integers before accessing the buffer, avoiding pointers formed outside the array. The access helper stays inline. The legacy tuning, damping, and pluck calculations remain unchanged.
