### PR TITLE
fix(metro2): add opt-in corrected timing

### DIFF
--- a/Opcodes/metro.c
+++ b/Opcodes/metro.c
@@ -34,9 +34,9 @@ typedef struct {
 // METRO2 ADDED BY GLEB ROGOZINSKY Oct 2019
 typedef struct {
         OPDS    h;
-        MYFLT   *sr, *xcps, *kswng, *iamp, *iphs;
+        MYFLT   *sr, *xcps, *kswng, *iamp, *iphs, *icorrect;
         double  amp2, curphs, curphs2, swng_init;
-        int32_t flag;
+        int32_t flag, flag2;
 } METRO2;
 //
 
@@ -118,7 +118,64 @@ static int32_t metrobpm(CSOUND *csound, METRO *p)
    Opcode metro2 in addition to 'classic' metro opcode,
    allows swinging with possibiliy of setting its own amplitude value
 */
-static int32_t metro2_set(CSOUND *csound, METRO2 *p)
+static int32_t metro2_legacy_set(CSOUND *csound, METRO2 *p)
+{
+    double phs = *p->iphs;
+    double swng = *p->kswng;
+    int32  longphs;
+    p->amp2 = *p->iamp;
+
+    if (phs >= 0.0) {
+      if (UNLIKELY((longphs = (int32)phs)))
+        csound->Warning(csound, "%s", Str("metro2:init phase truncation"));
+      p->curphs = (MYFLT)phs - (MYFLT)longphs;
+      p->curphs2 = (MYFLT)phs - (MYFLT)longphs + 1.0 - (MYFLT)swng;
+    }
+    p->flag = 1;
+    p->flag2 = 1;
+    p->swng_init = (MYFLT)swng;
+    return OK;
+}
+
+static int32_t metro2_legacy(CSOUND *csound, METRO2 *p)
+{
+    double      phs= p->curphs;
+    double      phs2= p->curphs2;
+    double      phs2_init = p->swng_init;
+    double      amp2= p->amp2;
+    double      swng= *p->kswng;
+    IGN(csound);
+// MAIN TICK
+    if (phs == 0.0 && p->flag) {
+      *p->sr = FL(1.0);
+      p->flag = 0;
+    }
+    else if ((phs += *p->xcps * CS_ONEDKR * 0.5) >= 1.0 ) {
+      *p->sr = FL(1.0);
+      phs -= 1.0;
+      p->flag = 0;
+    }
+    else
+      *p->sr = FL(0.0);
+    p->curphs = phs;
+
+// SWINGING TICK
+    if (phs2 == 0.0 && p->flag2) {
+      *p->sr = FL(amp2);
+      p->flag2 = 0;
+    }
+    else if ((phs2 += *p->xcps * CS_ONEDKR * 0.5) >= (1.0 + swng - phs2_init) ) {
+      *p->sr = FL(amp2);
+      phs2 -= 1.0;
+      p->flag2 = 0;
+    }
+    p->curphs2 = phs2;
+
+    return OK;
+}
+//
+
+static int32_t metro2_correct_set(CSOUND *csound, METRO2 *p)
 {
     double phs = *p->iphs;
 
@@ -136,7 +193,7 @@ static int32_t metro2_set(CSOUND *csound, METRO2 *p)
     return OK;
 }
 
-static int32_t metro2(CSOUND *csound, METRO2 *p)
+static int32_t metro2_correct(CSOUND *csound, METRO2 *p)
 {
     double phs = p->curphs, phs2 = p->curphs2;
     double swng = *p->kswng;
@@ -186,6 +243,19 @@ static int32_t metro2(CSOUND *csound, METRO2 *p)
     p->curphs = phs;
     p->curphs2 = phs2;
     return OK;
+}
+
+/* Preserve existing scores unless corrected timing is requested. */
+static int32_t metro2_set(CSOUND *csound, METRO2 *p)
+{
+    return *p->icorrect == FL(0.0) ? metro2_legacy_set(csound, p)
+                                 : metro2_correct_set(csound, p);
+}
+
+static int32_t metro2(CSOUND *csound, METRO2 *p)
+{
+    return *p->icorrect == FL(0.0) ? metro2_legacy(csound, p)
+                                 : metro2_correct(csound, p);
 }
 
 static int32_t split_trig_set(CSOUND *csound,   SPLIT_TRIG *p)
@@ -392,7 +462,7 @@ static int32_t timeseq(CSOUND *csound, TIMEDSEQ *p)
 
 static OENTRY localops[] = {
   { "metro",  S(METRO),  0,        "k", "ko",  (SUBR)metro_set, (SUBR)metro    },
-  { "metro2", S(METRO2), 0,        "k", "kkpo", (SUBR)metro2_set, (SUBR)metro2  },
+  { "metro2", S(METRO2), 0,        "k", "kkpoo", (SUBR)metro2_set, (SUBR)metro2  },
   { "metrobpm",S(METRO), 0,        "k", "koO",  (SUBR)metro_set, (SUBR)metrobpm },
   { "splitrig", S(SPLIT_TRIG), 0,  "",  "kkiiz",
                                         (SUBR)split_trig_set, (SUBR)split_trig },

--- a/Opcodes/metro.c
+++ b/Opcodes/metro.c
@@ -36,7 +36,7 @@ typedef struct {
         OPDS    h;
         MYFLT   *sr, *xcps, *kswng, *iamp, *iphs;
         double  amp2, curphs, curphs2, swng_init;
-        int32_t flag, flag2;
+        int32_t flag;
 } METRO2;
 //
 
@@ -121,59 +121,72 @@ static int32_t metrobpm(CSOUND *csound, METRO *p)
 static int32_t metro2_set(CSOUND *csound, METRO2 *p)
 {
     double phs = *p->iphs;
-    double swng = *p->kswng;
-    int32  longphs;
-    p->amp2 = *p->iamp;
 
-    if (phs >= 0.0) {
-      if (UNLIKELY((longphs = (int32)phs)))
-        csound->Warning(csound, "%s", Str("metro2:init phase truncation"));
-      p->curphs = (MYFLT)phs - (MYFLT)longphs;
-      p->curphs2 = (MYFLT)phs - (MYFLT)longphs + 1.0 - (MYFLT)swng;
+    if (UNLIKELY(!isfinite(phs) || phs < 0.0))
+      return csound->InitError(csound, "%s", Str("metro2: invalid initial phase"));
+    if (UNLIKELY(phs >= 1.0)) {
+      csound->Warning(csound, "%s", Str("metro2:init phase truncation"));
+      phs -= floor(phs);
     }
+    p->amp2 = *p->iamp;
+    p->curphs = phs;
+    p->curphs2 = 0.0;
     p->flag = 1;
-    p->flag2 = 1;
-    p->swng_init = (MYFLT)swng;
+    p->swng_init = 0.0;
     return OK;
 }
 
 static int32_t metro2(CSOUND *csound, METRO2 *p)
 {
-    double      phs= p->curphs;
-    double      phs2= p->curphs2;
-    double      phs2_init = p->swng_init;
-    double      amp2= p->amp2;
-    double      swng= *p->kswng;
-    IGN(csound);
-// MAIN TICK
-    if (phs == 0.0 && p->flag) {
-      *p->sr = FL(1.0);
+    double phs = p->curphs, phs2 = p->curphs2;
+    double swng = *p->kswng;
+    double frequency = *p->xcps, increment, threshold;
+
+    if (UNLIKELY(!(swng >= 0.0 && swng <= 1.0)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                              Str("metro2: swing must be between 0 and 1"));
+    if (UNLIKELY(!isfinite(frequency) || frequency < 0.0))
+      return csound->PerfError(csound, &(p->h), "%s",
+                              Str("metro2: frequency must be finite and nonnegative"));
+
+    /* An exact initial tick must hold both clocks for the same cycle.
+       At coincident endpoints, retain the documented initial main tick. */
+    if (p->flag) {
+      /* k-rate expressions may not have a value during initialization. */
+      p->swng_init = swng;
+      phs2 = phs - swng;
+      if (phs2 < 0.0) phs2 += 1.0;
+      p->curphs2 = phs2;
       p->flag = 0;
+      if (phs == 0.0 || phs2 == 0.0) {
+        *p->sr = phs == 0.0 ? FL(1.0) : (MYFLT)p->amp2;
+        return OK;
+      }
     }
-    else if ((phs += *p->xcps * CS_ONEDKR * 0.5) >= 1.0 ) {
-      *p->sr = FL(1.0);
-      phs -= 1.0;
-      p->flag = 0;
-    }
+
+    /* At most one output tick fits in a control cycle. Keep two whole
+       periods so even a swing change across its full range crosses a tick. */
+    if (UNLIKELY(frequency >= 6.0 * CS_EKR))
+      increment = 2.0 + fmod(frequency, 2.0 * CS_EKR) / (2.0 * CS_EKR);
     else
-      *p->sr = FL(0.0);
+      increment = frequency * (0.5 * CS_ONEDKR);
+    phs += increment;
+    phs2 += increment;
+    *p->sr = FL(0.0);
+    if (phs >= 1.0) {
+      *p->sr = FL(1.0);
+      phs -= floor(phs);
+    }
+
+    threshold = 1.0 + swng - p->swng_init;
+    if (phs2 >= threshold) {
+      *p->sr = (MYFLT)p->amp2;
+      phs2 -= floor(phs2 - threshold) + 1.0;
+    }
     p->curphs = phs;
-
-// SWINGING TICK
-    if (phs2 == 0.0 && p->flag2) {
-      *p->sr = FL(amp2);
-      p->flag2 = 0;
-    }
-    else if ((phs2 += *p->xcps * CS_ONEDKR * 0.5) >= (1.0 + swng - phs2_init) ) {
-      *p->sr = FL(amp2);
-      phs2 -= 1.0;
-      p->flag2 = 0;
-    }
     p->curphs2 = phs2;
-
     return OK;
 }
-//
 
 static int32_t split_trig_set(CSOUND *csound,   SPLIT_TRIG *p)
 {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -914,6 +914,8 @@ def runTest():
         ],
         ["test_wgpluck_excitation.csd", "wgpluck excitation reuse and partial blocks"],
         ["test_bformenc1_input_reuse.csd", "bformenc1 input reuse in scalar and array outputs"],
+        ["test_metro2_timing.csd", "metro2 startup, swing, and bounded phase timing"],
+        ["test_metro2_invalid_parameters.csd", "reject invalid metro2 phase, frequency, and swing", 1],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
 
         ["test_phasorbnk_phase_state.csd", "phasorbnk bank resizing and phase state"],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -914,7 +914,8 @@ def runTest():
         ],
         ["test_wgpluck_excitation.csd", "wgpluck excitation reuse and partial blocks"],
         ["test_bformenc1_input_reuse.csd", "bformenc1 input reuse in scalar and array outputs"],
-        ["test_metro2_timing.csd", "metro2 startup, swing, and bounded phase timing"],
+        ["test_metro2_timing.csd", "metro2 corrected startup, swing, and bounded phase timing"],
+        ["test_metro2_legacy_timing.csd", "metro2 preserves legacy timing by default"],
         ["test_metro2_invalid_parameters.csd", "reject invalid metro2 phase, frequency, and swing", 1],
         ["test_syncphasor_phase_wrap.csd", "test syncphasor phase wrapping"],
 

--- a/tests/commandline/test_metro2_invalid_parameters.csd
+++ b/tests/commandline/test_metro2_invalid_parameters.csd
@@ -1,0 +1,33 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 64
+nchnls = 1
+instr 1
+  kTick metro2 p4, p5, 1, p6
+endin
+instr 2
+  iPhase = log(p4)
+  kTick metro2 2, .5, 1, iPhase
+endin
+instr 3
+  kValue init p4
+  kFrequency = log(kValue)
+  kTick metro2 kFrequency, .5
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .1 -1 .5 0
+i 1 0 .1 2 -.1 0
+i 1 0 .1 2 1.1 0
+i 1 0 .1 2 .5 -1
+i 2 0 .1 -1
+i 2 0 .1 0
+i 3 0 .1 -1
+i 3 0 .1 0
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_metro2_invalid_parameters.csd
+++ b/tests/commandline/test_metro2_invalid_parameters.csd
@@ -7,16 +7,16 @@ sr = 1024
 ksmps = 64
 nchnls = 1
 instr 1
-  kTick metro2 p4, p5, 1, p6
+  kTick metro2 p4, p5, 1, p6, 1
 endin
 instr 2
   iPhase = log(p4)
-  kTick metro2 2, .5, 1, iPhase
+  kTick metro2 2, .5, 1, iPhase, 1
 endin
 instr 3
   kValue init p4
   kFrequency = log(kValue)
-  kTick metro2 kFrequency, .5
+  kTick metro2 kFrequency, .5, 1, 0, 1
 endin
 </CsInstruments>
 <CsScore>

--- a/tests/commandline/test_metro2_legacy_timing.csd
+++ b/tests/commandline/test_metro2_legacy_timing.csd
@@ -1,0 +1,44 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=64
+nchnls=1
+gkChecks init 0
+instr 1
+ ; Tick sequences from the original metro2, including startup and endpoints.
+ kExpected[] fillarray 1,0,0,0,0,0,0,-1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,-1,0,0,0,0,0,0,0,0,
+    -1,0,0,1,0,0,0,0,0,0,0,-1,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,-1,0,0,0,0,
+    -1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,
+    -1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+ kDefault metro2 2,p4,-1,p5
+ kLegacy metro2 2,p4,-1,p5,0
+ kCycle timeinstk
+ kReference = kExpected[p6*32+kCycle-1]
+ if kDefault != kReference || kLegacy != kReference then
+  printks "metro2 legacy swing=%g phase=%g cycle=%g: default=%g explicit=%g expected=%g\n",0,p4,p5,kCycle,kDefault,kLegacy,kReference
+  exitnowk(1)
+ endif
+ if kCycle == 32 then
+  gkChecks += 1
+  turnoff
+ endif
+endin
+instr 99
+ if i(gkChecks) != 4 then
+  prints "metro2 legacy checks did not complete\n"
+  exitnow(1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 2 .5 0 0
+i 1 0 2 .5 .75 1
+i 1 0 2 0 0 2
+i 1 0 2 1 0 3
+i 99 2.1 .1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_metro2_timing.csd
+++ b/tests/commandline/test_metro2_timing.csd
@@ -1,0 +1,99 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 64
+nchnls = 1
+gkChecks init 0
+
+; With 2 Hz at kr=16, a main/offbeat pair takes 16 control cycles.
+instr 1
+  kCycle init 0
+  kCycle += 1
+  kTick metro2 2, p4, -1, p5
+  iPhase = frac(p5)
+  iHeld = (iPhase == 0 || iPhase == p4 ? 1 : 0)
+  kPosition = iPhase*16+kCycle-iHeld
+  kExpected = 0
+  if kPosition % 16 == 0 then
+    kExpected = 1
+  endif
+  if (kPosition-p4*16) % 16 == 0 then
+    kExpected = -1
+  endif
+  if kCycle == 1 && iHeld == 1 then
+    kExpected = (iPhase == 0 ? 1 : -1)
+  endif
+  if kTick != kExpected then
+    printks "metro2 swing %g phase %g cycle %g: %g expected %g\n", 0, p4, p5, kCycle, kTick, kExpected
+    exitnowk -1
+  endif
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; A fast cycle must not leave ticks queued after the frequency becomes zero.
+instr 2
+  kCycle init 0
+  kCycle += 1
+  kFrequency = (kCycle == 2 ? p4 : 0)
+  kTick metro2 kFrequency, .5, -1
+  kExpected = (kCycle == 1 ? 1 : (kCycle == 2 ? -1 : 0))
+  if kTick != kExpected then
+    printks "metro2 fast frequency %g cycle %g: %g expected %g\n", 0, p4, kCycle, kTick, kExpected
+    exitnowk -1
+  endif
+  if kCycle == 8 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+; Changing swing must move the next offbeat, without duplicating a tick.
+instr 3
+  kCycle init 0
+  kCycle += 1
+  kSwing = (kCycle < 5 ? .5 : .75)
+  kTick metro2 2, kSwing, -1
+  kExpected = (kCycle == 1 || kCycle == 17 ? 1 : (kCycle == 13 || kCycle == 29 ? -1 : 0))
+  if kTick != kExpected then
+    printks "metro2 changing swing cycle %g: %g expected %g\n", 0, kCycle, kTick, kExpected
+    exitnowk -1
+  endif
+  if kCycle == 32 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 14 then
+    prints "metro2 checks did not finish\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 3 .5 0
+i 1 0 3 .5 .75
+i 1 0 3 .5 .5
+i 1 0 3 .25 0
+i 1 0 3 .75 .25
+i 1 0 3 0 0
+i 1 0 3 1 0
+i 1 0 3 .5 1
+i 2 0 1 64
+i 2 0 1 1024
+i 2 0 1 1e20
+i 3 0 3
+i 1 0 3 .5 1e20
+; Reuse an instance with an exact initial offbeat.
+i 1 3 3 .75 .75
+i 99 6.5 .1
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_metro2_timing.csd
+++ b/tests/commandline/test_metro2_timing.csd
@@ -12,7 +12,7 @@ gkChecks init 0
 instr 1
   kCycle init 0
   kCycle += 1
-  kTick metro2 2, p4, -1, p5
+  kTick metro2 2, p4, -1, p5, 1
   iPhase = frac(p5)
   iHeld = (iPhase == 0 || iPhase == p4 ? 1 : 0)
   kPosition = iPhase*16+kCycle-iHeld
@@ -41,7 +41,7 @@ instr 2
   kCycle init 0
   kCycle += 1
   kFrequency = (kCycle == 2 ? p4 : 0)
-  kTick metro2 kFrequency, .5, -1
+  kTick metro2 kFrequency, .5, -1, 0, 1
   kExpected = (kCycle == 1 ? 1 : (kCycle == 2 ? -1 : 0))
   if kTick != kExpected then
     printks "metro2 fast frequency %g cycle %g: %g expected %g\n", 0, p4, kCycle, kTick, kExpected
@@ -58,7 +58,7 @@ instr 3
   kCycle init 0
   kCycle += 1
   kSwing = (kCycle < 5 ? .5 : .75)
-  kTick metro2 2, kSwing, -1
+  kTick metro2 2, kSwing, -1, 0, 1
   kExpected = (kCycle == 1 || kCycle == 17 ? 1 : (kCycle == 13 || kCycle == 29 ? -1 : 0))
   if kTick != kExpected then
     printks "metro2 changing swing cycle %g: %g expected %g\n", 0, kCycle, kTick, kExpected


### PR DESCRIPTION
Keep the original metro2 timing by default, including startup offbeats and the offset between the two clocks.

Add a trailing optional `icorrect` argument. Set it to 1 to normalize startup phase from the first control-rate swing value, advance both clocks together, and wrap complete periods after large frequency changes. Existing calls use `icorrect=0` and retain their timing.

Documentation: csound/manual#797.
