### PR TITLE
fix(moogvcf2): apply input scaling once

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -119,6 +119,9 @@ static int32_t biquada(CSOUND *csound, BIQUAD *p)
 /* translated to C by Hans Mikelson            *****************************/
 /***************************************************************************/
 
+/* moogvcf historically applies 0dBFS scaling in addition to iscale.
+   Keep this known defect for compatibility with existing scores; moogvcf2
+   uses iscale alone. Do not change the legacy scaling to match moogvcf2. */
 static int32_t moogvcfset(CSOUND *csound, MOOGVCF *p)
 {
   if (*p->iskip==FL(0.0)) {
@@ -127,8 +130,16 @@ static int32_t moogvcfset(CSOUND *csound, MOOGVCF *p)
   }
   p->fcocod = IS_ASIG_ARG(p->fco) ? 1 : 0;
   p->rezcod = IS_ASIG_ARG(p->res) ? 1 : 0;
-  if ((p->maxint = *p->max)==FL(0.0)) p->maxint = csound->Get0dBFS(csound);
+  p->fullscale = csound->Get0dBFS(csound);
+  if ((p->maxint = *p->max)==FL(0.0)) p->maxint = p->fullscale;
 
+  return OK;
+}
+
+static int32_t moogvcf2set(CSOUND *csound, MOOGVCF *p)
+{
+  moogvcfset(csound, p);
+  p->fullscale = FL(1.0);
   return OK;
 }
 
@@ -146,7 +157,7 @@ static int32_t moogvcf(CSOUND *csound, MOOGVCF *p)
   double dmax = 1.0/max;
   double xnm1 = p->xnm1, y1nm1 = p->y1nm1, y2nm1 = p->y2nm1, y3nm1 = p->y3nm1;
   double y1n  = p->y1n, y2n = p->y2n, y3n = p->y3n, y4n = p->y4n;
-  MYFLT zerodb = csound->Get0dBFS(csound);
+  MYFLT zerodb = p->fullscale;
 
   in      = p->in;
   out     = p->out;
@@ -1741,7 +1752,7 @@ static OENTRY localops[] = {
 { "moogvcf", S(MOOGVCF), 0, "a", "axxpo",
                                (SUBR)moogvcfset,  (SUBR)moogvcf },
 { "moogvcf2", S(MOOGVCF),0, "a", "axxoo",
-                               (SUBR)moogvcfset,  (SUBR)moogvcf },
+                               (SUBR)moogvcf2set,  (SUBR)moogvcf },
 { "rezzy", S(REZZY),     0, "a", "axxoo", (SUBR)rezzyset,  (SUBR)rezzy },
 { "bqrez", S(REZZY),     0, "a", "axxoo", (SUBR)bqrezset,  (SUBR)bqrez },
 { "distort1", S(DISTORT),TR,  "a", "akkkko",  NULL,      (SUBR)distort   },

--- a/Opcodes/biquad.h
+++ b/Opcodes/biquad.h
@@ -40,7 +40,7 @@ typedef struct {
     OPDS    h;
     MYFLT   *out, *in, *fco, *res, *max, *iskip;
     double  xnm1, y1nm1, y2nm1, y3nm1, y1n, y2n, y3n, y4n;
-    MYFLT   maxint;
+    MYFLT   maxint, fullscale;
     int16   fcocod, rezcod;
 } MOOGVCF;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1030,6 +1030,7 @@ def runTest():
         ["test_powershape_zero_exponent.csd", "powershape preserves sign at zero exponent"],
         ["test_mode_zero_parameters.csd", "mode recovers from zero frequency and Q"],
         ["test_vbap_sample_ramps.csd", "VBAP active-sample ramps and zak channels"],
