### PR TITLE
fix(ephasor): wrap phase and clear inactive outputs

### DIFF
--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -54,17 +54,30 @@ int32_t phsset(CSOUND *csound, PHSOR *p)
 
 int32_t ephsset(CSOUND *csound, EPHSOR *p)
 {
-  MYFLT       phs;
-  int32_t  longphs;
-  if ((phs = *p->iphs) >= FL(0.0)) {
-    if (UNLIKELY((longphs = (int32_t)phs))) {
+  double phs = (double)*p->iphs;
+  if (UNLIKELY(!isfinite(phs)))
+    return csound->InitError(csound, "%s", Str("ephasor: initial phase must be finite"));
+  if (phs >= 0.0) {
+    if (UNLIKELY(phs >= 1.0)) {
       csound->Warning(csound, Str("init phase truncation\n"));
+      phs -= floor(phs);
     }
-    p->curphs = phs - (MYFLT)longphs;
+    p->curphs = phs;
   }
   p->b = 1.0;
   return OK;
 }
+
+/* Remove whole cycles before addition so large increments retain the phase.
+   Keep the wrap event: it also resets the exponential output. */
+#define EPHASOR_INCREMENT(incr, wrapped) do {                         \
+    (wrapped) = (incr) >= 1.0 || (incr) <= -1.0;                       \
+    if (UNLIKELY(wrapped)) (incr) -= trunc(incr);                       \
+  } while (0)
+
+/* A double phase just below one may round to one in a float build. */
+#define EPHASOR_OUTPUT(phase)                                        \
+  ((MYFLT)(phase) < FL(1.0) ? (MYFLT)(phase) : FL(0.0))
 
 int32_t ephsor(CSOUND *csound, EPHSOR *p)
 {
@@ -75,21 +88,27 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
     MYFLT       *rs, *aphs, onedsr = CS_ONEDSR;
     double      b = p->b;
     double      incr, R = *p->kR;
+    int32_t     whole_cycle;
 
   rs = p->sr;
-  if (UNLIKELY(offset)) memset(rs, '\0', offset*sizeof(MYFLT));
+  aphs = p->aphs;
+  if (UNLIKELY(offset)) {
+    memset(rs, '\0', offset*sizeof(MYFLT));
+    memset(aphs, '\0', offset*sizeof(MYFLT));
+  }
   if (UNLIKELY(early)) {
     nsmps -= early;
     memset(&rs[nsmps], '\0', early*sizeof(MYFLT));
+    memset(&aphs[nsmps], '\0', early*sizeof(MYFLT));
   }
-  aphs = p->aphs;
   phase = p->curphs;
   if (IS_ASIG_ARG(p->xcps)) {
     MYFLT *cps = p->xcps;
     for (n=offset; n<nsmps; n++) {
       incr = (double)(cps[n] * onedsr);
+      EPHASOR_INCREMENT(incr, whole_cycle);
       rs[n] = (MYFLT) b;
-      aphs[n] = (MYFLT) phase;
+      aphs[n] = EPHASOR_OUTPUT(phase);
       phase += incr;
       b *= R;
       if (UNLIKELY(phase >= 1.0)) {
@@ -100,13 +119,16 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
         phase += 1.0;
         b = pow(R, 1.0+phase);
       }
+      else if (UNLIKELY(whole_cycle))
+        b = pow(R, 1.0+phase);
     }
   }
   else {
     incr = (double)(*p->xcps * onedsr);
+    EPHASOR_INCREMENT(incr, whole_cycle);
     for (n=offset; n<nsmps; n++) {
       rs[n] = (MYFLT) b;
-      aphs[n] = (MYFLT) phase;
+      aphs[n] = EPHASOR_OUTPUT(phase);
       phase += incr;
       b *= R;
       if (UNLIKELY(phase >= 1.0)) {
@@ -117,6 +139,8 @@ int32_t ephsor(CSOUND *csound, EPHSOR *p)
         phase += 1.0;
         b = pow(R, 1.0+phase);
       }
+      else if (UNLIKELY(whole_cycle))
+        b = pow(R, 1.0+phase);
     }
   }
   p->curphs = phase;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -620,6 +620,7 @@ def runTest():
         ["test_arrayops_short_second.csd", "array math rejects a shortened second input", 1],
         ["test_dot_short_second.csd", "dot rejects a shortened second input", 1],
         ["test_changed2_arrays.csd", "changed2 array dimensions, resizing and first-cycle state"],
+        ["test_ephasor_phase.csd", "ephasor phase wrapping, exponential resets and sample bounds"],
         ["test_gtf_complex_state.csd", "gtf complex impulse response and sample bounds"],
         ["test_repluck_correctness.csd", "test plucked-string waveguide limits"],
         ["test_repluck_sample_offset.csd", "test repluck sample-accurate input"],

--- a/tests/commandline/test_ephasor_phase.csd
+++ b/tests/commandline/test_ephasor_phase.csd
@@ -1,0 +1,108 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  iOffset = int(p2*sr)%ksmps
+  iSamples = int(p3*sr)
+  kCycle timeinstk
+  kCount init 0
+  kAmplitude init 1
+  kInitial init p5
+  kR = kCycle < 3 ? .99 : .9
+  aFrequency = p4*sr
+  ; Seed inactive output slots so failure to clear them is visible.
+  aPhase = 0
+  aAudioPhase = 0
+  vaset .75, 0, aPhase
+  vaset .75, 15, aAudioPhase
+  if p7 == 1 && kCycle == 3 then
+    kInitial = -1
+    kAmplitude = 1
+    reinit OSC
+  endif
+OSC:
+  aAmplitude,aPhase ephasor p4*sr,kR,i(kInitial)
+  aAudioAmplitude,aAudioPhase ephasor aFrequency,kR,i(kInitial)
+  rireturn
+  kIndex = 0
+  while kIndex < ksmps do
+    kPhase vaget kIndex,aPhase
+    kAudioPhase vaget kIndex,aAudioPhase
+    kAmp vaget kIndex,aAmplitude
+    kAudioAmp vaget kIndex,aAudioAmplitude
+    if (kCycle != 1 || kIndex >= iOffset) && kCount < iSamples then
+      ; Huge increments here are exact whole cycles; keep the oracle small.
+      kStep = abs(p4) > 1e10 ? 0 : p4
+      kUnwrapped = p6 + kCount*kStep
+      kExpected = kUnwrapped - floor(kUnwrapped)
+      kNext = kUnwrapped + kStep
+      kNextPhase = kNext - floor(kNext)
+      kDistance = abs(kPhase-kExpected)
+      if kDistance > .5 then
+        kDistance = 1-kDistance
+      endif
+      if !(kPhase >= 0 && kPhase < 1) || kDistance > .00001 || abs(kAudioPhase-kPhase) > .00001 || abs(kAmp-kAmplitude) > .00001 || abs(kAudioAmp-kAmplitude) > .00001 then
+        printks "ephasor step=%g sample=%d phase=%g expected=%g amplitude=%g expected=%g\n",0,p4,kCount,kPhase,kExpected,kAmp,kAmplitude
+        exitnowk(-1)
+      endif
+      ; This dyadic case wraps after four samples. Count them explicitly so
+      ; the float oracle does not lose the increment next to phase one.
+      if p4 == .00000001490116119384765625 then
+        if kCount == 3 then
+          kAmplitude = kR
+        else
+          kAmplitude *= kR
+        endif
+      elseif abs(p4) >= 1 || floor(kNext) != floor(kUnwrapped) then
+        kAmplitude = kR ^ (1+kNextPhase)
+      else
+        kAmplitude *= kR
+      endif
+      kCount += 1
+      if kCount == iSamples then
+        gkChecks += 1
+      endif
+    elseif kPhase != 0 || kAudioPhase != 0 || kAmp != 0 || kAudioAmp != 0 then
+      printks "ephasor left an inactive sample uncleared\n",0
+      exitnowk(-1)
+    endif
+    kIndex += 1
+  od
+endin
+
+instr 99
+  if gkChecks != 15 then
+    printks "missing ephasor cases: %d\n",0,gkChecks
+    exitnowk(-1)
+  endif
+  turnoff
+endin
+</CsInstruments>
+<CsScore>
+; step, initial phase, wrapped initial phase, reinitialize with negative phase
+i 1 0 .0078125 .25 .25 .25 0
+i 1 0 .0078125 -.25 .25 .25 0
+i 1 0 .0078125 2.5 .25 .25 0
+i 1 0 .0078125 -2.5 .25 .25 0
+i 1 0 .0078125 2 .25 .25 0
+i 1 0 .0078125 -2 .25 .25 0
+i 1 0 .0078125 1e20 .25 .25 0
+i 1 0 .0078125 -1e20 .25 .25 0
+i 1 0 .0078125 0 1e20 0 0
+i 1 0 .0078125 .25 1.25 .25 0
+i 1 0 .0078125 .00000001490116119384765625 .9999999403953552 .9999999403953552 0
+i 1 .0159912109375 .0078125 .25 .25 .25 0
+i 1 .0159912109375 .0078125 -2.5 .25 .25 0
+i 1 .0159912109375 .0078125 2 .25 .25 0
+i 1 .03125 .0078125 .25 .25 .25 1
+i 99 .046875 .01
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
ephasor clears inactive samples only in its exponential output, leaving stale values in the phase output. Its single-wrap adjustment also lets phase leave [0, 1) when the frequency advances multiple cycles per sample.

Clear both outputs and reduce whole-cycle increments before adding them to phase, while retaining the wrap event that resets the exponential output. Keep float output below one when rounding reaches the endpoint.

Wrap initial phase without narrowing it to int32_t, and reject non-finite initial phases. The exponential reset formula stays unchanged.