### PR TITLE
fix: complete osciln table repeats without dropping samples

### DIFF
--- a/H/ugens2.h
+++ b/H/ugens2.h
@@ -59,8 +59,8 @@ typedef struct {
 typedef struct  {
         OPDS    h;
         MYFLT   *rslt, *kamp, *ifrq, *ifn, *itimes;
-        MYFLT   index, inc, maxndx;
-        int32   ntimes;
+        double  phase, inc;
+        int32_t ntimes, cycles;
         FUNC    *ftp;
 } OSCILN;
 

--- a/OOps/ugens2.c
+++ b/OOps/ugens2.c
@@ -345,63 +345,76 @@ int32_t kosc1i(CSOUND *csound, OSCIL1   *p)
 
 int32_t oscnset(CSOUND *csound, OSCILN *p)
 {
+    FUNC *ftp = csound->FTFind(csound, p->ifn);
+    double repeats = *p->itimes;
+    double frequency = *p->ifrq;
+    double advance;
 
-    FUNC        *ftp;
-    if (LIKELY((ftp = csound->FTFind(csound, p->ifn)) != NULL)) {
-      p->ftp = ftp;
-      p->inc = ftp->flen * *p->ifrq * CS_ONEDSR;
-      p->index = FL(0.0);
-      p->maxndx = ftp->flen - FL(1.0);
-      p->ntimes = (int32_t)*p->itimes;
-      return OK;
+    if (UNLIKELY(ftp == NULL)) return NOTOK;
+    if (UNLIKELY(!(repeats >= 0.0 && repeats < 2147483648.0)))
+      return csound->InitError(csound, "%s", Str("osciln: invalid repeat count"));
+    if (UNLIKELY(frequency < 0.0 || !isfinite(frequency)))
+      return csound->InitError(csound, "%s", Str("osciln: invalid frequency"));
+
+    p->ftp = ftp;
+    p->ntimes = (int32_t)repeats;
+    p->phase = 0.0;
+    advance = frequency / CS_ESR;
+    /* Split at init time: even several cycles per sample need no wrapping
+       function in the audio loop. Larger advances finish on the first sample. */
+    if (advance >= p->ntimes) {
+      p->cycles = p->ntimes;
+      p->inc = 0.0;
     }
-    else return NOTOK;
+    else {
+      p->cycles = (int32_t)advance;
+      p->inc = advance - p->cycles;
+    }
+    return OK;
 }
 
 int32_t osciln(CSOUND *csound, OSCILN *p)
 {
   MYFLT *rs = p->rslt;
   uint32_t offset = p->h.insdshead->ksmps_offset;
-  uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t n, nsmps = CS_KSMPS;
+  uint32_t early = p->h.insdshead->ksmps_no_end;
+  uint32_t n = offset, nsmps = CS_KSMPS;
 
-  if (UNLIKELY(p->ftp==NULL)) goto err1;
-  if (UNLIKELY(offset)) memset(rs, '\0', offset*sizeof(MYFLT));
+  if (UNLIKELY(p->ftp == NULL))
+    return csound->PerfError(csound, &(p->h), Str("osciln: not initialised"));
+  if (UNLIKELY(offset)) memset(rs, 0, offset*sizeof(MYFLT));
   if (UNLIKELY(early)) {
     nsmps -= early;
-    memset(&rs[nsmps], '\0', early*sizeof(MYFLT));
+    memset(&rs[nsmps], 0, early*sizeof(MYFLT));
   }
-  if (p->ntimes) {
+  if (p->ntimes > 0) {
     MYFLT *ftbl = p->ftp->ftable;
     MYFLT amp = *p->kamp;
-    MYFLT ndx = p->index;
-    MYFLT inc = p->inc;
-    MYFLT maxndx = p->maxndx;
-    for (n=offset; n<nsmps; n++) {
-      rs[n] = ftbl[(int32_t)ndx] * amp;
-      if (UNLIKELY((ndx += inc) > maxndx)) {
-        if (--p->ntimes)
-          ndx -= maxndx;
-        else if (UNLIKELY(n==nsmps))
-          return OK;
-        else
-          goto putz;
+    double phase = p->phase, inc = p->inc;
+    double length = p->ftp->flen;
+    int32_t remaining = p->ntimes, cycles = p->cycles;
+
+    for (; n < nsmps; n++) {
+      rs[n] = ftbl[(int32_t)(phase * length)] * amp;
+      phase += inc;
+      if (phase >= 1.0) {
+        phase -= 1.0;
+        remaining--;
+      }
+      remaining -= cycles;
+      if (remaining <= 0) {
+        remaining = 0;
+        phase = 0.0;
+        n++; /* Keep the sample just emitted. */
+        break;
       }
     }
-    p->index = ndx;
+    p->phase = phase;
+    p->ntimes = remaining;
   }
-  else {
-    n=0;              /* Can jump out of previous loop into this one */
-  putz:
+  if (n < nsmps)
     memset(&rs[n], 0, (nsmps-n)*sizeof(MYFLT));
-    /* for (; n<nsmps; n++) { */
-    /*   rs[n] = FL(0.0); */
-    /* } */
-  }
   return OK;
- err1:
-  return csound->PerfError(csound, &(p->h),
-                           Str("osciln: not initialised"));
 }
 
 /* Oscillators */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -670,6 +670,7 @@ def runTest():
         ["test_rspline_large_rate.csd", "test rspline with a large finite rate"],
         ["test_rspline_invalid_rate.csd", "reject invalid rspline rates", 1],
         ["test_oscil1i.csd", "oscil1i interpolates scans and holds their endpoints"],
+        ["test_osciln_repeat_state.csd", "osciln and oscilx complete their table repeats"],
         ["test_trigphasor_range.csd", "trigphasor starts, wraps, and resets within its range"],
         ["test_unwrap_state.csd", "unwrap input and phase history"],
         ["test_unwrap_invalid_mode.csd", "unwrap rejects invalid modes", 1],

--- a/tests/commandline/test_osciln_repeat_state.csd
+++ b/tests/commandline/test_osciln_repeat_state.csd
@@ -1,0 +1,117 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giFour ftgen 1, 0, 4, -2, .125, .25, .375, .5
+giThree ftgen 2, 0, -3, -2, .25, .5, .75
+giOne ftgen 3, 0, -1, -2, .75
+gkChecks init 0
+
+instr 1
+  iLength = ftlen(p4)
+  iRepeats = int(p6)
+  iOffset = int(p2*sr + .5) % ksmps
+  kCount init 0
+  kStart = (kCount == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart + 64 - kCount)
+  kAmp = .5 + kCount/128
+  aOut osciln kAmp, p5*sr, p4, p6
+  aAlias oscilx kAmp, p5*sr, p4, p6
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aOut
+    kAlias vaget kN, aAlias
+    kExpected = 0
+    if kN >= kStart && kN < kEnd then
+      kSample = kCount + kN - kStart
+      kCycles = kSample*p5
+      if kCycles < iRepeats then
+        kPhase = kCycles - floor(kCycles)
+        kIndex = int(kPhase*iLength)
+        kWave table kIndex, p4
+        kExpected = kAmp*kWave
+      endif
+    endif
+    if !(abs(kActual - kExpected) < .000001) || \
+       !(abs(kAlias - kExpected) < .000001) then
+      printks "FAIL osciln table=%g step=%g repeats=%g offset=%g sample=%g: %g/%g expected %g\n", \
+          0, p4, p5, p6, iOffset, kCount + kN - kStart, kActual, kAlias, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += kEnd - kStart
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 2
+  kBlock init 0
+  kAge init 0
+  if kBlock == 2 then
+    kAge = 0
+    reinit OSC
+  endif
+OSC:
+  aOut osciln 1, sr/4, giFour, 2
+  rireturn
+  kN = 0
+  while kN < ksmps do
+    kActual vaget kN, aOut
+    kSample = kAge + kN
+    kExpected = 0
+    if kSample < 8 then
+      kExpected = .125*(1 + kSample % 4)
+    endif
+    if kActual != kExpected then
+      printks "FAIL osciln reinit sample=%g: %g expected %g\n", 0, kSample, kActual, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kBlock += 1
+  kAge += ksmps
+  if kBlock == 4 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 17 then
+    prints "FAIL osciln checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; One/two repeats, last samples at and inside block boundaries.
+i 1 0 .0625 1 .25 1
+i 1 .125 .0625 1 .25 2
+i 1 .25 .0625 1 .25 4
+i 1 .3779296875 .0625 1 .25 4
+; Fractional table steps and non-power-of-two/one-entry tables.
+i 1 .5 .0625 1 .125 2
+i 1 .6279296875 .0625 1 .1875 3
+i 1 .75 .0625 2 .25 2
+i 1 .8779296875 .0625 3 .25 2
+; More than one cycle per sample, including an advance past all repeats.
+i 1 1 .0625 1 1.5 5
+i 1 1.1279296875 .0625 2 2.5 5
+i 1 1.25 .0625 1 8 2
+i 1 1.375 .0625 1 1099511627776 2
+; Zero repeats are silent; zero frequency holds the first table entry.
+i 1 1.5029296875 .0625 1 .25 0
+i 1 1.625 .0625 1 0 2
+i 1 1.7529296875 .0625 2 .25 2.75
+; Continue phase and remaining repeats across several blocks.
+i 1 1.8779296875 .0625 2 .125 8
+i 2 2 .0625
+i 99 2.125 .015625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`osciln` (also named `oscilx`) wraps by `table length - 1`, so subsequent repeats skip the first entry. It also clears the final sample it just wrote. A four-entry table played twice therefore produces only six samples instead of eight.

Track phase over the full table cycle and clear output starting after the final emitted sample. Split the rate into whole cycles and fractional phase at initialization so fractional rates, one-entry tables, and advances across multiple cycles all consume the correct number of repeats without calls in the sample loop. Reject invalid rates and repeat counts before converting them.