+        ["test_moogvcf2_scaling.csd", "moogvcf2 scaling and legacy moogvcf compatibility"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_moogvcf2_scaling.csd
+++ b/tests/commandline/test_moogvcf2_scaling.csd
@@ -1,0 +1,112 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+#ifndef FS
+#define FS #32768#
+#endif
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = $FS
+gkChecks init 0
+
+instr 1
+ iScale = (p4 == 0 ? 0dbfs : p4*0dbfs)
+ kBlock init 0
+ kBlock += 1
+ aPhase phasor 256
+ aInput = iScale*(.4+.1*aPhase)
+ aReuse = aInput
+ kCutoff = 900+100*(kBlock%2)
+ kResonance = .3+.1*(kBlock%2)
+ aCutoff = 900+200*aPhase
+ aResonance = .3+.2*aPhase
+ ; The legacy filter multiplies iscale by 0dBFS internally. Compensating
+ ; for that extra factor gives the documented moogvcf2 scaling.
+ if p5 == 0 then
+  aOut moogvcf2 aInput, kCutoff, kResonance, p4*0dbfs
+  aReference moogvcf aInput, kCutoff, kResonance, iScale/0dbfs
+  aReuse moogvcf2 aReuse, kCutoff, kResonance, p4*0dbfs
+ elseif p5 == 1 then
+  aOut moogvcf2 aInput, aCutoff, kResonance, p4*0dbfs
+  aReference moogvcf aInput, aCutoff, kResonance, iScale/0dbfs
+  aReuse moogvcf2 aReuse, aCutoff, kResonance, p4*0dbfs
+ elseif p5 == 2 then
+  aOut moogvcf2 aInput, kCutoff, aResonance, p4*0dbfs
+  aReference moogvcf aInput, kCutoff, aResonance, iScale/0dbfs
+  aReuse moogvcf2 aReuse, kCutoff, aResonance, p4*0dbfs
+ else
+  aOut moogvcf2 aInput, aCutoff, aResonance, p4*0dbfs
+  aReference moogvcf aInput, aCutoff, aResonance, iScale/0dbfs
+  aReuse moogvcf2 aReuse, aCutoff, aResonance, p4*0dbfs
+ endif
+ kN = 0
+ while kN < ksmps do
+  kOut vaget kN, aOut
+  kReference vaget kN, aReference
+  kReuse vaget kN, aReuse
+  if !(abs(kOut-kReference)/iScale < .000002 && abs(kReuse-kOut)/iScale < .000002) then
+   printks "moogvcf2 scale=%g rates=%g block=%g sample=%g actual=%g expected=%g reuse=%g\n", 0, p4, p5, kBlock, kN, kOut/iScale, kReference/iScale, kReuse/iScale
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 2
+ ; A fixed numerical check also protects the reference's legacy behavior.
+ aInput = .5*0dbfs
+ aDefault moogvcf2 aInput, 1000, 0
+ aExplicit moogvcf2 aInput, 1000, 0, 0dbfs
+ aLegacy moogvcf aInput, 1000, 0, 1
+ kDefault downsamp aDefault
+ kExplicit downsamp aExplicit
+ kLegacy downsamp aLegacy
+ kBlock init 0
+ kBlock += 1
+ if kBlock == 128 then
+  kExpected = .474289243981
+  if !(abs(kDefault/0dbfs-kExpected) < .000002 && abs(kExplicit/0dbfs-kExpected) < .000002 && abs(kLegacy/0dbfs-kExpected) < .000002) then
+   printks "moogvcf2 fullscale=%g default=%g explicit=%g legacy=%g expected=%g\n", 0, 0dbfs, kDefault/0dbfs, kExplicit/0dbfs, kLegacy/0dbfs, kExpected
+   exitnowk(-1)
+  endif
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 17 then
+  prints "moogvcf2 cases did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Each scale covers all control/audio parameter combinations. Alternate
+; full blocks and notes starting at sample 3 and ending before the block end.
+i 1 0 .0078125 0 0
+i 1 0.0159912109375 .0068359375 0 1
+i 1 .03125 .0078125 0 2
+i 1 0.0472412109375 .0068359375 0 3
+i 1 .0625 .0078125 .5 0
+i 1 0.0784912109375 .0068359375 .5 1
+i 1 .09375 .0078125 .5 2
+i 1 0.1097412109375 .0068359375 .5 3
+i 1 .125 .0078125 1 0
+i 1 0.1409912109375 .0068359375 1 1
+i 1 .15625 .0078125 1 2
+i 1 0.1722412109375 .0068359375 1 3
+i 1 .1875 .0078125 2 0
+i 1 0.2034912109375 .0068359375 2 1
+i 1 .21875 .0078125 2 2
+i 1 0.2347412109375 .0068359375 2 3
+i 2 .25 .25
+i 99 .51 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`moogvcf2` divides its input by both `iscale` and `0dbfs`, although `iscale` already defaults to `0dbfs`. The extra normalization weakens saturation as full scale increases: the same half-scale input settles at about 0.474289 of full scale with `0dbfs=1`, but 0.500000 with `0dbfs=32768`.

Give `moogvcf2` its own initializer so it applies `iscale` only once. Preserve the existing `moogvcf` scaling for old scores and document that compatibility choice in the source. The filter equations and sample loops stay unchanged; no new per-sample calls or checks.
