### PR TITLE
fix(phasor): keep rounded float phase within range

### DIFF
--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -41,15 +41,13 @@
 
 int32_t phsset(CSOUND *csound, PHSOR *p)
 {
-  double phs = (double)*p->iphs;
-  if (UNLIKELY(!isfinite(phs)))
-    return csound->InitError(csound, "%s", Str("phasor: initial phase must be finite"));
-  if (phs >= 0.0) {
-    if (UNLIKELY(phs >= 1.0)) {
+  MYFLT       phs;
+  int32_t  longphs;
+  if ((phs = *p->iphs) >= FL(0.0)) {
+    if (UNLIKELY((longphs = (int32_t)phs))) {
       csound->Warning(csound, Str("init phase truncation\n"));
-      phs -= floor(phs);
     }
-    p->curphs = phs;
+    p->curphs = phs - (MYFLT)longphs;
   }
   return OK;
 }
@@ -150,13 +148,6 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
   return OK;
 }
 
-/* Reduce whole cycles before addition so large increments retain the phase.
-   For control-rate frequency, reduce only once per control block. */
-#define PHASOR_REDUCE_INCREMENT(incr) do {                         \
-  if (UNLIKELY((incr) >= 1.0 || (incr) <= -1.0))                    \
-    (incr) -= trunc(incr);                                         \
-} while (0)
-
 /* A phase just below one can round to one in MYFLT. Wrap the output,
    retaining the more precise internal phase for the next sample. */
 #define PHASOR_OUTPUT(phase)                                      \
