### PR TITLE
fix: parse cmp operator text and respect array lengths

### DIFF
--- a/Opcodes/emugens/emugens.c
+++ b/Opcodes/emugens/emugens.c
@@ -1347,25 +1347,20 @@ typedef struct {
     int32_t mode;
 } Cmp2_array1;
 
-static int32_t op2mode(char *op, int64_t opsize) {
-    int32_t mode;
-    if (op[0] == '>') {
-        mode = (opsize == 1) ? 0 : 1;
-    } else if (op[0] == '<') {
-        mode = (opsize == 1) ? 2 : 3;
-    } else if (op[0] == '=') {
-        mode = 4;
-    } else if (op[0] == '!' && op[1] == '=') {
-        mode = 5;
-    } else {
-        return -1;
-    }
-    return mode;
+static int32_t op2mode(const char *op) {
+    if (strcmp(op, ">") == 0) return 0;
+    if (strcmp(op, ">=") == 0) return 1;
+    if (strcmp(op, "<") == 0) return 2;
+    if (strcmp(op, "<=") == 0) return 3;
+    /* Keep the historical single-equals alias. */
+    if (strcmp(op, "==") == 0 || strcmp(op, "=") == 0) return 4;
+    if (strcmp(op, "!=") == 0) return 5;
+    return -1;
 }
 
 static int32_t
 cmp_init(CSOUND *csound, Cmp *p) {
-    int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
+    int32_t mode = op2mode(p->op->data);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
                            "Expecting <, <=, >, >=, ==, !="));
@@ -1379,7 +1374,7 @@ cmparray1_init(CSOUND *csound, Cmp_array1 *p) {
     int32_t N = p->in->sizes[0];
     if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
       return csound_array_init_resize_error(csound);
-    int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
+    int32_t mode = op2mode(p->op->data);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
                            "Expecting <, <=, >, >=, ==, !="));
