### PR TITLE
Fix circular frame reads in PVS buffers

### DIFF
--- a/Opcodes/pvsbuffer.c
+++ b/Opcodes/pvsbuffer.c
@@ -212,7 +212,7 @@ static int32_t pvsbufreadset(CSOUND *csound, PVSBUFFERREAD *p)
      end /= (sr/N);
      strt = (int32_t)(strt < 0 ? 0 : strt > N/2 ? N/2 : strt);
      end = (int32_t)(end <= strt ? N/2 + 2 : end > N/2 + 2 ? N/2 + 2 : end);
-     frames = handle->frames-1;
+     frames = handle->frames;
      pos = *p->ktime*(sr/overlap);
 
      if (p->iclear) memset(fout, 0, sizeof(float)*(N+2));
@@ -277,7 +277,7 @@ static int32_t pvsbufreadproc2(CSOUND *csound, PVSBUFFERREAD *p)
     overlap = p->fout->overlap;
     if (p->scnt >= overlap) {
       float *frame1, *frame2;
-      frames = handle->frames-1;
+      frames = handle->frames;
       ftab = csound->FTFind(csound, p->strt);
       if (UNLIKELY((int32_t)ftab->flen < N/2+1))
         csound->PerfError(csound, &(p->h),

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -889,6 +889,7 @@ def runTest():
         ["test_pvsinit_invalid_parameters.csd", "reject invalid pvsinit parameters", 1],
         ["test_pvsosc_frames.csd", "pvsosc frame timing and harmonic selection"],
         ["test_pvsosc_invalid_parameters.csd", "reject invalid pvsosc parameters", 1],
+        ["test_pvsbufread_circular_frames.csd", "PVS buffer last-frame interpolation and circular reads"],
         ["test_shift_array_state.csd", "shiftin and shiftout sample state"],
         ["test_shift_array_invalid_inputs.csd", "shift arrays reject invalid inputs", 1],
         ["test_sa.csd", "test sample accurate mode"],

--- a/tests/commandline/test_pvsbufread_circular_frames.csd
+++ b/tests/commandline/test_pvsbufread_circular_frames.csd
@@ -1,0 +1,75 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 1
+0dbfs = 1
+giZero ftgen 0, 0, -33, -2, 0
+giQuarter ftgen 0, 0, -33, -7, 1/2048, 33, 1/2048
+gkChecks init 0
+
+; Interpolate between the last frame and the first, including negative times.
+instr 2
+  kSource[] init 66
+  kFirst[] init 66
+  kLast[] init 66
+  kRead[] init 66
+  kRead2[] init 66
+  kCycle init 0
+  aRamp phasor 137
+  aInput = .01*(kCycle+1)*aRamp
+  fInput pvsanal aInput, 64, 16, 64, 1
+  iBuffer, kTime pvsbuffer fInput, 2/512
+  kFrame pvs2tab kSource, fInput
+  kIndex = 0
+  while kIndex < 66 do
+    if kTime == 0 then
+      kFirst[kIndex] = kSource[kIndex]
+    else
+      kLast[kIndex] = kSource[kIndex]
+    endif
+    kIndex += 1
+  od
+  fRead pvsbufread p4/512, iBuffer
+  fRead2 pvsbufread2 p4/512, iBuffer, giZero, giQuarter
+  kFrame pvs2tab kRead, fRead
+  kFrame pvs2tab kRead2, fRead2
+  kIndex = 0
+  while kIndex < 66 do
+    kExpected = .75*kLast[kIndex]+.25*kFirst[kIndex]
+    if kIndex % 2 == 0 then
+      kExpected2 = kExpected
+    else
+      kExpected2 = kLast[kIndex]
+    endif
+    ; Check pvsbufread only below bin 16 so its separate range bug
+    ; does not affect this frame-wrapping test. Check all pvsbufread2 bins.
+    if !((kIndex >= 32 || abs(kRead[kIndex]-kExpected) <= .001) && abs(kRead2[kIndex]-kExpected2) <= .001) then
+      printks "pvsbufread wrap cycle %g index %g: got %g / %g, expected %g / %g\n", 0, kCycle, kIndex, kRead[kIndex], kRead2[kIndex], kExpected, kExpected2
+      exitnowk -1
+    endif
+    kIndex += 1
+  od
+  kCycle += 1
+  if kCycle == 40 then
+    gkChecks += 1
+    turnoff
+  endif
+endin
+
+instr 99
+  if i(gkChecks) != 2 then
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 2 0 .125 1.25
+i 2 0 .125 -.75
+i 99 .25 .01
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Both PVS buffer readers wrapped at one less than the stored frame count. This omitted the last frame and shortened the loop.

Use the full frame count for wrapping and interpolation from the last frame back to the first. Split from #2959; this PR covers only circular frame reads.
