### PR TITLE
Stop pvsbufread2 when delay tables are invalid

### DIFF
--- a/Opcodes/pvsbuffer.c
+++ b/Opcodes/pvsbuffer.c
@@ -279,14 +279,16 @@ static int32_t pvsbufreadproc2(CSOUND *csound, PVSBUFFERREAD *p)
       float *frame1, *frame2;
       frames = handle->frames-1;
       ftab = csound->FTFind(csound, p->strt);
+      if (UNLIKELY(ftab == NULL)) return NOTOK;
       if (UNLIKELY((int32_t)ftab->flen < N/2+1))
-        csound->PerfError(csound, &(p->h),
+        return csound->PerfError(csound, &(p->h),
                           Str("table length too small: needed %d, got %d\n"),
                           N/2+1, ftab->flen);
       tab = tab1 = ftab->ftable;
       ftab = csound->FTFind(csound, p->end);
+      if (UNLIKELY(ftab == NULL)) return NOTOK;
       if (UNLIKELY((int32_t)ftab->flen < N/2+1))
-        csound->PerfError(csound, &(p->h),
+        return csound->PerfError(csound, &(p->h),
                           Str("table length too small: needed %d, got %d\n"),
                           N/2+1, ftab->flen);
       tab2 = ftab->ftable;


### PR DESCRIPTION
`pvsbufread2` continued after reporting a short delay table and did not stop when a table lookup failed.

Return immediately when either delay table is missing or too short. Split from #2959; this PR covers only delay-table error handling.
