### PR TITLE
fix: correct buzz amplitude and floating phase

### DIFF
--- a/OOps/ugens4.c
+++ b/OOps/ugens4.c
@@ -34,9 +34,14 @@ int32_t bzzset(CSOUND *csound, BUZZ *p)
     if (LIKELY((ftp = csound->FTFind(csound, p->ifn)) != NULL)) {
       p->ftp = ftp;
       p->floatph = !IS_POW_TWO(p->ftp->flen);
-      if (*p->iphs >= 0) {
-        p->lphs = (int32_t)(*p->iphs * FL(0.5) * FMAXLEN);
-        p->fphs = *p->iphs;
+      double phase = *p->iphs;
+      if (UNLIKELY(!isfinite(phase)))
+        return csound->InitError(csound, "%s", Str("buzz: invalid initial phase"));
+      if (phase >= 0.0) {
+        phase *= 0.5; /* The sine quotient uses theta/2. */
+        phase -= floor(phase);
+        p->lphs = (int32_t)(phase * FMAXLEN);
+        p->fphs = phase;
       }
       p->ampcod = IS_ASIG_ARG(p->xamp) ? 1 : 0;
       p->cpscod = IS_ASIG_ARG(p->xcps) ? 1 : 0;
@@ -46,13 +51,27 @@ int32_t bzzset(CSOUND *csound, BUZZ *p)
     return NOTOK;
 }
 
+/* Keep non-power-of-two phase calculations in double precision. */
+#define BUZZ_WRAP(phase) do {                                      \
+    if ((phase) >= 1.0 || (phase) < 0.0) (phase) -= floor(phase);    \
+    if ((phase) >= 1.0) (phase) = 0.0;                             \
+  } while (0)
+
+/* Remove whole cycles before addition to retain the fractional phase. */
+#define BUZZ_INCREMENT(increment) do {                              \
+    if ((increment) >= 1.0 || (increment) <= -1.0)                  \
+      (increment) -= trunc(increment);                            \
+  } while (0)
+
 int32_t buzz(CSOUND *csound, BUZZ *p)
 {
     FUNC        *ftp;
-    MYFLT       *ar, *ampp, *cpsp, *ftbl;
-    int32_t       phs, inc, lobits, dwnphs, tnp1, lenmask,
-      floatph = p->floatph, flen = p->ftp->flen;
-    MYFLT       sicvt2, over2n, scal, num, denom, incf;
+    MYFLT       *ar, *ampp, *cpsp, *ftbl, amp;
+    int32_t       phs, inc, lobits, dwnphs, lenmask,
+      floatph = p->floatph, flen;
+    uint32_t tnp1;
+    MYFLT       sicvt2, over2n, scal, num, denom, harmonics;
+    double incf;
     uint32_t    offset = p->h.insdshead->ksmps_offset;
     uint32_t    early  = p->h.insdshead->ksmps_no_end;
     uint32_t    n, nsmps = CS_KSMPS;
@@ -62,6 +81,7 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
     ftp = p->ftp;
     if (UNLIKELY(ftp==NULL)) goto err1; /* RWD fix */
     ftbl = ftp->ftable;
+    flen = ftp->flen;
 
     if(floatph) sicvt2 = CS_ONEDSR*FL(0.5);
     else sicvt2 = CS_SICVT * FL(0.5); /* for theta/2  */
@@ -70,14 +90,22 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
     lenmask = ftp->lenmask;
     ampp = p->xamp;
     cpsp = p->xcps;
-    if ((nn = (int32_t)*p->knh) < 0) nn = -nn;
+    harmonics = FABS(*p->knh);
+    if (UNLIKELY(!(harmonics < 2147483648.0)))
+      return csound->PerfError(csound, &(p->h),
+                               Str("buzz: invalid harmonic count"));
+    nn = (int32_t)harmonics;
     if (UNLIKELY(nn == 0)) {     /* fix nn = knh */
       nn = 1;
     }
-    tnp1 = (nn<<1) + 1;          /* calc 2n + 1 */
+    tnp1 = 2U * (uint32_t)nn + 1U;          /* calc 2n + 1 */
     over2n = FL(0.5) / (MYFLT)nn;
-    scal = *ampp * over2n;
-    if(floatph) incf = *cpsp * sicvt2;
+    amp = *ampp;
+    scal = amp * over2n;
+    if(floatph) {
+      incf = *cpsp * sicvt2;
+      BUZZ_INCREMENT(incf);
+    }
     else inc = (int32_t)(*cpsp * sicvt2);
     ar = p->ar;
     phs = p->lphs;
@@ -88,8 +116,10 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
     for (n=offset; n<nsmps; n++) {
-      if (p->ampcod)
-        scal = ampp[n] * over2n;
+      if (p->ampcod) {
+        amp = ampp[n];
+        scal = amp * over2n;
+      }
       if(!floatph) {
       if (p->cpscod)
         inc = (int32_t)(cpsp[n] * sicvt2);
@@ -99,19 +129,24 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
         num = ftbl[dwnphs * tnp1 & lenmask];
         ar[n] = (num / denom - FL(1.0)) * scal;
       }
-      else ar[n] = *ampp;
+      else ar[n] = amp;
       phs += inc;
       phs &= PHMASK;
       } else {
-      if (p->cpscod)
+      if (p->cpscod) {
         incf = cpsp[n] * sicvt2;
+        BUZZ_INCREMENT(incf);
+      }
       denom = ftbl[(int32_t) (phsf*flen)];
       if (denom > FL(0.0002) || denom < -FL(0.0002)) {
-        num = ftbl[(int32_t)(PHMOD1(phsf * tnp1)*flen)];
+        double numerator_phase = phsf * tnp1;
+        BUZZ_WRAP(numerator_phase);
+        num = ftbl[(int32_t)(numerator_phase*flen)];
         ar[n] = (num / denom - FL(1.0)) * scal;
       }
-      else ar[n] = *ampp;
-      phsf = PHMOD1(incf+phsf);
+      else ar[n] = amp;
+      phsf += incf;
+      BUZZ_WRAP(phsf);
       }
     }
     p->lphs = phs;
