### PR TITLE
fix(mpulse): correct delay units and sample scheduling

### DIFF
--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1693,7 +1693,15 @@ int32_t clip(CSOUND *csound, CLIP *p)
 
 int32_t impulse_set(CSOUND *csound, IMPULSE *p)
 {
-    p->next = (uint32_t)MYFLT2LONG(*p->offset * CS_ESR);
+    double delay = *p->offset;
+    double samples = delay < 0.0 ? -delay : delay * CS_ESR;
+    if (UNLIKELY(!(samples < (double)INT64_MAX)))
+      return csound->InitError(csound, "%s", Str("mpulse: invalid initial delay"));
+#if defined(USE_LRINT) || defined(MSVC)
+    /* Preserve the initial-delay rounding used by MYFLT2LONG. */
+    samples = nearbyint(samples);
+#endif
+    p->next = (int64_t)samples;
     return OK;
 }
 
@@ -1701,34 +1709,37 @@ int32_t impulse(CSOUND *csound, IMPULSE *p)
 {
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
-    uint32_t n, nsmps = CS_KSMPS;
-    int32_t next = p->next;
+    uint32_t n = offset, nsmps = CS_KSMPS - early;
+    int64_t next = p->next, interval;
     MYFLT *ar = p->ar;
-    if (next<0) next = -next;
-    if (UNLIKELY(next < (int32)nsmps)) { /* Impulse in this frame */
-      MYFLT frq = *p->freq;     /* Freq at k-rate */
-      int32_t sfreq;                /* Converted to samples */
-      if (frq == FL(0.0)) sfreq = INT_MAX; /* Zero means infinite */
-      else if (frq < FL(0.0)) sfreq = -(int32_t)frq; /* Negative cnts in sample */
-      else sfreq = (int32_t)(frq*CS_ESR); /* Normal case */
-      if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
-      if (UNLIKELY(early)) {
-        nsmps -= early;
-        memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
-      }
-      for (n=offset;n<nsmps;n++) {
-        if (UNLIKELY(next-- == 0)) {
-          ar[n] = *p->amp;
-          next = sfreq - 1;     /* Note can be less than k-rate */
-        }
-        else ar[n] = FL(0.0);
-      }
+
+    memset(ar, 0, CS_KSMPS*sizeof(MYFLT));
+    if (next < 0 || offset >= nsmps)
+      return OK;
+    if (next >= nsmps-offset) {
+      p->next = next - (nsmps-offset);
+      return OK;
     }
-    else {                      /* Nothing this time so just fill */
-      memset(ar, 0, nsmps*sizeof(MYFLT));
-      next -= nsmps;
+
+    /* Read the interval only in a block containing an impulse. */
+    double seconds = *p->freq;
+    double samples = seconds < 0.0 ? -seconds : seconds * CS_ESR;
+    if (UNLIKELY(!(samples < (double)INT64_MAX)))
+      return csound->PerfError(csound, &p->h, "%s", Str("mpulse: invalid interval"));
+    interval = (int64_t)samples;
+    if (seconds != 0.0 && interval == 0)
+      interval = 1; /* A nonzero interval cannot be shorter than one sample. */
+
+    while (next < nsmps-n) {
+      n += (uint32_t)next;
+      ar[n++] = *p->amp;
+      if (interval == 0) {
+        p->next = -1; /* Zero interval means one impulse, with no countdown. */
+        return OK;
+      }
+      next = interval - 1;
     }
-    p->next = next;
+    p->next = next - (nsmps-n);
     return OK;
 }
 

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -261,7 +261,7 @@ typedef struct {
         OPDS    h;
         MYFLT   *ar;
         MYFLT   *amp, *freq, *offset;
-        uint32_t     next;
+        int64_t      next;       /* -1 means no further impulses */
 } IMPULSE;
 
 typedef struct {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1082,6 +1082,7 @@ def runTest():
         ["test_mode_zero_parameters.csd", "mode recovers from zero frequency and Q"],
         ["test_vbap_sample_ramps.csd", "VBAP active-sample ramps and zak channels"],
         ["test_moogvcf2_scaling.csd", "moogvcf2 scaling and legacy moogvcf compatibility"],
+        ["test_mpulse_sample_timing.csd", "mpulse delay units and sample scheduling"],
         ["test_chebyshevpoly2_empty_array.csd", "reject empty Chebyshev coefficients", 1],
         ["test_generic_chan.csd", "testing generic bus channel"],
         ["test_generic_chan_no_match.csd", "testing type mismatch for bus channel", 1],

--- a/tests/commandline/test_mpulse_sample_timing.csd
+++ b/tests/commandline/test_mpulse_sample_timing.csd
@@ -1,0 +1,94 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+ kBlock init 0
+ kBlock += 1
+ kInterval = p5
+ kPeriod = p7
+ if p8 == 1 then
+  ; Changes before the first pulse must not change its scheduled time.
+  ; Each pulse uses the interval from its own control block.
+  kPeriod = (kBlock == 1 ? 5 : (kBlock == 2 ? 10 : 7))
+  kInterval = -kPeriod
+ elseif p8 == 2 && kBlock > 1 then
+  ; Changing the interval cannot restart a completed one-shot.
+  kPeriod = 7
+  kInterval = -7
+ endif
+ aPulse mpulse .5, kInterval, p4
+ aGate = 1
+ kElapsed init 0
+ kNext init p6
+ kN = 0
+ while kN < ksmps do
+  kActive vaget kN, aGate
+  kPulse vaget kN, aPulse
+  kExpected = 0
+  if kActive != 0 then
+   if kElapsed == kNext then
+    kExpected = .5
+    if kPeriod == 0 then
+     kNext = -1
+    else
+     kNext += kPeriod
+    endif
+   endif
+   kElapsed += 1
+  endif
+  if kPulse != kExpected then
+   printks "mpulse delay=%g interval=%g block=%g sample=%g elapsed=%g actual=%g expected=%g\n", 0, p4, kInterval, kBlock, kN, kElapsed, kPulse, kExpected
+   exitnowk(-1)
+  endif
+  kN += 1
+ od
+ if kElapsed == 64 then
+  gkChecks += 1
+ endif
+endin
+
+instr 99
+ if i(gkChecks) != 24 then
+  prints "mpulse cases did not complete\n"
+  exitnow(-1)
+ endif
+endin
+</CsInstruments>
+<CsScore>
+; Alternate full blocks and notes starting at sample 3.
+i 1 0.0 .0078125 0 -32 0 32 0
+i 1 0.0159912109375 .0078125 -20 -32 20 32 0
+i 1 0.03125 .0078125 0.00244140625 -32 20 32 0
+i 1 0.0472412109375 .0078125 -16 -7 16 7 0
+i 1 0.0625 .0078125 -17 -7 17 7 0
+i 1 0.0784912109375 .0078125 -15 -7 15 7 0
+i 1 0.09375 .0078125 -32 -7 32 7 0
+i 1 0.1097412109375 .0078125 -40 -7 40 7 0
+i 1 0.125 .0078125 0 0.0008544921875 0 7 0
+i 1 0.1409912109375 .0078125 -20 0.00390625 20 32 0
+i 1 0.15625 .0078125 0.00244140625 0.0008544921875 20 7 0
+i 1 0.1722412109375 .0078125 0 -1 0 1 0
+i 1 0.1875 .0078125 0 0.0001220703125 0 1 0
+i 1 0.2034912109375 .0078125 0 -0.25 0 1 0
+i 1 0.21875 .0078125 0 3.0517578125e-05 0 1 0
+i 1 0.2347412109375 .0078125 -20 -1.75 20 1 0
+i 1 0.25 .0078125 0 0 0 0 0
+i 1 0.2659912109375 .0078125 -20 0 20 0 0
+i 1 0.28125 .0078125 0 0 0 0 2
+i 1 0.2972412109375 .0078125 -20 -32 20 32 1
+i 1 0.3125 .0078125 -4294967296 -32 4294967296 32 0
+i 1 0.3284912109375 .0078125 524288.0 -32 4294967296 32 0
+i 1 0.34375 .0078125 0 -4294967296 0 4294967296 0
+i 1 0.3597412109375 .0078125 0 524288.0 0 4294967296 0
+i 99 .4 .001
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Treat negative initial delays as sample counts, as documented, and count only active samples when carrying a delay across blocks. This keeps pulse timing correct for notes that start or end within a block.

Keep zero intervals as a true one-shot, clamp nonzero sub-sample intervals to one sample, and use a checked 64-bit countdown so long delays and intervals do not overflow.