### PR TITLE
fix(vbap): correct sample ramps and channel output

### DIFF
--- a/Opcodes/vbap.c
+++ b/Opcodes/vbap.c
@@ -1619,7 +1619,7 @@ int32_t vbap(CSOUND *csound, VBAP *p) /* during note performance: */
   MYFLT *outptr, *inptr;
   MYFLT ogain, ngain, gainsubstr;
   MYFLT invfloatn;
-  int32_t j;
+  int32_t j, channel, in_place = -1;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i, nsmps = CS_KSMPS;
@@ -1633,10 +1633,16 @@ int32_t vbap(CSOUND *csound, VBAP *p) /* during note performance: */
   /* write audio to result audio streams weighted
      with gain factors*/
   if (UNLIKELY(early)) nsmps -= early;
-  invfloatn =  FL(1.0)/(nsmps-offset);
-  for (j=0; j<cnt; j++) {
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
+  /* Render an output that reuses the input after all other channels. */
+  for (channel=0; channel<cnt+(in_place >= 0); channel++) {
+    j = (channel < cnt ? channel : in_place);
     inptr      = p->audio;
     outptr     = p->out_array[j];
+    if (channel < cnt && outptr == p->audio) {
+      in_place = j;
+      continue;
+    }
     ogain      = p->q.beg_gains[j];
     ngain      = p->q.end_gains[j];
     gainsubstr = ngain - ogain;
@@ -1647,10 +1653,9 @@ int32_t vbap(CSOUND *csound, VBAP *p) /* during note performance: */
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT)(i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->q.curr_gains[j]= ogain +
-          (MYFLT)(i) * invfloatn * gainsubstr;
+        p->q.curr_gains[j] = ngain;
       }
       else {
         for (i=offset; i<nsmps; ++i) {
@@ -1670,7 +1675,7 @@ int32_t vbap_a(CSOUND *csound, VBAPA *p) /* during note performance: */
   MYFLT *outptr, *inptr;
   MYFLT ogain, ngain, gainsubstr;
   MYFLT invfloatn;
-  int32_t j;
+  int32_t j, channel, in_place = -1;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i, nsmps = CS_KSMPS;
@@ -1686,9 +1691,15 @@ int32_t vbap_a(CSOUND *csound, VBAPA *p) /* during note performance: */
   /* write audio to result audio streams weighted
      with gain factors*/
   if (UNLIKELY(early)) nsmps -= early;
-  invfloatn =  FL(1.0)/(nsmps-offset);
-  for (j=0; j<cnt; j++) {
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
+  /* Render an output that reuses the input after all other channels. */
+  for (channel=0; channel<cnt+(in_place >= 0); channel++) {
+    j = (channel < cnt ? channel : in_place);
     outptr     = &p->tabout->data[j*ksmps];
+    if (channel < cnt && outptr == p->audio) {
+      in_place = j;
+      continue;
+    }
     inptr      = p->audio;
     ogain      = p->q.beg_gains[j];
     ngain      = p->q.end_gains[j];
@@ -1699,10 +1710,9 @@ int32_t vbap_a(CSOUND *csound, VBAPA *p) /* during note performance: */
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT)(i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->q.curr_gains[j]= ogain +
-          (MYFLT)(i) * invfloatn * gainsubstr;
+        p->q.curr_gains[j] = ngain;
       }
       else {
         for (i=offset; i<nsmps; ++i)
@@ -1916,7 +1926,7 @@ int32_t vbap_init_a(CSOUND *csound, VBAPA *p)
                              "%s", Str("vbap system NOT configured.\nMissing"
                                        " vbaplsinit opcode in orchestra?"));
   //printf("**** size = %d\n", p->q.ls_set_am);
-  if (UNLIKELY(tabinit(csound, p->tabout, p->q.ls_set_am,
+  if (UNLIKELY(tabinit(csound, p->tabout, p->q.ls_am,
                        p->h.insdshead) != OK))
     return csound_array_init_resize_error(csound);
   cnt = p->q.number = p->tabout->sizes[0];
@@ -1965,7 +1975,7 @@ int32_t vbap_moving(CSOUND *csound, VBAP_MOVING *p)
   MYFLT *outptr, *inptr;
   MYFLT ogain, ngain, gainsubstr;
   MYFLT invfloatn;
-  int32_t j;
+  int32_t j, channel, in_place = -1;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i, nsmps = CS_KSMPS;
@@ -1982,10 +1992,16 @@ int32_t vbap_moving(CSOUND *csound, VBAP_MOVING *p)
   /* write audio to resulting audio streams weighted
      with gain factors*/
   if (UNLIKELY(early)) nsmps -= early;
-  invfloatn = FL(1.0)/(nsmps-offset);
-  for (j=0; j<cnt ;j++) {
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
+  /* Render an output that reuses the input after all other channels. */
+  for (channel=0; channel<cnt+(in_place >= 0); channel++) {
+    j = (channel < cnt ? channel : in_place);
     inptr = p->audio;
     outptr = p->out_array[j];
+    if (channel < cnt && outptr == p->audio) {
+      in_place = j;
+      continue;
+    }
     if (UNLIKELY(offset)) memset(outptr, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) memset(&outptr[nsmps], '\0', early*sizeof(MYFLT));
     ogain  = p->q.beg_gains[j];
@@ -1995,10 +2011,9 @@ int32_t vbap_moving(CSOUND *csound, VBAP_MOVING *p)
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT)(i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->q.curr_gains[j]= ogain +
-          (MYFLT)(i) * invfloatn * gainsubstr;
+        p->q.curr_gains[j] = ngain;
       }
       else
         for (i=offset; i<nsmps; ++i)
@@ -2300,7 +2315,7 @@ int32_t vbap_moving_a(CSOUND *csound, VBAPA_MOVING *p)
   MYFLT *outptr, *inptr;
   MYFLT ogain, ngain, gainsubstr;
   MYFLT invfloatn;
-  int32_t j;
+  int32_t j, channel, in_place = -1;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i, nsmps = CS_KSMPS;
@@ -2318,11 +2333,16 @@ int32_t vbap_moving_a(CSOUND *csound, VBAPA_MOVING *p)
   /* write audio to resulting audio streams weighted
      with gain factors*/
   if (UNLIKELY(early)) nsmps -= early;
-  invfloatn = FL(1.0)/(nsmps-offset);
-  //outptr = p->tabout->data;
-  for (j=0; j<cnt ;j++) {
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
+  /* Render an output that reuses the input after all other channels. */
+  for (channel=0; channel<cnt+(in_place >= 0); channel++) {
+    j = (channel < cnt ? channel : in_place);
     inptr = p->audio;
     outptr = &p->tabout->data[j*ksmps];
+    if (channel < cnt && outptr == p->audio) {
+      in_place = j;
+      continue;
+    }
     if (UNLIKELY(offset)) memset(outptr, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) memset(&outptr[nsmps], '\0', early*sizeof(MYFLT));
     ogain  = p->q.beg_gains[j];
@@ -2332,10 +2352,9 @@ int32_t vbap_moving_a(CSOUND *csound, VBAPA_MOVING *p)
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT)(i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->q.curr_gains[j]= ogain +
-          (MYFLT)(i) * invfloatn * gainsubstr;
+        p->q.curr_gains[j] = ngain;
       }
       else
         for (i=offset; i<nsmps; ++i)
@@ -2457,7 +2476,7 @@ int32_t vbap_zak(CSOUND *csound, VBAP_ZAK *p)   /* during note performance: */
      with gain factors */
   outptr = p->out_array;
   if (UNLIKELY(early)) nsmps -= early;
-  invfloatn =  FL(1.0)/(nsmps-offset);
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
   for (j=0; j<n; j++) {
     inptr = p->audio;
     ogain = p->beg_gains[j];
@@ -2469,10 +2488,9 @@ int32_t vbap_zak(CSOUND *csound, VBAP_ZAK *p)   /* during note performance: */
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT) (i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->curr_gains[j]= ogain +
-          (MYFLT) (i) * invfloatn * gainsubstr;
+        p->curr_gains[j] = ngain;
       }
       else {
         for (i=offset; i<nsmps; ++i)
@@ -2480,7 +2498,7 @@ int32_t vbap_zak(CSOUND *csound, VBAP_ZAK *p)   /* during note performance: */
       }
     else
       memset(outptr, 0, nsmps*sizeof(MYFLT));
-    outptr += nsmps;
+    outptr += CS_KSMPS;
   }
   return OK;
 }
@@ -2611,8 +2629,7 @@ int32_t vbap_zak_init(CSOUND *csound, VBAP_ZAK *p)
     return csound->PerfError(csound, &(p->h),
                              "%s", Str("outz index < 0. No output."));
   }
-  if ((int32_t)*p->layout==0) strcpy(name, "vbap_ls_table");
-  else snprintf(name, 24, "vbap_ls_table_%d", (int32_t)*p->layout==0);
+  snprintf(name, 24, "vbap_ls_table_%d", (int32_t)*p->layout);
   /* Now read from the array in za space and write to the output. */
   p->out_array     = zastart + (indx * CS_KSMPS);/* outputs */
   csound->AuxAlloc(csound, p->n*sizeof(MYFLT)*4, &p->auxch);
@@ -2620,7 +2637,10 @@ int32_t vbap_zak_init(CSOUND *csound, VBAP_ZAK *p)
   p->beg_gains     = p->curr_gains + p->n;
   p->end_gains     = p->beg_gains + p->n;
   p->updated_gains = p->end_gains + p->n;
-  ls_table = (MYFLT*) (csound->QueryGlobalVariableNoCheck(csound, name));
+  ls_table = (MYFLT*) (csound->QueryGlobalVariable(csound, name));
+  if (UNLIKELY(ls_table == NULL))
+    return csound->InitError(csound, Str("could not find layout table no.%d"),
+                             (int32_t)*p->layout);
   p->dim           = (int32_t) ls_table[0];   /* reading in loudspeaker info */
   p->ls_am         = (int32_t) ls_table[1];
   p->ls_set_am     = (int32_t) ls_table[2];
@@ -2682,14 +2702,12 @@ int32_t vbap_zak_moving(CSOUND *csound, VBAP_ZAK_MOVING *p)
 
   /* write audio to resulting audio streams weighted
      with gain factors */
-  invfloatn =  FL(1.0)/(nsmps-offset);
+  if (UNLIKELY(early)) nsmps -= early;
+  invfloatn = (nsmps > offset ? FL(1.0)/(nsmps-offset) : FL(0.0));
   outptr = p->out_array;
-  if (UNLIKELY(offset)) memset(outptr, '\0', offset*sizeof(MYFLT));
-  if (UNLIKELY(early)) {
-    nsmps -= early;
-    memset(&outptr[nsmps], '\0', early*sizeof(MYFLT));
-  }
   for (j=0; j<p->n ;j++) {
+    if (UNLIKELY(offset)) memset(outptr, '\0', offset*sizeof(MYFLT));
+    if (UNLIKELY(early)) memset(&outptr[nsmps], '\0', early*sizeof(MYFLT));
     inptr = p->audio;
     ogain = p->beg_gains[j];
     ngain = p->end_gains[j];
@@ -2698,16 +2716,16 @@ int32_t vbap_zak_moving(CSOUND *csound, VBAP_ZAK_MOVING *p)
       if (ngain != ogain) {
         for (i = offset; i < nsmps; i++) {
           outptr[i] = inptr[i] *
-            (ogain + (MYFLT) (i+1) * invfloatn * gainsubstr);
+            (ogain + (MYFLT)(i-offset+1) * invfloatn * gainsubstr);
         }
-        p->curr_gains[j] =  ogain +
-          (MYFLT) (i) * invfloatn * gainsubstr;
+        p->curr_gains[j] = ngain;
       }
       else
         for (i=offset; i<nsmps; ++i)
           outptr[i] = inptr[i] * ogain;
     else
       memset(outptr, 0, nsmps*sizeof(MYFLT));
+    outptr += CS_KSMPS;
   }
   return OK;
 }
@@ -2911,8 +2929,7 @@ int32_t vbap_zak_moving_init(CSOUND *csound, VBAP_ZAK_MOVING *p)
   int32_t     i, j, indx;
   MYFLT   *ls_table, *ptr;
   LS_SET  *ls_set_ptr;
-  int32_t n = p->n;
-  p->n = (int32_t)MYFLT2LONG(*p->numb); /* Set size */
+  int32_t n = p->n = (int32_t)MYFLT2LONG(*p->numb); /* Set size */
   /* Check to see this index is within the limits of za space.    */
   MYFLT* zastart;
   int64_t zalast = GetZaBounds(csound, &zastart);
@@ -2935,6 +2952,8 @@ int32_t vbap_zak_moving_init(CSOUND *csound, VBAP_ZAK_MOVING *p)
   /* reading in loudspeaker info */
   ls_table = (MYFLT*) (csound->QueryGlobalVariableNoCheck(csound,
                                                           "vbap_ls_table_0"));
+  if (UNLIKELY(ls_table == NULL))
+    return csound->InitError(csound, "%s", Str("could not find layout table no.0"));
   p->dim           = (int32_t) ls_table[0];
   p->ls_am         = (int32_t) ls_table[1];
   p->ls_set_am     = (int32_t) ls_table[2];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1013,6 +1013,7 @@ def runTest():
         ["test_chebyshevpoly_high_order.csd", "test high-order Chebyshev evaluation"],
         ["test_powershape_zero_exponent.csd", "powershape preserves sign at zero exponent"],
         ["test_mode_zero_parameters.csd", "mode recovers from zero frequency and Q"],
+        ["test_vbap_sample_ramps.csd", "VBAP active-sample ramps and zak channels"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_vbap_sample_ramps.csd
+++ b/tests/commandline/test_vbap_sample_ramps.csd
@@ -1,0 +1,133 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+zakinit 8, 1
+vbaplsinit 2, 2, 0, 90
+vbaplsinit 2.03, 2, 90, 0
+gkChecks init 0
+
+instr 1
+ kBlock init 0
+ kBlock += 1
+ aInput = .5
+ aGate = 1
+ aReuse = aInput
+ aArray[] init 2
+ aArrayReuse[] init 2
+ aArrayReuse[0] = aInput
+ aLastReuse = aInput
+ kAzimuth init 0
+ kAzimuth = (kBlock < 3 ? 90 : 0)
+ if p4 == 0 then
+  aFirst, aSecond vbap aInput, kAzimuth, 0, 0, p5
+  aArray vbap aInput, kAzimuth, 0, 0, p5
+  aReuse, aReuseSecond vbap aReuse, kAzimuth, 0, 0, p5
+  aLastFirst, aLastReuse vbap aLastReuse, kAzimuth, 0, 0, p5
+  aArrayReuse vbap aArrayReuse[0], kAzimuth, 0, 0, p5
+  vbapz 2, 2, aInput, kAzimuth, 0, 0, p5
+  kOldAngle = (kBlock == 1 || kBlock > 3 ? 0 : 90)
+  kNewAngle = kAzimuth
+ else
+  ; The path advances once at init and once per control cycle.
+  aFirst, aSecond vbapmove aInput, 16/kr, 0, 2, 0, 90
+  aArray vbapmove aInput, 16/kr, 0, 2, 0, 90
+  aReuse, aReuseSecond vbapmove aReuse, 16/kr, 0, 2, 0, 90
+  aLastFirst, aLastReuse vbapmove aLastReuse, 16/kr, 0, 2, 0, 90
+  aArrayReuse vbapmove aArrayReuse[0], 16/kr, 0, 2, 0, 90
+  vbapzmove 2, 2, aInput, 16/kr, 0, 2, 0, 90
+  kOldAngle = 90*kBlock/16
+  kNewAngle = 90*(kBlock+1)/16
+ endif
+ aZakFirst zar 2
+ aZakSecond zar 3
+ kOldFirst = cos(kOldAngle*$M_PI/180)
+ kNewFirst = cos(kNewAngle*$M_PI/180)
+ kOldSecond = sin(kOldAngle*$M_PI/180)
+ kNewSecond = sin(kNewAngle*$M_PI/180)
+ if p5 != 0 then
+  kSwap = kOldFirst
+  kOldFirst = kOldSecond
+  kOldSecond = kSwap
+  kSwap = kNewFirst
+  kNewFirst = kNewSecond
+  kNewSecond = kSwap
+ endif
+ kCount = 0
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kCount += kActive
+  kN += 1
+ od
+ kPosition = 0
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kExpectedFirst = 0
+  kExpectedSecond = 0
+  if kActive != 0 then
+   kPosition += 1
+   kFraction = kPosition/kCount
+   kExpectedFirst = .5*(kOldFirst+kFraction*(kNewFirst-kOldFirst))
+   kExpectedSecond = .5*(kOldSecond+kFraction*(kNewSecond-kOldSecond))
+  endif
+  kFirst vaget kN, aFirst
+  kSecond vaget kN, aSecond
+  kArrayFirst vaget kN, aArray[0]
+  kArraySecond vaget kN, aArray[1]
+  kZakFirst vaget kN, aZakFirst
+  kZakSecond vaget kN, aZakSecond
+  kReuseFirst vaget kN, aReuse
+  kReuseSecond vaget kN, aReuseSecond
+  kLastFirst vaget kN, aLastFirst
+  kLastSecond vaget kN, aLastReuse
+  kArrayReuseFirst vaget kN, aArrayReuse[0]
+  kArrayReuseSecond vaget kN, aArrayReuse[1]
+  kError = abs(kFirst-kExpectedFirst)+abs(kSecond-kExpectedSecond)
+  kError += abs(kArrayFirst-kExpectedFirst)+abs(kArraySecond-kExpectedSecond)
+  kError += abs(kZakFirst-kExpectedFirst)+abs(kZakSecond-kExpectedSecond)
+  kError += abs(kReuseFirst-kExpectedFirst)+abs(kReuseSecond-kExpectedSecond)
+  kError += abs(kLastFirst-kExpectedFirst)+abs(kLastSecond-kExpectedSecond)
+  kError += abs(kArrayReuseFirst-kExpectedFirst)+abs(kArrayReuseSecond-kExpectedSecond)
+  if !(kError < .00002) then
+   printks "VBAP moving=%g layout=%g block=%g sample=%g error=%g expected=(%g,%g) scalar=(%g,%g) array=(%g,%g) zak=(%g,%g)\n", 0, p4, p5, kBlock, kN, kError, kExpectedFirst, kExpectedSecond, kFirst, kSecond, kArrayFirst, kArraySecond, kZakFirst, kZakSecond
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 1 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 12 then
+  prints "VBAP cases did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Full blocks, onset only, onset and end in one block, and partial final block.
+i 1 0 0.0078125 0 0
+i 1 0.015625 0.0078125 0 3
+i 1 0.0316162109375 0.0015869140625 0 0
+i 1 0.0472412109375 0.0015869140625 0 3
+i 1 0.0628662109375 0.0009765625 0 0
+i 1 0.0784912109375 0.0009765625 0 3
+i 1 0.0941162109375 0.0068359375 0 0
+i 1 0.1097412109375 0.0068359375 0 3
+i 1 0.125 0.0078125 1 0
+i 1 0.1409912109375 0.0015869140625 1 0
+i 1 0.1566162109375 0.0009765625 1 0
+i 1 0.1722412109375 0.0068359375 1 0
+i 99 .25 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
VBAP gain ramps count from the start of the block even when a note starts later. A ramp with eight active samples starting at sample 3 reaches 1.375 times its target gain. Count from the first active sample in all six audio output paths, and use the active length for `vbapzmove` too.

Also fix related channel output errors:
- Write an output that reuses the input last, so other channels receive the original signal.
- Size the `vbap` output array by speakers, rather than speaker pairs or triplets.
- Advance zak outputs by a full block per channel and clear inactive samples on every channel. `vbapzmove` previously overwrote the first bus for every speaker.
- Look up the requested `vbapz` layout by its correct name, report missing zak layouts, and initialize `vbapzmove` gains using the current channel count.

The existing gain calculation and sample loops stay in place, with no new per-sample function calls.
