### PR TITLE
fix: preserve foscil and foscili floating phase

### DIFF
--- a/OOps/ugens3.c
+++ b/OOps/ugens3.c
@@ -32,10 +32,14 @@ int32_t foscset(CSOUND *csound, FOSC *p)
   if (LIKELY((ftp = csound->FTFind(csound, p->ifn)) != NULL)) {
     p->ftp = ftp;
     p->floatph = !IS_POW_TWO(p->ftp->flen);
-    if (*p->iphs >= 0) {
-      p->cphs = p->mphs = (int32_t)(*p->iphs * FMAXLEN);
-      p->cphsf = p->mphsf = *p->iphs * FMAXLEN;
-    }  
+    double phase = *p->iphs;
+    if (UNLIKELY(!isfinite(phase)))
+      return csound->InitError(csound, "%s", Str("foscil: invalid initial phase"));
+    if (phase >= 0.0) {
+      phase -= floor(phase);
+      p->cphs = p->mphs = (int32_t)(phase * FMAXLEN);
+      p->cphsf = p->mphsf = phase;
+    }
     p->ampcod = IS_ASIG_ARG(p->xamp) ? 1 : 0;
     p->carcod = IS_ASIG_ARG(p->xcar) ? 1 : 0;
     p->modcod = IS_ASIG_ARG(p->xmod) ? 1 : 0;
@@ -43,6 +47,20 @@ int32_t foscset(CSOUND *csound, FOSC *p)
   }
   return NOTOK;
 }
+
+/* Keep the non-power-of-two phase in double precision. Remove whole
+   cycles before addition so they do not erase the fractional phase. */
+#define FOSC_PHASE_ADVANCE(phase, increment) do {                   \
+    double fosc_increment = (increment);                           \
+    if (UNLIKELY(fosc_increment >= 1.0 || fosc_increment <= -1.0))   \
+      fosc_increment -= trunc(fosc_increment);                     \
+    (phase) += fosc_increment;                                     \
+    if ((phase) >= 1.0) (phase) -= 1.0;                             \
+    else if ((phase) < 0.0) {                                      \
+      (phase) += 1.0;                                             \
+      if ((phase) >= 1.0) (phase) = 0.0;                           \
+    }                                                             \
+  } while (0)
 
 int32_t foscil(CSOUND *csound, FOSC *p)
 {
@@ -53,7 +71,7 @@ int32_t foscil(CSOUND *csound, FOSC *p)
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
-  MYFLT    mincf, cincf;
+  double   mincf, cincf;
   double   cphsf, mphsf;
   MYFLT    sicvt = CS_SICVT;
 
@@ -101,14 +119,12 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf = PHMOD1(mphsf);
         fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
-        mphsf += mincf;
+        FOSC_PHASE_ADVANCE(mphsf, mincf);
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
         ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
-        cphsf += cincf;
+        FOSC_PHASE_ADVANCE(cphsf, cincf);
       }
     }
   }
@@ -118,7 +134,7 @@ int32_t foscil(CSOUND *csound, FOSC *p)
     car = cps * *carp;
     mod = cps * *modp;
     ndx = *p->kndx * mod;
-    minc = (int32_t)(mod * sicvt);
+    if (!floatph) minc = (int32_t)(mod * sicvt);
     mincf = mod * CS_ONEDSR;
     for (n=offset;n<nsmps;n++) {
       if(!floatph) {      
@@ -131,14 +147,12 @@ int32_t foscil(CSOUND *csound, FOSC *p)
         ar[n] = *(ftab + (cphs >>lobits)) * amp;
         cphs += cinc;
       } else {
-        mphsf = PHMOD1(mphsf);
         fmod = *(ftab + (int32_t)(mphsf*ftlen)) * ndx;
-        mphsf += mincf;
+        FOSC_PHASE_ADVANCE(mphsf, mincf);
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
         ar[n] = *(ftab + (int32_t)(cphsf*ftlen)) * amp;
-        cphsf += cincf;
+        FOSC_PHASE_ADVANCE(cphsf, cincf);
       }
     }
   }
@@ -163,7 +177,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
   uint32_t early  = p->h.insdshead->ksmps_no_end;
   uint32_t n, nsmps = CS_KSMPS;
   MYFLT    *ft, sicvt = CS_SICVT;
-  MYFLT    cincf, mincf;
+  double   cincf, mincf;
   double   cphsf = p->cphsf, mphsf = p->mphsf;
 
 
@@ -213,24 +227,22 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         cphs += cinc;
       } else {
         mincf = mod * CS_ONEDSR;
-        mphsf = PHMOD1(mphsf);
-        MYFLT siz = mphsf*ftlen;
-        fract = PHMOD1(siz);
+        double siz = mphsf*ftlen;
         int32_t i = (int32_t)siz;
+        fract = (MYFLT)(siz - i);
         v1 = ft[i++];
         v2 = ft[i];
         fmod = (v1 + (v2 - v1) * fract) * ndx;
-        mphsf += mincf;
+        FOSC_PHASE_ADVANCE(mphsf, mincf);
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
         siz = cphsf*ftlen;
-        fract = PHMOD1(siz);
         i = (int32_t)siz;
+        fract = (MYFLT)(siz - i);
         v1 = ft[i++];
         v2 = ft[i];
         ar[n] = (v1 + (v2 - v1) * fract) * amp;
-        cphsf += cincf;
+        FOSC_PHASE_ADVANCE(cphsf, cincf);
       }
     }
   }
