### PR TITLE
ci: cancel superseded pull request builds

### DIFF
--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -13,7 +13,8 @@ on:
       - develop
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   update_version:


### PR DESCRIPTION
Cancel an older native CI run when a new commit arrives on the same PR. Group runs by workflow and PR so each PR keeps its own checks.

Keep runs on master and develop running to completion, including release jobs.
