### PR TITLE
fix: correct pinkish amplitude offsets and state handling

### DIFF
--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -1325,9 +1325,9 @@ int32_t pinkset(CSOUND *csound, PINKISH *p)
       p->ampinc = 0;
     }
     /* Unless we're reinitializing a tied note, zero coefs */
-    if (*p->iskip != FL(1.0)) {
+    if (*p->iskip == FL(0.0)) {
       if (*p->imethod == GARDNER_PINK)
-        GardnerPink_init(csound,p);
+        return GardnerPink_init(csound,p);
       else                                      /* Filter method */
         p->b0 = p->b1 = p->b2 = p->b3 = p->b4 = p->b5 = p->b6 = FL(0.0);
     }
@@ -1450,23 +1450,28 @@ int32_t GardnerPink_init(CSOUND *csound, PINKISH *p)
       /* Warn if user tried but failed to give sensible number */
       if (UNLIKELY(*p->iparam1 != FL(0.0)))
         csound->Warning(csound, Str("pinkish: Gardner method requires 4-%d bands. "
-                                    "Default %"PRIi32" substituted for %d.\n"),
+                                    "Default %"PRIi32" substituted for %g.\n"),
                         GRD_MAX_RANDOM_ROWS, p->grd_NumRows,
-                        (int32_t) *p->iparam1);
+                        (double) *p->iparam1);
     }
 
     /* Seed random generator by user value or by time (default) */
     if (*p->iseed != FL(0.0)) {
-      if (*p->iseed > -1.0 && *p->iseed < 1.0)
-        p->randSeed = (uint32) (*p->iseed * (MYFLT)0x80000000);
-      else p->randSeed = (uint32) *p->iseed;
+      double seed = *p->iseed;
+      if (UNLIKELY(!isfinite(seed)))
+        return csound->InitError(csound, "%s", Str("pinkish: invalid seed"));
+      if (seed > -1.0 && seed < 1.0)
+        seed *= 2147483648.0;
+      /* Convert the truncated seed modulo 2^32, including negative seeds. */
+      seed = fmod(trunc(seed), 4294967296.0);
+      if (seed < 0.0) seed += 4294967296.0;
+      p->randSeed = (uint32_t) seed;
     }
     else p->randSeed = (uint32) csound->GetRandomSeedFromTime();
 
     numRows = p->grd_NumRows;
     p->grd_Index = 0;
-    if (numRows == 32) p->grd_IndexMask = 0xFFFFFFFF;
-    else p->grd_IndexMask = (1<<numRows) - 1;
+    p->grd_IndexMask = UINT32_MAX >> (32 - numRows);
 
     /* Calculate reasonable maximum signed random value. */
     /* Tweaked to get sameish peak value over all numRows values (re) */
