### PR TITLE
fix: preserve delay1 input when buffers are shared

### DIFF
--- a/OOps/ugens6.c
+++ b/OOps/ugens6.c
@@ -900,21 +900,24 @@ int32_t delay1(CSOUND *csound, DELAY1 *p)
 {
     IGN(csound);
     MYFLT       *ar, *asig;
+    MYFLT       last;
     uint32_t offset = p->h.insdshead->ksmps_offset;
     uint32_t early  = p->h.insdshead->ksmps_no_end;
     uint32_t nsmps = CS_KSMPS;
 
     ar = p->ar;
-    /* asig = p->asig - 1; */
     asig = p->asig;
-    ar[offset] = p->sav1;
     if (UNLIKELY(offset)) memset(ar, '\0', offset*sizeof(MYFLT));
     if (UNLIKELY(early)) {
       nsmps -= early;
       memset(&ar[nsmps], '\0', early*sizeof(MYFLT));
     }
+    if (UNLIKELY(offset >= nsmps)) return OK;
+    /* Preserve both endpoints when input and output share the buffer. */
+    last = asig[nsmps-1];
     memmove(&ar[offset+1], &asig[offset], sizeof(MYFLT)*(nsmps-1-offset));
-    p->sav1 = asig[nsmps-1];
+    ar[offset] = p->sav1;
+    p->sav1 = last;
     return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -670,6 +670,7 @@ def runTest():
         ["test_crossfm_correctness.csd", "test crossed FM and PM correctness"],
         ["test_foscil_phase_state.csd", "foscil and foscili phase initialization and advancement"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
+        ["test_delay1_samples.csd", "delay1 input reuse, active samples and retained state"],
         ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],
         ["test_hvs_interpolation.csd", "HVS configuration and grid endpoints"],

--- a/tests/commandline/test_delay1_samples.csd
+++ b/tests/commandline/test_delay1_samples.csd
@@ -1,0 +1,79 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+gkSaved1 init 0
+gkSaved2 init 0
+gkNotes init 0
+
+instr 1, 2
+  setksmps p4
+  iSlot = p1
+  iSize = p4
+  iStart = int(p2*sr+.5)
+  iEnd = int((p2+p3)*sr+.5)
+  iBlock = iStart - iStart%iSize
+  iPrevious = (iSlot == 1 ? i(gkSaved1) : i(gkSaved2))
+  kPrevious init (p5 == 0 ? 0 : iPrevious)
+  kCycle init 0
+  aSource phasor sr/32
+  aSource += 1
+  aSeparate delay1 aSource, p5
+  aReuse = aSource
+  aReuse delay1 aReuse, p5
+  kN = 0
+  while kN < iSize do
+    kTime = iBlock + kCycle*iSize + kN
+    kInput vaget kN, aSource
+    kSeparate vaget kN, aSeparate
+    kReuse vaget kN, aReuse
+    if kTime >= iStart && kTime < iEnd then
+      kExpected = kPrevious
+      kPrevious = kInput
+    else
+      kExpected = 0
+    endif
+    if kSeparate != kExpected || kReuse != kExpected then
+      printks "delay1 mismatch at sample %g, block size %g: %g, %g, expected %g\n", 0, kTime, iSize, kSeparate, kReuse, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  if iSlot == 1 then
+    gkSaved1 = kPrevious
+  else
+    gkSaved2 = kPrevious
+  endif
+  if kCycle == 0 then
+    gkNotes += 1
+  endif
+  kCycle += 1
+endin
+
+instr 99
+  if i(gkNotes) != 8 then
+    prints "delay1 tests did not run every note\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Full and partial blocks, including one active sample, with reset and preserved state.
+i 1 0 .03125 16 0
+i 1 .0654296875 .0205078125 16 1
+i 1 .1279296875 .0009765625 16 1
+i 1 .1904296875 .0205078125 16 0
+; One-sample blocks must retain the original input for the next cycle.
+i 2 .25 .0078125 1 0
+i 2 .28125 .0078125 1 1
+i 2 .3125 .0009765625 1 1
+i 2 .34375 .0078125 1 0
+i 99 .5 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`delay1` overwrites input samples when its output reuses the input buffer. With `ksmps = 1`, a constant input can produce silence indefinitely.

Save the final input sample before shifting the buffer, and write the delayed first sample after the shift. This preserves the input needed for both the current block and the next one.

Skip the copy when a block has no active samples, preserving the saved sample and avoiding an invalid copy length.
