### PR TITLE
Fix filepeak channel queries and file cleanup

### DIFF
--- a/OOps/sndinfUG.c
+++ b/OOps/sndinfUG.c
@@ -318,10 +318,12 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
     else {
       double  *peaks;
       size_t  nBytes;
-      if (UNLIKELY(channel > sfinfo.channels))
+      if (UNLIKELY(channel > sfinfo.channels)) {
+        csound->FileClose(csound, fd, CSFILE_CLOSE_SYNC);
         return csound->InitError(csound,
                                  Str("Input channel for peak exceeds number "
                                 "of channels in file"));
+      }
       nBytes = sizeof(double)* sfinfo.channels;
       peaks = (double*)csound->Malloc(csound, nBytes);
       if (csound->SndfileCommand(csound,sf, SFC_GET_MAX_ALL_CHANNELS, peaks, (int32_t) nBytes) == SFLIB_FALSE) {
@@ -330,8 +332,11 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
         if (csound->SndfileCommand(csound,sf, SFC_CALC_NORM_MAX_ALL_CHANNELS, peaks, (int32_t) nBytes) == 0)
           peakVal = peaks[channel - 1];
       }
+      else
+        peakVal = peaks[channel - 1];
       csound->Free(csound, peaks);
     }
+    csound->FileClose(csound, fd, CSFILE_CLOSE_SYNC);
     if (UNLIKELY(peakVal < 0.0))
       return csound->InitError(csound, Str("filepeak: error getting peak value"));
     /* scale output consistently with soundin opcode (see diskin2.c) */
@@ -342,8 +347,6 @@ int32_t filepeak_(CSOUND *csound, SNDINFOPEAK *p, char *soundiname)
       *p->r1 = (MYFLT)(peakVal * (double)csound->e0dbfs);
     else
       *p->r1 = (MYFLT)peakVal;
-    csound->FileClose(csound, fd, CSFILE_CLOSE_SYNC);
-
     return OK;
 }
 

--- a/tests/commandline/test.py
+++ b/tests/commandline/test.py
@@ -499,6 +499,7 @@ def runTest():
         ["test_local_ksmps_global_struct_a_fail.csd", "reject global a-rate struct member with local ksmps", 1],
         ["test_local_ksmps_global_struct_copy_fail.csd", "reject global struct containing audio with local ksmps", 1],
         ["test_schedwhen.csd", "schedwhen opcode"],
+        ["test_filepeak_channels.csd", "filepeak stored and scanned channel peaks"],
         ["test_parse_error_unary.csd", "expected failure: unary parse error", 1],
         ["test_parse_error_unary_not.csd", "expected failure: unary ! parse error", 1],
         ["test_parse_error_unary_minus.csd", "expected failure: unary - parse error", 1],

--- a/tests/commandline/test_filepeak_channels.csd
+++ b/tests/commandline/test_filepeak_channels.csd
@@ -1,0 +1,53 @@
+<CsoundSynthesizer>
+<CsOptions>
+-n -d -m0
+</CsOptions>
+<CsInstruments>
+sr = 8192
+ksmps = 16
+nchnls = 3
+0dbfs = 4
+giChecks init 0
+strset 1, "filepeak_float.wav"
+strset 2, "filepeak_pcm.wav"
+
+instr 1
+  aLeft upsamp 1
+  aRight upsamp -2
+  aSilent upsamp 0
+  ; Floating-point WAVs store PEAK chunks; integer WAVs require a scan.
+  fout "filepeak_float.wav", 16, aLeft, aRight, aSilent
+  fout "filepeak_pcm.wav", 14, aLeft, aRight, aSilent
+endin
+
+instr 2
+  SFile strget p4
+  iOverall filepeak SFile
+  iLeft filepeak SFile, 1
+  iRight filepeak SFile, 2
+  iSilent filepeak SFile, 3
+  ; Also cover the numeric file identifier overload.
+  iNumeric filepeak p4, 2
+  if abs(iOverall - 2) > .000001 || abs(iLeft - 1) > .000001 || abs(iRight - 2) > .000001 || iSilent != 0 || abs(iNumeric - 2) > .000001 then
+    prints "filepeak mismatch for %s: all=%g left=%g right=%g silent=%g numeric=%g\n", SFile, iOverall, iLeft, iRight, iSilent, iNumeric
+    exitnow(-1)
+  endif
+  giChecks += 1
+endin
+
+instr 99
+  if giChecks != 2 then
+    prints "filepeak checks did not complete\n"
+    exitnow(-1)
+  endif
+endin
+</CsInstruments>
+<CsScore>
+i 1 0 .0078125
+; Wait for fout to close both files and finish their headers.
+i 2 .03125 .0078125 1
+i 2 .046875 .0078125 2
+i 99 .0625 .0078125
+e
+</CsScore>
+</CsoundSynthesizer>


### PR DESCRIPTION
`filepeak` reports an error when selecting a channel from a file with stored peak data: it reads the per-channel peaks but never copies the selected value into the result. Use that value when the header lookup succeeds, keeping the scan fallback for files without peak data.

Close the file before returning errors for an invalid channel or a failed peak query, as well as on success.
