### PR TITLE
Fix convolve sample and overlap handling

### DIFF
--- a/Engine/memfiles.c
+++ b/Engine/memfiles.c
@@ -127,7 +127,7 @@ static int32_t load_cv_file(CSOUND *csound, const char *filnam,
     cvh.channel = (int32_t) strtol(p, &p, 10);
     cvh.Hlen = (int32_t) strtol(p, &p, 10);
     cvh.Format = (int32_t) strtol(p, &p, 10);
-    cvh.headBsize = sizeof(int32)*8 + sizeof(MYFLT);
+    cvh.headBsize = sizeof(CVSTRUCT);
     memcpy(&all[0], &cvh, sizeof(CVSTRUCT));
 
     /* Read data until end, pack as MYFLTs */

--- a/Opcodes/ugens9.c
+++ b/Opcodes/ugens9.c
@@ -29,11 +29,11 @@
 
 static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
 {
-  char     cvfilnam[MAXNAME];
+  char     *cvfilnam, *allocatedName = NULL;
   MEMFIL   *mfp;
   MYFLT    *fltp;
   CVSTRUCT *cvh;
-  int32_t       siz;
+  uint64_t      siz;
   int32     Hlenpadded = 1, obufsiz, Hlen;
   uint32_t  nchanls;
   uint32_t  nsmps = CS_KSMPS;
@@ -43,20 +43,28 @@ static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
 
   if (stringname==0){
     if (IsStringCode(*p->ifilno))
-      strncpy(cvfilnam,csound->GetArgString(csound, *p->ifilno), MAXNAME-1);
-    else csound->StringArg2Name(csound, cvfilnam,p->ifilno, "convolve.",0);
+      cvfilnam = csound->GetArgString(csound, *p->ifilno);
+    else cvfilnam = allocatedName =
+      csound->StringArg2Name(csound, NULL, p->ifilno, "convolve.", 0);
   }
-  else strncpy(cvfilnam, ((STRINGDAT *)p->ifilno)->data, MAXNAME-1);
+  else cvfilnam = ((STRINGDAT *)p->ifilno)->data;
 
   if ((mfp = p->mfp) == NULL || strcmp(mfp->filename, cvfilnam) != 0) {
     /* if file not already readin */
     if (UNLIKELY((mfp = csound->LoadMemoryFile(csound, cvfilnam,
                                                CSFTYPE_CVANAL,NULL))
                  == NULL)) {
-      return csound->InitError(csound,
-                               Str("CONVOLVE cannot load %s"), cvfilnam);
+      int32_t status = csound->InitError(csound,
+                                         Str("CONVOLVE cannot load %s"), cvfilnam);
+      if (allocatedName != NULL)
+        csound->Free(csound, allocatedName);
+      return status;
     }
   }
+  if (allocatedName != NULL)
+    csound->Free(csound, allocatedName);
+  p->mfp = mfp;
+  cvfilnam = mfp->filename;
   cvh = (CVSTRUCT *)mfp->beginp;
   if (UNLIKELY(cvh->magic != CVMAGIC)) {
     return csound->InitError(csound,
@@ -76,7 +84,7 @@ static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
     }
   }
   else {
-    if (*p->channel <= nchanls) {
+    if (*p->channel >= FL(1.0) && *p->channel <= nchanls) {
       if (UNLIKELY(p->OUTOCOUNT != 1)) {
         return csound->InitError(csound,
                                  "%s", Str("CONVOLVE: output channels not equal "
@@ -92,12 +100,14 @@ static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
     }
   }
   Hlen = p->Hlen = cvh->Hlen;
+  if (UNLIKELY(Hlen < 1 || Hlen > (1 << 29)))
+    return csound->InitError(csound, "%s", Str("convolve: invalid impulse length"));
   while (Hlenpadded < 2*Hlen-1)
     Hlenpadded <<= 1;
   p->Hlenpadded = Hlenpadded;
   p->H = (MYFLT *) ((char *)cvh+cvh->headBsize);
   if ((p->nchanls == 1) && (*p->channel > 0))
-    p->H += (Hlenpadded + 2) * (int32_t)(*p->channel - 1);
+    p->H += (size_t)(Hlenpadded + 2) * (int32_t)(*p->channel - 1);
 
   if (UNLIKELY(cvh->samplingRate != CS_ESR)) {
     /* & chk the data */
@@ -111,28 +121,29 @@ static int32_t cvset_(CSOUND *csound, CONVOLVE *p, int32_t stringname)
                              cvh->dataFormat, cvfilnam);
   }
 
-  /* Determine size of circular output buffer */
-  if (Hlen >= (int32)nsmps)
-    obufsiz = (int32) CEIL((MYFLT) Hlen / nsmps) * nsmps;
+  /* Round up in samples without losing precision for long impulses. */
+  int64_t outputSize = Hlen >= (int32_t)nsmps ?
+    ((int64_t)Hlen + nsmps - 1) / nsmps * nsmps :
+    ((int64_t)nsmps + Hlen - 1) / Hlen * Hlen;
+  if (UNLIKELY(outputSize > INT32_MAX))
+    return csound->InitError(csound, "%s", Str("convolve: output buffer is too large"));
+  obufsiz = (int32_t)outputSize;
+  siz = (uint64_t)Hlenpadded + 2 + nsmps +
+    (uint64_t)p->nchanls * ((uint64_t)Hlen - 1 + obufsiz) +
+    (p->nchanls > 1 ? (uint64_t)Hlenpadded + 2 : 0);
+  if (UNLIKELY(siz > SIZE_MAX / sizeof(MYFLT)))
+    return csound->InitError(csound, "%s", Str("convolve: buffer size is too large"));
+  if (p->auxch.auxp == NULL || p->auxch.size < siz * sizeof(MYFLT))
+    csound->AuxAlloc(csound, siz * sizeof(MYFLT), &p->auxch);
   else
-    obufsiz = (int32) CEIL(CS_KSMPS / (MYFLT) Hlen) * Hlen;
-
-  siz = ((Hlenpadded + 2) + p->nchanls * ((Hlen - 1) + obufsiz)
-         + (p->nchanls > 1 ? (Hlenpadded + 2) : 0));
-  if (p->auxch.auxp == NULL || p->auxch.size < siz*sizeof(MYFLT)) {
-    /* if no buffers yet, alloc now */
-    csound->AuxAlloc(csound, (size_t) siz*sizeof(MYFLT), &p->auxch);
-    fltp = (MYFLT *) p->auxch.auxp;
-    p->fftbuf = fltp;   fltp += (Hlenpadded + 2); /* and insert addresses */
-    p->olap = fltp;     fltp += p->nchanls*(Hlen - 1);
-    p->outbuf = fltp;   fltp += p->nchanls*obufsiz;
-    p->X  = fltp;
-  }
-  else {
-    fltp = (MYFLT *) p->auxch.auxp;
-    memset(fltp, 0, sizeof(MYFLT)*siz);
-    /* for(i=0; i < siz; i++) fltp[i] = FL(0.0); */
-  }
+    memset(p->auxch.auxp, 0, siz * sizeof(MYFLT));
+  /* Rebuild the layout even when reinitialization reuses a larger allocation. */
+  fltp = (MYFLT *)p->auxch.auxp;
+  p->fftbuf = fltp; fltp += Hlenpadded + 2;
+  p->olap = fltp; fltp += (size_t)p->nchanls * (Hlen - 1);
+  p->outbuf = fltp; fltp += (size_t)p->nchanls * obufsiz;
+  p->input = fltp; fltp += nsmps;
+  p->X = fltp;
   p->obufsiz = obufsiz;
   p->outcnt = obufsiz;
   p->incount = 0;
@@ -195,7 +206,7 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
   int32  Hlen = p->Hlen;
   int32  Hlenm1 = Hlen - 1;
   int32  obufsiz = p->obufsiz;
-  MYFLT  *outhead = NULL;
+  MYFLT  *outhead = p->outhead;
   MYFLT  *outail = p->outail;
   MYFLT  *olap;
   MYFLT  *X;
@@ -203,7 +214,8 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
   MYFLT  scaleFac;
   uint32_t offset = p->h.insdshead->ksmps_offset;
   uint32_t early  = p->h.insdshead->ksmps_no_end;
-  uint32_t nn,nsmpso_sav;
+  uint32_t nn = 0, nsmpso_sav;
+  uint32_t end = CS_KSMPS - early;
 
   scaleFac = csound->GetInverseRealFFTScale(csound, (int32_t) Hlenpadded);
   ar[0] = p->ar1;
@@ -212,6 +224,14 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
   ar[3] = p->ar4;
 
   if (UNLIKELY(p->auxch.auxp==NULL)) goto err1;
+  /* Output may reuse input while previously buffered output is drained. */
+  for (chn = 0; chn < p->nchanls; chn++) {
+    if (ar[chn] == ai) {
+      memcpy(p->input, ai, CS_KSMPS * sizeof(MYFLT));
+      ai = p->input;
+      break;
+    }
+  }
   /* First dump as much pre-existing audio in output buffer as possible */
   if (outcnt > 0) {
     if (outcnt <= (int32_t)CS_KSMPS)
@@ -220,9 +240,9 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
       i = CS_KSMPS;
     nsmpso -= i; outcnt -= i;
     for (chn = nchm1;chn >= 0;chn--) {
-      outhead = p->outhead + chn*obufsiz;
-      writeFromCircBuf(&outhead,&ar[chn],p->outbuf+chn*obufsiz,
-                       p->obufend+chn*obufsiz,i);
+      outhead = p->outhead + (size_t)chn*obufsiz;
+      writeFromCircBuf(&outhead,&ar[chn],p->outbuf+(size_t)chn*obufsiz,
+                       p->obufend+(size_t)chn*obufsiz,i);
     }
     p->outhead = outhead;
   }
@@ -236,9 +256,8 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
       i = Hlen - incount;
     nsmpsi -= i;
     incount += i;
-    nsmpso_sav = CS_KSMPS-early;
-    for (nn=0; i>0; nn++, i--) {
-      if (nn<offset|| nn>(uint32_t)nsmpso_sav)
+    for (; i>0; nn++, i--) {
+      if (nn < offset || nn >= end)
         *fftbufind++ = FL(0.0);
       else
         *fftbufind++ = scaleFac * ai[nn];
@@ -261,9 +280,9 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
       nsmpso_sav = nsmpso;
       outcnt_sav = outcnt;
       for (chn = nchm1;chn >= 0;chn--) {
-        outhead = p->outhead + chn*obufsiz;
-        outail = p->outail + chn*obufsiz;
-        olap = p->olap + chn*Hlenm1;
+        outhead = p->outhead + (size_t)chn*obufsiz;
+        outail = p->outail + (size_t)chn*obufsiz;
+        olap = p->olap + (size_t)chn*Hlenm1;
         if (chn < nchm1) {
           fftbufind = p->fftbuf;
           X = p->X;
@@ -276,7 +295,7 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
         {
           MYFLT *a, *b, re, im;
           int32_t   i;
-          a = (MYFLT*) p->H + (int32_t) (chn * (Hlenpadded + 2));
+          a = (MYFLT*) p->H + (size_t)chn * (Hlenpadded + 2);
           b = (MYFLT*) p->fftbuf;
           for (i = 0; i <= (int32_t) Hlenpadded; i += 2) {
             re = a[i + 0] * b[i + 0] - a[i + 1] * b[i + 1];
@@ -321,24 +340,26 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
         /*csound->Message(csound, "Outputting to circ. buffer\n");*/
         i = (int32_t) (Hlen - (fftbufind - p->fftbuf));
         outcnt += i;
-        i--; /* do first Hlen -1 samples with overlap */
-        j = (int32_t) (p->obufend+chn*obufsiz - outail + 1);
-        if (i >= j) {
-          i -= j;
-          for (;j > 0;--j)
+        if (i > 0) {
+          i--; /* do first Hlen -1 samples with overlap */
+          j = (int32_t) (p->obufend+(size_t)chn*obufsiz - outail + 1);
+          if (i >= j) {
+            i -= j;
+            for (;j > 0;--j)
+              *outail++ = *fftbufind++ + *olap++;
+            outail = p->outbuf+(size_t)chn*obufsiz;
+          }
+          for (;i > 0;--i)
             *outail++ = *fftbufind++ + *olap++;
-          outail = p->outbuf+chn*obufsiz;
+          /*  just need to do sample at Hlen now */
+          *outail++ = *fftbufind++;
+          if (outail > p->obufend+(size_t)chn*obufsiz)
+            outail = p->outbuf+(size_t)chn*obufsiz;
         }
-        for (;i > 0;--i)
-          *outail++ = *fftbufind++ + *olap++;
-        /*  just need to do sample at Hlen now */
-        *outail++ = *fftbufind++;
-        if (outail > p->obufend+chn*obufsiz)
-          outail = p->outbuf+chn*obufsiz;
 
         /*  Pad the rest to zero, and save first remaining (Hlen - 1) to overlap
             buffer */
-        olap = p->olap+chn*Hlenm1;
+        olap = p->olap+(size_t)chn*Hlenm1;
         for (i = Hlenm1;i > 0;--i) {
           *olap++ = *fftbufind;
           *fftbufind++ = FL(0.0);
@@ -355,6 +376,15 @@ static int32_t convolve(CSOUND *csound, CONVOLVE *p)
       p->outail = outail;
     }
   } /* end while */
+
+  for (chn = 0; chn < p->nchanls; chn++) {
+    MYFLT *output = chn == 0 ? p->ar1 : chn == 1 ? p->ar2 :
+      chn == 2 ? p->ar3 : p->ar4;
+    if (UNLIKELY(offset))
+      memset(output, 0, offset * sizeof(MYFLT));
+    if (UNLIKELY(early))
+      memset(output + end, 0, early * sizeof(MYFLT));
+  }
 
   /* update state in p */
   p->incount = incount;

--- a/Opcodes/ugens9.h
+++ b/Opcodes/ugens9.h
@@ -32,6 +32,7 @@ typedef struct {
     int32_t     nchanls; /* number of channels we are actually processing */
     MYFLT   *H,*cvlut,*outhead,*outail,*obufend;
     AUXCH   auxch;    /* use AUXDS to manage the following buffer spaces */
+    MYFLT   *input;   /* [ksmps] saved when output shares the input buffer */
     MYFLT   *fftbuf;  /* [Hlenpadded + 2] (general FFT working buffer) */
     MYFLT   *olap;    /* [(Hlen - 1) * nchnls] (samples to overlap on next run) */
     MYFLT   *outbuf;  /* (to store output audio if
@@ -66,4 +67,3 @@ typedef struct {
     int32   outCount;   /* number of valid samples in the outbuf */
     void    *fwdsetup, *invsetup;   /* setup for FFT */
 } PCONVOLVE;
-

--- a/tests/python/test_convolve_samples.py
+++ b/tests/python/test_convolve_samples.py
@@ -1,0 +1,183 @@
+"""Compare convolve with a direct FIR sum across block and impulse lengths."""
+
+import cmath
+import ctypes as ct
+import math
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+def write_cv(path, length, channels, sample_type, text_format=False):
+    """Write the native CV layout with a three-tap impulse per channel."""
+    class Header(ct.Structure):
+        _fields_ = [(name, ct.c_int32) for name in
+                    ("magic", "head_bytes", "data_bytes", "data_format")]
+        _fields_ += [("rate", sample_type)]
+        _fields_ += [(name, ct.c_int32) for name in
+                     ("channels", "channel", "length", "format")]
+        _fields_ += [("info", ct.c_char * 4)]
+
+    fft_size = 1 << (2 * length - 2).bit_length()
+    data = []
+    for channel in range(channels):
+        for bin_number in range(fft_size // 2 + 1):
+            value = sum(gain * cmath.exp(-2j * math.pi * bin_number * tap / fft_size)
+                        for tap, gain in ((0, .5), (1, -.125), (length - 1, .25)))
+            value /= 2 ** channel
+            data.extend((value.real, value.imag))
+    samples = (sample_type * len(data))(*data)
+    header = Header(666, ct.sizeof(Header), ct.sizeof(samples), 36,
+                    1024, channels, 32767, length, 1)
+    if text_format:
+        path.write_text(f"CVANAL\n{header.head_bytes} {header.data_bytes} 36 "
+                        f"1024 {channels} 32767 {length} 1\n" +
+                        "\n".join(float(value).hex() for value in data) + "\n")
+    else:
+        path.write_bytes(bytes(header) + bytes(samples))
+
+
+class ConvolveSampleTests(unittest.TestCase):
+    def test_block_boundaries_and_input_reuse(self):
+        default = Path(__file__).resolve().parents[2] / "build" / "csound"
+        executable = os.environ.get("CSOUND_TEST_EXECUTABLE", str(default))
+        if not Path(executable).is_file():
+            self.skipTest("Set CSOUND_TEST_EXECUTABLE to the built csound command")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for length in (3, 8, 17, 25, 32):
+                for size, sample_type in ((4, ct.c_float), (8, ct.c_double)):
+                    write_cv(root / f"impulse-{length}-{size}.cv", length, 4, sample_type)
+                    write_cv(root / f"text-{length}-{size}.cv", length, 4,
+                             sample_type, text_format=True)
+            events = []
+            for case, (length, mode, offset) in enumerate(
+                    (length, mode, offset) for length in (3, 8, 17, 25, 32)
+                    for mode in (0, 1, 2, 3, 4) for offset in (0, 3)):
+                events.append(f"i1 {case / 2 + offset / 1024:.10f} .1875 {length} {mode}")
+            csd = """<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+gkChecks init 0
+instr 1
+  iSize floatsize
+  SFile sprintf "impulse-%d-%d.cv", p4, iSize
+  if p5==3 then
+    SFile sprintf "text-%d-%d.cv", p4, iSize
+  endif
+  iOffset=int(p2*sr+.5)%ksmps
+  iTotal=int(p3*sr+.5)
+  iDelay=(p4>=ksmps ? ceil(p4/ksmps)*ksmps : ceil(ksmps/p4)*p4)
+  kCount init 0
+  kStart=(kCount==0 ? iOffset : 0)
+  kEnd=min(ksmps,kStart+iTotal-kCount)
+  aInput init 0
+  kN=0
+  while kN<ksmps do
+    kIndex=kCount+kN-kStart
+    ; Nonzero inactive input makes incorrect sample masking visible.
+    kValue=(kN>=kStart && kN<kEnd ? (kIndex%19-9)/16 : 10)
+    vaset kValue,kN,aInput
+    kN+=1
+  od
+  if p5==0 || p5==3 then
+    a1,a2,a3,a4 convolve aInput,SFile
+  elseif p5==1 then
+    a1,a2,aInput,a4 convolve aInput,SFile
+    a3=aInput
+  elseif p5==2 then
+    a1 convolve aInput,SFile,3
+  else
+    strset 77,SFile
+    a1 convolve aInput,77,3
+  endif
+  kN=0
+  while kN<ksmps do
+    kIndex=kCount+kN-kStart-iDelay
+    kExpected=0
+    if kN>=kStart && kN<kEnd then
+      if kIndex>=0 then
+        kExpected=.5*(kIndex%19-9)/16
+      endif
+      if kIndex>=1 then
+        kExpected-=.125*((kIndex-1)%19-9)/16
+      endif
+      if kIndex>=p4-1 then
+        kExpected+=.25*((kIndex-p4+1)%19-9)/16
+      endif
+    endif
+    kActual vaget kN,a1
+    kFirst=(p5==2 || p5==4 ? kExpected/4 : kExpected)
+    if !(abs(kActual-kFirst)<.00001) then
+      printks "FAIL convolve length=%g mode=%g index=%g: %g expected %g\\n",0,p4,p5,kIndex,kActual,kFirst
+      exitnowk -1
+    endif
+    if p5!=2 && p5!=4 then
+      k2 vaget kN,a2
+      k3 vaget kN,a3
+      k4 vaget kN,a4
+      if !(abs(k2-kExpected/2)<.00001) || !(abs(k3-kExpected/4)<.00001) || !(abs(k4-kExpected/8)<.00001) then
+        printks "FAIL convolve channel separation\\n",0
+        exitnowk -1
+      endif
+    endif
+    kN+=1
+  od
+  kCount+=kEnd-kStart
+  if kCount==iTotal then
+    gkChecks+=1
+  endif
+endin
+instr 2
+  iSize floatsize
+  kCycle init 0
+  kCycle+=1
+  if kCycle==13 || kCycle==25 || kCycle==37 then
+    reinit LOAD
+  endif
+LOAD:
+  iLength=(i(kCycle)<13 ? 25 : i(kCycle)<25 ? 8 : i(kCycle)<37 ? 32 : 3)
+  iLast=iLength-1
+  SFile sprintf "impulse-%d-%d.cv",iLength,iSize
+  iDelay=(iLength>=ksmps ? ceil(iLength/ksmps)*ksmps : ceil(ksmps/iLength)*iLength)
+  aInput=1
+  a1,a2,a3,a4 convolve aInput,SFile
+  rireturn
+  kN=0
+  while kN<ksmps do
+    kIndex=((kCycle-1)%12)*ksmps+kN-iDelay
+    kExpected=(kIndex<0 ? 0 : kIndex==0 ? .5 : kIndex<iLast ? .375 : .625)
+    k1 vaget kN,a1
+    k4 vaget kN,a4
+    if !(abs(k1-kExpected)<.00001) || !(abs(k4-kExpected/8)<.00001) then
+      printks "FAIL convolve reinit length=%g sample=%g: %g expected %g\\n",0,iLength,kIndex,k1,kExpected
+      exitnowk -1
+    endif
+    kN+=1
+  od
+endin
+instr 99
+  if i(gkChecks)!=50 then
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+""" + "\n".join(events) + "\ni2 25 .75\ni99 26 .015625\ne\n</CsScore>\n</CsoundSynthesizer>\n"
+            path = root / "check.csd"
+            path.write_text(csd)
+            result = subprocess.run([executable, path.name], cwd=root,
+                                    capture_output=True, text=True, timeout=60)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`convolve` restarts its input cursor for each impulse-sized chunk. With an 8-frame impulse and `ksmps=16`, it reads samples 0–7 twice and skips 8–15. Keep the cursor moving through the block and exclude inactive samples at both note boundaries.

Also preserve input when an output shares its buffer, avoid advancing the output and overlap cursors when no samples remain to copy, and rebuild buffer pointers when reinitialization changes the impulse length. These changes keep the existing buffering delay and FFT arithmetic.

Fix the data offset for text-format convolution files, remove the fixed filename buffer, and check impulse and allocation sizes before computing buffer offsets. No new per-sample function calls or finite-value checks.
