### PR TITLE
fix: correct maxk sample counts and accumulator state

### DIFF
--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -33,8 +33,6 @@
 #include "interlocks.h"
 #include "arrays.h"
 
-#define FLT_MAX ((MYFLT)0x7fffffff)
-
 static int32_t krsnsetx(CSOUND *csound, KRESONX *p)
 /* Gabriel Maldonado, modified for arb order  */
 {
@@ -803,17 +801,8 @@ static int32_t isAChanged(CSOUND *csound,ISACHANGED *p)
 static int32_t partial_maximum_set(CSOUND *csound,P_MAXIMUM *p)
 {
   IGN(csound);
-  int32_t flag = (int32_t) *p->imaxflag;
-  switch (flag) {
-  case 1:
-    p->max = 0; break;
-  case 2:
-    p->max = -FLT_MAX; break;
-  case 3:
-    p->max = FLT_MAX; break;
-  case 4:
-    p->max = 0; break;
-  }
+  *p->kout = FL(0.0);
+  p->max = FL(0.0);
   p->counter = 0;
   return OK;
 }
@@ -827,29 +816,33 @@ static int32_t partial_maximum(CSOUND *csound,P_MAXIMUM *p)
   MYFLT *a = p->asig;
   MYFLT max = p->max;
   if (UNLIKELY(early)) nsmps -= early;
+  if (UNLIKELY(offset >= nsmps)) return OK;
+  /* Seed extrema from the signal instead of imposing a fixed value limit. */
+  if (p->counter == 0 && (flag == 2 || flag == 3))
+    max = a[offset];
+  p->counter += nsmps - offset;
   switch(flag) {
   case 1: /* absolute maximum */
     for (n=offset; n<nsmps; n++) {
       MYFLT temp;
       if ((temp = FABS(a[n])) > max) max = temp;
     }
-    if (max > p->max) p->max = max;
+    p->max = max;
     break;
   case 2: /* actual maximum */
     for (n=offset; n<nsmps; n++) {
       if (a[n] > max) max = a[n];
     }
-    if (max > p->max) p->max = max;
+    p->max = max;
     break;
   case 3: /* actual minimum */
     for (n=offset; n<nsmps; n++) {
       if (a[n] < max) max = a[n];
     }
-    if (max < p->max) p->max = max;
+    p->max = max;
     break;
   case 4: { /* average */
     MYFLT temp = FL(0.0);
-    p->counter += nsmps;
     for (n=offset; n<nsmps; n++) {
       temp += a[n];
     }
@@ -861,22 +854,9 @@ static int32_t partial_maximum(CSOUND *csound,P_MAXIMUM *p)
                              "%s", Str("max_k: invalid imaxflag value"));
   }
   if (*p->ktrig) {
-    switch (flag) {
-    case 4:
-      *p->kout = p->max / (MYFLT) p->counter;
-      p->counter = 0;
-      p->max = FL(0.0);
-      break;
-    case 1:
-      *p->kout = p->max;
-      p->max = 0; break;
-    case 2:
-      *p->kout = p->max;
-      p->max = -FLT_MAX; break;
-    case 3:
-      *p->kout = p->max;
-      p->max = FLT_MAX; break;
-    }
+    *p->kout = flag == 4 ? p->max / (MYFLT)p->counter : p->max;
+    p->counter = 0;
+    p->max = FL(0.0);
   }
   return OK;
 }

--- a/Opcodes/gab/gab.h
+++ b/Opcodes/gab/gab.h
@@ -126,7 +126,7 @@ typedef struct {
     OPDS    h;
     MYFLT   *kout, *asig, *ktrig, *imaxflag;
     MYFLT   max;
-    int32_t     counter;
+    uint64_t    counter;
 } P_MAXIMUM;
 
 /* From fractals.h */

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -1004,6 +1004,7 @@ def runTest():
         ["test_raw_strings.csd", "test new-style raw strings"],
         ["test_min_max_values.csd", "test MIN_VALUE and MAX_VALUE math constants"],
         ["test_minmax_accumulator_bounds.csd", "min/max accumulators preserve inactive samples"],
+        ["test_maxk_accumulation.csd", "maxk active sample counts, extrema and trigger state"],
         ["test_counter_state.csd", "counter state and slot reuse"],
         ["test_counter_deleted.csd", "counter readers reject deleted objects", 1],
         ["test_counter_invalid_handle.csd", "counter rejects invalid handles", 1],