@@ -1494,7 +1499,8 @@ int32_t GardnerPink_perf(CSOUND *csound, PINKISH *p)
 {
     IGN(csound);
     MYFLT *aout, *amp, scalar;
-    int32 *rows, rowIndex, indexMask, randSeed, newRandom;
+    int32 *rows, randSeed, newRandom;
+    uint32_t rowIndex, indexMask;
     int32 runningSum, sum, ampinc;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t n, nsmps = CS_KSMPS - p->h.insdshead->ksmps_no_end;
@@ -1502,6 +1508,7 @@ int32_t GardnerPink_perf(CSOUND *csound, PINKISH *p)
     aout        = p->aout;
     amp         = p->xin;
     ampinc      = p->ampinc;    /* Used to increment user amp if a-rate */
+    if (ampinc) amp += offset;
     scalar      = p->grd_Scalar;
     rowIndex    = p->grd_Index;
     indexMask   = p->grd_IndexMask;
@@ -1518,7 +1525,7 @@ int32_t GardnerPink_perf(CSOUND *csound, PINKISH *p)
         /* Determine how many trailing zeros in PinkIndex. */
         /* This algorithm will hang if n==0 so test first. */
         int32_t numZeros = 0;
-        int32_t n = rowIndex;
+        uint32_t n = rowIndex;
         while( (n & 1) == 0 ) {
           n = n >> 1;
           numZeros++;

--- a/Opcodes/spectra.h
+++ b/Opcodes/spectra.h
@@ -243,8 +243,8 @@ typedef struct {
     int32       grd_Rows[GRD_MAX_RANDOM_ROWS];
     int32       grd_NumRows;    /* Number of rows (octave bands of noise) */
     int32       grd_RunningSum; /* Used to optimize summing of generators. */
-    int32_t         grd_Index;      /* Incremented each sample. */
-    int32_t         grd_IndexMask;  /* Index wrapped by ANDing with this mask. */
+    uint32_t    grd_Index;      /* Incremented modulo 2^32 each sample. */
+    uint32_t    grd_IndexMask;  /* Index wrapped by ANDing with this mask. */
     MYFLT       grd_Scalar;     /* Used to scale to normalize generated noise. */
 } PINKISH;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -977,6 +977,7 @@ def runTest():
         ["test_random_rate_correctness.csd", "randomi and randomh rate handling"],
         ["test_pinker_sequence.csd", "pinker preserves its noise sequence across block sizes"],
         ["test_pinker_sample_bounds.csd", "pinker clears inactive samples"],
+        ["test_pinkish_sample_state.csd", "pinkish amplitude offsets, seeds, and preserved state"],
         ["test_gausstrig_frequency_mode.csd", "gausstrig frequency-change and first-impulse modes"],
         ["test_mirror_bounds.csd", "test mirror boundaries and large inputs"],
         ["test_atonex_order_one.csd", "test atonex order-one filtering"],

--- a/tests/commandline/test_pinkish_sample_state.csd
+++ b/tests/commandline/test_pinkish_sample_state.csd
@@ -1,0 +1,136 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+instr 1
+  iOffset = int(p2*sr + .5) % ksmps
+  iLegacy[] fillarray -.248472238, -.387805123, -.349853654, -.434099817
+  kCount init 0
+  kStart = (kCount == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart + 64 - kCount)
+  aAmplitude init 0
+  kN = 0
+  while kN < ksmps do
+    kAmplitude = 0
+    if kN >= kStart && kN < kEnd then
+      kAmplitude = .25 + (kCount + kN - kStart)/64
+    endif
+    vaset kAmplitude, kN, aAmplitude
+    kN += 1
+  od
+  aReference pinkish 1, 0, p4, 1234
+  if p5 == 0 then
+    aActual pinkish aAmplitude, 0, p4, 1234
+  else
+    aAmplitude pinkish aAmplitude, 0, p4, 1234
+    aActual = aAmplitude
+  endif
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aActual
+    kReference vaget kN, aReference
+    kExpected = 0
+    if kN >= kStart && kN < kEnd then
+      kSample = kCount + kN - kStart
+      kExpected = kReference*(.25 + kSample/64)
+      if p4 == 20 && kSample < 4 then
+        if !(abs(kReference - iLegacy[kSample]) < .000001) then
+          printks "FAIL pinkish changed the seeded sequence\n", 0
+          exitnowk -1
+        endif
+      endif
+    elseif kReference != 0 then
+      printks "FAIL pinkish control amplitude left an inactive sample\n", 0
+      exitnowk -1
+    endif
+    if !(abs(kActual - kExpected) < .000001) then
+      printks "FAIL pinkish bands=%g offset=%g reuse=%g sample=%g: %g expected %g\n", \
+          0, p4, iOffset, p5, kCount + kN - kStart, kActual, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += kEnd - kStart
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; Seeds with the same low 32 bits must produce the same sequence.
+  aActual pinkish 1, 0, 20, p4
+  aReference pinkish 1, 0, 20, p5
+  kError max_k abs(aActual - aReference), 1, 1
+  if !(kError < .000001) then
+    printks "FAIL pinkish seed=%g differs from seed=%g by %g\n", 0, p4, p5, kError
+    exitnowk -1
+  endif
+  kBlock init 0
+  kBlock += 1
+  if kBlock == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  aInput = .5
+  aReference pinkish aInput, p4, 20, 1234
+  kBlock init 0
+  kSkip init 0
+  if kBlock == 2 then
+    kSkip = p5
+    reinit RESET
+  endif
+RESET:
+  aActual pinkish aInput, p4, 20, 1234, i(kSkip)
+  rireturn
+  kError max_k abs(aActual - aReference), 1, 1
+  if !(kError < .000001) then
+    printks "FAIL pinkish method=%g skip=%g reset its state\n", 0, p4, p5
+    exitnowk -1
+  endif
+  kBlock += 1
+  if kBlock == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 18 then
+    prints "FAIL pinkish checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Aligned and partial blocks, with and without input reuse.
+i 1 0 .0625 20 0
+i 1 .1279296875 .0625 20 0
+i 1 .2529296875 .0625 20 1
+i 1 .3779296875 .0625 4 0
+i 1 .5029296875 .0625 31 0
+i 1 .6279296875 .0625 32 1
+; Fractional, negative, and whole-cycle seed normalization.
+i 2 .75 .0625 -.5 3221225472
+i 2 .875 .0625 -1024 4294966272
+i 2 1 .0625 -1024.5 4294966272
+i 2 1.125 .0625 .5 1073741824
+i 2 1.25 .0625 4294968320 1024
+i 2 1.375 .0625 1234.5 1234
+; All methods must preserve state for any nonzero skip value.
+i 3 1.5 .0625 0 2
+i 3 1.625 .0625 0 -1
+i 3 1.75 .0625 1 2
+i 3 1.875 .0625 1 -1
+i 3 2 .0625 2 2
+i 3 2.125 .0625 2 -1
+i 99 2.25 .015625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
With audio-rate amplitude, `pinkish` reads from the start of the block even when a note starts partway through it. This shifts the amplitude and can silence the first active samples. Advance the amplitude pointer to the note's first sample.

Also fix related state handling:
- Use unsigned band masks and counters to avoid signed shifts and overflow while preserving the noise sequence.
- Convert seeds modulo 2^32 before the integer cast, preserving fractional-seed scaling and handling negative seeds. Reject non-finite seeds at initialization, and avoid an integer cast when reporting an invalid band count.
- Preserve state for any nonzero `iskip`, as documented, rather than only for exactly `1`.
