### PR TITLE
fix(mode): recover from zero frequency and Q

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -1614,15 +1614,22 @@ static int32_t vco(CSOUND *csound, VCO *p)
         }
         if (asgq) kq = p->kq[n];
         if (lfq != kfq || lq != kq) {
-          double kfreq  = kfq*TWOPI;
-          double kalpha = (CS_ESR/kfreq);
-          double kbeta  = kalpha*kalpha;
-          d      = 0.5*kalpha;
-
           lq = kq; lfq = kfq;
-          a0     = 1.0/ (kbeta+d/kq);
-          a1     = a0 * (1.0-2.0*kbeta);
-          a2     = a0 * (kbeta-d/kq);
+          if (UNLIKELY(kfq == FL(0.0) || kq == FL(0.0))) {
+            /* Zero frequency or Q silences the resonator. Clear feedback
+               so a later positive value can start from finite state. */
+            a0 = a1 = a2 = d = 0.0;
+            ynm1 = ynm2 = 0.0;
+          }
+          else {
+            double kfreq  = kfq*TWOPI;
+            double kalpha = (CS_ESR/kfreq);
+            double kbeta  = kalpha*kalpha;
+            d      = 0.5*kalpha;
+            a0     = 1.0/ (kbeta+d/kq);
+            a1     = a0 * (1.0-2.0*kbeta);
+            a2     = a0 * (kbeta-d/kq);
+          }
         }
         xn = (double)p->ain[n];
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1007,6 +1007,7 @@ def runTest():
         ["test_nlfilt2_feedback.csd", "test nonlinear filter feedback and output"],
         ["test_chebyshevpoly_high_order.csd", "test high-order Chebyshev evaluation"],
         ["test_powershape_zero_exponent.csd", "powershape preserves sign at zero exponent"],
+        ["test_mode_zero_parameters.csd", "mode recovers from zero frequency and Q"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_mode_zero_parameters.csd
+++ b/tests/commandline/test_mode_zero_parameters.csd
@@ -1,0 +1,141 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode ModeReference, a, aaa
+ setksmps 1
+ aIn, aFrequency, aQ xin
+ kIn downsamp aIn
+ kFrequency downsamp aFrequency
+ kQ downsamp aQ
+ kX init 0
+ kY1 init 0
+ kY2 init 0
+ kOut = 0
+ if kFrequency == 0 || kQ == 0 then
+  kY1 = 0
+  kY2 = 0
+ else
+  ; Equivalent coefficients expressed in normalized frequency, without
+  ; the production code's reciprocal-frequency intermediates.
+  kW = 2*$M_PI*kFrequency/sr
+  kR = kQ/(kQ+kW/2)
+  kY = kR*kW*kW*kX-kR*(kW*kW-2)*kY1-(2*kR-1)*kY2
+  kY2 = kY1
+  kY1 = kY
+  kOut = kY/(2*kW)
+ endif
+ kX = kIn
+ aOut = kOut
+ xout aOut
+endop
+
+instr 1
+ kBlock init 0
+ kBlock += 1
+ kZeroBlock = (p6 == 1 ? 1 : 2)
+ kFrequency = (kBlock == kZeroBlock && p4 != 1 ? 0 : 440)
+ kQ = (kBlock == kZeroBlock && p4 != 0 ? 0 : 10)
+ aFrequency = kFrequency
+ aQ = kQ
+ aInput = .1
+ aReuse = aInput
+ if p5 == 0 then
+  aOut mode aInput, kFrequency, kQ
+  aReuse mode aReuse, kFrequency, kQ
+ elseif p5 == 1 then
+  aOut mode aInput, aFrequency, kQ
+  aReuse mode aReuse, aFrequency, kQ
+ elseif p5 == 2 then
+  aOut mode aInput, kFrequency, aQ
+  aReuse mode aReuse, kFrequency, aQ
+ else
+  aOut mode aInput, aFrequency, aQ
+  aReuse mode aReuse, aFrequency, aQ
+ endif
+ aExpected ModeReference aInput, aFrequency, aQ
+ kN = 0
+ while kN < ksmps do
+  kOut vaget kN, aOut
+  kExpected vaget kN, aExpected
+  kReuse vaget kN, aReuse
+  if !(abs(kOut-kExpected) < .00002 && abs(kReuse-kExpected) < .00002) then
+   printks "mode zero=%g rates=%g block=%g sample=%g output=%g expected=%g reuse=%g\n", 0, p4, p5, kBlock, kN, kOut, kExpected, kReuse
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 2
+ ; Zero for a single sample within each block, with recovery on the next
+ ; sample. Alternate between zero frequency and zero Q across notes.
+ aFrequency = 440
+ aQ = 10
+ if p4 == 0 then
+  vaset 0, 8, aFrequency
+ else
+  vaset 0, 8, aQ
+ endif
+ aInput = .1
+ aOut mode aInput, aFrequency, aQ
+ aExpected ModeReference aInput, aFrequency, aQ
+ kN = 0
+ while kN < ksmps do
+  kOut vaget kN, aOut
+  kExpected vaget kN, aExpected
+  if !(abs(kOut-kExpected) < .00002) then
+   printks "mode single zero=%g sample=%g output=%g expected=%g\n", 0, p4, kN, kOut, kExpected
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ kBlock init 0
+ kBlock += 1
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 17 then
+  prints "mode cases did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Frequency, Q, and both zero; each control/audio parameter combination.
+; Alternate full blocks with onset at sample 3 and an early final block.
+i 1 0 .0078125 0 0
+i 1 .0159912109375 .0068359375 0 1
+i 1 .03125 .0078125 0 2
+i 1 .0472412109375 .0068359375 0 3
+i 1 .0625 .0078125 1 0
+i 1 .0784912109375 .0068359375 1 1
+i 1 .09375 .0078125 1 2
+i 1 .1097412109375 .0068359375 1 3
+i 1 .125 .0078125 2 0
+i 1 .1409912109375 .0068359375 2 1
+i 1 .15625 .0078125 2 2
+i 1 .1722412109375 .0068359375 2 3
+i 2 .1875 .0078125 0
+i 2 .203125 .0078125 1
+; Start with zero frequency, zero Q, or both, then enable the resonator.
+i 1 .21875 .0078125 0 0 1
+i 1 .234375 .0078125 1 3 1
+i 1 .25 .0078125 2 1 1
+i 99 .28 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Setting `mode` frequency or Q to zero divides by zero while calculating its coefficients. The resulting NaNs enter the feedback state, so restoring positive values cannot recover the output. A 440 → 0 → 440 Hz sweep leaves the resonator permanently NaN.

Treat zero frequency or Q as silence and clear the feedback state. This also handles a single zero sample in audio-rate modulation. Keep the existing equations for nonzero parameters; the new check runs only when a parameter changes and adds no function calls.
