### PR TITLE
Fix stereo loop amplitude reuse and default playback rate

### DIFF
--- a/Opcodes/gab/newgabopc.c
+++ b/Opcodes/gab/newgabopc.c
@@ -77,7 +77,6 @@ typedef struct  {
   OPDS    h;
   MYFLT   *out1, *out2, *amp, *freq, *kloop, *kend, *ift, *iphs;
   int64_t    tablen;
-  MYFLT   fsr;
   MYFLT *ft; /*table */
   double  phs, fsrUPsr /* , looplength */;
   int64_t    phs_int;
@@ -92,7 +91,7 @@ static int32_t lposc_stereo_set(CSOUND *csound, LPOSC_ST *p)
   if (UNLIKELY(!(fsr = ftp->gen01args.sample_rate))) {
     csound->Message(csound, "%s", Str("lposcil: no sample rate stored in function;"
                                       " assuming=sr\n"));
-    p->fsr=CS_ESR;
+    fsr = CS_ESR;
   }
   p->fsrUPsr = fsr/CS_ESR;
   p->ft     = ftp->ftable;
@@ -141,11 +140,12 @@ static int32_t lposca_stereo(CSOUND *csound, LPOSC_ST *p) /* stereo lposcinta */
   }
   for (n=offset; n<nsmps; n++) {
     double fract;
+    MYFLT amplitude = amp[n];
     MYFLT *curr_samp1 = ft + (int64_t) *phs * 2;
     MYFLT *curr_samp2 = curr_samp1 +1;
     fract= *phs - (int64_t) *phs;
-    out1[n] = amp[n] * (MYFLT)(*curr_samp1 +(*(curr_samp1+2)-*curr_samp1)*fract);
-    out2[n] = amp[n] * (MYFLT)(*curr_samp2 +(*(curr_samp2+2)-*curr_samp2)*fract);
+    out1[n] = amplitude * (MYFLT)(*curr_samp1 +(*(curr_samp1+2)-*curr_samp1)*fract);
+    out2[n] = amplitude * (MYFLT)(*curr_samp2 +(*(curr_samp2+2)-*curr_samp2)*fract);
     *phs += si;
     while (*phs  >= end) *phs -= looplength;
     while (*phs  < loop) *phs += looplength;
@@ -181,9 +181,10 @@ static int32_t lposca_stereo_no_trasp(CSOUND *csound, LPOSC_ST *p)
     memset(&out2[nsmps], '\0', early*sizeof(MYFLT));
   }
   for (n=offset; n<nsmps; n++) {
+    MYFLT amplitude = amp[n];
     MYFLT *curr_samp1 = ft + *phs * 2;
-    out1[n] = amp[n] * (MYFLT) *curr_samp1 ;
-    out2[n] = amp[n] * (MYFLT) *(curr_samp1+1) ;
+    out1[n] = amplitude * (MYFLT) *curr_samp1 ;
+    out2[n] = amplitude * (MYFLT) *(curr_samp1+1) ;
     *phs += si;
     while (*phs  >= end) *phs -= looplength;
     while (*phs  < loop) *phs += looplength;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -654,6 +654,7 @@ def runTest():
         ["test_cmp_operator_text.csd", "cmp operator text and array lengths"],
         ["test_cmp_invalid_operator.csd", "reject malformed cmp operators", 3],
         ["test_pconvolve_frames.csd", "pconvolve impulse frames and channel selection"],
+        ["test_lposcilsa_amplitude_reuse.csd", "stereo loop amplitude reuse and default sample rate"],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
         ["test_flooper_stereo_frame_bounds.csd", "reject flooper ranges past stereo frames", 1],
         ["test_sndloop_state.csd", "sndloop recording, playback, and partial blocks"],

--- a/tests/commandline/test_lposcilsa_amplitude_reuse.csd
+++ b/tests/commandline/test_lposcilsa_amplitude_reuse.csd
@@ -1,0 +1,124 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr = 1024
+ksmps = 16
+nchnls = 2
+0dbfs = 1
+giFile ftgen 0, 0, 0, -1, "test_flooper_stereo_guard.wav", 0, 0, 0
+; Copy the samples into a table without soundfile rate metadata.
+giRaw ftgen 0, 0, -ftlen(giFile), -2, 0
+iN = 0
+while iN < ftlen(giFile) do
+  iValue table iN, giFile
+  tableiw iValue, iN, giRaw
+  iN += 1
+od
+gkChecks init 0
+
+instr 1
+  iTable = (p6 == 0 ? giFile : giRaw)
+  iRatio = (p6 == 0 ? p7*sr/44100 : p7)
+  iOffset = int(p2*sr + .5) % ksmps
+  kCount init 0
+  kPhase init 1
+  kStart = (kCount == 0 ? iOffset : 0)
+  kEnd = min(ksmps, kStart + 64 - kCount)
+  aAmp init 0
+  kN = 0
+  while kN < ksmps do
+    kValue = 0
+    if kN >= kStart && kN < kEnd then
+      kValue = .25 + (kCount + kN - kStart)/128
+    endif
+    vaset kValue, kN, aAmp
+    kN += 1
+  od
+  if p4 == 1 then
+    if p5 == 0 then
+      aLeft, aRight lposcilsa aAmp, iRatio, 1, 6, iTable, 1
+    elseif p5 == 1 then
+      aAmp, aRight lposcilsa aAmp, iRatio, 1, 6, iTable, 1
+      aLeft = aAmp
+    else
+      aLeft, aAmp lposcilsa aAmp, iRatio, 1, 6, iTable, 1
+      aRight = aAmp
+    endif
+  else
+    if p5 == 0 then
+      aLeft, aRight lposcilsa2 aAmp, p7, 1, 6, iTable, 1
+    elseif p5 == 1 then
+      aAmp, aRight lposcilsa2 aAmp, p7, 1, 6, iTable, 1
+      aLeft = aAmp
+    else
+      aLeft, aAmp lposcilsa2 aAmp, p7, 1, 6, iTable, 1
+      aRight = aAmp
+    endif
+  endif
+  kN = 0
+  while kN < ksmps do
+    kExpectedL = 0
+    kExpectedR = 0
+    if kN >= kStart && kN < kEnd then
+      kIndex = int(kPhase)*2
+      kFraction = kPhase - int(kPhase)
+      kL table kIndex, giFile
+      kR table kIndex + 1, giFile
+      kNextL table kIndex + 2, giFile
+      kNextR table kIndex + 3, giFile
+      kAmp = .25 + (kCount + kN - kStart)/128
+      kExpectedL = kAmp*(kL + kFraction*(kNextL - kL))
+      kExpectedR = kAmp*(kR + kFraction*(kNextR - kR))
+      kPhase += p7
+      if kPhase >= 6 then
+        kPhase -= 5
+      elseif kPhase < 1 then
+        kPhase += 5
+      endif
+    endif
+    kLeft vaget kN, aLeft
+    kRight vaget kN, aRight
+    if !(abs(kLeft - kExpectedL) < .000001 && abs(kRight - kExpectedR) < .000001) then
+      printks "FAIL lposcilsa variant=%g reuse=%g raw=%g sample=%g: (%g,%g) expected (%g,%g)\n", \
+          0, p4, p5, p6, kCount + kN - kStart, kLeft, kRight, kExpectedL, kExpectedR
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCount += kEnd - kStart
+  if kCount == 64 then
+    gkChecks += 1
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 14 then
+    prints "FAIL lposcilsa checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; p7 is the phase step in frames. 44100/32768 gives an exact file-rate
+; ratio of 1/32 in both float and double builds.
+; Separate outputs, then amplitude reused as each output. Both table types.
+i 1 0.0 .0625 1 0 0 1.3458251953125
+i 1 0.1279296875 .0625 1 1 0 1.3458251953125
+i 1 0.2529296875 .0625 1 2 0 1.3458251953125
+i 1 0.375 .0625 1 0 1 .5
+i 1 0.5029296875 .0625 1 1 1 .5
+i 1 0.6279296875 .0625 1 2 1 .5
+i 1 0.75 .0625 2 0 0 2
+i 1 0.8779296875 .0625 2 1 0 2
+i 1 1.0029296875 .0625 2 2 0 2
+i 1 1.125 .0625 2 0 1 2
+i 1 1.2529296875 .0625 2 1 1 2
+i 1 1.3779296875 .0625 2 2 1 2
+; Reverse playback uses the same amplitude for both channels.
+i 1 1.5029296875 .0625 1 1 0 -1.3458251953125
+i 1 1.6279296875 .0625 2 1 0 -1
+i 99 1.75 .015625
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`lposcilsa` and `lposcilsa2` overwrite the amplitude when it also holds the left output, then use that changed value for the right channel. Read each amplitude sample before writing either output so reusing a variable preserves the stereo signal.

Also correct `lposcilsa`'s fallback for tables without sample-rate metadata: use the orchestra rate when computing playback speed. The old assignment left the speed at zero, repeating the first sample.
