### PR TITLE
fix(moogladder2): track current audio resonance

### DIFF
--- a/Opcodes/newfils.c
+++ b/Opcodes/newfils.c
@@ -163,6 +163,10 @@ static int32_t moogladder_process(CSOUND *csound, moogladder *p)
   return OK;
 }
 
+/* Legacy moogladder caches the block's first resonance even after it changes.
+   Returning to that value can retain the previous feedback gain. Preserve
+   this audible behavior for existing scores; fix it only in moogladder2.
+   Its audio resonance also retains the historical lack of a negative clamp. */
 static int32_t moogladder_process_aa(CSOUND *csound, moogladder *p)
 {
   MYFLT   *out = p->out;
@@ -359,6 +363,8 @@ static int32_t moogladder_process_ak(CSOUND *csound, moogladder *p)
   return OK;
 }
 
+/* Legacy moogladder does not clamp negative audio resonance within the block.
+   Preserve this behavior for existing scores; use moogladder2 for the fix. */
 static int32_t moogladder_process_ka(CSOUND *csound, moogladder *p)
 {
   MYFLT   *out = p->out;
@@ -558,6 +564,8 @@ static int32_t moogladder2_process_aa(CSOUND *csound, moogladder *p)
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t i, nsmps = CS_KSMPS;
 
+  if (cres < 0) cres = 0;
+
   if (p->oldfreq != cfreq || p->oldres != cres) {
     double  f, fc, fc2, fc3, fcr;
     p->oldfreq = cfreq;
@@ -587,7 +595,9 @@ static int32_t moogladder2_process_aa(CSOUND *csound, moogladder *p)
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
   for (i = offset; i < nsmps; i++) {
-    if (p->oldfreq != freq[i] || p->oldres != res[i]) {
+    MYFLT resonance = res[i];
+    if (resonance < 0) resonance = 0;
+    if (p->oldfreq != freq[i] || p->oldres != resonance) {
       double  f, fc, fc2, fc3, fcr;
       p->oldfreq = freq[i];
       /* sr is half the actual filter sampling rate  */
@@ -599,10 +609,10 @@ static int32_t moogladder2_process_aa(CSOUND *csound, moogladder *p)
       fcr = 1.8730*fc3 + 0.4955*fc2 - 0.6490*fc + 0.9988;
       acr = -3.9364*fc2 + 1.8409*fc + 0.9968;
       tune = (1.0 - exp(-(TWOPI*f*fcr))) / vt;   /* filter tuning  */
-      p->oldres = cres;
+      p->oldres = resonance;
       p->oldacr = acr;
       p->oldtune = tune;
-      res4 = 4.0*(double)res[i]*acr;
+      res4 = 4.0*(double)resonance*acr;
     }
     /* oversampling  */
     for (j = 0; j < 2; j++) {
@@ -785,7 +795,9 @@ static int32_t moogladder2_process_ka(CSOUND *csound, moogladder *p)
     memset(&out[nsmps], '\0', early*sizeof(MYFLT));
   }
   for (i = offset; i < nsmps; i++) {
-    if (cres != res[i]) {
+    MYFLT resonance = res[i];
+    if (resonance < 0) resonance = 0;
+    if (cres != resonance) {
       double  f, fc, fc2, fc3, fcr;
       /* sr is half the actual filter sampling rate  */
       fc =  (double)(freq/CS_ESR);
@@ -796,7 +808,7 @@ static int32_t moogladder2_process_ka(CSOUND *csound, moogladder *p)
       fcr = 1.8730*fc3 + 0.4955*fc2 - 0.6490*fc + 0.9988;
       acr = -3.9364*fc2 + 1.8409*fc + 0.9968;
       tune = (1.0 - exp(-(TWOPI*f*fcr))) / vt;   /* filter tuning  */
-      p->oldres = cres = res[i];
+      p->oldres = cres = resonance;
       p->oldacr = acr;
       p->oldtune = tune;
       res4 = 4.0*(double)cres*acr;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -886,6 +886,7 @@ def runTest():
         ["test_areson_audio.csd", "test areson audio coefficients and preserved state"],
         ["test_svfilter_state.csd", "svfilter reset, preserved state, and input reuse"],
         ["test_statevar_oversampling.csd", "statevar oversampling and preserved filter history"],
+        ["test_moogladder2_resonance.csd", "moogladder2 resonance changes and parameter-rate parity"],
         ["test_phaser_reinit.csd", "phaser reset and preserved state on reinit"],
         [
             "test_audio_input_sample_bounds.csd",

--- a/tests/commandline/test_moogladder2_resonance.csd
+++ b/tests/commandline/test_moogladder2_resonance.csd
@@ -1,0 +1,100 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+opcode Reference, a, aaa
+  setksmps 1
+  aInput, aFrequency, aResonance xin
+  kFrequency downsamp aFrequency
+  kResonance downsamp aResonance
+  aOutput moogladder2 aInput, kFrequency, kResonance
+  xout aOutput
+endop
+
+instr 1
+  kCycle timeinstk
+  aInput = .2
+  aFrequency = 1000
+  kResonance = kCycle%2 == 1 ? 0 : .4
+  if p4 == 0 then
+    kResonance = .6
+  elseif p4 == 2 then
+    kResonance = .8
+  elseif p4 == 5 then
+    kResonance = -.5
+  endif
+  aResonance = kResonance
+  if p4 == 1 || p4 == 4 then
+    vaset .8, 4, aResonance
+  elseif p4 == 2 then
+    vaset 0, 4, aResonance
+  elseif p4 == 3 then
+    vaset -.8, 4, aResonance
+  endif
+  if p4 == 4 then
+    vaset 1200, 6, aFrequency
+  endif
+
+  aReference Reference aInput, aFrequency, aResonance
+  aBoth moogladder2 aInput, aFrequency, aResonance
+  aInputCopy = aInput
+  aFrequencyCopy = aFrequency
+  aResonanceCopy = aResonance
+  aInputCopy moogladder2 aInputCopy, aFrequency, aResonance
+  aFrequencyCopy moogladder2 aInput, aFrequencyCopy, aResonance
+  aResonanceCopy moogladder2 aInput, aFrequency, aResonanceCopy
+  aError = abs(aBoth-aReference)+abs(aInputCopy-aReference)+abs(aFrequencyCopy-aReference)+abs(aResonanceCopy-aReference)
+  if p4 != 4 then
+    aMixed moogladder2 aInput, 1000, aResonance
+    aError += abs(aMixed-aReference)
+  endif
+  if p4 == 0 || p4 == 5 then
+    aControl moogladder2 aInput, 1000, kResonance
+    aOtherMixed moogladder2 aInput, aFrequency, kResonance
+    aError += abs(aControl-aReference)+abs(aOtherMixed-aReference)
+  endif
+  kIndex = 0
+  while kIndex < ksmps do
+    kError vaget kIndex, aError
+    if !(kError < .00001) then
+      printks "moogladder2 case=%d cycle=%d sample=%d error=%g\n", 0, p4, kCycle, kIndex, kError
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+  if kCycle == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if gkChecks != 12 then
+    printks "missing moogladder2 cases: %d\n", 0, gkChecks
+    exitnowk(-1)
+  endif
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .0078125 0
+i 1 0 .0078125 1
+i 1 0 .0078125 2
+i 1 0 .0078125 3
+i 1 0 .0078125 4
+i 1 0 .0078125 5
+i 1 .0159912109375 .0078125 0
+i 1 .0159912109375 .0078125 1
+i 1 .0159912109375 .0078125 2
+i 1 .0159912109375 .0078125 3
+i 1 .0159912109375 .0078125 4
+i 1 .0159912109375 .0078125 5
+i 99 .03125 .01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
When cutoff and resonance both run at audio rate, moogladder2 caches the block’s first resonance instead of the current sample. Returning to that earlier value can leave the previous feedback gain active. Store the resonance actually used to calculate the gain.

Clamp each audio-rate resonance sample to zero when negative, matching the control-rate behavior. These changes add no function calls.

Leave legacy moogladder behavior unchanged, with comments explaining why its corresponding code must stay for compatibility.