### PR TITLE
Fix pvsbufread frequency-bin selection

### DIFF
--- a/Opcodes/pvsbuffer.c
+++ b/Opcodes/pvsbuffer.c
@@ -211,7 +211,7 @@ static int32_t pvsbufreadset(CSOUND *csound, PVSBUFFERREAD *p)
      strt /= (sr/N);
      end /= (sr/N);
      strt = (int32_t)(strt < 0 ? 0 : strt > N/2 ? N/2 : strt);
-     end = (int32_t)(end <= strt ? N/2 + 2 : end > N/2 + 2 ? N/2 + 2 : end);
+     end = (int32_t)(end <= strt ? N/2 : end > N/2 ? N/2 : end);
      frames = handle->frames-1;
      pos = *p->ktime*(sr/overlap);
 
@@ -225,7 +225,8 @@ static int32_t pvsbufreadset(CSOUND *csound, PVSBUFFERREAD *p)
        frame2 = buffer + (N + 2)*(posi != frames-1 ? posi+1 : 0);
        frac = pos - posi;
 
-       for (i=strt; i < end; i+=2){
+       /* Each bin contains an amplitude and a frequency. */
+       for (i=2*strt; i <= 2*end; i+=2){
          fout[i] = frame1[i] + frac*(frame2[i] - frame1[i]);
          fout[i+1] = frame1[i+1] + frac*(frame2[i+1] - frame1[i+1]);
        }

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -609,6 +609,7 @@ def runTest():
         ],
         ["test_pvsbin_output.csd", "pvsbin output rates, bin changes, and partial blocks"],
         ["test_pvsbin_invalid_bin.csd", "reject invalid pvsbin indices", 1],
+        ["test_pvsbufread_bin_ranges.csd", "PVS buffer full spectrum and selected bin ranges"],
         ["test_hilbert2_state.csd", "hilbert2 input reuse, partial blocks and reinit"],
         ["test_arrayops_current_length.csd", "array math and sorting follow current input lengths"],
         ["test_arrayops_short_second.csd", "array math rejects a shortened second input", 1],

--- a/tests/commandline/test_pvsbufread_bin_ranges.csd
+++ b/tests/commandline/test_pvsbufread_bin_ranges.csd
@@ -1,0 +1,66 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+gkChecks init 0
+
+; Compare frequency ranges at a fixed frame, independent of circular wrapping.
+instr 1
+  kSource[] init 66
+  kFirst[] init 66
+  kRead[] init 66
+  kCycle init 0
+  aRamp phasor 137
+  aTone oscili .2, 3072
+  aInput = aTone+.01*(kCycle+1)*aRamp
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, 3/512
+  kFrame pvs2tab kSource, fInput
+  kIndex = 0
+  while kIndex < 66 do
+    if kTime == 0 then
+      kFirst[kIndex] = kSource[kIndex]
+    endif
+    kIndex += 1
+  od
+  fRead pvsbufread 0, iBuffer, p4*128, p5*128, 1
+  kFrame pvs2tab kRead, fRead
+  kIndex = 0
+  while kIndex < 66 do
+    kBin = int(kIndex/2)
+    kExpected = 0
+    if kBin >= p4 && (p5 <= p4 || kBin <= p5) then
+      kExpected = kFirst[kIndex]
+    endif
+    if !(abs(kRead[kIndex]-kExpected) <= .001) then
+      printks "pvsbufread range %g..%g cycle %g index %g: got %g, expected %g\n", 0, p4, p5, kCycle, kIndex, kRead[kIndex], kExpected
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+instr 99
+  if i(gkChecks) != 3 then
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Full spectrum, an odd-numbered high bin range, and Nyquist alone.
+i 1 0 .125 0 0
+i 1 0 .125 23 25
+i 1 0 .125 32 32
+i 99 .25 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`pvsbufread` used bin numbers as positions in an array of amplitude/frequency pairs. This made the default read omit the upper half of the spectrum and shifted explicit frequency ranges.

Convert bin numbers to pair offsets and include the upper selected bin through Nyquist. Split from #2959; this PR covers only frequency-bin selection.
