### PR TITLE
fix: correct bformdec2 sample and speaker processing

### DIFF
--- a/Opcodes/bformdec2.cpp
+++ b/Opcodes/bformdec2.cpp
@@ -894,9 +894,9 @@ typedef struct {
 
 typedef struct FCOMPLEX {double r,i;} fcomplex;
 
-static double readFilter(HOAMBDEC*, int32_t, int32_t);
-static void insertFilter(HOAMBDEC*,double, int32_t);
-static void process_nfc(CSOUND*,HOAMBDEC*, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+static inline double readFilter(HOAMBDEC*, int32_t, int32_t);
+static inline void insertFilter(HOAMBDEC*,double, int32_t);
+static inline void process_nfc(HOAMBDEC*, int32_t, int32_t, MYFLT*, int32_t);
 
 #ifndef MAX
 #define MAX(a,b) ((a>b)?(a):(b))
@@ -1348,14 +1348,14 @@ static int32_t ihoambdec(CSOUND *csound, HOAMBDEC* p)
       // (  0.1767766953,  0.2165063509, -0.2165063509)
       //(  0.1767766953,  0.2165063509, -0.2165063509)
 
-      double M_lf[8][4] = { { const1, const2, const2, 0.0 },
-                            { const1, const2, const2, 0.0 },
-                            { const1, -const2, const2, 0.0 },
-                            { const1, -const2, const2, 0.0 },
-                            { const1, -const2, -const2, 0.0 },
-                            { const1, -const2, -const2, 0.0 },
-                            { const1, const2, -const2, 0.0 },
-                            { const1, const2, -const2, 0.0 } };
+      double M_lf[8][4] = { { const1, const2, const2, -const2 },
+                            { const1, const2, const2, const2 },
+                            { const1, -const2, const2, -const2 },
+                            { const1, -const2, const2, const2 },
+                            { const1, -const2, -const2, -const2 },
+                            { const1, -const2, -const2, const2 },
+                            { const1, const2, -const2, -const2 },
+                            { const1, const2, -const2, const2 } };
 
       for (int32_t i = 0; i < 8; i++) {
         for (int32_t j = 0; j < 4; j++) {
@@ -1746,7 +1746,7 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
     /* Outer loop */
     if (UNLIKELY(offset)) {
       for (j = 0; j < n_outs; j++) {
-        memset(&out[j], '\0', offset*sizeof(MYFLT));
+        memset(&out[j*ksmps], '\0', offset*sizeof(MYFLT));
       }}
     if (UNLIKELY(early)) {
       nsmps -= early;
@@ -1758,7 +1758,8 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
     // ***** FIX MEMORY ALOCATION *****
     //double poleSamp[p->n_signals],inSamp[p->n_signals];
     //double zeroSamp_lf[p->n_signals],zeroSamp_hf[p->n_signals];
-    double poleSamp[36],inSamp[36];
+    double poleSamp[36];
+    MYFLT inSamp[36];
     double zeroSamp_lf[36],zeroSamp_hf[36];
     //double poleSamp_nfc[p->n_signals],inSamp_nfc[p->n_signals],zeroSamp_nfc[p->n_signals];
 
@@ -1786,15 +1787,25 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
     out_A = (MYFLT*)p->out_A.auxp;
     out_binaural0 = (MYFLT*)p->out_binaural0.auxp;
     out_binaural1 = (MYFLT*)p->out_binaural1.auxp;
+    int32_t decoder = (int32_t)*p->band;
+    double (*matrix)[MAX_INPUTS] = decoder == 1 ? p->M_lf : p->M_hf;
+    MYFLT *decoded = (isetup == 21 || isetup == 31) ? out_A : out;
 
     for (n=offset; n<nsmps; n++) {
 
       if (isetup == 1) { // Stereo configuration. Nor band splitting nor near field compensation.
+        MYFLT w = in[n], y = in[2*ksmps+n];
         /* Left: */
-        out[n] = in[n]*SQRT(FL(0.5)) + in[2*ksmps+n]*FL(0.5);    // w*sqrt(0.5) + y*0.5;
+        out[n] = w*SQRT(FL(0.5)) + y*FL(0.5);
         /* Right: */
-        out[ksmps+n] = in[n]*SQRT(FL(0.5)) - in[2*ksmps+n]*FL(0.5);    // w*sqrt(0.5) - y*0.5;
+        out[ksmps+n] = w*SQRT(FL(0.5)) - y*FL(0.5);
         continue;
+      }
+
+      /* Read every input before an output can overwrite a shared array. */
+      for (j = 0; j < p->n_signals; j++) {
+        int32_t in_ix = p->horizontal ? dict_3dto2d[j] : j;
+        inSamp[j] = in[in_ix*ksmps+n];
       }
 
       out_binaural0[n] = 0.0;
@@ -1823,12 +1834,18 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
           signal_order = order_signals3d[j];
 
         if (signal_order != 0) {
-          if ((int)*(p->r)!=-1)
-            process_nfc(csound,p,signal_order,n,j,in_ix,CS_ESR,CS_KSMPS);
+          if (*p->r != FL(-1.0))
+            process_nfc(p,signal_order,j,&inSamp[j],CS_ESR);
+        }
+
+        if (decoder == 1 || decoder == 2) {
+          /* A single decoder uses its full-band matrix, without a crossover. */
+          for (int32_t o = 0; o < n_outs_A; o++)
+            decoded[o*ksmps+n] += (MYFLT)(matrix[o][in_ix] * inSamp[j]);
+          continue;
         }
 
         // band splitting
-        inSamp[j] = in[in_ix*ksmps+n];
         poleSamp[j] = inSamp[j];
         zeroSamp_lf[j] = 0.0;
         zeroSamp_hf[j] = 0.0;
@@ -1851,23 +1868,9 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
         y_hf = (p->b_hf[0])*poleSamp[j] + zeroSamp_hf[j];
         y_lf = (p->b_lf[0])*poleSamp[j] + zeroSamp_lf[j];
 
-        for (int32_t o = 0; o < n_outs_A; o++) {
-          if (isetup == 21 || isetup == 31) { //binaural
-            switch((int)*(p->band)) {
-            case 0: out_A[o*ksmps+n] += (MYFLT) ((p->M_lf[o][in_ix])*y_lf - (p->M_hf[o][in_ix])*y_hf); break;
-            case 1: out_A[o*ksmps+n] += (MYFLT) y_lf; break;
-            case 2: out_A[o*ksmps+n] += (MYFLT) y_hf; break;
-            default: ;
-            }
-          } else {
-            switch((int)*(p->band)) {
-            case 0: out[o*ksmps+n] += (MYFLT) ((p->M_lf[o][in_ix])*y_lf - (p->M_hf[o][in_ix])*y_hf); break;
-            case 1: out[o*ksmps+n] += (MYFLT) y_lf; break;
-            case 2: out[o*ksmps+n] += (MYFLT) y_hf; break;
-            default: ;
-            }
-          }
-        }
+        if (decoder == 0)
+          for (int32_t o = 0; o < n_outs_A; o++)
+            decoded[o*ksmps+n] += (MYFLT)(p->M_lf[o][in_ix]*y_lf - p->M_hf[o][in_ix]*y_hf);
       }
     }
 
@@ -1896,24 +1899,14 @@ static int32_t ahoambdec(CSOUND *csound, HOAMBDEC* p)
  * (adapted from  csound/Opcodes/hrtfopcodes.c)
  *
  */
-static double readFilter(HOAMBDEC* p, int32_t i, int32_t j)
+static inline double readFilter(HOAMBDEC* p, int32_t i, int32_t j)
 {
-
-    double* readPoint; /* Generic pointer address */
-    int32_t delay;
-    /* Calculate the address of the index for this read */
-    readPoint = p->currPos[j] - i;
-    delay = p->ndelay;
-
-    /* Wrap around for time-delay if necessary */
-    if (readPoint < ((double*)p->delay[j].auxp) )
-      readPoint += delay;
-    else
-      /* Wrap for time-advance if necessary */
-      if (readPoint > ((double*)p->delay[j].auxp + (delay-1)) )
-        readPoint -= delay;
-
-    return *readPoint; /* Dereference read address for delayed value */
+    double *base = (double*)p->delay[j].auxp;
+    int32_t index = (int32_t)(p->currPos[j] - base) - i;
+    /* Wrap the index before forming a pointer outside the delay array. */
+    if (index < 0) index += p->ndelay;
+    else if (index >= p->ndelay) index -= p->ndelay;
+    return base[index];
 }
 
 
@@ -1924,7 +1917,7 @@ static double readFilter(HOAMBDEC* p, int32_t i, int32_t j)
  * (adapted from  csound/Opcodes/hrtfopcodes.c)
  *
  */
-static void insertFilter(HOAMBDEC* p, double val, int32_t j)
+static inline void insertFilter(HOAMBDEC* p, double val, int32_t j)
 {
 
     int32_t delay;
@@ -1944,13 +1937,13 @@ static void insertFilter(HOAMBDEC* p, double val, int32_t j)
  * This code was adapted from The Ambisonic Decoder Toolbox
  *
  */
-static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32_t n, int32_t j, int32_t in_ix, int32_t sr,
-                        int32_t ksmps)
+static inline void process_nfc(HOAMBDEC* p, int32_t signal_order, int32_t j,
+                               MYFLT *sample, int32_t sr)
 {
     //char buffer[50];
 
     double d; // meters
-    if ((int)*(p->r) == 0) {
+    if (*p->r == FL(0.0)) {
       d = 1.0;
     } else {
       d = (double)*(p->r);
@@ -1959,7 +1952,6 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
     double c = 343.2; // m/s
     double omega = c/(d*sr);
     double gain = 1.0;
-    MYFLT *in = p->in->data;
     //MYFLT *out = p->out->data;
     //  1  1
 
@@ -1969,12 +1961,12 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       double d1 = 0.0 - (2.0 * b1) / g1;
       double g = gain/g1;
 
-      double fTemp0 = (g * in[in_ix*ksmps+n]);
+      double fTemp0 = (g * *sample);
       double fTemp1 = (d1 * p->fRec0[j][1]);
       p->fRec2[j][0] = (fTemp0 + p->fRec2[j][1] + fTemp1);
       p->fRec0[j][0] = p->fRec2[j][0];
       double fRec1 = (fTemp1 + fTemp0);
-      in[in_ix*ksmps+n] = (MYFLT) fRec1;
+      *sample = (MYFLT) fRec1;
       p->fRec2[j][1] = p->fRec2[j][0];
       p->fRec0[j][1] = p->fRec0[j][0];
     }
@@ -1991,7 +1983,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       double d2 = 0.0 - (4.0 * b2) / g2;
       double g = gain/g2;
 
-      double fTemp0 = (g * in[in_ix*ksmps+n]);
+      double fTemp0 = (g * *sample);
       double fTemp1 = (d2 * p->fRec0[j][1]);
       double fTemp2 = (d1 * p->fRec3[j][1]);
       p->fRec5[j][0] = (fTemp0 + (fTemp1 + (p->fRec5[j][1] + fTemp2)));
@@ -2000,7 +1992,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       p->fRec2[j][0] = (p->fRec3[j][0] + p->fRec2[j][1]);
       p->fRec0[j][0] =  p->fRec2[j][0];
       float fRec1 = fRec4;
-      in[in_ix*ksmps+n] = (MYFLT) fRec1;
+      *sample = (MYFLT) fRec1;
       p->fRec5[j][1] = p->fRec5[j][0];
       p->fRec3[j][1] = p->fRec3[j][0];
       p->fRec2[j][1] = p->fRec2[j][0];
@@ -2025,7 +2017,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
 
       double g = gain/(g3*g2);
       double fTemp0 = (d3 * p->fRec0[j][1]);
-      double fTemp1 = (g * in[in_ix*ksmps+n]);
+      double fTemp1 = (g * *sample);
       double fTemp2 = (d2 * p->fRec3[j][1]);
       double fTemp3 = (d1 * p->fRec6[j][1]);
       p->fRec8[j][0] = (fTemp1 + (fTemp2 + (p->fRec8[j][1] + fTemp3)));
@@ -2037,7 +2029,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       p->fRec2[j][0] = (fTemp0 + (fRec4 + p->fRec2[j][1]));
       p->fRec0[j][0] = p->fRec2[j][0];
       float fRec1 = (fRec4 + fTemp0);
-      in[in_ix*ksmps+n] = (MYFLT) fRec1;
+      *sample = (MYFLT) fRec1;
       p->fRec8[j][1] = p->fRec8[j][0];
       p->fRec6[j][1] = p->fRec6[j][0];
       p->fRec5[j][1] = p->fRec5[j][0];
@@ -2071,7 +2063,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       double fTemp1 = (d3 * p->fRec3[j][1]);
       double fTemp2 = (d2 * p->fRec6[j][1]);
       double fTemp3 = (d1 * p->fRec9[j][1]);
-      double fTemp4 = (g * in[in_ix*ksmps+n]);
+      double fTemp4 = (g * *sample);
       p->fRec11[j][0] = ((fTemp2 + (p->fRec11[j][1] + fTemp3)) + fTemp4);
       p->fRec9[j][0] = p->fRec11[j][0];
       double fRec10 = ((fTemp3 + fTemp2) + fTemp4);
@@ -2084,7 +2076,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       p->fRec2[j][0] = (p->fRec3[j][0] + p->fRec2[j][1]);
       p->fRec0[j][0] = p->fRec2[j][0];
       double fRec1 = fRec4;
-      in[in_ix*ksmps+n] = (MYFLT) fRec1;
+      *sample = (MYFLT) fRec1;
       p->fRec11[j][1] = p->fRec11[j][0];
       p->fRec9[j][1] = p->fRec9[j][0];
       p->fRec8[j][1] = p->fRec8[j][0];
@@ -2127,7 +2119,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       double fTemp2 = (d3 * p->fRec6[j][1]);
       double fTemp3 = (d2 * p->fRec9[j][1]);
       double fTemp4 = (d1 * p->fRec12[j][1]);
-      double fTemp5 = (g * in[in_ix*ksmps+n]);
+      double fTemp5 = (g * *sample);
       p->fRec14[j][0] = ((fTemp3 + (p->fRec14[j][1] + fTemp4)) + fTemp5);
       p->fRec12[j][0] = p->fRec14[j][0];
       double fRec13 = ((fTemp4 + fTemp3) + fTemp5);
@@ -2143,7 +2135,7 @@ static void process_nfc(CSOUND *csound, HOAMBDEC* p, int32_t signal_order, int32
       p->fRec2[j][0] = (fTemp0 + (fRec4 + p->fRec2[j][1]));
       p->fRec0[j][0] = p->fRec2[j][0];
       double fRec1 = (fRec4 + fTemp0);
-      in[in_ix*ksmps+n] = (MYFLT) fRec1;
+      *sample = (MYFLT) fRec1;
       p->fRec14[j][1] = p->fRec14[j][0];
       p->fRec12[j][1] = p->fRec12[j][0];
       p->fRec11[j][1] = p->fRec11[j][0];

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -674,6 +674,7 @@ def runTest():
         ["test_foscil_phase_state.csd", "foscil and foscili phase initialization and advancement"],
         ["test_pan2_input_aliasing.csd", "pan2 preserves input samples when outputs reuse them"],
         ["test_bformdec1_surround.csd", "bformdec1 preserves partial blocks and selects the input order"],
+        ["test_bformdec2_samples.csd", "bformdec2 sample bounds, input reuse and decoder responses"],
         ["test_space_trajectory_endpoint.csd", "space and spdist handle the last trajectory frame"],
         ["test_hvs_interpolation.csd", "HVS configuration and grid endpoints"],
         ["test_physmod_vibrato_bounds.csd", "test waveguide vibrato bounds"],

--- a/tests/commandline/test_bformdec2_samples.csd
+++ b/tests/commandline/test_bformdec2_samples.csd
@@ -1,0 +1,189 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=8192
+ksmps=16
+nchnls=2
+0dbfs=1
+gaStereo[] init 2
+gaStereo[0] init 9
+gaStereo[1] init 9
+gkNotes init 0
+gkPrefixChecks init 0
+
+instr 1
+  aInput[] init 4
+  aOne upsamp 1
+  aInput[0] = aOne
+  gaStereo bformdec2 1, aInput
+endin
+
+; Observe the raw output from a full block so array reads retain its prefix.
+instr 2
+  kCycle init 0
+  aLeft = gaStereo[0]
+  aRight = gaStereo[1]
+  kN = 0
+  while kN < ksmps do
+    kSample = kCycle*ksmps+kN
+    kExpected = (kSample >= 3 && kSample < 24 ? sqrt(.5) : 0)
+    kLeft vaget kN, aLeft
+    kRight vaget kN, aRight
+    if abs(kLeft-kExpected) > .000001 || abs(kRight-kExpected) > .000001 then
+      printks "bformdec2 stereo sample %g: %g %g, expected %g\n", 0, kSample, kLeft, kRight, kExpected
+      exitnowk -1
+    endif
+    kN += 1
+  od
+  kCycle += 1
+  gkPrefixChecks += 1
+endin
+
+instr 10
+  ; p4 decoder, p5 distance, p6 input channels, p7 setup, p8 outputs, p9 crossover.
+  aInput[] init p6
+  aOriginal[] init p6
+  aCopy[] init p6
+  aFirst[] init p8
+  aSecond[] init p8
+  aSeparate[] init p8
+  aReuse[] init p6
+  aBase oscili .25, 256
+  aBase += .5
+  kCh = 0
+  while kCh < p6 do
+    aInput[kCh] = aBase * ((kCh+1)*.01)
+    kCh += 1
+  od
+  aOriginal = aInput
+  aCopy = aInput
+  aReuse = aInput
+  aFirst bformdec2 p7, aInput, p4, p5, p9
+  aSecond bformdec2 p7, aInput, p4, p5, p9
+  aSeparate bformdec2 p7, aCopy, p4, p5, p9
+  if p7 == 2 then
+    aReuse bformdec2 p7, aReuse, p4, p5, p9
+  endif
+
+  ; A first-order NFC reference, followed by independent crossover filters.
+  iDistance = (p5 == 0 ? 1 : p5)
+  if p5 == -1 then
+    aDirection = aBase
+  else
+    iOmega = 343.2/(iDistance*sr)
+    iGain = 1/(1+iOmega/2)
+    iFeedback = 1-iOmega/(1+iOmega/2)
+    aDirection biquad aBase, iGain, -iGain, 0, 1, -iFeedback, 0
+  endif
+  iG = tan($M_PI*p9/sr)
+  iDen = (1+iG)*(1+iG)
+  iA1 = 2*(iG*iG-1)/iDen
+  iA2 = (1-iG)*(1-iG)/iDen
+  iLP = iG*iG/iDen
+  iHP = 1/iDen
+  aLPW biquad aBase, iLP, 2*iLP, iLP, 1, iA1, iA2
+  aHPW biquad aBase, iHP, -2*iHP, iHP, 1, iA1, iA2
+  aLPD biquad aDirection, iLP, 2*iLP, iLP, 1, iA1, iA2
+  aHPD biquad aDirection, iHP, -2*iHP, iHP, 1, iA1, iA2
+
+  kCh = 0
+  while kCh < p6 do
+    aDifference = aInput[kCh]-aOriginal[kCh]
+    kN = 0
+    while kN < ksmps do
+      kDifference vaget kN, aDifference
+      if kDifference != 0 then
+        printks "bformdec2 changed input channel %g\n", 0, kCh
+        exitnowk -1
+      endif
+      kN += 1
+    od
+    kCh += 1
+  od
+  kCh = 0
+  while kCh < p8 do
+    aFirstChannel = aFirst[kCh]
+    aSecondChannel = aSecond[kCh]
+    aSeparateChannel = aSeparate[kCh]
+    if p7 == 2 then
+      aReuseChannel = aReuse[kCh]
+    else
+      aReuseChannel = aFirstChannel
+    endif
+    if p6 == 4 then
+      kPair = (p7 == 5 ? int(kCh/2) : kCh)
+      kX = (kPair == 0 || kPair == 3 ? 1 : -1)
+      kY = (kPair < 2 ? 1 : -1)
+      if p7 == 2 then
+        kW = .3535533906*.01
+        kD = .3535533906*(kX*.02+kY*.03)
+        kHighW = sqrt(2)
+        kHighD = 1
+      else
+        kZ = (kCh%2 == 0 ? -1 : 1)
+        kW = .1767766953*.01
+        kD = .2165063509*(kX*.02+kY*.03+kZ*.04)
+        kHighW = 2
+        kHighD = sqrt(2)
+      endif
+      if p4 == 0 then
+        aExpected = kW*aLPW+kD*aLPD-kW*kHighW*aHPW-kD*kHighD*aHPD
+      elseif p4 == 1 then
+        aExpected = kW*aBase+kD*aDirection
+      else
+        aExpected = kW*kHighW*aBase+kD*kHighD*aDirection
+      endif
+    else
+      aExpected = aSeparateChannel
+    endif
+    kN = 0
+    while kN < ksmps do
+      kFirst vaget kN, aFirstChannel
+      kSecond vaget kN, aSecondChannel
+      kSeparate vaget kN, aSeparateChannel
+      kReuse vaget kN, aReuseChannel
+      kExpected vaget kN, aExpected
+      if abs(kFirst-kExpected) > .000001 || abs(kSecond-kFirst) > .000001 || abs(kSeparate-kFirst) > .000001 || abs(kReuse-kFirst) > .000001 then
+        printks "bformdec2 setup %g decoder %g distance %g channel %g: %g %g %g %g, expected %g\n", 0, p7, p4, p5, kCh, kFirst, kSecond, kSeparate, kReuse, kExpected
+        exitnowk -1
+      endif
+      kN += 1
+    od
+    kCh += 1
+  od
+  kCycle init 0
+  if kCycle == 0 then
+    gkNotes += 1
+  endif
+  kCycle += 1
+endin
+
+instr 99
+  if i(gkPrefixChecks) != 2 || i(gkNotes) != 12 then
+    prints "bformdec2 cases did not all run\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 .0003662109375 .0025634765625
+i 2 0 .00390625
+i 10 .03125 .03125 0 -1 4 2 4 400
+i 10 .03125 .03125 1 -1 4 2 4 400
+i 10 .03125 .03125 2 -1 4 2 4 400
+i 10 .0941162109375 .0205078125 0 .5 4 2 4 400
+i 10 .0941162109375 .0205078125 1 .5 4 2 4 1000
+i 10 .0941162109375 .0205078125 2 .5 4 2 4 1000
+i 10 .15625 .03125 0 1 4 5 8 400
+i 10 .15625 .03125 1 1 4 5 8 1000
+i 10 .15625 .03125 2 1 4 5 8 1000
+; Higher orders also preserve shared input with NFC enabled.
+i 10 .2191162109375 .0205078125 0 1 9 4 8 400
+i 10 .2191162109375 .0205078125 0 1 16 4 8 400
+i 10 .28125 .03125 0 0 4 2 4 400
+i 99 .375 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
Fix several `bformdec2` output errors:

- Clear pre-note samples at each channel's actual buffer offset.
- Keep near-field compensation in local samples, so it cannot alter shared input or compound when two decoders read the same array. Read all input channels before writing an in-place output.
- Apply the full-band velocity or energy matrix in decoder modes 1 and 2. They previously sent the same filtered sum to every speaker.
- Restore the cube decoder's missing vertical weights, so upper and lower speakers differ.
- Honor distances below one metre and wrap delay indices before forming pointers, avoiding undefined pointer arithmetic.