@@ -1398,7 +1393,7 @@ cmparray2_init(CSOUND *csound, Cmp_array2 *p) {
     // grow the array if necessary
     if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
       return csound_array_init_resize_error(csound);
-    int32_t mode = (int32_t) op2mode(p->op->data, p->op->size-1);
+    int32_t mode = op2mode(p->op->data);
     if(mode == -1) {
         return INITERR(Str("cmp: unknown operator. "
                            "Expecting <, <=, >, >=, ==, !="));
@@ -1413,23 +1408,13 @@ cmp2array1_init(CSOUND *csound, Cmp2_array1 *p) {
     if (UNLIKELY(tabinit(csound, p->out, N, p->h.insdshead) != OK))
       return csound_array_init_resize_error(csound);
 
-    char *op1 = (char*)p->op1->data;
-    int64_t op1size = p->op1->size - 1;
-    char *op2 = (char*)p->op2->data;
-    int64_t op2size = p->op2->size - 1;
-    int32_t mode;
-
-    if (op1[0] == '<') {
-        mode = (op1size == 1) ? 0 : 1;
-        if(op2[0] == '<')
-            mode += 2 * ((op2size == 1) ? 0 : 1);
-        else
-            return INITERR(Str("cmp (ternary comparator): operator 2 expected <"));
-    }
-    else {
-        return INITERR(Str("cmp (ternary comparator): operator 1 expected <"));
-    }
-    p->mode = mode;
+    int32_t mode1 = op2mode(p->op1->data);
+    int32_t mode2 = op2mode(p->op2->data);
+    if (mode1 != 2 && mode1 != 3)
+        return INITERR(Str("cmp (ternary comparator): operator 1 expected < or <="));
+    if (mode2 != 2 && mode2 != 3)
+        return INITERR(Str("cmp (ternary comparator): operator 2 expected < or <="));
+    p->mode = (mode1 - 2) + 2 * (mode2 - 2);
     return OK;
 }
 
@@ -1524,7 +1509,8 @@ cmp_ak(CSOUND *csound, Cmp *p) {
 static int32_t
 cmparray1_k(CSOUND *csound, Cmp_array1 *p) {
     int32_t L = p->in->sizes[0];
-    ARRAY_ENSURESIZE_PERF(csound, p->out, L);
+    if (UNLIKELY(ARRAY_ENSURESIZE_PERF(csound, p->out, L) != OK))
+        return NOTOK;
 
     MYFLT *out = p->out->data;
     MYFLT *in  = p->in->data;
@@ -1568,7 +1554,8 @@ cmparray1_k(CSOUND *csound, Cmp_array1 *p) {
 
 static int32_t
 cmparray1_i(CSOUND *csound, Cmp_array1 *p) {
-    cmparray1_init(csound, p);
+    if (UNLIKELY(cmparray1_init(csound, p) != OK))
+        return NOTOK;
     return cmparray1_k(csound, p);
 }
 
@@ -1576,7 +1563,8 @@ cmparray1_i(CSOUND *csound, Cmp_array1 *p) {
 static int32_t
 cmp2array1_k(CSOUND *csound, Cmp2_array1 *p) {
     int32_t L = p->in->sizes[0];
-    ARRAY_ENSURESIZE_PERF(csound, p->out, L);
+    if (UNLIKELY(ARRAY_ENSURESIZE_PERF(csound, p->out, L) != OK))
+        return NOTOK;
 
     MYFLT *out = p->out->data;
     MYFLT *in  = p->in->data;
@@ -1616,14 +1604,18 @@ cmp2array1_k(CSOUND *csound, Cmp2_array1 *p) {
 
 static int32_t
 cmp2array1_i(CSOUND *csound, Cmp2_array1 *p) {
-    cmp2array1_init(csound, p);
+    if (UNLIKELY(cmp2array1_init(csound, p) != OK))
+        return NOTOK;
     return cmp2array1_k(csound, p);
 }
 
 static int32_t
 cmparray2_k(CSOUND *csound, Cmp_array2 *p) {
-    int32_t L = p->in1->sizes[0];
-    ARRAY_ENSURESIZE_PERF(csound, p->out, L);
+    int32_t N1 = p->in1->sizes[0];
+    int32_t N2 = p->in2->sizes[0];
+    int32_t L = N1 < N2 ? N1 : N2;
+    if (UNLIKELY(ARRAY_ENSURESIZE_PERF(csound, p->out, L) != OK))
+        return NOTOK;
 
     MYFLT *out = p->out->data;
     MYFLT *in1  = p->in1->data;
@@ -1666,7 +1658,8 @@ cmparray2_k(CSOUND *csound, Cmp_array2 *p) {
 
 static int32_t
 cmparray2_i(CSOUND *csound, Cmp_array2 *p) {
-    cmparray2_init(csound, p);
+    if (UNLIKELY(cmparray2_init(csound, p) != OK))
+        return NOTOK;
     return cmparray2_k(csound, p);
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -641,6 +641,8 @@ def runTest():
         ["test_fof_float_rise_range.csd", "reject fof rise beyond the float-phase range", 1],
         ["test_fof2_fixed_rise_range.csd", "reject fof2 rise beyond the fixed-phase range", 1],
         ["test_fof2_float_rise_range.csd", "reject fof2 rise beyond the float-phase range", 1],
+        ["test_cmp_operator_text.csd", "cmp operator text and array lengths"],
+        ["test_cmp_invalid_operator.csd", "reject malformed cmp operators", 3],
         ["test_flooper_stereo_guard.csd", "flooper preserves the stereo wrap sample"],
         ["test_flooper_stereo_frame_bounds.csd", "reject flooper ranges past stereo frames", 1],
         ["test_flooper_zero_duration.csd", "reject zero flooper duration", 1],

--- a/tests/commandline/test_cmp_invalid_operator.csd
+++ b/tests/commandline/test_cmp_invalid_operator.csd
@@ -1,0 +1,25 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+instr 1
+  iValues[] fillarray 0, 1, 2
+  iScalar[] cmp iValues, "<>", 1
+endin
+instr 2
+  iValues[] fillarray 0, 1, 2
+  iArray[] cmp iValues, "===", iValues
+endin
+instr 3
+  iValues[] fillarray 0, 1, 2
+  iRange[] cmp 0, "<", iValues, "<bad", 2
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .01
+i 2 0 .01
+i 3 0 .01
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_cmp_operator_text.csd
+++ b/tests/commandline/test_cmp_operator_text.csd
@@ -1,0 +1,161 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+gkChecks init 0
+
+instr 1
+  SText strget p4
+  SOp strcpy "previous operator text"
+  SOp strcpy SText
+  iValues[] fillarray 0, 1, 2
+  iOnes[] fillarray 1, 1, 1
+  iExpected[] fillarray p5, p6, p7
+  iScalar[] cmp iValues, SOp, 1
+  iArray[] cmp iValues, SOp, iOnes
+  iN=0
+  while iN<3 do
+    if iScalar[iN]!=iExpected[iN] || iArray[iN]!=iExpected[iN] then
+      prints "FAIL cmp init operator %s\n", SOp
+      exitnow -1
+    endif
+    iN+=1
+  od
+  kValues[] fillarray 0, 1, 2
+  kOnes[] fillarray 1, 1, 1
+  kScalar[] cmp kValues, SOp, 1
+  kArray[] cmp kValues, SOp, kOnes
+  aValues init 0
+  aOnes init 1
+  kN=0
+  while kN<ksmps do
+    vaset kN%3, kN, aValues
+    kN+=1
+  od
+  aScalar cmp aValues, SOp, 1
+  aArray cmp aValues, SOp, aOnes
+  aValues cmp aValues, SOp, 1
+  kN=0
+  while kN<ksmps do
+    kExpected=iExpected[kN%3]
+    kScalarSample vaget kN, aScalar
+    kArraySample vaget kN, aArray
+    kReuseSample vaget kN, aValues
+    if kScalar[kN%3]!=kExpected || kArray[kN%3]!=kExpected || \
+        kScalarSample!=kExpected || kArraySample!=kExpected || kReuseSample!=kExpected then
+      printks "FAIL cmp perf operator %s sample %g\n", 0, SOp, kN
+      exitnowk -1
+    endif
+    kN+=1
+  od
+  gkChecks+=1
+endin
+
+instr 2
+  SText1 strget p4
+  SText2 strget p5
+  SOp1 strcpy "previous operator text"
+  SOp2 strcpy "previous operator text"
+  SOp1 strcpy SText1
+  SOp2 strcpy SText2
+  iValues[] fillarray 0, 1, 2
+  iExpected[] fillarray p6, 1, p7
+  iResult[] cmp 0, SOp1, iValues, SOp2, 2
+  iN=0
+  while iN<3 do
+    if iResult[iN]!=iExpected[iN] then
+      prints "FAIL cmp init range\n"
+      exitnow -1
+    endif
+    iN+=1
+  od
+  kValues[] fillarray 0, 1, 2
+  kResult[] cmp 0, SOp1, kValues, SOp2, 2
+  kN=0
+  while kN<3 do
+    if kResult[kN]!=iExpected[kN] then
+      printks "FAIL cmp perf range\n", 0
+      exitnowk -1
+    endif
+    kN+=1
+  od
+  gkChecks+=1
+endin
+
+instr 3
+  ; Unequal input lengths in either order use the common prefix.
+  iLong[] fillarray 0, 1, 2
+  iShort[] fillarray 0, 1
+  iForward[] cmp iLong, "==", iShort
+  iReverse[] cmp iShort, "==", iLong
+  if lenarray(iForward)!=2 || lenarray(iReverse)!=2 || \
+      sumarray(iForward)!=2 || sumarray(iReverse)!=2 then
+    prints "FAIL cmp init array lengths\n"
+    exitnow -1
+  endif
+  kA[] fillarray 0, 1, 2
+  kB[] fillarray 0, 1, 2
+  kBlock init 0
+  if kBlock==1 then
+    trim kB, 2
+  elseif kBlock==2 then
+    trim kA, 1
+  elseif kBlock==3 then
+    trim kA, 3
+    trim kB, 3
+  endif
+  kLengthA lenarray kA
+  kLengthB lenarray kB
+  kN=0
+  while kN<kLengthA do
+    kA[kN]=kN
+    kN+=1
+  od
+  kN=0
+  while kN<kLengthB do
+    kB[kN]=kN
+    kN+=1
+  od
+  kResult[] cmp kA, "==", kB
+  kExpected=min(kLengthA, kLengthB)
+  kLength lenarray kResult
+  kSum sumarray kResult
+  if kLength!=kExpected || kSum!=kExpected then
+    printks "FAIL cmp changing array lengths\n", 0
+    exitnowk -1
+  endif
+  kBlock+=1
+  if kBlock==4 then
+    gkChecks+=1
+  endif
+endin
+
+instr 99
+  if i(gkChecks)!=12 then
+    prints "FAIL cmp checks did not complete\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0    .015625 ">"  0 0 1
+i 1 .125 .015625 ">=" 0 1 1
+i 1 .25  .015625 "<"  1 0 0
+i 1 .375 .015625 "<=" 1 1 0
+i 1 .5   .015625 "==" 0 1 0
+i 1 .625 .015625 "!=" 1 0 1
+i 1 .75  .015625 "="  0 1 0
+i 2 .875 .015625 "<"  "<"  0 0
+i 2 1    .015625 "<=" "<"  1 0
+i 2 1.125 .015625 "<" "<=" 0 1
+i 2 1.25 .015625 "<=" "<=" 1 1
+i 3 1.375 .0625
+i 99 1.5 .015625
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`cmp` uses the operator string's buffer size to distinguish `<` from `<=` and `>` from `>=`. Reusing a string that once held longer text can therefore make `1 < 1` return 1.

Parse the actual text for audio, array, and range comparisons. Reject malformed operators while keeping the historical `=` alias. Parsing stays at init time; the audio loops are unchanged.

Array-to-array comparisons now use the shorter input length on every call, matching initialization and preventing reads past the second array. Stop evaluation if initialization or output resizing fails.
