### PR TITLE
fix: update mandel iteration cache and boundary handling

### DIFF
--- a/Opcodes/gab/gab.c
+++ b/Opcodes/gab/gab.c
@@ -886,28 +886,33 @@ static int32_t partial_maximum(CSOUND *csound,P_MAXIMUM *p)
 static int32_t mandel_set(CSOUND *csound,MANDEL *p)
 {
   IGN(csound);
-  p->oldx=-99999; /*probably unused values  */
-  p->oldy=-99999;
+  p->oldx = p->oldy = p->oldMaxIter = FL(0.0);
   p->oldCount = -1;
   return OK;
 }
 
 static int32_t mandel(CSOUND *csound,MANDEL *p)
 {
-  IGN(csound);
   MYFLT px=*p->kx, py=*p->ky;
-  if (*p->ktrig && (px != p->oldx || py != p->oldy)) {
-    int32_t maxIter = (int32_t) *p->kmaxIter, j;
+  MYFLT limit = *p->kmaxIter;
+  if (*p->ktrig && (p->oldCount < 0 || px != p->oldx || py != p->oldy ||
+                   limit != p->oldMaxIter)) {
+    if (UNLIKELY(!((double)limit >= 0.0 && (double)limit <= INT32_MAX)))
+      return csound->PerfError(csound, &(p->h), "%s",
+                               Str("mandel: iteration limit out of range"));
+    int32_t maxIter = (int32_t) limit, j;
     MYFLT x=FL(0.0), y=FL(0.0), newx, newy;
+    /* Preserve the historical zero-based escape count. */
     for (j=0; j<maxIter; j++) {
       newx = x*x - y*y + px;
       newy = FL(2.0)*x*y + py;
       x=newx;
       y=newy;
-      if (x*x+y*y >= FL(4.0)) break;
+      if (x*x+y*y > FL(4.0)) break;
     }
     p->oldx = px;
     p->oldy = py;
+    p->oldMaxIter = limit;
     if (p->oldCount != j) *p->koutrig = FL(1.0);
     else *p->koutrig = FL(0.0);
     *p->kr = (MYFLT) (p->oldCount = j);

--- a/Opcodes/gab/gab.h
+++ b/Opcodes/gab/gab.h
@@ -133,7 +133,7 @@ typedef struct {
 typedef struct {
     OPDS    h;
     MYFLT   *kr, *koutrig,  *ktrig, *kx, *ky, *kmaxIter;
-    MYFLT   oldx, oldy;
+    MYFLT   oldx, oldy, oldMaxIter;
     int32_t oldCount;
 } MANDEL;
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -638,6 +638,8 @@ def runTest():
         ["test_grain4_correctness.csd", "grain4 handles envelopes, boundaries, and unused pitches"],
         ["test_gendy_correctness.csd", "gendy handles audio blocks and bounded integer state"],
         ["test_lorenz_skip.csd", "lorenz integration steps per sample"],
+        ["test_mandel_state.csd", "mandel trigger, iteration cache and boundary points"],
+        ["test_mandel_invalid_limit.csd", "mandel rejects an unrepresentable iteration limit", 1],
         ["test_looptseg_curves.csd", "looptseg curve stability"],
         ["test_gtadsr_stages.csd", "gtadsr stage endpoints, retriggering and sample offsets"],
         ["test_gtadsr_invalid_times.csd", "reject out-of-range gtadsr stage times", 1],

--- a/tests/commandline/test_mandel_invalid_limit.csd
+++ b/tests/commandline/test_mandel_invalid_limit.csd
@@ -1,0 +1,18 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+instr 1
+  kCount, kChanged mandel 1, 0, 0, 2147483648
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .015625
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/tests/commandline/test_mandel_state.csd
+++ b/tests/commandline/test_mandel_state.csd
@@ -1,0 +1,58 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr=1024
+ksmps=16
+nchnls=1
+0dbfs=1
+gkChecks init 0
+
+instr 1
+  kTriggers[] fillarray 0,1,1,1,0,1,1,1,1,1,1,1,1,1,0,1,1,0,1,1
+  kX[] fillarray 0,0,0,0,0,0,.5,3,3,0,0,-2,0,1,-2,-2,-2,-2,-2,0
+  kY[] fillarray 0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0
+  kLimits[] fillarray -1,4,8,8,2,2,2,8,4,0,4.9,8,8,8,4,4,4,0,0,1
+  ; Interior points return the limit; escape counts retain their zero-based convention.
+  kExpected[] fillarray -1,4,8,8,8,2,2,0,0,0,4,8,1,2,2,4,4,4,0,1
+  kChanges[] fillarray 0,1,1,0,0,1,0,1,0,0,1,1,1,1,0,1,0,0,1,1
+  kCycle init 0
+  kCount, kChanged mandel kTriggers[kCycle], kX[kCycle], kY[kCycle], kLimits[kCycle]
+  if kCount != kExpected[kCycle] || kChanged != kChanges[kCycle] then
+    printks "mandel cycle %g: count %g change %g, expected %g %g\n", 0, kCycle, kCount, kChanged, kExpected[kCycle], kChanges[kCycle]
+    exitnowk -1
+  endif
+  kCycle += 1
+  gkChecks += 1
+endin
+
+instr 2
+  ; The first trigger must run even at the former coordinate sentinel.
+  kCycle init 0
+  kCount, kChanged mandel 1, -99999, -99999, 4
+  kExpectedChange = (kCycle == 0 ? 1 : 0)
+  if kCount != 0 || kChanged != kExpectedChange then
+    printks "mandel skipped its first trigger at the former sentinel\n", 0
+    exitnowk -1
+  endif
+  kCycle += 1
+  gkChecks += 1
+endin
+
+instr 99
+  if i(gkChecks) != 44 then
+    prints "mandel cases did not all run\n"
+    exitnow -1
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .3125
+; Repeat in a reused instance to check initialization.
+i 1 .5 .3125
+i 2 .875 .0625
+i 99 1 0
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`mandel` ignores changes to `kmaxIter` when coordinates stay fixed. At `(0,0)`, raising the limit from 4 to 8 still returns 4. Include the limit in the cache and always evaluate the first trigger.

Use a strict radius-2 escape test so boundary points such as `(-2,0)` can reach the iteration limit. Preserve the existing zero-based escape counts and trigger only when the result changes. Reject out-of-range limits before converting them to an integer.