@@ -239,7 +251,7 @@ int32_t foscili(CSOUND *csound, FOSC *p)
     car = cps * *carp;
     mod = cps * *modp;
     ndx = *p->kndx * mod;
-    minc = (int32_t)(mod * sicvt);
+    if (!floatph) minc = (int32_t)(mod * sicvt);
     mincf = mod * CS_ONEDSR;
     for (n=offset;n<nsmps;n++) {
       if(!floatph) {
@@ -258,24 +270,22 @@ int32_t foscili(CSOUND *csound, FOSC *p)
         ar[n] = (v1 + (*ftab - v1) * fract) * amp;
         cphs += cinc;
       } else {
-        mphsf = PHMOD1(mphsf);
-        MYFLT siz = mphsf*ftlen;
-        fract = PHMOD1(siz);
+        double siz = mphsf*ftlen;
         int32_t i = (int32_t)siz;
+        fract = (MYFLT)(siz - i);
         v1 = ft[i++];
         v2 = ft[i];
         fmod = (v1 + (v2 - v1) * fract) * ndx;
-        mphsf += mincf;
+        FOSC_PHASE_ADVANCE(mphsf, mincf);
         cfreq = car + fmod;
         cincf = cfreq * CS_ONEDSR;
-        cphsf = PHMOD1(cphsf);
         siz = cphsf*ftlen;
-        fract = PHMOD1(siz);
         i = (int32_t)siz;
+        fract = (MYFLT)(siz - i);
         v1 = ft[i++];
         v2 = ft[i];
         ar[n] = (v1 + (v2 - v1) * fract) * amp;
-        cphsf += cincf;
+        FOSC_PHASE_ADVANCE(cphsf, cincf);
       }
     }
   }
@@ -289,6 +299,8 @@ int32_t foscili(CSOUND *csound, FOSC *p)
                            Str("foscili: not initialised"));
 }
 