@@ -120,6 +155,9 @@ int32_t buzz(CSOUND *csound, BUZZ *p)
  err1:
     return csound->PerfError(csound, &(p->h), Str("buzz: not initialised"));
 }
+
+#undef BUZZ_WRAP
+#undef BUZZ_INCREMENT
 
 int32_t gbzset(CSOUND *csound, GBUZZ *p)
 {

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -667,6 +667,7 @@ def runTest():
         ["test_gbuzz_nonpower_phase.csd", "gbuzz scales non-power-of-two table indexes correctly"],
         ["test_harmon_state.csd", "harmon234 partial blocks and pulse state"],
         ["test_harmon_invalid_size.csd", "harmon234 rejects unsupported history sizes", 1],
+        ["test_buzz_amplitude_phase.csd", "buzz current amplitude and phase across table types"],
         ["test_crossfm_correctness.csd", "test crossed FM and PM correctness"],
         ["test_foscil_phase_state.csd", "foscil and foscili phase initialization and advancement"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],

--- a/tests/commandline/test_buzz_amplitude_phase.csd
+++ b/tests/commandline/test_buzz_amplitude_phase.csd
@@ -1,0 +1,150 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giPower ftgen 1, 0, 128, 10, 1
+giOther ftgen 2, 0, -96, 10, 1
+gkChecks init 0
+
+instr 1
+  iOffset = int(p2*sr + .5) % ksmps
+  iHarmonics = max(1, int(abs(p6)))
+  kPhase init p5 - floor(p5)
+  kCount init 0
+  kStart = (kCount == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart + 64 - kCount)
+  aAmplitude init 0
+  aFrequency init 0
+  kN = 0
+  while kN < ksmps do
+    kSample = kCount + kN - kStart
+    vaset .25 + kSample/128, kN, aAmplitude
+    vaset p8*sr*(1 + kSample % 2), kN, aFrequency
+    kN += 1
+  od
+  if p7 == 0 then
+    aOut buzz .5, p8*sr, p6, p4, p5
+  elseif p7 == 1 then
+    aOut buzz aAmplitude, aFrequency, p6, p4, p5
+  else
+    aAmplitude buzz aAmplitude, aFrequency, p6, p4, p5
+    aOut = aAmplitude
+  endif
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aOut
+    kExpected = 0
+    if kN >= kStart && kN < kEnd then
+      kSample = kCount + kN - kStart
+      kAmp = (p7 == 0 ? .5 : .25 + kSample/128)
+      kStep = (p7 == 0 ? p8 : p8*(1 + kSample % 2))
+      ; buzz is the equal-amplitude sum of cosine harmonics.
+      ; These phases lie on both sine tables' sample grids.
+      kH = 1
+      while kH <= iHarmonics do
+        kExpected += cos(2*$M_PI*kH*kPhase)*kAmp/iHarmonics
+        kH += 1
+      od
+      kPhase += kStep
+      kPhase -= floor(kPhase)
+    endif
+    if !(abs(kActual - kExpected) < .00001) then
+      printks "FAIL buzz table=%g phase=%g harmonics=%g mode=%g sample=%g: %g expected %g\n", \
+          0, p4, p5, p6, p7, kCount + kN - kStart, kActual, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += kEnd - kStart
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  aReference buzz .5, 128, 3, p4, .25
+  kBlock init 0
+  kPhase init .25
+  if kBlock == 2 then
+    kPhase = -1
+    reinit OSC
+  endif
+OSC:
+  aActual buzz .5, 128, 3, p4, i(kPhase)
+  rireturn
+  kError max_k abs(aActual - aReference), 1, 1
+  if !(kError < .000001) then
+    printks "FAIL buzz negative initial phase reset the oscillator\n", 0
+    exitnowk -1
+  endif
+  kBlock += 1
+  if kBlock == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 3
+  ; A reverse step smaller than float spacing must still move off the
+  ; exact table grid point. The next 63 samples stay in the same cells.
+  iNumerator table 83, giOther
+  iDenominator table 11, giOther
+  iExpected = (iNumerator/iDenominator - 1)/6
+  aOut buzz 1, -sr/268435456, 3, giOther, .25
+  kCount init 0
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aOut
+    kExpected = (kCount + kN == 0 ? -1/3 : iExpected)
+    if !(abs(kActual - kExpected) < .000001) then
+      printks "FAIL buzz lost a small phase increment: %g expected %g\n", 0, kActual, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += ksmps
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 21 then
+    prints "FAIL buzz checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Control inputs, audio inputs, and input/output reuse.
+i 1 0 .0625 1 0 3 0 .125
+i 1 .1279296875 .0625 2 0 3 0 .125
+i 1 .2529296875 .0625 1 0 3 1 .125
+i 1 .3779296875 .0625 2 0 3 1 .125
+i 1 .5029296875 .0625 1 0 3 2 .125
+i 1 .6279296875 .0625 2 0 3 2 .125
+; Initial phase must agree across table types, including whole cycles.
+i 1 .75 .0625 1 .25 3 0 .125
+i 1 .8779296875 .0625 2 .25 3 0 .125
+i 1 1 .0625 1 1.25 3 1 .125
+i 1 1.1279296875 .0625 2 1.25 3 1 .125
+; Negative counts use their absolute value; zero means one harmonic.
+i 1 1.25 .0625 1 0 -3 1 .125
+i 1 1.3779296875 .0625 2 0 -3 1 .125
+i 1 1.5 .0625 1 .25 0 0 .125
+i 1 1.6279296875 .0625 2 .25 0 0 .125
+; Reverse playback, whole cycles, and stationary phase at the peak.
+i 1 1.75 .0625 2 .25 3 1 -.125
+i 1 1.8779296875 .0625 2 .25 3 1 -2
+i 1 2 .0625 1 0 3 1 0
+i 1 2.1279296875 .0625 2 0 3 2 0
+i 2 2.25 .0625 1
+i 2 2.375 .0625 2
+i 3 2.5 .0625
+i 99 2.625 .015625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`buzz` uses the block's first amplitude when the sine denominator is near zero, rather than the current sample's amplitude. This gives the wrong level at cycle peaks and at partial-block note starts. Use the current amplitude for that case.

Also correct related phase and index handling:
- Initialize both table paths in half-cycle units. The non-power-of-two path currently starts at twice the requested phase.
- Keep floating phase calculations in double precision and wrap through local macros, preserving small increments and fractional phase during reverse playback or whole-cycle advances.
- Use unsigned harmonic-index arithmetic so wrapping does not rely on signed overflow. Check the harmonic count before conversion, and check the table pointer before reading its length.