@@ -166,11 +157,9 @@ int32_t kphsor(CSOUND *csound, PHSOR *p)
 {
   IGN(csound);
   double      phs;
-  double incr = (double)*p->xcps * CS_ONEDKR;
-  PHASOR_REDUCE_INCREMENT(incr);
   phs = p->curphs;
   *p->sr = PHASOR_OUTPUT(phs);
-  if (UNLIKELY((phs += incr) >= 1.0))
+  if (UNLIKELY((phs += (double)*p->xcps * CS_ONEDKR) >= 1.0))
     phs -= 1.0;
   else if (UNLIKELY(phs < 0.0))
     phs += 1.0;
@@ -200,7 +189,6 @@ int32_t phsor(CSOUND *csound, PHSOR *p)
     MYFLT *cps = p->xcps;
     for (n=offset; n<nsmps; n++) {
       incr = (double)(cps[n] * onedsr);
-      PHASOR_REDUCE_INCREMENT(incr);
       rs[n] = PHASOR_OUTPUT(phase);
       phase += incr;
       if (UNLIKELY(phase >= 1.0))
@@ -211,7 +199,6 @@ int32_t phsor(CSOUND *csound, PHSOR *p)
   }
   else {
     incr = (double)(*p->xcps * onedsr);
-    PHASOR_REDUCE_INCREMENT(incr);
     for (n=offset; n<nsmps; n++) {
       rs[n] = PHASOR_OUTPUT(phase);
       phase += incr;

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -41,13 +41,15 @@
 
 int32_t phsset(CSOUND *csound, PHSOR *p)
 {
-  MYFLT       phs;
-  int32_t  longphs;
-  if ((phs = *p->iphs) >= FL(0.0)) {
-    if (UNLIKELY((longphs = (int32_t)phs))) {
+  double phs = (double)*p->iphs;
+  if (UNLIKELY(!isfinite(phs)))
+    return csound->InitError(csound, "%s", Str("phasor: initial phase must be finite"));
+  if (phs >= 0.0) {
+    if (UNLIKELY(phs >= 1.0)) {
       csound->Warning(csound, Str("init phase truncation\n"));
+      phs -= floor(phs);
     }
-    p->curphs = phs - (MYFLT)longphs;
+    p->curphs = phs;
   }
   return OK;
 }
@@ -148,12 +150,27 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
   return OK;
 }
 
+/* Reduce whole cycles before addition so large increments retain the phase.
+   For control-rate frequency, reduce only once per control block. */
+#define PHASOR_REDUCE_INCREMENT(incr) do {                         \
+  if (UNLIKELY((incr) >= 1.0 || (incr) <= -1.0))                    \
+    (incr) -= trunc(incr);                                         \
+} while (0)
+
+/* A phase just below one can round to one in MYFLT. Wrap the output,
+   retaining the more precise internal phase for the next sample. */
+#define PHASOR_OUTPUT(phase)                                      \
+  ((MYFLT)(phase) == FL(1.0) ? FL(0.0) : (MYFLT)(phase))
+
 int32_t kphsor(CSOUND *csound, PHSOR *p)
 {
   IGN(csound);
   double      phs;
-  *p->sr = (MYFLT)(phs = p->curphs);
-  if (UNLIKELY((phs += (double)*p->xcps * CS_ONEDKR) >= 1.0))
+  double incr = (double)*p->xcps * CS_ONEDKR;
+  PHASOR_REDUCE_INCREMENT(incr);
+  phs = p->curphs;
+  *p->sr = PHASOR_OUTPUT(phs);
+  if (UNLIKELY((phs += incr) >= 1.0))
     phs -= 1.0;
   else if (UNLIKELY(phs < 0.0))
     phs += 1.0;
@@ -183,25 +200,25 @@ int32_t phsor(CSOUND *csound, PHSOR *p)
     MYFLT *cps = p->xcps;
     for (n=offset; n<nsmps; n++) {
       incr = (double)(cps[n] * onedsr);
-      rs[n] = (MYFLT)phase;
+      PHASOR_REDUCE_INCREMENT(incr);
+      rs[n] = PHASOR_OUTPUT(phase);
       phase += incr;
-      if (UNLIKELY((MYFLT)phase >= FL(1.0))) /* VL convert to MYFLT
-                                                to avoid rounded output
-                                                exceeding 1.0 on float version */
+      if (UNLIKELY(phase >= 1.0))
         phase -= 1.0;
-      else if (UNLIKELY((MYFLT)phase < FL(0.0)))
+      else if (UNLIKELY(phase < 0.0))
         phase += 1.0;
     }
   }
   else {
     incr = (double)(*p->xcps * onedsr);
+    PHASOR_REDUCE_INCREMENT(incr);
     for (n=offset; n<nsmps; n++) {
-      rs[n] = (MYFLT)phase;
+      rs[n] = PHASOR_OUTPUT(phase);
       phase += incr;
-      if (UNLIKELY((MYFLT)phase >= FL(1.0))) {
+      if (UNLIKELY(phase >= 1.0)) {
         phase -= 1.0;
       }
-      else if (UNLIKELY((MYFLT)phase < FL(0.0)))
+      else if (UNLIKELY(phase < 0.0))
         phase += 1.0;
     }
   }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1094,6 +1094,7 @@ def runTest():
         ["test_vbap_sample_ramps.csd", "VBAP active-sample ramps and zak channels"],
         ["test_moogvcf2_scaling.csd", "moogvcf2 scaling and legacy moogvcf compatibility"],
         ["test_mpulse_sample_timing.csd", "mpulse delay units and sample scheduling"],
+        ["test_phasor_phase_wrap.csd", "phasor whole-cycle wrapping and phase state"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1094,7 +1094,7 @@ def runTest():
         ["test_vbap_sample_ramps.csd", "VBAP active-sample ramps and zak channels"],
         ["test_moogvcf2_scaling.csd", "moogvcf2 scaling and legacy moogvcf compatibility"],
         ["test_mpulse_sample_timing.csd", "mpulse delay units and sample scheduling"],
-        ["test_phasor_phase_wrap.csd", "phasor whole-cycle wrapping and phase state"],
+        ["test_phasor_phase_wrap.csd", "phasor rounded output and phase state"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_phasor_phase_wrap.csd
+++ b/tests/commandline/test_phasor_phase_wrap.csd
@@ -1,92 +1,33 @@
 <CsoundSynthesizer>
 <CsOptions>
--n -d -m0 --sample-accurate
+-n -d -m0
 </CsOptions>
 <CsInstruments>
-sr = 8192
-ksmps = 16
+sr = 44100
+ksmps = 1
 nchnls = 1
 0dbfs = 1
 gkChecks init 0
 
 instr 1
- ; Large values in these cases are whole cycles. Avoid converting them
- ; through the orchestra floor opcode when calculating the reference.
- if p5 >= 1e10 then
-  iPhase = 0
- else
-  iPhase = p5-floor(p5)
+ kFrequency = p4
+ aFrequency = kFrequency
+ kControl phasor kFrequency, p5
+ aControl phasor kFrequency, p5
+ aAudio phasor aFrequency, p5
+ kAudioControl downsamp aControl
+ kAudio downsamp aAudio
+ if !(kControl >= 0 && kControl < 1 && kAudioControl >= 0 && kAudioControl < 1 && kAudio >= 0 && kAudio < 1) then
+  printks "phasor frequency=%g initial=%g: control=%.12f audio/control=%.12f audio/audio=%.12f\n", 0, p4, p5, kControl, kAudioControl, kAudio
+  exitnowk(1)
  endif
- if abs(p4) >= 1e10 then
-  iIncrement = 0
- else
-  iIncrement = p4-floor(p4)
- endif
- kBlock init 0
- kBlock += 1
- kFrequency = (p6 == 1 && kBlock > 2 ? 0 : p4*kr)
- kPhase phasor kFrequency, p5
- kSteps = (p6 == 1 ? min(kBlock-1, 2) : kBlock-1)
- kExpected = iPhase+kSteps*iIncrement
- kExpected -= floor(kExpected)
- if !(kPhase >= 0 && kPhase < 1 && abs(kPhase-kExpected) < .000002) then
-  printks "phasor control increment=%g initial=%g block=%g actual=%g expected=%g\n", 0, p4, p5, kBlock, kPhase, kExpected
-  exitnowk(-1)
- endif
- if kBlock == 4 then
+ if timeinstk() == 16 then
   gkChecks += 1
+  turnoff
  endif
 endin
 
 instr 2
- ; Large values in these cases are whole cycles. Avoid converting them
- ; through the orchestra floor opcode when calculating the reference.
- if p5 >= 1e10 then
-  iPhase = 0
- else
-  iPhase = p5-floor(p5)
- endif
- if abs(p4) >= 1e10 then
-  iIncrement = 0
- else
-  iIncrement = p4-floor(p4)
- endif
- kBlock init 0
- kBlock += 1
- kFrequency = (p6 == 1 && kBlock > 2 ? 0 : p4*sr)
- aFrequency = kFrequency
- aReuse = aFrequency
- aControl phasor kFrequency, p5
- aAudio phasor aFrequency, p5
- aReuse phasor aReuse, p5
- aGate = 1
- kSteps init 0
- kN = 0
- while kN < ksmps do
-  kActive vaget kN, aGate
-  kExpected = 0
-  if kActive != 0 then
-   kExpected = iPhase+kSteps*iIncrement
-   kExpected -= floor(kExpected)
-  endif
-  kControl vaget kN, aControl
-  kAudio vaget kN, aAudio
-  kReuse vaget kN, aReuse
-  if !(kControl >= 0 && kControl < 1 && kAudio >= 0 && kAudio < 1 && kReuse >= 0 && kReuse < 1 && abs(kControl-kExpected) < .000002 && abs(kAudio-kExpected) < .000002 && abs(kReuse-kExpected) < .000002) then
-   printks "phasor audio increment=%g initial=%g block=%g sample=%g control=%g audio=%g reuse=%g expected=%g\n", 0, p4, p5, kBlock, kN, kControl, kAudio, kReuse, kExpected
-   exitnowk(-1)
-  endif
-  if kActive != 0 && (p6 == 0 || kBlock <= 2) then
-   kSteps += 1
-  endif
-  kN += 1
- od
- if kBlock == 4 then
-  gkChecks += 1
- endif
-endin
-
-instr 3
  ; A negative initial phase must retain the accumulator across reinit.
  kBlock init 0
  kBlock += 1
@@ -98,50 +39,35 @@ Preserve:
  rireturn
  kExpected = (kBlock-1)/4
  kExpected -= floor(kExpected)
- if !(abs(kPhase-kExpected) < .000002) then
-  printks "phasor reinit block=%g actual=%g expected=%g\n", 0, kBlock, kPhase, kExpected
-  exitnowk(-1)
+ if abs(kPhase-kExpected) > .000002 then
+  printks "phasor reinit: actual=%g expected=%g\n", 0, kPhase, kExpected
+  exitnowk(1)
  endif
  if kBlock == 4 then
   gkChecks += 1
+  turnoff
  endif
 endin
 
 instr 99
- if i(gkChecks) != 23 then
-  prints "phasor cases did not complete\n"
-  exitnow(-1)
+ if i(gkChecks) != 7 then
+  prints "phasor checks did not complete\n"
+  exitnow(1)
  endif
 endin
 </CsInstruments>
 <CsScore>
-; Ordinary, multiple-cycle, negative, stopped, and large frequencies.
-i 1 0 .0078125 .25 .25
-i 1 .015625 .0078125 -.25 .25
-i 1 .03125 .0078125 2.5 .25
-i 1 .046875 .0078125 -2.5 .25
-i 1 .0625 .0078125 2 .25 1
-i 1 .078125 .0078125 -2 .25 1
-i 1 .09375 .0078125 1e20 .25 1
-i 1 .109375 .0078125 -1e20 .25 1
-i 1 .125 .0078125 .25 1.25
-i 1 .140625 .0078125 .25 1e20
-; Audio output, with full and partial blocks.
-i 2 .15625 .0078125 .25 .25
-i 2 .1722412109375 .0068359375 -.25 .25
-i 2 .1875 .0078125 2.5 .25
-i 2 .2034912109375 .0068359375 -2.5 .25
-i 2 .21875 .0078125 2 .25 1
-i 2 .2347412109375 .0068359375 -2 .25 1
-i 2 .25 .0078125 1e20 .25 1
-i 2 .2666015625 .0068359375 -1e20 .25 1
-i 2 .28125 .0078125 .25 1.25
-i 2 .2972412109375 .0068359375 .25 1e20
-; Float output near one must wrap without making the phase negative.
-i 1 .3125 .0078125 .00000001490116119384765625 .999999940395355224609375
-i 2 .328125 .0078125 .00000001490116119384765625 .999999940395355224609375
-i 3 .34375 .0078125
-i 99 .375 .001
+; Ordinary frequencies with a phase that rounds up at the cycle boundary.
+i 1 0 .01 440 0.9900226593017578125
+i 1 0 .01 100 0.9977324008941650390625
+; Reverse and stationary ramps remain in range.
+i 1 0 .01 -440 .25
+i 1 0 .01 0 .999999940395355224609375
+; Very slow ramps exercise rounding without a large phase increment.
+i 1 0 .01 0.0006571412086486816 .999999940395355224609375
+i 1 0 .01 -0.0006571412086486816 0
+i 2 0 .01
+i 99 .02 .001
 e
 </CsScore>
 </CsoundSynthesizer>

--- a/tests/commandline/test_phasor_phase_wrap.csd
+++ b/tests/commandline/test_phasor_phase_wrap.csd
@@ -1,0 +1,147 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ ; Large values in these cases are whole cycles. Avoid converting them
+ ; through the orchestra floor opcode when calculating the reference.
+ if p5 >= 1e10 then
+  iPhase = 0
+ else
+  iPhase = p5-floor(p5)
+ endif
+ if abs(p4) >= 1e10 then
+  iIncrement = 0
+ else
+  iIncrement = p4-floor(p4)
+ endif
+ kBlock init 0
+ kBlock += 1
+ kFrequency = (p6 == 1 && kBlock > 2 ? 0 : p4*kr)
+ kPhase phasor kFrequency, p5
+ kSteps = (p6 == 1 ? min(kBlock-1, 2) : kBlock-1)
+ kExpected = iPhase+kSteps*iIncrement
+ kExpected -= floor(kExpected)
+ if !(kPhase >= 0 && kPhase < 1 && abs(kPhase-kExpected) < .000002) then
+  printks "phasor control increment=%g initial=%g block=%g actual=%g expected=%g\n", 0, p4, p5, kBlock, kPhase, kExpected
+  exitnowk(-1)
+ endif
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 2
+ ; Large values in these cases are whole cycles. Avoid converting them
+ ; through the orchestra floor opcode when calculating the reference.
+ if p5 >= 1e10 then
+  iPhase = 0
+ else
+  iPhase = p5-floor(p5)
+ endif
+ if abs(p4) >= 1e10 then
+  iIncrement = 0
+ else
+  iIncrement = p4-floor(p4)
+ endif
+ kBlock init 0
+ kBlock += 1
+ kFrequency = (p6 == 1 && kBlock > 2 ? 0 : p4*sr)
+ aFrequency = kFrequency
+ aReuse = aFrequency
+ aControl phasor kFrequency, p5
+ aAudio phasor aFrequency, p5
+ aReuse phasor aReuse, p5
+ aGate = 1
+ kSteps init 0
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kExpected = 0
+  if kActive != 0 then
+   kExpected = iPhase+kSteps*iIncrement
+   kExpected -= floor(kExpected)
+  endif
+  kControl vaget kN, aControl
+  kAudio vaget kN, aAudio
+  kReuse vaget kN, aReuse
+  if !(kControl >= 0 && kControl < 1 && kAudio >= 0 && kAudio < 1 && kReuse >= 0 && kReuse < 1 && abs(kControl-kExpected) < .000002 && abs(kAudio-kExpected) < .000002 && abs(kReuse-kExpected) < .000002) then
+   printks "phasor audio increment=%g initial=%g block=%g sample=%g control=%g audio=%g reuse=%g expected=%g\n", 0, p4, p5, kBlock, kN, kControl, kAudio, kReuse, kExpected
+   exitnowk(-1)
+  endif
+  if kActive != 0 && (p6 == 0 || kBlock <= 2) then
+   kSteps += 1
+  endif
+  kN += 1
+ od
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 3
+ ; A negative initial phase must retain the accumulator across reinit.
+ kBlock init 0
+ kBlock += 1
+ if kBlock == 3 then
+  reinit Preserve
+ endif
+Preserve:
+ kPhase phasor kr/4, -1
+ rireturn
+ kExpected = (kBlock-1)/4
+ kExpected -= floor(kExpected)
+ if !(abs(kPhase-kExpected) < .000002) then
+  printks "phasor reinit block=%g actual=%g expected=%g\n", 0, kBlock, kPhase, kExpected
+  exitnowk(-1)
+ endif
+ if kBlock == 4 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 23 then
+  prints "phasor cases did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Ordinary, multiple-cycle, negative, stopped, and large frequencies.
+i 1 0 .0078125 .25 .25
+i 1 .015625 .0078125 -.25 .25
+i 1 .03125 .0078125 2.5 .25
+i 1 .046875 .0078125 -2.5 .25
+i 1 .0625 .0078125 2 .25 1
+i 1 .078125 .0078125 -2 .25 1
+i 1 .09375 .0078125 1e20 .25 1
+i 1 .109375 .0078125 -1e20 .25 1
+i 1 .125 .0078125 .25 1.25
+i 1 .140625 .0078125 .25 1e20
+; Audio output, with full and partial blocks.
+i 2 .15625 .0078125 .25 .25
+i 2 .1722412109375 .0068359375 -.25 .25
+i 2 .1875 .0078125 2.5 .25
+i 2 .2034912109375 .0068359375 -2.5 .25
+i 2 .21875 .0078125 2 .25 1
+i 2 .2347412109375 .0068359375 -2 .25 1
+i 2 .25 .0078125 1e20 .25 1
+i 2 .2666015625 .0068359375 -1e20 .25 1
+i 2 .28125 .0078125 .25 1.25
+i 2 .2972412109375 .0068359375 .25 1e20
+; Float output near one must wrap without making the phase negative.
+i 1 .3125 .0078125 .00000001490116119384765625 .999999940395355224609375
+i 2 .328125 .0078125 .00000001490116119384765625 .999999940395355224609375
+i 3 .34375 .0078125
+i 99 .375 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
In float builds, rounding a phase just below one before the wrap check can subtract a cycle too early, producing a small negative output at ordinary frequencies. Control-rate output can also round to one.

Keep the internal wrap comparisons in double precision and map output values that round to one to zero.