+
+#undef FOSC_PHASE_ADVANCE
 
 int32_t losset(CSOUND *csound, LOSC *p)
 {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -648,6 +648,7 @@ def runTest():
         ["test_syncloop_envelope_end.csd", "syncloop retires grains at the envelope end"],
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_crossfm_correctness.csd", "test crossed FM and PM correctness"],
+        ["test_foscil_phase_state.csd", "foscil and foscili phase initialization and advancement"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
         ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],

--- a/tests/commandline/test_foscil_phase_state.csd
+++ b/tests/commandline/test_foscil_phase_state.csd
@@ -1,0 +1,164 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+; Explicit knots keep quarter-cycle values exact in both sample formats.
+giPower ftgen 1, 0, 8, -2, 0, .5, 1, .5, 0, -.5, -1, -.5
+giOther ftgen 2, 0, -12, -2, 0, .3333333333333333, .6666666666666666, \
+    1, .6666666666666666, .3333333333333333, 0, -.3333333333333333, \
+    -.6666666666666666, -1, -.6666666666666666, -.3333333333333333
+gkChecks init 0
+
+instr 1
+  iOffset = int(p2*sr + .5) % ksmps
+  ; Large test frequencies are exact whole cycles. Keep the oracle small.
+  iStep = (abs(p6) > 1e10 ? 0 : p6)
+  kCount init 0
+  kCarrierPhase init p5 - floor(p5)
+  kModPhase init p5 - floor(p5)
+  kStart = (kCount == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart + 64 - kCount)
+  aAmp1 init 0
+  aAmp2 init 0
+  aCarrier init 0
+  aMod = 4
+  kN = 0
+  while kN < ksmps do
+    kSample = kCount + kN - kStart
+    vaset .25 + kSample/128, kN, aAmp1
+    vaset .25 + kSample/128, kN, aAmp2
+    vaset 1 + (kSample % 4)/4, kN, aCarrier
+    kN += 1
+  od
+  if p8 == 0 then
+    aPlain foscil .5, p6*sr, 1, 4, p7, p4, p5
+    aInterp foscili .5, p6*sr, 1, 4, p7, p4, p5
+  elseif p8 == 1 then
+    aPlain foscil aAmp1, p6*sr, aCarrier, aMod, p7, p4, p5
+    aInterp foscili aAmp2, p6*sr, aCarrier, aMod, p7, p4, p5
+  else
+    aAmp1 foscil aAmp1, p6*sr, aCarrier, aMod, p7, p4, p5
+    aAmp2 foscili aAmp2, p6*sr, aCarrier, aMod, p7, p4, p5
+    aPlain = aAmp1
+    aInterp = aAmp2
+  endif
+  kN = 0
+  while kN < ksmps do
+    kPlain vaget kN, aPlain
+    kInterp vaget kN, aInterp
+    kExpected1 = 0
+    kExpected2 = 0
+    if kN >= kStart && kN < kEnd then
+      kSample = kCount + kN - kStart
+      kAmp = (p8 == 0 ? .5 : .25 + kSample/128)
+      kCarrier = (p8 == 0 ? 1 : 1 + (kSample % 4)/4)
+      kWave1 table kCarrierPhase, p4, 1
+      kWave2 tablei kCarrierPhase, p4, 1
+      kExpected1 = kAmp*kWave1
+      kExpected2 = kAmp*kWave2
+      ; FM cases sample the modulator at quarter-cycle points, where
+      ; both lookup methods agree. Other cases use a zero FM index.
+      kModulator tablei kModPhase, p4, 1
+      kAdvance = iStep*(kCarrier + p7*4*kModulator)
+      kCarrierPhase += kAdvance - floor(kAdvance)
+      kCarrierPhase -= floor(kCarrierPhase)
+      kModPhase += iStep*4 - floor(iStep*4)
+      kModPhase -= floor(kModPhase)
+    endif
+    if !(abs(kPlain - kExpected1) < .000002) || \
+       !(abs(kInterp - kExpected2) < .000002) then
+      printks "FAIL foscil table=%g phase=%g step=%g mode=%g sample=%g: %g/%g expected %g/%g\n", \
+          0, p4, p5, p6, p8, kCount + kN - kStart, kPlain, kInterp, kExpected1, kExpected2
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += kEnd - kStart
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  ; A small increment must accumulate even when it is below a float's
+  ; spacing at the starting phase. The triangle is linear in this region.
+  aOut foscili 1, sr/67108864, 1, 0, 0, giOther, .5
+  kBase init 0
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aOut
+    kExpected = -4*(kBase + kN)/67108864
+    if !(abs(kActual - kExpected) < .0000001) then
+      printks "FAIL foscili lost small phase increments: %g expected %g\n", 0, kActual, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kBase += ksmps
+  if kBase == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  aRef1 foscil .5, 64, 1, 4, .5, p4, .25
+  aRef2 foscili .5, 64, 1, 4, .5, p4, .25
+  kBlock init 0
+  kPhase init .25
+  if kBlock == 2 then
+    kPhase = -1
+    reinit OSC
+  endif
+OSC:
+  aOut1 foscil .5, 64, 1, 4, .5, p4, i(kPhase)
+  aOut2 foscili .5, 64, 1, 4, .5, p4, i(kPhase)
+  rireturn
+  kError1 max_k abs(aOut1 - aRef1), 1, 1
+  kError2 max_k abs(aOut2 - aRef2), 1, 1
+  if !(kError1 < .000001) || !(kError2 < .000001) then
+    printks "FAIL foscil negative initial phase reset the oscillator\n", 0
+    exitnowk -1
+  endif
+  kBlock += 1
+  if kBlock == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 18 then
+    prints "FAIL foscil checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Quarter phase, whole initial cycles, and interpolation between entries.
+i 1 0 .0625 1 .25 0 0 0
+i 1 .1279296875 .0625 2 .25 0 0 0
+i 1 .25 .0625 1 1.25 0 0 0
+i 1 .3779296875 .0625 2 1.25 0 0 1
+i 1 .5 .0625 2 .125 0 0 0
+; FM and changing audio parameters, including input/output reuse.
+i 1 .6279296875 .0625 1 .25 .0625 .5 0
+i 1 .7529296875 .0625 2 .25 .0625 .5 0
+i 1 .8779296875 .0625 1 .25 .0625 .5 1
+i 1 1.0029296875 .0625 2 .25 .0625 .5 1
+i 1 1.1279296875 .0625 1 .25 .0625 .5 2
+i 1 1.2529296875 .0625 2 .25 .0625 .5 2
+; Reverse playback and whole-cycle increments retain a fractional phase.
+i 1 1.375 .0625 2 .25 -.25 0 0
+i 1 1.5 .0625 2 .25 -1 0 1
+i 1 1.625 .0625 2 .25 1099511627776 0 0
+i 1 1.75 .0625 2 .25 -1099511627776 0 1
+i 2 1.875 .0625
+i 3 2 .0625 1
+i 3 2.125 .0625 2
+i 99 2.25 .015625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`foscil` and `foscili` store the initial phase in fixed-point units even for non-power-of-two tables, whose playback path expects cycles. At phase `0.25`, an 8-point sine table starts at `1`, while a 12-point table incorrectly starts at `0`.

Normalize the initial phase and store each phase in its proper units. Keep floating phase and interpolation positions in double precision so float builds retain small increments. A local macro handles reverse playback and removes whole cycles before addition, preserving the fractional phase. Avoid the unused integer increment conversion on this path.

Negative initial phases still preserve state. Normal fixed-point playback stays unchanged.
