### PR TITLE
Fix pitchamdf resampling and analysis history

### DIFF
--- a/Opcodes/pitch.c
+++ b/Opcodes/pitch.c
@@ -859,13 +859,18 @@ int32_t hsboscil(CSOUND *csound, HSBOSC   *p)
 int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
 {
     MYFLT srate, downs;
-    int32  size, minperi, maxperi, downsamp, upsamp, msize, bufsize;
+    int32  size, minperi, maxperi, downsamp, upsamp;
+    size_t msize, bufsize;
+    double minperiod, maxperiod, period, requested, blocksize, maxmedian;
     uint32_t interval;
     uint32_t nsmps = CS_KSMPS;
 
-    p->inerr = 0;
+    p->inerr = 1;
 
     downs = *p->idowns;
+    if (UNLIKELY(!(downs >= -(double)INT32_MAX + 1 &&
+                   downs <= (double)INT32_MAX - 1)))
+      return csound->InitError(csound, Str("pitchamdf: invalid resampling factor"));
     if (downs < (-FL(1.9))) {
       upsamp = (int32_t)MYFLT2LONG((-downs));
       downsamp = 0;
@@ -879,27 +884,38 @@ int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
       upsamp = 0;
     }
 
-    minperi = (int32)(srate / *p->imaxcps);
-    maxperi = (int32)(FL(0.5)+srate / *p->imincps);
+    if (UNLIKELY(!(*p->imincps > 0 && *p->imaxcps > *p->imincps)))
+      return csound->InitError(csound, Str("pitchamdf: invalid frequency range"));
+    minperiod = (double)srate / *p->imaxcps;
+    maxperiod = 0.5 + (double)srate / *p->imincps;
+    if (UNLIKELY(!(minperiod >= 1 && maxperiod < INT32_MAX)))
+      return csound->InitError(csound, Str("pitchamdf: frequency range is too wide"));
+    minperi = (int32_t)minperiod;
+    maxperi = (int32_t)maxperiod;
     if (UNLIKELY(maxperi <= minperi)) {
-      p->inerr = 1;
       return csound->InitError(csound,
-                               "%s", Str("pitchamdf: maxcps must be > mincps !"));
+                               "%s", Str("pitchamdf: frequency range has no distinct periods"));
     }
 
     if (*p->iexcps < 1)
-        interval = maxperi;
+        requested = maxperi;
     else
-        interval = (uint32_t)(srate / *p->iexcps);
-    if (interval < nsmps) {
-      if (downsamp)
-        interval = nsmps / downsamp;
-      else
-        interval = nsmps * upsamp;
-    }
+        requested = (double)srate / *p->iexcps;
+    if (UNLIKELY(!(requested >= 0 && requested < INT32_MAX)))
+      return csound->InitError(csound, Str("pitchamdf: invalid analysis interval"));
+    /* At least one control block, measured at the resampled rate. */
+    blocksize = downsamp ? ceil((double)nsmps / downsamp) :
+      (double)nsmps * upsamp;
+    if (requested < blocksize)
+      requested = blocksize;
+    if (UNLIKELY(requested > INT32_MAX - maxperi))
+      return csound->InitError(csound, Str("pitchamdf: analysis window is too large"));
+    interval = (uint32_t)requested;
 
     size = maxperi + interval;
-    bufsize = sizeof(MYFLT)*(size + interval + 2);
+    if (UNLIKELY((size_t)size > SIZE_MAX / sizeof(MYFLT)))
+      return csound->InitError(csound, Str("pitchamdf: analysis window is too large"));
+    bufsize = sizeof(MYFLT) * (size_t)size;
 
     p->srate = srate;
     p->downsamp = downsamp;
@@ -911,9 +927,20 @@ int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
     p->index = 0;
     p->lastval = FL(0.0);
     if (*p->icps < 1)
-        p->peri = (minperi + maxperi) / 2;
-    else
-        p->peri = (int32_t)(srate / *p->icps);
+        p->peri = minperi + (maxperi - minperi) / 2;
+    else {
+      period = (double)srate / *p->icps;
+      if (UNLIKELY(!(period >= minperi && period < (double)maxperi + 1)))
+        return csound->InitError(csound, Str("pitchamdf: initial pitch is outside the range"));
+      p->peri = (int32_t)period;
+    }
+
+    /* Three arrays share each median allocation; validate before rounding. */
+    maxmedian = (double)(SIZE_MAX / sizeof(MYFLT) / 3 - 1) / 2;
+    if (maxmedian > (INT32_MAX - 3) / 6)
+      maxmedian = (INT32_MAX - 3) / 6;
+    if (UNLIKELY(!(*p->irmsmedi < maxmedian && *p->imedi < maxmedian)))
+      return csound->InitError(csound, Str("pitchamdf: median window is too large"));
 
     if (*p->irmsmedi < 1)
         p->rmsmedisize = 0;