--- a/tests/commandline/test_maxk_accumulation.csd
+++ b/tests/commandline/test_maxk_accumulation.csd
@@ -1,0 +1,103 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0 --sample-accurate
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+gkNotes init 0
+
+instr 1
+  ; p4 trigger period, p5 input scale, p6 input bias, p7 local block size.
+  setksmps p7
+  iSize = p7
+  iStart = int(p2*sr+.5)
+  iEnd = int((p2+p3)*sr+.5)
+  iBlock = iStart-iStart%iSize
+  kCycle init 0
+  kTrigger = (kCycle%p4 == p4-1 ? 1 : 0)
+  aPhase phasor sr/16
+  aInput = (aPhase+p6)*p5
+  kAbs maxk aInput, kTrigger, 1
+  kMax maxk aInput, kTrigger, 2
+  kMin maxk aInput, kTrigger, 3
+  kMean maxk aInput, kTrigger, 4
+  kAliasAbs max_k aInput, kTrigger, 1
+  kAliasMax max_k aInput, kTrigger, 2
+  kAliasMin max_k aInput, kTrigger, 3
+  kAliasMean max_k aInput, kTrigger, 4
+  kSum init 0
+  kCount init 0
+  kHigh init 0
+  kLow init 0
+  kAbsolute init 0
+  kExpectedAbs init 0
+  kExpectedMax init 0
+  kExpectedMin init 0
+  kExpectedMean init 0
+  kN = 0
+  while kN < iSize do
+    kSample = iBlock+kCycle*iSize+kN
+    if kSample >= iStart && kSample < iEnd then
+      kValue vaget kN, aInput
+      if kCount == 0 then
+        kHigh = kValue
+        kLow = kValue
+      endif
+      kHigh = max(kHigh,kValue)
+      kLow = min(kLow,kValue)
+      kAbsolute = max(kAbsolute,abs(kValue))
+      kSum += kValue
+      kCount += 1
+    endif
+    kN += 1
+  od
+  if kTrigger != 0 then
+    kExpectedAbs = kAbsolute
+    kExpectedMax = kHigh
+    kExpectedMin = kLow
+    kExpectedMean = kSum/kCount
+    kSum = 0
+    kCount = 0
+    kAbsolute = 0
+  endif
+  kTolerance = max(1,abs(p5))*.000001
+  if abs(kAbs-kExpectedAbs) > kTolerance || abs(kMax-kExpectedMax) > kTolerance || abs(kMin-kExpectedMin) > kTolerance || abs(kMean-kExpectedMean) > kTolerance then
+    printks "maxk block %g: %g %g %g %g, expected %g %g %g %g\n", 0, kCycle, kAbs, kMax, kMin, kMean, kExpectedAbs, kExpectedMax, kExpectedMin, kExpectedMean
+    exitnowk -1
+  endif
+  if kAliasAbs != kAbs || kAliasMax != kMax || kAliasMin != kMin || kAliasMean != kMean then
+    printks "max_k and maxk differ\n", 0
+    exitnowk -1
+  endif
+  if kCycle == 0 then
+    gkNotes += 1
+  endif
+  kCycle += 1
+endin
+
+instr 99
+  if i(gkNotes) != 8 then
+    prints "maxk cases did not all run\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+; Full and partial blocks, with immediate and delayed triggers.
+i 1 0 .0625 1 1 -.5 16
+i 1 .0703125 .03125 1 1 1 16
+i 1 .1279296875 .0712890625 3 1 -.5 16
+; Extrema exceed the old +/- 2147483647 starting values.
+i 1 .25 .0625 1 4294967296 2 16
+i 1 .3154296875 .0205078125 1 -4294967296 2 16
+i 1 .3779296875 .0712890625 3 -4294967296 2 16
+; One active sample and one-sample local blocks.
+i 1 .5029296875 .0009765625 1 -1 2 16
+i 1 .53125 .0078125 2 1 -.5 1
+i 99 .625 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`maxk`/`max_k` counts inactive prefix samples in averaging mode. A constant input of 1 therefore reports 0.5 when a note starts halfway through a block.

Count only active samples, preserve state across empty blocks, and use a 64-bit counter for long intervals. Seed min/max from the first sample instead of the fixed +/-2147483647 limit. Reset the output at initialization so a reused note cannot report the previous note's result before its first trigger.
