### PR TITLE
fix(changed2): track complete arrays and size changes

### DIFF
--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -31,6 +31,7 @@
 #include "gab.h"
 #include <math.h>
 #include "interlocks.h"
+#include "arrays.h"
 
 #define FLT_MAX ((MYFLT)0x7fffffff)
 
@@ -741,7 +742,7 @@ static int32_t isChanged(CSOUND *csound,ISCHANGED *p)
     }
   }
   *p->ktrig = (MYFLT) ktrig;
-  p->cnt++;
+  p->cnt = 1;
   return OK;
 }
 
@@ -753,17 +754,21 @@ static int32_t isChanged2_set(CSOUND *csound,ISCHANGED *p)
 }
 
 /* changed in array */
+static int32_t isAChanged_size(ARRAYDAT *arr, size_t *size)
+{
+  size_t count;
+  if (csound_array_member_count(arr, &count) != OK)
+    return NOTOK;
+  return csound_array_allocation_size(arr->arrayMemberSize, count, size);
+}
+
 static int32_t isAChanged_set(CSOUND *csound, ISACHANGED *p)
 {
-  int32_t size = 0, i;
-  ARRAYDAT *arr = p->chk;
-  //char *tmp;
-  for (i=0; i<arr->dimensions; i++) size += arr->sizes[i];
-  size *= arr->arrayMemberSize;
-  csound->AuxAlloc(csound, size, &p->old_chk);
-  /* tmp = (char*)p->old_chk.auxp; */
-  /* for (i=0; i<size; i++) tmp[i]=rand()&0xff; */
-  /* memset(p->old_chk.auxp, '\0', size); */
+  size_t size;
+  if (UNLIKELY(isAChanged_size(p->chk, &size) != OK))
+    return csound->InitError(csound, "%s", Str("changed2: invalid array size"));
+  if (size > p->old_chk.size)
+    csound->AuxAlloc(csound, size, &p->old_chk);
   p->size = size;
   p->cnt = 0;
   return OK;
@@ -772,14 +777,23 @@ static int32_t isAChanged_set(CSOUND *csound, ISACHANGED *p)
 
 static int32_t isAChanged(CSOUND *csound,ISACHANGED *p)
 {
-  IGN(csound);
   ARRAYDAT *chk = p->chk;
-  void *old_chk = p->old_chk.auxp;
-  int32_t size = p->size;
-  int32_t ktrig = memcmp(chk->data, old_chk, size);
-  memcpy(old_chk, chk->data, size);
+  size_t size;
+  int32_t ktrig;
+  if (UNLIKELY(isAChanged_size(chk, &size) != OK))
+    return csound->PerfError(csound, &(p->h), "%s",
+                             Str("changed2: invalid array size"));
+  ktrig = size != p->size;
+  if (size > p->old_chk.size)
+    csound->AuxAlloc(csound, size, &p->old_chk);
+  if (size != 0) {
+    if (p->cnt && !ktrig)
+      ktrig = memcmp(chk->data, p->old_chk.auxp, size);
+    memcpy(p->old_chk.auxp, chk->data, size);
+  }
   *p->ktrig = (p->cnt && ktrig)?FL(1.0):FL(0.0);
-  p->cnt++;
+  p->size = size;
+  p->cnt = 1;
   return OK;
 }
 

--- a/Opcodes/gab/gab.h
+++ b/Opcodes/gab/gab.h
@@ -112,7 +112,7 @@ typedef struct {
     OPDS     h;
     MYFLT    *ktrig;
     ARRAYDAT *chk;
-    int32_t  size;
+    size_t   size;
     int32_t  cnt;
     AUXCH    old_chk;
 } ISACHANGED;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -611,6 +611,7 @@ def runTest():
         ["test_arrayops_current_length.csd", "array math and sorting follow current input lengths"],
         ["test_arrayops_short_second.csd", "array math rejects a shortened second input", 1],
         ["test_dot_short_second.csd", "dot rejects a shortened second input", 1],
+        ["test_changed2_arrays.csd", "changed2 array dimensions, resizing and first-cycle state"],
         ["test_gtf_complex_state.csd", "gtf complex impulse response and sample bounds"],
         ["test_repluck_correctness.csd", "test plucked-string waveguide limits"],
         ["test_repluck_sample_offset.csd", "test repluck sample-accurate input"],

--- a/tests/commandline/test_changed2_arrays.csd
+++ b/tests/commandline/test_changed2_arrays.csd
@@ -1,0 +1,110 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 1
+gkChecks init 0
+
+opcode Check, 0, kk
+  kActual, kExpected xin
+  if kActual != kExpected then
+    printks "changed detector: expected=%d actual=%d\n", 0, kExpected, kActual
+    exitnowk(-1)
+  endif
+endop
+
+instr 1
+  kArray[][] init p4,p5
+  kCycle timeinstk
+  if kCycle == 2 then
+    kArray[p4-1][p5-1] = 1
+  elseif kCycle == 4 then
+    kArray[0][0] = 2
+  endif
+  kTrigger changed2 kArray
+  Check kTrigger, (kCycle == 2 || kCycle == 4 ? 1 : 0)
+  if kCycle == 5 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 2
+  aArray[][][] init 2,2,3
+  kCycle timeinstk
+  aValue = kCycle >= 2 ? 1 : 0
+  aArray[1][1][2] = aValue
+  kTrigger changed2 aArray
+  Check kTrigger, (kCycle == 2 ? 1 : 0)
+  if kCycle == 5 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 3
+  kArray[] init 6
+  trim_i kArray, 2
+  kCycle timeinstk
+  kSize = kCycle < 2 ? 2 : (kCycle < 5 ? 6 : (kCycle == 5 ? 1 : (kCycle < 8 ? 0 : 3)))
+  trim kArray, kSize
+  if kCycle == 3 then
+    kArray[5] = 1
+  elseif kCycle == 9 then
+    kArray[2] = 1
+  endif
+  kTrigger changed2 kArray
+  Check kTrigger, (kCycle == 2 || kCycle == 3 || kCycle == 5 || kCycle == 6 || kCycle == 8 || kCycle == 9 ? 1 : 0)
+  if kCycle == 10 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 4
+  kEmpty[] init 0
+  kArray[] init 1
+  kCycle timeinstk
+  kArray[0] = kCycle
+  if kCycle == 3 then
+    reinit WATCH
+  endif
+WATCH:
+  kTrigger changed2 kArray
+  rireturn
+  kEmptyTrigger changed2 kEmpty
+  Check kEmptyTrigger, 0
+  Check kTrigger, (kCycle == 1 || kCycle == 3 ? 0 : 1)
+  kValue = kCycle < 3 ? 5 : 7
+  kLegacy changed kValue
+  kNew changed2 kValue
+  Check kLegacy, (kCycle == 1 || kCycle == 3 ? 1 : 0)
+  Check kNew, (kCycle == 3 ? 1 : 0)
+  if kCycle == 5 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if gkChecks != 7 then
+    printks "missing changed2 cases: %d\n", 0, gkChecks
+    exitnowk(-1)
+  endif
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .125 2 3
+i 1 .125 .125 3 2
+i 1 .25 .125 1 3
+i 1 .375 .125 3 1
+i 2 .5 .125
+i 3 .625 .25
+i 4 .875 .125
+i 99 1 .01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
changed2 adds array dimensions instead of multiplying them, so a 2×3 array checks only five elements. It also keeps the initial byte count after resizing.

Use the shared array-size helpers and size_t, compare the full current array, and update the snapshot when its length changes. Empty arrays need no data access, and the first cycle still produces no trigger.

Use the first-cycle flag without incrementing it in both changed and changed2, preventing signed counter overflow in long-running instruments.