@@ -922,7 +949,7 @@ int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
     p->rmsmediptr = 0;
 
     if (p->rmsmedisize) {
-      msize = p->rmsmedisize * 3 * sizeof(MYFLT);
+      msize = (size_t)p->rmsmedisize * 3 * sizeof(MYFLT);
       if (p->rmsmedian.auxp==NULL || p->rmsmedian.size < (size_t)msize)
         csound->AuxAlloc(csound, msize, &p->rmsmedian);
       else {
@@ -937,7 +964,7 @@ int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
     p->mediptr = 0;
 
     if (p->medisize) {
-      msize = p->medisize * 3 * sizeof(MYFLT);
+      msize = (size_t)p->medisize * 3 * sizeof(MYFLT);
       if (p->median.auxp==NULL || p->median.size < (size_t)msize)
         csound->AuxAlloc(csound, (size_t)msize, &p->median);
       else {
@@ -950,6 +977,7 @@ int32_t pitchamdfset(CSOUND *csound, PITCHAMDF *p)
     }
     else
       memset(p->buffer.auxp, 0, bufsize);
+    p->inerr = 0;
     return OK;
 }
 
@@ -1020,9 +1048,9 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
     MYFLT  upsmp = (MYFLT)upsamp;
     MYFLT  lastval = p->lastval;
     MYFLT  newval, delta;
-    int32  readp = p->readp;
+    int64_t readp = p->readp + (int64_t)p->h.insdshead->ksmps_offset;
     int32  interval = size - maxperi;
-    int32_t    nsmps = CS_KSMPS;
+    int32_t    nsmps = CS_KSMPS - p->h.insdshead->ksmps_no_end;
     int32_t    i;
     int32  i1, i2;
     MYFLT  val, rms;
@@ -1033,12 +1061,15 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
       return csound->PerfError(csound, &(p->h),
                                "%s", Str("pitchamdf: not initialised"));
     }
+    if (UNLIKELY(p->h.insdshead->ksmps_offset >= (uint32_t)nsmps))
+      return OK;
 
     if (upsamp) {
-      while (1) {
-        newval = asig[readp++];
-        delta = (newval-lastval) / upsmp;
-        lastval = newval;
+      while (readp < nsmps) {
+        MYFLT sample = asig[readp++];
+        delta = (sample-lastval) / upsmp;
+        newval = lastval;
+        lastval = sample;
 
         for (i=0; i<upsamp; i++) {
           newval += delta;
@@ -1047,14 +1078,14 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
           if (index == size) {
             peri = minperi;
             accmin = FL(0.0);
-            for (i2 = 0; i2 < size; ++i2) {
+            for (i2 = 0; i2 < interval; ++i2) {
               diff = buffer[i2+minperi] - buffer[i2];
               if (diff > 0) accmin += diff;
               else          accmin -= diff;
             }
             for (i1 = minperi + 1; i1 <= maxperi; ++i1) {
               acc = FL(0.0);
-              for (i2 = 0; i2 < size; ++i2) {
+              for (i2 = 0; i2 < interval; ++i2) {
                 diff = buffer[i1+i2] - buffer[i2];
                 if (diff > 0) acc += diff;
                 else          acc -= diff;
@@ -1065,7 +1096,7 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
               }
             }
 
-            for (i1 = 0; i1 < interval; i1++)
+            for (i1 = 0; i1 < maxperi; i1++)
               buffer[i1] = buffer[i1+interval];
             index = maxperi;
 
@@ -1084,28 +1115,27 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
             }
           }
         }
-        if (readp >= nsmps) break;
       }
-      readp = readp % nsmps;
+      readp = 0;
       p->lastval = lastval;
     }
     else {
       int32  downsamp = p->downsamp;
-      while (1) {
+      while (readp < nsmps) {
         buffer[index++] = asig[readp];
         readp += downsamp;
 
         if (index == size) {
           peri = minperi;
           accmin = FL(0.0);
-          for (i2 = 0; i2 < size; ++i2) {
+          for (i2 = 0; i2 < interval; ++i2) {
             diff = buffer[i2+minperi] - buffer[i2];
             if (diff > FL(0.0)) accmin += diff;
             else                accmin -= diff;
           }
           for (i1 = minperi + 1; i1 <= maxperi; ++i1) {
             acc = FL(0.0);
-            for (i2 = 0; i2 < size; ++i2) {
+            for (i2 = 0; i2 < interval; ++i2) {
               diff = buffer[i1+i2] - buffer[i2];
               if (diff > FL(0.0)) acc += diff;
               else                acc -= diff;
@@ -1116,7 +1146,7 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
             }
           }
 
-          for (i1 = 0; i1 < interval; i1++)
+          for (i1 = 0; i1 < maxperi; i1++)
             buffer[i1] = buffer[i1+interval];
           index = maxperi;
 
@@ -1134,16 +1164,14 @@ int32_t pitchamdf(CSOUND *csound, PITCHAMDF *p)
             p->mediptr = mediptr;
           }
         }
-
-        if (readp >= nsmps) break;
       }
-      readp = readp % nsmps;
+      readp -= nsmps;
     }
-    buffer = &buffer[(index + size - peri) % size];
+    /* The buffer is linear history; samples before note onset are zero. */
     sum = 0.0;
-    for (i1=0; i1<peri; i1++) {
+    for (i1 = (index > peri ? index - peri : 0); i1 < index; i1++) {
       val = buffer[i1];
-      sum += (double)(val * val);
+      sum += (double)val * (double)val;
     }
     if (UNLIKELY(peri==0))      /* How xould thus happen??? */
       rms = FL(0.0);

--- a/tests/python/test_pitchamdf_history.py
+++ b/tests/python/test_pitchamdf_history.py
@@ -1,0 +1,182 @@
+"""Compare pitchamdf with AMDF and RMS computed from a resampled sequence."""
+
+import math
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import tempfile
+import unittest
+
+
+def reference(block, offset, count, factor, requested, median):
+    up = -factor if factor < 0 else 1
+    down = factor if factor > 0 else 1
+    rate = 1024 * up / down
+    if rate / requested < 1:
+        requested = 64
+    interval = max(requested, math.ceil(block / down) * up)
+    raw = [(n * 7 % 31 - 15) / 32 for n in range(count)]
+    samples = []
+    if factor < 0:
+        previous = 0
+        for value in raw:
+            samples.extend(previous + (value-previous) * j / up
+                           for j in range(1, up+1))
+            previous = value
+    else:
+        samples = raw[::down]
+    width = median * 2 + 1
+    periods = [0] * width
+    medians = [0] * width
+    rms_values = [0] * width
+    rms_medians = [0] * width
+    position = rms_position = 0
+    pitch = 34
+    next_analysis = 64 + interval
+    consumed = 0
+    result = []
+    while consumed < count:
+        consumed += min(block-offset if consumed == 0 else block, count-consumed)
+        available = consumed * up if factor < 0 else (consumed+down-1) // down
+        while next_analysis <= available:
+            start = next_analysis - (64 + interval)
+            scores = [sum(abs(samples[start+j+lag] - samples[start+j])
+                          for j in range(interval)) for lag in range(4, 65)]
+            pitch = 4 + scores.index(min(scores))
+            if median:
+                periods[position] = pitch
+                medians[position] = statistics.median(periods)
+                pitch = medians[(position+median+1) % width]
+                position = (position+1) % width
+            next_analysis += interval
+        rms = math.sqrt(sum(value*value for value in samples[max(0, available-pitch):available])
+                        / pitch) if pitch else 0
+        if median:
+            rms_values[rms_position] = rms
+            rms_medians[rms_position] = statistics.median(rms_values)
+            rms = rms_medians[(rms_position+median+1) % width]
+            rms_position = (rms_position+1) % width
+        result.append((rate/pitch if pitch else 0, rms))
+    return result
+
+
+class PitchamdfHistoryTests(unittest.TestCase):
+    def test_invalid_frequency_ranges(self):
+        default = Path(__file__).resolve().parents[2] / "build" / "csound"
+        executable = os.environ.get("CSOUND_TEST_EXECUTABLE", str(default))
+        if not Path(executable).is_file():
+            self.skipTest("Set CSOUND_TEST_EXECUTABLE to the built csound command")
+        csd = """<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+instr 1
+  aInput=0
+  kPitch,kRms pitchamdf aInput,p4,p5,p6,0,p7
+endin
+</CsInstruments>
+<CsScore>
+i1 0 .015625 0 128 0 1
+i1 0 .015625 64 128 1000 1
+i1 0 .015625 64 128 0 32
+e
+</CsScore>
+</CsoundSynthesizer>
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "invalid.csd"
+            path.write_text(csd)
+            result = subprocess.run([executable, str(path)], capture_output=True,
+                                    text=True, timeout=60)
+            self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
+
+    def test_resampling_windows_and_partial_notes(self):
+        default = Path(__file__).resolve().parents[2] / "build" / "csound"
+        executable = os.environ.get("CSOUND_TEST_EXECUTABLE", str(default))
+        if not Path(executable).is_file():
+            self.skipTest("Set CSOUND_TEST_EXECUTABLE to the built csound command")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for block in (1, 8, 16):
+                tables, events = [], []
+                start = 0
+                cases = [(factor, interval, median)
+                         for factor in (1, 3, 32, -2, -4)
+                         for interval, median in ((16, 0), (64, 1), (128, 0))]
+                for case, (factor, interval, median) in enumerate(cases):
+                    offset = 3 if block > 1 and case % 2 else 0
+                    count = max(256, max(1, factor) * 192)
+                    rate = 1024 / factor if factor > 0 else 1024 * -factor
+                    expected = reference(block, offset, count, factor, interval, median)
+                    for column in (0, 1):
+                        number = 2*case+column+1
+                        filename = f"expected-{number}.txt"
+                        (root / filename).write_text("\n".join(
+                            format(row[column], ".17g") for row in expected))
+                        tables.append(f'giT{number} ftgen {number},0,-{len(expected)},-23,"{filename}"')
+                    events.append(f"i1 {start+offset/1024:.10f} {count/1024:.10f} "
+                                  f"{factor} {rate:.17g} {interval} {median} {2*case+1} {len(expected)}")
+                    start += math.ceil(count/1024) + 1
+                csd = f"""<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps={block}
+nchnls=1
+0dbfs=1
+""" + "\n".join(tables) + """
+gkChecks init 0
+instr 1
+  iOffset=int(p2*sr+.5)%ksmps
+  iCount=int(p3*sr+.5)
+  kCount init 0
+  kCycle init 0
+  kStart=(kCount==0 ? iOffset : 0)
+  kEnd=min(ksmps,kStart+iCount-kCount)
+  aInput init 0
+  kN=0
+  while kN<ksmps do
+    kIndex=kCount+kN-kStart
+    kValue=(kN>=kStart && kN<kEnd ? (kIndex*7%31-15)/32 : 99)
+    vaset kValue,kN,aInput
+    kN+=1
+  od
+  kPitch,kRms pitchamdf aInput,p5/64,p5/4,0,p7,p4,p5/p6,p7
+  kExpectedPitch table kCycle,p8
+  kExpectedRms table kCycle,p8+1
+  if !(abs(kPitch-kExpectedPitch)<.0001) || !(abs(kRms-kExpectedRms)<.00001) then
+    printks "FAIL pitchamdf factor=%g interval=%g median=%g cycle=%g: pitch %g expected %g, rms %g expected %g\\n",0,p4,p6,p7,kCycle,kPitch,kExpectedPitch,kRms,kExpectedRms
+    exitnowk -1
+  endif
+  kCycle+=1
+  kCount+=kEnd-kStart
+  if kCount==iCount && kCycle==p9 then
+    gkChecks+=1
+  endif
+endin
+instr 99
+  if i(gkChecks)!=15 then
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+""" + "\n".join(events) + f"\ni99 {start} .015625\ne\n</CsScore>\n</CsoundSynthesizer>\n"
+                path = root / "check.csd"
+                path.write_text(csd)
+                with self.subTest(block=block):
+                    result = subprocess.run([executable, path.name], cwd=root,
+                                            capture_output=True, text=True, timeout=60)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`pitchamdf` upsamples by extrapolating beyond each new sample. Interpolate from the previous sample instead, and preserve the downsampling position across control blocks, including partial notes.

The AMDF loop also compares samples beyond the filled window and retains the wrong amount of history when the analysis interval changes. Compare only the filled interval, retain the maximum pitch period, and compute RMS from the latest samples in that linear history.

Check resampling, frequency, initial-pitch, and window sizes before converting or allocating them. Keep these checks at initialization and add no per-sample function calls.
