### PR TITLE
fix: correct bqrez band-pass gain

### DIFF
--- a/Opcodes/biquad.c
+++ b/Opcodes/biquad.c
@@ -1482,7 +1482,10 @@ static int32_t vco(CSOUND *csound, VCO *p)
           mu    = 0.0;
           sigma = -1.0;
         }
-        alpha = (beta + 1.0 + chi*gamma) * 0.5;
+        /* Band-pass gain follows the low/high-pass center gain (2 * rez).
+           The high-pass numerator gives an unwanted cot(theta/2) factor. */
+        alpha = mode == 2 ? (beta + 1.0) * sin2
+                          : (beta + 1.0 + chi*gamma) * 0.5;
 
         for (n=offset; n<nsmps; n++) {                        /* do ksmp times   */
           /* Handle a-rate modulation of fco and rez */
@@ -1498,7 +1501,8 @@ static int32_t vco(CSOUND *csound, VCO *p)
             cos2 = cos(theta);
             beta = (rez - sin2) / (rez + sin2);
             gamma = (beta + 1.0) * cos2;
-            alpha = (beta + 1.0 + chi*gamma) * 0.5;
+            alpha = mode == 2 ? (beta + 1.0) * sin2
+                              : (beta + 1.0 + chi*gamma) * 0.5;
           }
           xn     = (double)in[n];   /* Get the next sample */
           yn     = alpha*(xn + mu*xnm1 + sigma*xnm2) + gamma*ynm1 - beta*ynm2;

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -937,6 +937,7 @@ def runTest():
         ["test_sa.csd", "test sample accurate mode"],
         ["test_diode_ladder_saturation.csd", "diode_ladder saturation and filter history"],
         ["test_pareq_initial_state.csd", "pareq first skip, reset, and preserved state"],
+        ["test_bqrez_response.csd", "bqrez mode responses and band-pass center gain"],
         ["test_gain_sample_bounds.csd", "gain RMS and output over partial blocks"],
         ["test_eqfil_sample_offset.csd", "eqfil advances state only for active samples"],
         ["test_areson_audio.csd", "test areson audio coefficients and preserved state"],

--- a/tests/commandline/test_bqrez_response.csd
+++ b/tests/commandline/test_bqrez_response.csd
@@ -1,0 +1,131 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=8192
+ksmps=16
+nchnls=1
+0dbfs=1
+gkNotes init 0
+gkGains init 0
+
+instr 1
+  iStart = int(p2*sr+.5)
+  iEnd = int((p2+p3)*sr+.5)
+  iBlock = iStart - iStart%ksmps
+  kCycle init 0
+  kFrequency = (kCycle%2 == 0 ? 512 : 1536)
+  kResonance = (kCycle%3 == 0 ? 1 : 4)
+  aFrequency upsamp kFrequency
+  aResonance upsamp kResonance
+  aInput oscili .01, 256
+  aKK bqrez aInput, kFrequency, kResonance, p4
+  aAK bqrez aInput, aFrequency, kResonance, p4
+  aKA bqrez aInput, kFrequency, aResonance, p4
+  aAA bqrez aInput, aFrequency, aResonance, p4
+  aReuse = aInput
+  aReuse bqrez aReuse, aFrequency, aResonance, p4
+
+  ; Independent bilinear-transform coefficients, using g = tan(pi*f/sr).
+  ; Preserve bqrez's factor of two in the low/high/band-pass modes.
+  kG = tan($M_PI*kFrequency/sr)
+  kDen = 1 + kG/kResonance + kG*kG
+  kA1 = 2*(kG*kG-1)/kDen
+  kA2 = (1-kG/kResonance+kG*kG)/kDen
+  if p4 == 0 then
+    kB0 = 2*kG*kG/kDen
+    kB1 = 2*kB0
+    kB2 = kB0
+  elseif p4 == 1 then
+    kB0 = 2/kDen
+    kB1 = -2*kB0
+    kB2 = kB0
+  elseif p4 == 2 then
+    kB0 = 2*kG/kDen
+    kB1 = 0
+    kB2 = -kB0
+  elseif p4 == 3 then
+    kB0 = (1+kG*kG)/kDen
+    kB1 = kA1
+    kB2 = kB0
+  else
+    kB0 = kA2
+    kB1 = kA1
+    kB2 = 1
+  endif
+  aReference biquad aInput, kB0, kB1, kB2, 1, kA1, kA2
+  kN = 0
+  while kN < ksmps do
+    kTime = iBlock + kCycle*ksmps + kN
+    kReference vaget kN, aReference
+    kKK vaget kN, aKK
+    kAK vaget kN, aAK
+    kKA vaget kN, aKA
+    kAA vaget kN, aAA
+    kReuse vaget kN, aReuse
+    if kTime < iStart || kTime >= iEnd then
+      kReference = 0
+    endif
+    if abs(kKK-kReference) > .000002 || abs(kAK-kReference) > .000002 || abs(kKA-kReference) > .000002 || abs(kAA-kReference) > .000002 || abs(kReuse-kReference) > .000002 then
+      printks "bqrez mode %g sample %g: %g %g %g %g %g, expected %g\n", 0, p4, kTime, kKK, kAK, kKA, kAA, kReuse, kReference
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  if kCycle == 0 then
+    gkNotes += 1
+  endif
+  kCycle += 1
+endin
+
+instr 2
+  setksmps 1
+  aInput oscili .01, p4
+  aOutput bqrez aInput, p4, p5, 2
+  kInput downsamp aInput
+  kOutput downsamp aOutput
+  kSample init 0
+  kInPower init 0
+  kOutPower init 0
+  if kSample >= 4096 then
+    kInPower += kInput*kInput
+    kOutPower += kOutput*kOutput
+  endif
+  if kSample == 8191 then
+    kGain = sqrt(kOutPower/kInPower)
+    if abs(kGain-2*p5) > .0001 then
+      printks "bqrez center %g resonance %g: gain %g, expected %g\n", 0, p4, p5, kGain, 2*p5
+      exitnowk -1
+    endif
+    gkGains += 1
+  endif
+  kSample += 1
+endin
+
+instr 99
+  if i(gkNotes) != 10 || i(gkGains) != 4 then
+    prints "bqrez cases did not all run\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .03125 0
+i 1 0 .03125 1
+i 1 0 .03125 2
+i 1 0 .03125 3
+i 1 0 .03125 4
+i 1 .0631103515625 .0205078125 0
+i 1 .0631103515625 .0205078125 1
+i 1 .0631103515625 .0205078125 2
+i 1 .0631103515625 .0205078125 3
+i 1 .0631103515625 .0205078125 4
+i 2 .125 1 1024 1
+i 2 .125 1 2048 1
+i 2 .125 1 1024 4
+i 2 .125 1 2048 4
+i 99 1.25 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`bqrez` mode 2 uses the high-pass gain coefficient with a band-pass numerator. This adds a frequency-dependent gain: at resonance 1 and sample rate 8192, a sine at the filter's center frequency gets gain 4.828 at 1024 Hz but 2 at 2048 Hz.

Use the band-pass coefficient for both control-rate and audio-rate inputs. Its center gain becomes `2 * resonance`, matching the existing low-pass and high-pass modes. Other modes keep their current response. Existing scores using mode 2 will hear a level change except at one quarter of the sample rate.
